### PR TITLE
Fix: Fixing vanity urls for excel online on IE11

### DIFF
--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -193,7 +193,7 @@ const MESSAGE_HOST_READY = 'Host_PostmessageReady';
                 const tempAnchor = document.createElement('a');
                 tempAnchor.href = sharedLink;
                 const vanitySubdomain = tempAnchor.hostname.split('.')[0];
-                const vanityName = tempAnchor.pathname.split('/v/')[1];
+                const vanityName = tempAnchor.href.split('/v/')[1];
                 src = `${src}?v=${vanityName}&vanity_subdomain=${vanitySubdomain}&fileId=${fileId}`;
             }
         } else {


### PR DESCRIPTION
Pathname doesn't do what's expected on IE11: https://stackoverflow.com/questions/956233/javascript-pathname-ie-quirk