### PR TITLE
Update: Make media viewer settings menu larger so scrollbars don't show

### DIFF
--- a/src/lib/viewers/media/Settings.js
+++ b/src/lib/viewers/media/Settings.js
@@ -257,10 +257,10 @@ const SUBTITLES_SUBITEM_TEMPLATE = `<div class="bp-media-settings-sub-item" data
     setMenuContainerDimensions(menu) {
         // NOTE: need to explicitly set the dimensions in order to get css transitions. width=auto doesn't work with css transitions
         this.settingsEl.style.width = `${menu.offsetWidth + 18}px`;
-        // height = n * $item-height + 2 * $padding (see Settings.scss)
+        // height = n * $item-height + 2 * $padding (see Settings.scss) + 2 * border (see Settings.scss)
         // where n is the number of displayed items in the menu
         const sumHeight = [].reduce.call(menu.children, (sum, child) => sum + child.offsetHeight, 0);
-        this.settingsEl.style.height = `${sumHeight + 16}px`;
+        this.settingsEl.style.height = `${sumHeight + 18}px`;
     }
 
     /**


### PR DESCRIPTION
Before, scrollbars could show on the various menus depending on your
scrollbar settings (e.g. OS settings, or mouse plugged in). This is
because the menu height was sized based on heights of items inside plus
padding, but forgot about border. Accounting for the 1px border fixes
this issue