### PR TITLE
Fix: Prevent MP3 from hiding

### DIFF
--- a/src/lib/viewers/media/MP3.scss
+++ b/src/lib/viewers/media/MP3.scss
@@ -20,6 +20,7 @@
     .bp-media-controls-wrapper {
         background: $black;
         opacity: 1;
+        visibility: visible;
     }
 
     .bp-media-settings-item-quality,


### PR DESCRIPTION
Caused by switching to using both opacity and visibility to hide/show the controls. The reason for that change was so that the controls were not clickable while hidden and could still use the fade in/out transition. 