### PR TITLE
Fix: Give preview some min width and height

### DIFF
--- a/src/lib/_common.scss
+++ b/src/lib/_common.scss
@@ -20,6 +20,8 @@ $header-height: 48px;
     font-size: 13px;
     height: 100%;
     margin: 0;
+    min-height: 300px;
+    min-width: 300px;
     overflow: hidden;
     padding: 0;
     position: relative;


### PR DESCRIPTION
So that by default it doesn't render all squishy making the user consider it to be a bug. Some dimensions will at least show some preview.