### PR TITLE
Chore: Removing rotateLeft method from DocBaseViewer

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -503,25 +503,6 @@ class DocBaseViewer extends BaseViewer {
     }
 
     /**
-     * Rotates documents by delta degrees
-     *
-     * @param {number} delta - Degrees to rotate
-     * @return {void}
-     */
-    rotateLeft(delta = -90) {
-        const currentPageNum = this.pdfViewer.currentPageNumber;
-
-        // Calculate and set rotation
-        this.pageRotation = this.pageRotation || 0;
-        this.pageRotation = (this.pageRotation + 360 + delta) % 360;
-        this.pdfViewer.pagesRotation = this.pageRotation;
-
-        // Re-render and scroll to appropriate page
-        this.pdfViewer.update();
-        this.setPage(currentPageNum);
-    }
-
-    /**
      * Returns whether or not viewer is annotatable. If an optional type is
      * passed in, we check if that type of annotation is allowed.
      *

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -844,22 +844,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
     });
 
-    describe('rotateLeft()', () => {
-        it('should set the pdf viewer rotation, update the viewer, and reset the page', () => {
-            docBase.pdfViewer = {
-                currentPageNumber: 1,
-                update: sandbox.stub()
-            };
-            const setPageStub = sandbox.stub(docBase, 'setPage');
-            const rotation = 180;
-
-            docBase.rotateLeft(rotation);
-            expect(setPageStub).to.be.called;
-            expect(docBase.pdfViewer.update).to.be.called;
-            expect(docBase.pdfViewer.pagesRotation).to.equal(rotation);
-        });
-    });
-
     describe('isAnnotatable()', () => {
         beforeEach(() => {
             stubs.getViewerOption = sandbox.stub(docBase, 'getViewerOption');


### PR DESCRIPTION
We no longer support this function of the Document viewer