### PR TITLE
Fix: Restore crawler for buffering video

### DIFF
--- a/src/lib/PreviewUI.js
+++ b/src/lib/PreviewUI.js
@@ -14,6 +14,7 @@ import {
     SELECTOR_BOX_PREVIEW_BTN_PRINT,
     SELECTOR_BOX_PREVIEW_BTN_DOWNLOAD,
     SELECTOR_BOX_PREVIEW_BTN_LOADING_DOWNLOAD,
+    SELECTOR_BOX_PREVIEW_CRAWLER_WRAPPER,
     SELECTOR_BOX_PREVIEW_LOADING_TEXT,
     SELECTOR_BOX_PREVIEW_LOADING_WRAPPER,
     SELECTOR_BOX_PREVIEW_LOGO_CUSTOM,
@@ -248,6 +249,12 @@ class PreviewUI {
     hideLoadingIndicator() {
         if (this.contentContainer) {
             this.contentContainer.classList.add(CLASS_PREVIEW_LOADED);
+            const crawler = this.contentContainer.querySelector(SELECTOR_BOX_PREVIEW_CRAWLER_WRAPPER);
+            if (crawler) {
+                // We need to remove this since it was hidden specially as a
+                // part of finishLoadingSetup in BaseViewer.js
+                crawler.classList.remove(CLASS_HIDDEN);
+            }
         }
     }
 

--- a/src/lib/__tests__/PreviewUI-test.js
+++ b/src/lib/__tests__/PreviewUI-test.js
@@ -192,6 +192,12 @@ describe('lib/PreviewUI', () => {
                 ui.hideLoadingIndicator();
                 expect(contentContainerEl).to.have.class(constants.CLASS_PREVIEW_LOADED);
             });
+
+            it('should remove the hidden class from the crawler', () => {
+                const crawlerEl = containerEl.querySelector(constants.SELECTOR_BOX_PREVIEW_CRAWLER_WRAPPER);
+                ui.hideLoadingIndicator();
+                expect(crawlerEl).to.not.have.class(constants.CLASS_HIDDEN);
+            });
         });
     });
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -79,6 +79,7 @@ const CLASS_PLAY_BUTTON = 'bp-media-play-button';
     pauseHandler() {
         super.pauseHandler();
         this.showPlayButton();
+        this.hideLoadingIcon();
     }
 
     /**
@@ -90,6 +91,7 @@ const CLASS_PLAY_BUTTON = 'bp-media-play-button';
     waitingHandler() {
         if (this.containerEl) {
             this.containerEl.classList.add(CLASS_IS_BUFFERING);
+            this.hidePlayButton();
         }
     }
 

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -126,12 +126,28 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
             expect(videoBase.showPlayButton).to.be.called;
         });
+
+        it('should hide the loading icon', () => {
+            sandbox.stub(videoBase, 'hideLoadingIcon');
+            videoBase.loadeddataHandler(); // load media controls UI
+
+            videoBase.pauseHandler();
+
+            expect(videoBase.hideLoadingIcon).to.be.called;
+        });
     });
 
     describe('waitingHandler()', () => {
         it('should add the buffering class', () => {
             videoBase.waitingHandler();
             expect(videoBase.containerEl.classList.contains('bp-is-buffering'));
+        });
+
+        it('should hide the play button', () => {
+            sandbox.stub(videoBase, 'hidePlayButton');
+
+            videoBase.waitingHandler();
+            expect(videoBase.hidePlayButton).to.be.called;
         });
     });
 


### PR DESCRIPTION
Additional fixes:
- Hides the play button when 'waiting' after a seek
- Hides the loading icon if you pause while the video is buffering