### PR TITLE
Fix: Sets the pdf scale after page render rather than on resize

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -136,6 +136,7 @@ import './Annotator.scss';
     /**
      * Hides annotations on a specified page.
      *
+     * @param {number} pageNum - Page number
      * @return {void}
      */
     hideAnnotationsOnPage(pageNum) {
@@ -180,11 +181,18 @@ import './Annotator.scss';
      *
      * @override
      * @param {number} [rotationAngle] - current angle image is rotated
+     * @param {number} [pageNum] - Page number
      * @return {void}
      * @private
      */
-    rotateAnnotations(rotationAngle = 0) {
-        this.renderAnnotations();
+    rotateAnnotations(rotationAngle = 0, pageNum = 0) {
+        // Only render a specific page's annotations unless no page number
+        // is specified
+        if (pageNum) {
+            this.renderAnnotationsOnPage(pageNum);
+        } else {
+            this.renderAnnotations();
+        }
 
         // Only show/hide point annotation button if user has the
         // appropriate permissions
@@ -208,7 +216,7 @@ import './Annotator.scss';
     /**
      * Sets the zoom scale.
      *
-     * @param {number} scale
+     * @param {number} scale - current zoom scale
      * @return {void}
      */
     setScale(scale) {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -599,8 +599,13 @@ const RESIZE_WAIT_TIME_IN_MILLIS = 300;
      * @return {void}
      */
     scaleAnnotations(data) {
+        // Don't try to render annotations if none have been fetched yet
+        if (Object.keys(this.annotator.threads).length === 0) {
+            return;
+        }
+
         this.annotator.setScale(data.scale);
-        this.annotator.rotateAnnotations(data.rotationAngle);
+        this.annotator.rotateAnnotations(data.rotationAngle, data.pageNum);
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -699,12 +699,16 @@ describe('lib/viewers/BaseViewer', () => {
     describe('scaleAnnotations()', () => {
         const scaleData = {
             scale: 0.4321,
-            rotationAngle: 90
+            rotationAngle: 90,
+            pageNum: 2
         };
         beforeEach(() => {
             base.annotator = {
                 setScale: sandbox.stub(),
                 rotateAnnotations: sandbox.stub()
+            };
+            base.annotator.threads = {
+                2: [{}]
             };
 
             base.scaleAnnotations(scaleData);
@@ -715,7 +719,7 @@ describe('lib/viewers/BaseViewer', () => {
         });
 
         it('should invoke rotateAnnotations() on annotator to orient annotations', () => {
-            expect(base.annotator.rotateAnnotations).to.be.calledWith(scaleData.rotationAngle);
+            expect(base.annotator.rotateAnnotations).to.be.calledWith(scaleData.rotationAngle, scaleData.pageNum);
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -414,8 +414,7 @@ const MOBILE_MAX_CANVAS_SIZE = 2949120; // ~3MP 1920x1536
                 canZoomIn: newScale < MAX_SCALE
             });
         }
-
-        this.setScale(newScale);
+        this.pdfViewer.currentScaleValue = newScale;
     }
 
     /**
@@ -440,19 +439,7 @@ const MOBILE_MAX_CANVAS_SIZE = 2949120; // ~3MP 1920x1536
                 canZoomIn: true
             });
         }
-
-        this.setScale(newScale);
-    }
-
-    /**
-     * Sets zoom scale.
-     *
-     * @param {number} scale - Numerical zoom scale
-     * @return {void}
-     */
-    setScale(scale) {
-        this.pdfViewer.currentScaleValue = scale;
-        this.emit('scale', { scale });
+        this.pdfViewer.currentScaleValue = newScale;
     }
 
     /**
@@ -1029,7 +1016,7 @@ const MOBILE_MAX_CANVAS_SIZE = 2949120; // ~3MP 1920x1536
      * Handler for 'pagerendered' event.
      *
      * @private
-     * @param {Event} event - Pagerendered event
+     * @param {Event} event - 'pagerendered' event
      * @return {void}
      */
     pagerenderedHandler(event) {
@@ -1038,7 +1025,12 @@ const MOBILE_MAX_CANVAS_SIZE = 2949120; // ~3MP 1920x1536
         if (pageNumber) {
             // Page rendered event
             this.emit('pagerender', pageNumber);
-            this.setScale(this.pdfViewer.currentScale); // Set scale to current numerical scale
+
+            // Set scale to current numerical scale & rendered page number
+            this.emit('scale', {
+                scale: this.pdfViewer.currentScaleValue,
+                pageNum: pageNumber
+            });
 
             // Fire postload event to hide progress bar and cleanup preload after a page is rendered
             if (!this.somePageRendered) {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -638,7 +638,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.pdfViewer = {
                 currentScale: 5
             };
-            stubs.setScale = sandbox.stub(docBase, 'setScale');
             stubs.emit = sandbox.stub(docBase, 'emit');
         });
 
@@ -648,12 +647,12 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
         describe('zoomIn()', () => {
             it('should zoom in until it hits the number of ticks or the max scale', () => {
-                docBase.zoomIn(10);
-                expect(stubs.setScale).to.be.calledWith(MAX_SCALE);
+                docBase.zoomIn(12);
+                expect(docBase.pdfViewer.currentScaleValue).to.equal(MAX_SCALE);
 
                 docBase.pdfViewer.currentScale = 1;
                 docBase.zoomIn(1);
-                expect(stubs.setScale).to.be.calledWith(DEFAULT_SCALE_DELTA);
+                expect(docBase.pdfViewer.currentScaleValue).to.equal(DEFAULT_SCALE_DELTA);
             });
 
             it('should emit the zoom event', () => {
@@ -674,11 +673,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.pdfViewer.currentScale = 0.2;
 
                 docBase.zoomOut(10);
-                expect(stubs.setScale).to.be.calledWith(MIN_SCALE);
+                expect(docBase.pdfViewer.currentScaleValue).to.equal(MIN_SCALE);
 
                 docBase.pdfViewer.currentScale = DEFAULT_SCALE_DELTA;
                 docBase.zoomOut(1);
-                expect(stubs.setScale).to.be.calledWith(1);
+                expect(docBase.pdfViewer.currentScaleValue).to.equal(1);
             });
 
             it('should emit the zoom event', () => {
@@ -692,20 +691,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.zoomOut(1);
                 expect(stubs.emit).to.not.be.calledWith('zoom');
             });
-        });
-    });
-
-    describe('setScale()', () => {
-        it('should set the pdf viewer and the annotator\'s scale if it exists', () => {
-            sandbox.stub(docBase, 'emit');
-            docBase.pdfViewer = {
-                currentScaleValue: 0
-            };
-            const newScale = 5;
-
-            docBase.setScale(newScale);
-            expect(docBase.emit).to.be.calledWith('scale', { scale: newScale });
-            expect(docBase.pdfViewer.currentScaleValue).to.equal(newScale);
         });
     });
 
@@ -1481,7 +1466,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
     describe('pagerenderedHandler()', () => {
         beforeEach(() => {
             docBase.pdfViewer = {
-                currentScale: 0.5
+                currentScale: 0.5,
+                currentScaleValue: 0.5
             };
             docBase.event = {
                 detail: {
@@ -1489,13 +1475,12 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 }
             };
             stubs.emit = sandbox.stub(docBase, 'emit');
-            stubs.setscale = sandbox.stub(docBase, 'setScale');
         });
 
         it('should emit the pagerender event', () => {
             docBase.pagerenderedHandler(docBase.event);
             expect(stubs.emit).to.be.calledWith('pagerender');
-            expect(stubs.setscale).to.be.called;
+            expect(stubs.emit).to.be.calledWith('scale', { pageNum: 1, scale: 0.5 });
         });
 
         it('should emit postload event if not already emitted', () => {


### PR DESCRIPTION
- Fixes issue where the first device orientation change would disable some
  event listeners due to the scale not being set
- On document load, the scale is set to auto. So when the phone's orientation is changed the first time, resize() is called and the new scale is set to the previous scale (auto). Then when the orientation is changed again, it'll have a scale value to set.