### PR TITLE
New: Demo for adding FreeText annotation support

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -656,7 +656,7 @@ class DocBaseViewer extends BaseViewer {
         const { file, location } = this.options;
         const { size, extension, watermark_info: watermarkInfo } = file;
         const assetUrlCreator = createAssetUrlCreator(location);
-        PDFJS.workerSrc = assetUrlCreator(`third-party/doc/${DOC_STATIC_ASSETS_VERSION}/pdf.worker.min.js`);
+        PDFJS.workerSrc = assetUrlCreator(`third-party/doc/${DOC_STATIC_ASSETS_VERSION}/pdf.worker.js`);
         PDFJS.cMapUrl = `${location.staticBaseURI}third-party/doc/${DOC_STATIC_ASSETS_VERSION}/cmaps/`;
         PDFJS.cMapPacked = true;
 

--- a/src/lib/viewers/doc/docAssets.js
+++ b/src/lib/viewers/doc/docAssets.js
@@ -2,9 +2,9 @@ import { DOC_STATIC_ASSETS_VERSION } from '../../constants';
 
 const STATIC_URI = `third-party/doc/${DOC_STATIC_ASSETS_VERSION}/`;
 export const JS = [
-    `${STATIC_URI}pdf.min.js`,
-    `${STATIC_URI}pdf_viewer.min.js`,
-    `${STATIC_URI}pdf.worker.min.js`,
+    `${STATIC_URI}pdf.js`,
+    `${STATIC_URI}pdf_viewer.js`,
+    `${STATIC_URI}pdf.worker.js`,
     `${STATIC_URI}exif.min.js`
 ];
-export const CSS = [`${STATIC_URI}pdf_viewer.min.css`];
+export const CSS = [`${STATIC_URI}pdf_viewer.css`];

--- a/src/third-party/doc/0.119.0/pdf.js
+++ b/src/third-party/doc/0.119.0/pdf.js
@@ -1493,6 +1493,8 @@ AnnotationElementFactory.prototype = {
         return new LinkAnnotationElement(parameters);
       case AnnotationType.TEXT:
         return new TextAnnotationElement(parameters);
+      case AnnotationType.FREETEXT:
+        return new FreeTextAnnotationElement(parameters);
       case AnnotationType.WIDGET:
         var fieldType = parameters.data.fieldType;
         switch (fieldType) {
@@ -1692,6 +1694,27 @@ var TextAnnotationElement = function TextAnnotationElementClosure() {
     }
   });
   return TextAnnotationElement;
+}();
+var FreeTextAnnotationElement = function FreeTextAnnotationElementClosure() {
+  function FreeTextAnnotationElement(parameters) {
+    var isRenderable = !!(parameters.data.hasPopup || parameters.data.title || parameters.data.contents);
+    AnnotationElement.call(this, parameters, isRenderable);
+  }
+  Util.inherit(FreeTextAnnotationElement, AnnotationElement, {
+    render: function FreeTextAnnotationElement_render() {
+      this.container.className = 'freeTextAnnotation';
+      var text = document.createElement('div');
+      text.style.height = this.container.style.height;
+      text.style.width = this.container.style.width;
+      text.style.visibility = 'hidden';
+      text.dataset.l10nId = 'free_text_annotation_type';
+      text.dataset.annotationTitle = this.data.title;
+      text.textContent = this.data.contents;
+      this.container.appendChild(text);
+      return this.container;
+    }
+  });
+  return FreeTextAnnotationElement;
 }();
 var WidgetAnnotationElement = function WidgetAnnotationElementClosure() {
   function WidgetAnnotationElement(parameters, isRenderable) {

--- a/src/third-party/doc/0.119.0/pdf.worker.js
+++ b/src/third-party/doc/0.119.0/pdf.worker.js
@@ -24466,6 +24466,9 @@ AnnotationFactory.prototype = {
         return new LinkAnnotation(parameters);
       case 'Text':
         return new TextAnnotation(parameters);
+      case 'FreeText':
+        console.log('Free Text yo');
+        return new FreeTextAnnotation(parameters);
       case 'Widget':
         var fieldType = Util.getInheritableProperty(dict, 'FT');
         fieldType = isName(fieldType) ? fieldType.name : null;
@@ -24520,6 +24523,7 @@ var Annotation = function AnnotationClosure() {
     this.setFlags(dict.get('F'));
     this.setRectangle(dict.getArray('Rect'));
     this.setColor(dict.getArray('C'));
+    this.setContents(dict.getArray('Contents'));
     this.setBorderStyle(dict);
     this.setAppearance(dict);
     this.data = {};
@@ -24592,6 +24596,9 @@ var Annotation = function AnnotationClosure() {
           this.color = rgbColor;
           break;
       }
+    },
+    setContents: function Annotation_setContent(contents) {
+      this.contents = contents || '';
     },
     setBorderStyle: function Annotation_setBorderStyle(borderStyle) {
       this.borderStyle = new AnnotationBorderStyle();
@@ -24950,6 +24957,19 @@ var TextAnnotation = function TextAnnotationClosure() {
   }
   Util.inherit(TextAnnotation, Annotation, {});
   return TextAnnotation;
+}();
+var FreeTextAnnotation = function FreeTextAnnotationClosure() {
+  var DEFAULT_ICON_SIZE = 22;
+  function FreeTextAnnotation(parameters) {
+    Annotation.call(this, parameters);
+    this.data.annotationType = AnnotationType.FREETEXT;
+    this.data.rect[1] = this.data.rect[3] - DEFAULT_ICON_SIZE;
+    this.data.rect[2] = this.data.rect[0] + DEFAULT_ICON_SIZE;
+    this.data.name = parameters.dict.has('Contents') ? parameters.dict.get('Contents') : '';
+    this._preparePopup(parameters.dict);
+  }
+  Util.inherit(FreeTextAnnotation, Annotation, {});
+  return FreeTextAnnotation;
 }();
 var LinkAnnotation = function LinkAnnotationClosure() {
   function LinkAnnotation(params) {


### PR DESCRIPTION
Do not merge - this is a prototype of adding support for FreeText annotations to pdf.js. The size of the annotation is off in this demo, but there is a DOM element with the 'title' of the FreeText annotation as a data attribute and the contents as its textContent.

See:
![2017-04-20_17-24-50](https://cloud.githubusercontent.com/assets/689351/25257700/a4d7d196-25ee-11e7-910e-3233e570f0d2.png)
