### PR TITLE
Docs: Use ISO date format for LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
                                     BOX
                           SOFTWARE LICENSE AGREEMENT
-                                (v.05162017)
+                                (v.20170516)
 
                                 BOX UI KITS
 
-This “Agreement” forms a legally binding agreement between Box (as defined in
-Section 14) and you (“Developer”) that governs Developer's right to access and
+This "Agreement" forms a legally binding agreement between Box (as defined in
+Section 14) and you ("Developer") that governs Developer's right to access and
 use this SDK (as defined below).
 
 DEVELOPER'S RIGHT TO USE THE SDK IS SUBJECT TO DEVELOPER'S ACCEPTANCE OF AND
@@ -30,18 +30,18 @@ This Agreement does not govern use of any Box software or services other than
 the SDK. See the relevant agreements accompanying the other Box software or
 services for their respective governing terms.
 
-1. General. The “SDK” means the Box software development kit, including any
+1. General. The "SDK" means the Box software development kit, including any
    subsequent updates or upgrade made available to Developer, and any
    associated documentation, software code, or other materials made
    available by Box to assist Developer in developing solution(s) (each a
-   “Developer Application”) that are customizable and responsive web based
+   "Developer Application") that are customizable and responsive web based
    UI components, optimized for web and mobile that enable certain features
-   and functionality with respect to Box’s cloud-based content collaboration
-   service (“Box Service”). This Agreement applies to any SDK provided by
+   and functionality with respect to Box's cloud-based content collaboration
+   service ("Box Service"). This Agreement applies to any SDK provided by
    Box or that includes, displays, or links to this Agreement, and to any
    updates, supplements or support services for this SDK. Developer may only
    use this SDK to develop a Developer Application that interoperates with
-   the Box Service and to certify compatibility of Developer’s Product(s)
+   the Box Service and to certify compatibility of Developer's Product(s)
    with the Box Service.
 
    Box reserves the right to discontinue offering the SDK (or any updates
@@ -52,7 +52,7 @@ services for their respective governing terms.
    https://cloud.box.com/v/preview-licenses-v1.
 
 2. Use Rights & Requirements.
-    a. Subject to Developer’s compliance with the terms of this Agreement,
+    a. Subject to Developer's compliance with the terms of this Agreement,
        Developer may:
         i. download, install, and use the SDK on its devices solely to design,
            develop, and test Developer Application(s);
@@ -64,14 +64,14 @@ services for their respective governing terms.
       iii. use, reproduce, modify, and distribute the sample code included in
            the SDK only as embedded in a Developer Application that complies
            with the technical limitations and the Acceptable Use Policy (set
-           forth in Exhibit A hereto) (“AUP”).
+           forth in Exhibit A hereto) ("AUP").
     b. Developer shall ensure the Developer Application displays prominently,
        and made apparent to each end-user of the Developer Application, the
        following notice and disclaimer in full:
 
-        “Copyright 2017 Box, Inc. All rights reserved.
+        "Copyright 2017 Box, Inc. All rights reserved.
 
