### PR TITLE
Fix: Don't swallow 'touchstart' event to prevent iOS inertia scrolling

### DIFF
--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -157,6 +157,7 @@ class PresentationViewer extends DocBaseViewer {
         this.docEl.addEventListener('wheel', this.wheelHandler());
         if (this.hasTouch) {
             this.docEl.addEventListener('touchstart', this.mobileScrollHandler);
+            this.docEl.addEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.addEventListener('touchend', this.mobileScrollHandler);
         }
     }
@@ -174,6 +175,7 @@ class PresentationViewer extends DocBaseViewer {
         this.docEl.removeEventListener('wheel', this.wheelHandler());
         if (this.hasTouch) {
             this.docEl.removeEventListener('touchstart', this.mobileScrollHandler);
+            this.docEl.removeEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.removeEventListener('touchend', this.mobileScrollHandler);
         }
     }
@@ -228,10 +230,10 @@ class PresentationViewer extends DocBaseViewer {
             return;
         }
 
-        event.preventDefault();
-
         if (event.type === 'touchstart') {
             this.scrollStart = event.changedTouches[0].clientY;
+        } else if (event.type === 'touchmove') {
+            event.preventDefault();
         } else {
             const scrollEnd = event.changedTouches[0].clientY;
 

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -273,6 +273,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
 
             presentation.bindDOMListeners();
             expect(stubs.addEventListener).to.be.calledWith('touchstart', presentation.mobileScrollHandler);
+            expect(stubs.addEventListener).to.be.calledWith('touchmove', presentation.mobileScrollHandler);
             expect(stubs.addEventListener).to.be.calledWith('touchend', presentation.mobileScrollHandler);
         });
     });
@@ -292,6 +293,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
 
             presentation.unbindDOMListeners();
             expect(stubs.removeEventListener).to.be.calledWith('touchstart', presentation.mobileScrollHandler);
+            expect(stubs.removeEventListener).to.be.calledWith('touchmove', presentation.mobileScrollHandler);
             expect(stubs.removeEventListener).to.be.calledWith('touchend', presentation.mobileScrollHandler);
         });
     });
@@ -374,6 +376,13 @@ describe('lib/viewers/doc/PresentationViewer', () => {
 
             presentation.mobileScrollHandler(stubs.event);
             expect(presentation.scrollStart).to.equal(100);
+        });
+
+        it('should prevent default behaviour if the event is touchmove', () => {
+            stubs.event.type = 'touchmove';
+            stubs.event.changedTouches[0].clientY = 100;
+
+            presentation.mobileScrollHandler(stubs.event);
             expect(stubs.event.preventDefault).to.be.called;
         });
 


### PR DESCRIPTION
This was blocking annotation creation on mobile. 