### PR TITLE
Chore: Mock super.setup() in all Viewer unit tests

### DIFF
--- a/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
+++ b/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
@@ -23,6 +23,8 @@ let box3d;
 let stubs = {};
 
 describe('lib/viewers/box3d/Box3DViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -45,6 +47,9 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        box3d.containerEl = containerEl;
         box3d.setup();
 
         sandbox.stub(box3d, 'createSubModules');
@@ -66,6 +71,8 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (box3d && typeof box3d.destroy === 'function') {
             box3d.destroy();
@@ -91,6 +98,8 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
                     }
                 }
             });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+            box3d.containerEl = containerEl;
             box3d.setup();
 
             box3d.createSubModules();
@@ -325,6 +334,8 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
         });
 
         it('should call renderer.load()', () => {
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+            box3d.containerEl = containerEl;
             Object.defineProperty(BaseViewer.prototype, 'load', { value: sandbox.mock() });
             sandbox.stub(box3d, 'loadAssets').returns(Promise.resolve());
             sandbox.stub(box3d, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });

--- a/src/lib/viewers/box3d/image360/__tests__/Image360Viewer-test.js
+++ b/src/lib/viewers/box3d/image360/__tests__/Image360Viewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import Image360Viewer from '../Image360Viewer';
+import BaseViewer from '../../../BaseViewer';
 import Box3DControls from '../../Box3DControls';
 import Image360Renderer from '../Image360Renderer';
 
@@ -9,6 +10,7 @@ const CSS_CLASS_IMAGE_360 = 'bp-image-360';
 describe('lib/viewers/box3d/image360/Image360Viewer', () => {
     let containerEl;
     let viewer;
+    const setupFunc = BaseViewer.prototype.setup;
 
     before(() => {
         fixture.setBase('src/lib');
@@ -24,11 +26,15 @@ describe('lib/viewers/box3d/image360/Image360Viewer', () => {
                 id: '0'
             }
         });
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        viewer.containerEl = containerEl;
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (viewer && typeof viewer.destroy === 'function') {
             viewer.destroy();

--- a/src/lib/viewers/box3d/model3d/__tests__/Model3DViewer-test.js
+++ b/src/lib/viewers/box3d/model3d/__tests__/Model3DViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import Model3DViewer from '../Model3DViewer';
+import BaseViewer from '../../../BaseViewer';
 import Model3DControls from '../Model3DControls';
 import Model3DRenderer from '../Model3DRenderer';
 import {
@@ -21,6 +22,8 @@ let model3d;
 let stubs = {};
 
 describe('lib/viewers/box3d/model3d/Model3DViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -43,6 +46,9 @@ describe('lib/viewers/box3d/model3d/Model3DViewer', () => {
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        model3d.containerEl = containerEl;
         model3d.setup();
 
         sandbox.stub(model3d, 'createSubModules');
@@ -92,6 +98,8 @@ describe('lib/viewers/box3d/model3d/Model3DViewer', () => {
         fixture.cleanup();
         stubs = {};
 
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
+
         if (model3d && typeof model3d.destroy === 'function') {
             model3d.destroy();
         }
@@ -115,6 +123,8 @@ describe('lib/viewers/box3d/model3d/Model3DViewer', () => {
                     }
                 }
             });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+            m3d.containerEl = containerEl;
             m3d.setup();
 
             m3d.createSubModules();

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -35,6 +35,8 @@ let containerEl;
 let stubs = {};
 
 describe('src/lib/viewers/doc/DocBaseViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -54,6 +56,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 id: '0'
             }
         });
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        docBase.containerEl = containerEl;
         docBase.setup();
         stubs = {};
     });
@@ -61,6 +65,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         docBase.pdfViewer = undefined;
         if (typeof docBase.destroy === 'function') {

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import DocumentViewer from '../DocumentViewer';
 import DocBaseViewer from '../DocBaseViewer';
+import BaseViewer from '../../BaseViewer';
 import DocPreloader from '../DocPreloader';
 import fullscreen from '../../../Fullscreen';
 import {
@@ -19,6 +20,8 @@ let doc;
 let stubs = {};
 
 describe('lib/viewers/doc/DocumentViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -33,6 +36,9 @@ describe('lib/viewers/doc/DocumentViewer', () => {
                 id: '0'
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        doc.containerEl = containerEl;
         doc.setup();
 
         doc.pdfViewer = {
@@ -47,6 +53,8 @@ describe('lib/viewers/doc/DocumentViewer', () => {
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (doc && typeof doc.destroy === 'function') {
             doc.destroy();

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import PresentationViewer from '../PresentationViewer';
+import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
 import DocBaseViewer from '../DocBaseViewer';
 import PresentationPreloader from '../PresentationPreloader';
@@ -22,6 +23,8 @@ let presentation;
 let stubs = {};
 
 describe('lib/viewers/doc/PresentationViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -33,6 +36,9 @@ describe('lib/viewers/doc/PresentationViewer', () => {
         presentation = new PresentationViewer({
             container: containerEl
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        presentation.containerEl = containerEl;
         presentation.setup();
 
         presentation.pdfViewer = {
@@ -53,6 +59,8 @@ describe('lib/viewers/doc/PresentationViewer', () => {
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (presentation && typeof presentation.destroy === 'function') {
             presentation.pdfViewer = undefined;

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import PreviewErrorViewer from '../PreviewErrorViewer';
+import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
 import * as file from '../../../file';
 import { PERMISSION_DOWNLOAD } from '../../../constants';
@@ -11,25 +12,33 @@ import {
 
 const sandbox = sinon.sandbox.create();
 let error;
+let containerEl;
 
 describe('lib/viewers/error/PreviewErrorViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
 
     beforeEach(() => {
         fixture.load('viewers/error/__tests__/PreviewErrorViewer-test.html');
+        containerEl = document.querySelector('.container');
         error = new PreviewErrorViewer({
             file: {
                 id: '1'
             },
-            container: '.container'
+            container: containerEl
         });
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        error.containerEl = containerEl;
     });
 
     afterEach(() => {
         fixture.cleanup();
         sandbox.verifyAndRestore();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (error && typeof error.destroy === 'function') {
             error.destroy();

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -1,10 +1,13 @@
 import IFrameViewer from '../IFrameViewer';
+import BaseViewer from '../../BaseViewer';
 
 const sandbox = sinon.sandbox.create();
 let containerEl;
 let iframe;
 
 describe('lib/viewers/iframe/IFrameViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -19,11 +22,16 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
                 extension: 'boxnote'
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        iframe.containerEl = containerEl;
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (iframe && typeof iframe.destroy === 'function') {
             iframe.destroy();

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import ImageViewer from '../ImageViewer';
+import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
 import * as file from '../../../file';
 import * as util from '../../../util';
@@ -16,6 +17,8 @@ let containerEl;
 let clock;
 
 describe('lib/viewers/image/ImageViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -45,6 +48,9 @@ describe('lib/viewers/image/ImageViewer', () => {
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        image.containerEl = containerEl;
         image.setup();
     });
 
@@ -52,6 +58,8 @@ describe('lib/viewers/image/ImageViewer', () => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
         clock.restore();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (image && typeof image.destroy === 'function') {
             image.destroy();
@@ -70,6 +78,8 @@ describe('lib/viewers/image/ImageViewer', () => {
             });
             sandbox.stub(image, 'initAnnotations');
 
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+            image.containerEl = containerEl;
             image.setup();
 
             expect(image.wrapperEl).to.have.class('bp-image');

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import MultiImageViewer from '../MultiImageViewer';
 import fullscreen from '../../../Fullscreen';
+import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
 
 const CLASS_INVISIBLE = 'bp-is-invisible';
@@ -15,6 +16,8 @@ let containerEl;
 
 describe('lib/viewers/image/MultiImageViewer', () => {
     stubs.errorHandler = MultiImageViewer.prototype.errorHandler;
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -45,9 +48,14 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         };
 
         multiImage = new MultiImageViewer(options);
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        multiImage.containerEl = containerEl;
     });
 
     afterEach(() => {
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
+
         if (multiImage && multiImage.imagesEl) {
             multiImage.destroy();
         }

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import DashViewer from '../DashViewer';
 import VideoBaseViewer from '../VideoBaseViewer';
+import BaseViewer from '../../BaseViewer';
 import cache from '../../../Cache';
 import fullscreen from '../../../Fullscreen';
 import * as util from '../../../util';
@@ -15,6 +16,8 @@ const CSS_CLASS_HD = 'bp-media-controls-is-hd';
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/media/DashViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -69,11 +72,15 @@ describe('lib/viewers/media/DashViewer', () => {
         };
         stubs.mockControls = sandbox.mock(dash.mediaControls);
 
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        dash.containerEl = containerEl;
         dash.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (dash && typeof dash.destroy === 'function' && !dash.destroyed) {
             dash.destroy();

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -1,11 +1,14 @@
 /* eslint-disable no-unused-expressions */
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
+import BaseViewer from '../../BaseViewer';
 
 const sandbox = sinon.sandbox.create();
 let mp3;
 
 describe('lib/viewers/media/MP3Viewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -19,11 +22,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
                 id: 1
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        mp3.containerEl = containerEl;
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
+
         if (mp3 && typeof mp3.destroy === 'function') {
             mp3.destroy();
         }

--- a/src/lib/viewers/media/__tests__/MP4Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP4Viewer-test.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-unused-expressions */
 import MP4Viewer from '../MP4Viewer';
+import BaseViewer from '../../BaseViewer';
 
 const sandbox = sinon.sandbox.create();
 let mp4;
 
 describe('lib/viewers/media/MP4Viewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -18,11 +21,17 @@ describe('lib/viewers/media/MP4Viewer', () => {
                 id: 1
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        mp4.containerEl = containerEl;
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
+
         if (mp4 && typeof mp4.destroy === 'function') {
             mp4.destroy();
         }

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -1,14 +1,18 @@
 /* eslint-disable no-unused-expressions */
 import Browser from '../../../Browser';
 import MediaBaseViewer from '../MediaBaseViewer';
+import BaseViewer from '../../BaseViewer';
 import MediaControls from '../MediaControls';
 import cache from '../../../Cache';
 
 let media;
 let stubs;
+let containerEl;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/media/MediaBaseViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -16,17 +20,21 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
     beforeEach(() => {
         fixture.load('viewers/media/__tests__/MediaBaseViewer-test.html');
         stubs = {};
+        containerEl = document.querySelector('.container');
         media = new MediaBaseViewer({
             file: {
                 id: 1
             },
-            container: '.container',
+            container: containerEl,
             representation: {
                 content: {
                     url_template: 'www.netflix.com'
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        media.containerEl = containerEl;
         media.setup();
         media.mediaControls = {
             addListener: sandbox.stub(),
@@ -47,6 +55,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
     afterEach(() => {
         sandbox.verifyAndRestore();
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
         media.destroy();
         media = null;
         stubs = null;

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1,31 +1,40 @@
 /* eslint-disable no-unused-expressions */
 import VideoBaseViewer from '../VideoBaseViewer';
 import MediaBaseViewer from '../MediaBaseViewer';
+import BaseViewer from '../../BaseViewer';
 
+let containerEl;
 let videoBase;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/media/VideoBaseViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
 
     beforeEach(() => {
         fixture.load('viewers/media/__tests__/VideoBaseViewer-test.html');
+        containerEl = document.querySelector('.container');
         videoBase = new VideoBaseViewer({
             file: {
                 id: 1
             },
-            container: '.container',
+            container: containerEl,
             content: {
                 url_template: 'www.netflix.com'
             }
         });
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        videoBase.containerEl = containerEl;
         videoBase.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (videoBase && typeof videoBase.destroy === 'function') {
             videoBase.destroy();
@@ -45,8 +54,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 file: {
                     id: 1
                 },
-                container: '.container'
+                container: containerEl
             });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+            videoBase.containerEl = containerEl;
             videoBase.setup();
 
             expect(videoBase.mediaEl.getAttribute('preload')).to.equal('auto');

--- a/src/lib/viewers/office/__tests__/OfficeViewer-test.js
+++ b/src/lib/viewers/office/__tests__/OfficeViewer-test.js
@@ -11,9 +11,11 @@ const PRINT_DIALOG_TIMEOUT_MS = 500;
 const sandbox = sinon.sandbox.create();
 let office;
 let stubs = {};
+let containerEl;
 
 describe('lib/viewers/office/OfficeViewer', () => {
     let clock;
+    const setupFunc = BaseViewer.prototype.setup;
 
     before(() => {
         fixture.setBase('src/lib');
@@ -21,8 +23,9 @@ describe('lib/viewers/office/OfficeViewer', () => {
 
     beforeEach(() => {
         fixture.load('viewers/office/__tests__/OfficeViewer-test.html');
+        containerEl = document.querySelector('.container');
         office = new OfficeViewer({
-            container: '.container',
+            container: containerEl,
             file: {
                 id: '123'
             }
@@ -31,12 +34,16 @@ describe('lib/viewers/office/OfficeViewer', () => {
             setupPDFUrl: sandbox.stub(office, 'setupPDFUrl')
         };
         clock = sinon.useFakeTimers();
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        office.containerEl = containerEl;
     });
 
     afterEach(() => {
         clock.restore();
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (office && typeof office.destroy === 'function') {
             office.destroy();

--- a/src/lib/viewers/swf/__tests__/SWFViewer-test.js
+++ b/src/lib/viewers/swf/__tests__/SWFViewer-test.js
@@ -8,6 +8,8 @@ let swf;
 let containerEl;
 
 describe('lib/viewers/SWFViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -29,12 +31,17 @@ describe('lib/viewers/SWFViewer', () => {
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        swf.containerEl = containerEl;
         swf.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (swf && typeof swf.destroy === 'function') {
             swf.destroy();

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import CSVViewer from '../CSVViewer';
 import TextBaseViewer from '../TextBaseViewer';
+import BaseViewer from '../../BaseViewer';
 import * as util from '../../../util';
 
 let containerEl;
@@ -10,6 +11,8 @@ let csv;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/text/CSVViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -30,12 +33,16 @@ describe('lib/viewers/text/CSVViewer', () => {
         };
 
         csv = new CSVViewer(options);
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        csv.containerEl = containerEl;
         csv.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (typeof csv.destroy === 'function') {
             csv.destroy();

--- a/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
+++ b/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import MarkdownViewer from '../MarkdownViewer';
+import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
 
@@ -8,6 +9,8 @@ let markdown;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/text/MarkdownViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -21,12 +24,17 @@ describe('lib/viewers/text/MarkdownViewer', () => {
             },
             container: containerEl
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        markdown.containerEl = containerEl;
         markdown.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (markdown && typeof markdown.destroy === 'function') {
             markdown.destroy();

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import Browser from '../../../Browser';
 import PlainTextViewer from '../PlainTextViewer';
+import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
 import TextBaseViewer from '../TextBaseViewer';
 import * as util from '../../../util';
@@ -11,6 +12,8 @@ let text;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/text/PlainTextViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -32,12 +35,17 @@ describe('lib/viewers/text/PlainTextViewer', () => {
                 }
             }
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+        text.containerEl = containerEl;
         text.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (typeof text.destroy === 'function') {
             text.destroy();
@@ -54,6 +62,8 @@ describe('lib/viewers/text/PlainTextViewer', () => {
                 container: containerEl
             });
             sandbox.stub(text, 'initPrint');
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+            text.containerEl = containerEl;
 
             text.setup();
 
@@ -255,6 +265,8 @@ describe('lib/viewers/text/PlainTextViewer', () => {
                 },
                 container: containerEl
             });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
+            text.containerEl = containerEl;
             text.setup();
         });
 

--- a/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
+++ b/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import Controls from '../../../Controls';
 import TextBaseViewer from '../TextBaseViewer';
+import BaseViewer from '../../BaseViewer';
 import * as file from '../../../file';
 import { PERMISSION_DOWNLOAD } from '../../../constants';
 
@@ -9,6 +10,8 @@ let textBase;
 const sandbox = sinon.sandbox.create();
 
 describe('lib/viewers/text/TextBaseViewer', () => {
+    const setupFunc = BaseViewer.prototype.setup;
+
     before(() => {
         fixture.setBase('src/lib');
     });
@@ -22,11 +25,15 @@ describe('lib/viewers/text/TextBaseViewer', () => {
             },
             container: containerEl
         });
+
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
+        textBase.containerEl = containerEl;
         textBase.setup();
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
+        Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
         if (typeof textBase.destroy === 'function') {
             textBase.destroy();
         }


### PR DESCRIPTION
Viewer unit tests shouldn't be testing super.setup() in addition to testing their own setup() method