-        This product includes software developed by Box, Inc. (“Box”)
+        This product includes software developed by Box, Inc. ("Box")
         (http://www.box.com)
 
         ALL BOX SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
@@ -86,7 +86,7 @@ services for their respective governing terms.
         OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
         See the Box license for the specific language governing permissions
-        and limitations under the license.”
+        and limitations under the license."
 
 3. Restrictions. Except as set forth above, Developer may not:
     a. distribute, sell, lease, rent, lend, or sublicense the SDK (or any copy
@@ -95,31 +95,31 @@ services for their respective governing terms.
        Application(s);
     c. modify or distribute any portion of the SDK, or distribute any
        Developer Application, in any way that would subject any portion of the
-       SDK to an Excluded License. An “Excluded License” is a license that
+       SDK to an Excluded License. An "Excluded License" is a license that
        requires, as a condition of use, modification, or distribution of code
        subject to that license, that the code be disclosed or distributed in
        source code form or that others have the right to modify the code;
     d. create or attempt to create a product that mimics or interferes with
-       the communications and commands between Box’s API services; or
+       the communications and commands between Box's API services; or
     e. use the SDK: (i) to violate the AUP; (ii) to circumvent any technical
        or licensing restrictions of the Box Service; or (iii) in violation of
        any U.S. denied party-list, embargoed country restriction, export law
        or regulation.
 
-4. Contributions. Developer Contributions (as defined in the “Contributor
-   License Agreement” (CLA)), made by the Developer pursuant to the rights
+4. Contributions. Developer Contributions (as defined in the "Contributor
+   License Agreement" (CLA)), made by the Developer pursuant to the rights
    granted or permitted under this Agreement, are subject to the following:
     a. Developer shall comply with the Contribution policy set forth here:
        https://github.com/box/box-content-preview/blob/master/CONTRIBUTING.md;
        and
-    b. For each Contribution, Developer shall agree to the Box “Contributor
-       License Agreement” (or “CLA”) located here:
+    b. For each Contribution, Developer shall agree to the Box "Contributor
+       License Agreement" (or "CLA") located here:
        https://developer.box.com/docs/ui-kits-contribution-license.
 
 5. Feedback. Developer may, from time to time, provide feedback to Box
    concerning the functionality and performance of the SDK or Box Service
    including, without limitation, identifying potential errors and
-   improvements (“Feedback”). In such event, Box may freely use and exploit
+   improvements ("Feedback"). In such event, Box may freely use and exploit
    any such Feedback without any obligation to Developer, unless otherwise
    agreed upon in writing.  Developer hereby assigns to Box any proprietary
    right that Developer may have in or to any modification, enhancement,
@@ -142,7 +142,7 @@ services for their respective governing terms.
    terminate this Agreement upon thirty days written notice if the other party
    is in material breach of any term of this Agreement. Developer agrees, upon
    termination, to immediately destroy all copies of the SDK within the
-   Developer’s possession or control. The following Sections survive any
+   Developer's possession or control. The following Sections survive any
    termination of this Agreement: Sections 4, 5, 9, 11, 12, 13, 15, 16 and 17.
 
 9. Ownership. The SDK is licensed, not sold. Box reserves all other rights not
@@ -151,7 +151,7 @@ services for their respective governing terms.
        Property Rights in and to the SDK; and
     b. Developer or its licensors retain complete ownership of all
        Intellectual Property Rights in the Developer Application(s) (subject
-       to Box’s underlying ownership of the Intellectual Property Rights in
+       to Box's underlying ownership of the Intellectual Property Rights in
        and to the SDK).
    Nothing in this Agreement will be construed to transfer or assign any
    Intellectual Property Rights of either party to the other. "Intellectual
@@ -159,9 +159,9 @@ services for their respective governing terms.
    trade secret law, trademark law, and any and all other proprietary rights.
 
 10.	Data Privacy. Developer agrees that Box may periodically collect, process
-    and store Technical Data. “Technical Data” means technical data and
-    related information about the Developer Application and Developer’s
-    device, system, peripherals, account and Developer’s use of the SDK,
+    and store Technical Data. "Technical Data" means technical data and
+    related information about the Developer Application and Developer's
+    device, system, peripherals, account and Developer's use of the SDK,
     including without limitation:
     a. internet protocol address;
     b. hardware identification;
@@ -193,7 +193,7 @@ services for their respective governing terms.
     ensure that the Developer Application complies with the Box Privacy Policy
     and any privacy policy it creates for a Developer Application.
 
-11.	DISCLAIMER OF WARRANTIES. THE SDK IS PROVIDED “AS IS” WITHOUT ANY
+11.	DISCLAIMER OF WARRANTIES. THE SDK IS PROVIDED "AS IS" WITHOUT ANY
     WARRANTIES OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW,
     BOX MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, WHETHER EXPRESS,
     IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, ANY
@@ -211,7 +211,7 @@ services for their respective governing terms.
     DAMAGES FOR LOST PROFITS, GOODWILL, USE OR DATA) HOWEVER CAUSED, UNDER ANY
     THEORY OF LIABILITY, INCLUDING, WITHOUT LIMITATION, CONTRACT, TORT,
     WARRANTY, NEGLIGENCE OR OTHERWISE, EVEN IF BOX HAS BEEN ADVISED AS TO THE
-    POSSIBILITY OF SUCH DAMAGES.  IN NO EVENT WILL BOX’S TOTAL AND CUMULATIVE
+    POSSIBILITY OF SUCH DAMAGES.  IN NO EVENT WILL BOX'S TOTAL AND CUMULATIVE
     LIABILITY FOR ALL CLAIMS OF ANY NATURE ARISING OUT OF THIS AGREEMENT
     EXCEED $50.00. SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF
     INCIDENTAL, CONSEQUENTIAL OR OTHER DAMAGES. IN SUCH AN EVENT THIS
@@ -229,7 +229,7 @@ services for their respective governing terms.
        MADE AVAILABLE BY DEVELOPER'S FAILURE TO TAKE REASONABLE MEASURES TO
        PROTECT DEVELOPER'S USERNAME AND PASSWORD AGAINST MISUSE.
     Developer will not settle any claim, and no settlement of a claim will be
-    binding on Box, without Box’s prior written consent, which will not be
+    binding on Box, without Box's prior written consent, which will not be
     unreasonably withheld or delayed.
 
 14.	Box Entity. The location of Developer will determine the Box entity with
@@ -251,9 +251,9 @@ services for their respective governing terms.
     |               |                   | United Kingdom                   |
     +---------------+-------------------+----------------------------------+
 
-15.	Confidentiality. “Confidential Information” means all information
-    disclosed by one Party (“Disclosing Party”) to the other Party (“Receiving
-    Party”) that is in tangible form and labeled “confidential” or the like,
+15.	Confidentiality. "Confidential Information" means all information
+    disclosed by one Party ("Disclosing Party") to the other Party ("Receiving
+    Party") that is in tangible form and labeled "confidential" or the like,
     or that reasonably should be understood to be confidential given the
     nature of the information and the circumstances of the disclosure.   The
     following information will be considered Confidential Information whether
@@ -262,11 +262,11 @@ services for their respective governing terms.
     b. license keys;
     c. the terms of this Agreement including all orders and pricing thereto;
        and
-    d. Box’s strategic roadmaps, product plans, product designs and
+    d. Box's strategic roadmaps, product plans, product designs and
        architecture, technology and technical information, security audit
        reviews, business and marketing plans, and business processes.
     Confidential Information will not include information that as shown by the
-    Receiving Party’s records was:
+    Receiving Party's records was:
         i. already known to Receiving Party at the time of disclosure by the
            Disclosing Party;
        ii. was disclosed to the Receiving Party by a third party who had the
@@ -275,7 +275,7 @@ services for their respective governing terms.
       iii. is, or through no fault of the Receiving Party has become,
            generally available to the public; or
        iv. was independently developed by Receiving Party without use of the
-           Disclosing Party’s Confidential Information.
+           Disclosing Party's Confidential Information.
     The Receiving Party will use no less than a reasonable standard of care to
     safeguard the Confidential Information received from the Disclosing Party
     and will only use the Confidential Information of the Disclosing Party to
@@ -289,7 +289,7 @@ services for their respective governing terms.
         A. as compelled by law provided that to the extent legally permissible
            the Receiving Party gives the Disclosing Party prior notice of such
            compelled disclosure and reasonable assistance, at the Disclosing
-           Party’s expense, if the Disclosing Party seeks to contest such
+           Party's expense, if the Disclosing Party seeks to contest such
            disclosure;
         B. in confidence, to legal counsel, accountants, banks, and financing
            sources and their advisors;
@@ -311,7 +311,7 @@ services for their respective governing terms.
     unconditionally consents to the exclusive jurisdiction and venue in the
     state and federal courts sitting in Santa Clara County, California.  In
     any such dispute, the prevailing party will be entitled to recover its
-    reasonable attorneys’ fees and expenses from the other party.
+    reasonable attorneys' fees and expenses from the other party.
 
 17.	General. Developer will not, directly, indirectly, by operation of law or
     otherwise, assign all or any part of this Agreement or its rights
@@ -324,7 +324,7 @@ services for their respective governing terms.
     party to insist upon or enforce strict performance of any of the
     provisions of this Agreement or to exercise any rights or remedies under
     this Agreement will not be construed as a waiver or relinquishment to any
-    extent of such party’s right to assert or rely upon any such provision,
+    extent of such party's right to assert or rely upon any such provision,
     right or remedy in that or any other instance; rather, the same will
     remain in full force and effect. In the event that any provision of this
     Agreement or the application thereof, becomes or is declared by a court of
@@ -385,12 +385,12 @@ Acceptable Use Policy.  Developer shall not, and shall not use the SDKs to:
     k) Collect, or facilitate the collection of, any information or data of
        any kind for any unlawful purpose;
     l) Intercept, monitor, or modify the communications of others;
-    m) Disseminate “spam,” "junk mail," "phishing," "chain letters," "pyramid
+    m) Disseminate "spam," "junk mail," "phishing," "chain letters," "pyramid
        schemes," illegal contests or sweepstakes, spyware, adware, viruses,
        worms, Trojan horses, time bombs, or any other type of malware or
        malicious code;
     n) Install software: (i) to perform hidden activities without the
-       end-user’s consent; (ii) that may harm or alter an end-user’s system;
+       end-user's consent; (ii) that may harm or alter an end-user's system;
        (iii) that is downloaded as a hidden component of other software; or
        (iv) that is automatically downloaded in whole or in part without
        express end-user consent; and

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Copyright and License
 ---------------------
 Copyright 2016-2017 Box, Inc. All Rights Reserved.
 
-Licensed under the Box Software License Agreement v.05162017.
+Licensed under the Box Software License Agreement v.20170516.
 You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 


### PR DESCRIPTION
ISO date improves legibility, searching, and sorting