### PR TITLE
Fix: Allow legacy annotations to render in PDF.js

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -54,7 +54,7 @@
 
         // Fixes annotation icon broken src
         .textAnnotation > img {
-            display: none;
+            opacity: 0;
         }
     }
 


### PR DESCRIPTION
We should do this first, then we can discuss supplying SVG's to fully support native PDF annotations.