### PR TITLE
Chore: Document viewer tweaks

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -632,6 +632,10 @@ class DocBaseViewer extends BaseViewer {
 
         // Decrease mobile canvas size to ~3MP (1920x1536)
         PDFJS.maxCanvasPixels = this.isMobile ? MOBILE_MAX_CANVAS_SIZE : PDFJS.maxCanvasPixels;
+
+        // Do not disable create object URL in IE11 or iOS Chrome - pdf.js issues #3977 and #8081 are
+        // not applicable to Box's use case and disabling causes performance issues
+        PDFJS.disableCreateObjectURL = false;
     }
 
     /**

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -72,6 +72,8 @@ class PresentationViewer extends DocBaseViewer {
         const pageEl = this.docEl.querySelector(`[data-page-number="${this.pdfViewer.currentPageNumber}"]`);
         pageEl.classList.remove(CLASS_INVISIBLE);
 
+        // Force page to be rendered - this is needed because the presentation
+        // DOM layout can trick pdf.js into thinking that this page is not visible
         this.pdfViewer.update();
     }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1004,6 +1004,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.setupPdfjs();
             expect(PDFJS.maxCanvasPixels).to.equal(MOBILE_MAX_CANVAS_SIZE);
         });
+
+        it('should set disableCreateObjectURL to false', () => {
+            docBase.setupPdfjs();
+            expect(PDFJS.disableCreateObjectURL).to.equal(false);
+        });
     });
 
     describe('initPrint()', () => {


### PR DESCRIPTION
- Add comment for why this.pdfViewer.update() is needed in presentation setPage()
- Force enable createObjectURL() in IE11 and iOS Chrome for performance gains