### PR TITLE
Fix: Limit iOS font fix to 10.3.1

### DIFF
--- a/src/lib/Browser.js
+++ b/src/lib/Browser.js
@@ -314,12 +314,12 @@ class Browser {
     }
 
     /**
-     * Returns whether or not the device is running IOS 10.3.X that has Font Ligature rendering issue.
+     * Returns whether or not the device is running IOS 10.3.1 that has Font Ligature rendering issue.
      *
-     * @return {boolean} True if device is running IOS 10.3.x
+     * @return {boolean} Whether device is running 10.3.1
      */
     static isIOSWithFontIssue() {
-        return Browser.isIOS() && /(?:OS\s)10_3/i.test(userAgent);
+        return Browser.isIOS() && /(?:OS\s)10_3_1/i.test(userAgent);
     }
 }
 

--- a/src/lib/__tests__/Browser-test.js
+++ b/src/lib/__tests__/Browser-test.js
@@ -462,20 +462,20 @@ describe('lib/Browser', () => {
     });
 
     describe('isIOSWithFontIssue()', () => {
-        it('should return true if device is on ios and is OS 10.3.XX', () => {
-            Browser.overrideUserAgent('iPhone OS 10_3_90 safari/2');
+        it('should return true if device is on ios and is OS 10.3.1', () => {
+            Browser.overrideUserAgent('iPhone OS 10_3_1 safari/2');
             const hasIssue = Browser.isIOSWithFontIssue();
             expect(hasIssue).to.be.true;
         });
 
-        it('should return false if device is on ios and is not OS 10.3.XX', () => {
-            Browser.overrideUserAgent('iPhone OS 10_5_90 safari/2');
+        it('should return false if device is on ios and is not OS 10.3.1', () => {
+            Browser.overrideUserAgent('iPhone OS 10_3_2 safari/2');
             const hasIssue = Browser.isIOSWithFontIssue();
             expect(hasIssue).to.be.false;
         });
 
         it('should return false if device is on ios and is not mobile', () => {
-            Browser.overrideUserAgent('DesktopDevice OS 10_3_90 safari/18902374701347589235');
+            Browser.overrideUserAgent('DesktopDevice OS 10_3_1 safari/18902374701347589235');
             const hasIssue = Browser.isAndroid();
             expect(hasIssue).to.be.false;
         });


### PR DESCRIPTION
Apple fixed the font issue in 10.3.2, so we only limit the disableFontFace fix to 10.3.1