### PR TITLE
Fix: 3D Error messages

### DIFF
--- a/src/lib/viewers/box3d/model3d/Model3DLoader.js
+++ b/src/lib/viewers/box3d/model3d/Model3DLoader.js
@@ -31,7 +31,7 @@ class Model3DLoader extends AssetLoader {
     determineViewer(file, disabledViewers = []) {
         const viewer = super.determineViewer(file, disabledViewers);
 
-        if (!Browser.supportsModel3D()) {
+        if (viewer && !Browser.supportsModel3D()) {
             const message = replacePlaceholders(__('error_unsupported'), [__('3d_models')]);
             throw new Error(message);
         }

--- a/src/lib/viewers/box3d/model3d/__tests__/Model3DLoader-test.js
+++ b/src/lib/viewers/box3d/model3d/__tests__/Model3DLoader-test.js
@@ -3,39 +3,47 @@ import Model3DLoader from '../Model3DLoader';
 import Browser from '../../../../Browser';
 
 const sandbox = sinon.sandbox.create();
-
+let file;
 describe('lib/viewers/box3d/model3d/Model3DLoader', () => {
+    beforeEach(() => {
+        file = {
+            extension: 'box3d',
+            name: 'blah.box3d',
+            representations: {
+                entries: [{
+                    representation: '3d'
+                }]
+            }
+        };
+    });
+
     afterEach(() => {
+        file = undefined;
         sandbox.verifyAndRestore();
     });
 
     describe('determineViewer()', () => {
-        it('should throw an error if browser doesn\'t support 3D', () => {
-            const file = {
-                extension: 'box3d',
-                name: 'blah.box3d',
+        it('should throw an error if browser doesn\'t support 3D and it is a 3d file', () => {
+            sandbox.stub(Browser, 'supportsModel3D').returns(false);
+            expect(() => Model3DLoader.determineViewer(file)).to.throw(Error, /browser doesn't support preview for 3D models/);
+        });
+
+        it('should not throw an error if browser doesn\'t support 3D and it is a non 3d file', () => {
+            file = {
+                extension: 'pdf',
+                name: 'blah.pdf',
                 representations: {
                     entries: [{
-                        representation: '3d'
+                        representation: 'pdf'
                     }]
                 }
             };
 
             sandbox.stub(Browser, 'supportsModel3D').returns(false);
-            expect(() => Model3DLoader.determineViewer(file)).to.throw(Error, /browser doesn't support preview for 3D models/);
+            expect(() => Model3DLoader.determineViewer(file)).to.not.throw(Error, /browser doesn't support preview for 3D models/);
         });
 
         it('should return viewer if browser supports 3D', () => {
-            const file = {
-                extension: 'box3d',
-                name: 'blah.box3d',
-                representations: {
-                    entries: [{
-                        representation: '3d'
-                    }]
-                }
-            };
-
             sandbox.stub(Browser, 'supportsModel3D').returns(true);
             expect(Model3DLoader.determineViewer(file)).to.equal(Model3DLoader.viewers[0]);
         });


### PR DESCRIPTION
Preventing a 3D support error from being thrown if the file is not a 3D file