### PR TITLE
Fix: Bug fixes for expiring embed Preview

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -18,7 +18,8 @@ import {
     decodeKeydown,
     openUrlInsideIframe,
     getHeaders,
-    findScriptLocation } from './util';
+    findScriptLocation
+} from './util';
 import {
     getURL,
     getDownloadURL,
@@ -47,6 +48,7 @@ import {
     PERMISSION_DOWNLOAD,
     PERMISSION_ANNOTATE,
     PERMISSION_PREVIEW,
+    PREVIEW_SCRIPT_NAME,
     X_REP_HINT_BASE,
     X_REP_HINT_DOC_THUMBNAIL,
     X_REP_HINT_IMAGE,
@@ -208,7 +210,7 @@ class Preview extends EventEmitter {
         // All preview assets are relative to preview.js. Here we create a location
         // object that mimics the window location object and points to where
         // preview.js is loaded from by the browser.
-        this.location = findScriptLocation('preview.js', document.currentScript);
+        this.location = findScriptLocation(PREVIEW_SCRIPT_NAME);
     }
 
     /**
@@ -242,6 +244,9 @@ class Preview extends EventEmitter {
         // Save a reference to the options to be used later
         if (typeof token === 'string' || typeof token === 'function') {
             this.previewOptions = Object.assign({}, options, { token });
+        } else if (token) {
+            // @TODO(tjin): Remove this after expiring embed updates to new calling pattern
+            this.previewOptions = Object.assign({}, token || {});
         } else {
             throw new Error('Missing access token!');
         }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -83,3 +83,5 @@ export const FILE_EXT_ERROR_MAP = {
     pages: __('error_iwork'),
     keynote: __('error_iwork')
 };
+
+export const PREVIEW_SCRIPT_NAME = 'preview.js';

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -502,14 +502,10 @@ export function decodeKeydown(event) {
  * Find location information about a script include
  *
  * @param {string} name - Script name
- * @param {HTMLScriptElement} [currentScript] - Current script tag
  * @return {Object} Script location object
  */
-export function findScriptLocation(name, currentScript = null) {
-    const scriptSrc = currentScript
-                        ? currentScript.src
-                        : document.querySelector(`script[src*="/${name}"]`).src;
-
+export function findScriptLocation(name) {
+    const scriptSrc = document.querySelector(`script[src*="/${name}"]`).src;
     if (!scriptSrc) {
         throw new Error('Missing or malformed preview library');
     }


### PR DESCRIPTION
- Temporarily allow token in options for `show()` until expiring embed code is updated
- Update `findScriptLocation()` to only use DOM script search method since `document.currentScript` doesn't seem to work with Preview as an instance