### PR TITLE
Update: Tweak pdf.js range requests for improved performance

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,6 +10,6 @@
         "value-no-vendor-prefix": true,
         "number-leading-zero": never,
         "declaration-no-important": true,
-        "order/declaration-block-properties-alphabetical-order": [true, { "severity": "warning" }]
+        "order/properties-alphabetical-order": [true, { "severity": "warning" }]
     }
 }

--- a/src/lib/polyfill.js
+++ b/src/lib/polyfill.js
@@ -1,11 +1,11 @@
 /* eslint-disable */
-(function() {
+(function () {
     var testObject = {};
 
     if (!(Object.setPrototypeOf || testObject.__proto__)) {
         var nativeGetPrototypeOf = Object.getPrototypeOf;
 
-        Object.getPrototypeOf = function(object) {
+        Object.getPrototypeOf = function (object) {
             if (object.__proto__) {
                 return object.__proto__;
             } else {
@@ -16,8 +16,8 @@
 })();
 
 if (typeof Object.assign != 'function') {
-    (function() {
-        Object.assign = function(target) {
+    (function () {
+        Object.assign = function (target) {
             'use strict';
             if (target === undefined || target === null) {
                 throw new TypeError('Cannot convert undefined or null to object');
@@ -39,60 +39,153 @@ if (typeof Object.assign != 'function') {
     })();
 }
 
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
 if (!Array.prototype.find) {
     Object.defineProperty(Array.prototype, 'find', {
         configurable: true,
         enumerable: false,
         writable: true,
-        value: function(predicate) {
-            'use strict';
-            if (this === null) {
-                throw new TypeError('Array.prototype.find called on null or undefined');
+        value: function (predicate) {
+            // 1. Let O be ? ToObject(this value).
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
             }
+
+            var o = Object(this);
+
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            var len = o.length >>> 0;
+
+            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
             if (typeof predicate !== 'function') {
                 throw new TypeError('predicate must be a function');
             }
-            var list = Object(this);
-            var length = list.length >>> 0;
-            var thisArg = arguments[1];
-            var value;
 
-            for (var i = 0; i < length; i++) {
-                value = list[i];
-                if (predicate.call(thisArg, value, i, list)) {
-                    return value;
+            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+            var thisArg = arguments[1];
+
+            // 5. Let k be 0.
+            var k = 0;
+
+            // 6. Repeat, while k < len
+            while (k < len) {
+                // a. Let Pk be ! ToString(k).
+                // b. Let kValue be ? Get(O, Pk).
+                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                // d. If testResult is true, return kValue.
+                var kValue = o[k];
+                if (predicate.call(thisArg, kValue, k, o)) {
+                    return kValue;
                 }
+                // e. Increase k by 1.
+                k++;
             }
+
+            // 7. Return undefined.
             return undefined;
         }
     });
 }
 
+// https://tc39.github.io/ecma262/#sec-array.prototype.findIndex
 if (!Array.prototype.findIndex) {
     Object.defineProperty(Array.prototype, 'findIndex', {
         configurable: true,
         enumerable: false,
         writable: true,
-        value: function(predicate) {
-            'use strict';
-            if (this === null) {
-                throw new TypeError('Array.prototype.findIndex called on null or undefined');
+        value: function (predicate) {
+            // 1. Let O be ? ToObject(this value).
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
             }
+
+            var o = Object(this);
+
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            var len = o.length >>> 0;
+
+            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
             if (typeof predicate !== 'function') {
                 throw new TypeError('predicate must be a function');
             }
-            var list = Object(this);
-            var length = list.length >>> 0;
-            var thisArg = arguments[1];
-            var value;
 
-            for (var i = 0; i < length; i++) {
-                value = list[i];
-                if (predicate.call(thisArg, value, i, list)) {
-                    return i;
+            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+            var thisArg = arguments[1];
+
+            // 5. Let k be 0.
+            var k = 0;
+
+            // 6. Repeat, while k < len
+            while (k < len) {
+                // a. Let Pk be ! ToString(k).
+                // b. Let kValue be ? Get(O, Pk).
+                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                // d. If testResult is true, return k.
+                var kValue = o[k];
+                if (predicate.call(thisArg, kValue, k, o)) {
+                    return k;
                 }
+                // e. Increase k by 1.
+                k++;
             }
+
+            // 7. Return -1.
             return -1;
+        }
+    });
+}
+
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+    Object.defineProperty(Array.prototype, 'includes', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: function (searchElement, fromIndex) {
+
+            // 1. Let O be ? ToObject(this value).
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
+            }
+
+            var o = Object(this);
+
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            var len = o.length >>> 0;
+
+            // 3. If len is 0, return false.
+            if (len === 0) {
+                return false;
+            }
+
+            // 4. Let n be ? ToInteger(fromIndex).
+            //    (If fromIndex is undefined, this step produces the value 0.)
+            var n = fromIndex | 0;
+
+            // 5. If n ≥ 0, then
+            //  a. Let k be n.
+            // 6. Else n < 0,
+            //  a. Let k be len + n.
+            //  b. If k < 0, let k be 0.
+            var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+            function sameValueZero(x, y) {
+                return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+            }
+
+            // 7. Repeat, while k < len
+            while (k < len) {
+                // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+                // b. If SameValueZero(searchElement, elementK) is true, return true.
+                // c. Increase k by 1.
+                if (sameValueZero(o[k], searchElement)) {
+                    return true;
+                }
+                k++;
+            }
+
+            // 8. Return false
+            return false;
         }
     });
 }
@@ -102,7 +195,7 @@ if (!String.prototype.endsWith) {
         configurable: true,
         enumerable: false,
         writable: true,
-        value: function(searchString, position) {
+        value: function (searchString, position) {
             var subjectString = this.toString();
             if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
                 position = subjectString.length;


### PR DESCRIPTION
- Re-enable range requests for Safari and iOS that was previously disabled by pdf.js' new built-in compatability checking
- Increase non-US locale chunk size to 512KB
- Disable range requests for files with original size <4MB except for Excel files, see code for details
- Add polyfill for Array.includes and update other polyfills to MDN ones