### PR TITLE
Fix: Allow legacy annotations to render in PDF.js

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -54,7 +54,7 @@
 
         // Fixes annotation icon broken src
         .textAnnotation > img {
-            display: none;
+            opacity: 0;
         }
     }
 


### PR DESCRIPTION
PDF.js relies on the presence of annotation icons in the DOM to render popups. Once our migration tool removes the hidden flag from the native annotations it creates, PDF.js will be able to render migrated annotations fully.