### PR TITLE
Fix: Set media viewers' settings menu dimensions with javascript

### DIFF
--- a/src/lib/viewers/media/Settings.scss
+++ b/src/lib/viewers/media/Settings.scss
@@ -8,45 +8,32 @@ $item-hover-color: #f6fafd;
     border-radius: 2px;
     bottom: 60px;
     color: $fours;
-    display: none;
+    display: block;
     font-size: 10px;
-    height: 2 * ($item-height + $padding + 1px);
     line-height: $item-height - $padding;
     margin: 0;
     overflow: hidden;
     padding: $padding;
     position: absolute;
     right: 16px;
-    transition: width .2s, height .2s;
-    width: 148px;
+    transition: width .25s, height .25s;
+    visibility: hidden;
 
     .bp-media-settings-is-open & {
-        display: block;
-    }
-
-    // For MP3 and MP4 we only have speed option
-    .bp-media-mp4 &,
-    .bp-media-mp3 & {
-        height: $item-height + (2 * ($padding + 1px));
+        visibility: visible;
     }
 
     .bp-media-mp3 & {
         bottom: 65px;
         right: 0;
     }
+}
 
-    &.bp-media-settings-show-speed,
-    &.bp-media-settings-show-quality {
-        /* stylelint-disable declaration-no-important */
-        height: ((4 * $item-height) + (2 * $padding)) !important;
-        width: (88px + (2 * $padding)) !important;
-        /* stylelint-enable declaration-no-important */
-    }
-
-    &.bp-media-settings-show-speed {
-        /* stylelint-disable declaration-no-important */
-        height: ((7 * $item-height) + (2 * $padding)) !important;
-        /* stylelint-enable declaration-no-important */
+// For MP3 and MP4 we only have speed option
+.bp-media-mp4,
+.bp-media-mp3 {
+    .bp-media-settings-item-quality {
+        display: none;
     }
 }
 
@@ -88,7 +75,6 @@ $item-hover-color: #f6fafd;
     padding-left: $padding / 2;
     text-align: left;
     text-transform: uppercase;
-    width: 55px;
 }
 
 .bp-media-settings-value {
@@ -99,11 +85,6 @@ $item-hover-color: #f6fafd;
     .bp-media-settings-item & {
         color: $sunset-grey;
         font-weight: 400;
-        width: 48px;
-    }
-
-    .bp-media-settings-sub-item & {
-        width: 30px;
     }
 
     .bp-media-settings-selected & {
@@ -116,7 +97,6 @@ $item-hover-color: #f6fafd;
     font-weight: 400;
     text-align: center;
     text-transform: uppercase;
-    width: 48px;
 }
 
 .bp-media-settings-options-quality,

--- a/src/lib/viewers/media/__tests__/Settings-test.js
+++ b/src/lib/viewers/media/__tests__/Settings-test.js
@@ -102,6 +102,15 @@ describe('lib/viewers/media/Settings', () => {
             expect(settings.chooseOption).to.be.calledWith('quality', quality);
             expect(settings.chooseOption).to.be.calledWith('speed', speed);
         });
+
+        it('should initialize the menu dimensions', () => {
+            sandbox.stub(settings, 'chooseOption');
+            sandbox.stub(settings, 'setSettingsMenuWidths');
+
+            settings.init();
+
+            expect(settings.setSettingsMenuWidths).to.be.called;
+        });
     });
 
     describe('reset()', () => {
@@ -111,6 +120,52 @@ describe('lib/viewers/media/Settings', () => {
             settings.reset();
 
             expect(settings.settingsEl).to.have.class('bp-media-settings');
+        });
+
+        it('should reset the menu height', () => {
+            sandbox.stub(settings, 'setMenuHeight');
+
+            settings.reset();
+
+            expect(settings.setMenuHeight).to.be.calledWith(settings.mainMenu);
+        });
+    });
+
+    describe('setMenuWidth()', () => {
+        // NOTE: labels and values do not need matching widths - only internal consistency
+        // is needed amongst labels and amongst values. They happen to end up being the same
+        // in this test. This test cannot test that the widths get set to the max width
+        // because offsetWidth cannot be mocked out, since it's a readonly property
+        it('should set consistent width across all labels', () => {
+            const fakeMenuHTML = `<div role="menu">
+                <div class="menu-item">
+                    <div class="bp-media-settings-label" style="width:10px"/>
+                    <div class="bp-media-settings-value" style="width:100px"/>
+                </div>
+                <div class="menu-item">
+                    <div class="bp-media-settings-label" style="width:15px"/>
+                    <div class="bp-media-settings-value" style="width:95px"/>
+                </div>
+                <div class="menu-item">
+                    <div class="bp-media-settings-label" style="width:12px"/>
+                    <div class="bp-media-settings-value" style="width:105px"/>
+                </div>
+            </div>`;
+            const parent = document.createElement('div');
+            parent.innerHTML = fakeMenuHTML;
+            const fakeMenu = parent.firstChild;
+            const labels = fakeMenu.querySelectorAll('.bp-media-settings-label');
+            const values = fakeMenu.querySelectorAll('.bp-media-settings-value');
+
+            settings.setMenuWidth(fakeMenu);
+
+            // Assert that all the widths are consistent across labels, and across widths
+            [].forEach.call(labels, (label) => {
+                expect(label.style.width).to.equal(labels[0].style.width);
+            });
+            [].forEach.call(values, (value) => {
+                expect(value.style.width).to.equal(values[0].style.width);
+            });
         });
     });
 
@@ -506,6 +561,14 @@ describe('lib/viewers/media/Settings', () => {
             settings.showSubMenu('speed');
 
             expect(document.activeElement).to.equal(selected);
+        });
+
+        it('should recompute the menu height', () => {
+            sandbox.stub(settings, 'setMenuHeight');
+
+            settings.showSubMenu('speed');
+
+            expect(settings.setMenuHeight).to.be.called;
         });
     });
 


### PR DESCRIPTION
This fixes a bug for when the localized items in the menu would not fit
in the menu's fixed width size set by CSS. This will also pave the way
for adding more dynamic submenus, e.g. when there are a variable number
of subtitles or audio tracks