### PR TITLE
Fix: Disables annotations after 'load' event on shared links

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -292,7 +292,7 @@ const RESIZE_WAIT_TIME_IN_MILLIS = 300;
         });
 
         this.addListener('load', () => {
-            if (this.areAnnotationsEnabled()) {
+            if (this.annotationsPromise) {
                 this.annotationsPromise.then(this.loadAnnotator);
             }
         });


### PR DESCRIPTION
- Fixes issue where annotations cookieswitch causes preview to fail on shared folder
- The promise is only created after the areAnnotationsEnabled() and sharedlink check