### PR TITLE
Chore: Use whatwg-fetch instead of isomorphic-fetch

### DIFF
--- a/build/webpack.karma.config.js
+++ b/build/webpack.karma.config.js
@@ -10,8 +10,7 @@ const config = merge(baseConfig, {
     devtool: 'inline-source-map',
     resolve: {
         alias: {
-            sinon: 'sinon/pkg/sinon',
-            'isomorphic-fetch': 'fetch-mock-forwarder'
+            sinon: 'sinon/pkg/sinon'
         }
     }
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "fetch-mock-forwarder": "^1.0.0",
     "file-loader": "^0.10.1",
     "i18n-webpack-plugin": "^0.3.0",
-    "isomorphic-fetch": "^2.2.1",
     "karma": "^1.5.0",
     "karma-chai": "^0.1.0",
     "karma-chai-as-promised": "^0.1.2",
@@ -92,7 +91,8 @@
     "stylelint-config-standard": "^16.0.0",
     "stylelint-order": "^0.4.1",
     "url-loader": "^0.5.8",
-    "webpack": "^2.2.1"
+    "webpack": "^2.2.1",
+    "whatwg-fetch": "^2.0.3"
   },
   "scripts": {
     "build": "yarn run clean && yarn run build-rb && yarn run lint && yarn run dev",

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import 'isomorphic-fetch';
+import 'whatwg-fetch';
 import fetchMock from 'fetch-mock';
 import * as util from '../util';
 

--- a/src/lib/annotations/AnnotationService.js
+++ b/src/lib/annotations/AnnotationService.js
@@ -1,5 +1,5 @@
+import 'whatwg-fetch';
 import EventEmitter from 'events';
-import fetch from 'isomorphic-fetch';
 import autobind from 'autobind-decorator';
 import Annotation from './Annotation';
 import { getHeaders } from '../util';

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch';
+import 'whatwg-fetch';
 
 const HEADER_CLIENT_NAME = 'X-Box-Client-Name';
 const HEADER_CLIENT_VERSION = 'X-Box-Client-Version';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,7 +3332,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
+isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -6506,6 +6506,10 @@ webpack@^2.2.1:
 whatwg-fetch@>=0.10.0, whatwg-fetch@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.10.1.tgz#365125d40b36823feac8ab41b71c4d56e84a531f"
+
+whatwg-fetch@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
isomorphic-fetch is a wrapper around whatwg-fetch and we don't need its isomorphic nature