### PR TITLE
Fix: Prevent double tap zoom in control bar

### DIFF
--- a/src/lib/Controls.scss
+++ b/src/lib/Controls.scss
@@ -26,6 +26,7 @@
     display: table-cell;
     margin: 0;
     padding: 0;
+    touch-action: manipulation;
     vertical-align: middle;
 }
 
@@ -40,6 +41,8 @@
     opacity: .7;
     outline: 0;
     padding: 0;
+    touch-action: manipulation;
+    user-select: none;
     width: 48px;
     zoom: 1;
 


### PR DESCRIPTION
- Adding it to `.bp-controls-cell` for when the button is disabled
- `user-select: none` prevents copy paste dialog from appearing on control bar