### PR TITLE
New: Adding 'annotationfocus' event to threads

### DIFF
--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -6,6 +6,8 @@ import * as annotatorUtil from './annotatorUtil';
 import { ICON_PLACED_ANNOTATION } from '../icons/icons';
 import { STATES, TYPES, CLASS_ANNOTATION_POINT_MARKER, DATA_TYPE_ANNOTATION_INDICATOR } from './annotationConstants';
 
+const CLASS_HAS_FOCUS = 'bp-has-focus';
+
 @autobind
 class AnnotationThread extends EventEmitter {
     //--------------------------------------------------------------------------
@@ -408,6 +410,41 @@ class AnnotationThread extends EventEmitter {
         indicatorEl.setAttribute('data-type', DATA_TYPE_ANNOTATION_INDICATOR);
         indicatorEl.innerHTML = ICON_PLACED_ANNOTATION;
         return indicatorEl;
+    }
+
+    /**
+     * Toggles annotation focus on/off
+     *
+     * @protected
+     * @return {void}
+     */
+    toggleThreadFocus() {
+        const threadIsFocused = this.element.classList.contains(`${CLASS_HAS_FOCUS}`);
+        const svgElement = this.element.querySelector('.icon');
+        const xVal = parseInt(this.element.style.left, 10);
+        const yVal = parseInt(this.element.style.top, 10);
+
+        if (threadIsFocused) {
+            this.element.classList.remove(CLASS_HAS_FOCUS);
+
+            // Shrink SVG to original size
+            svgElement.setAttribute('height', '30px');
+            svgElement.setAttribute('width', '24px');
+
+            // Re-adjust positioning
+            this.element.style.left = `${xVal + 3}px`;
+            this.element.style.top = `${yVal + 3}px`;
+        } else {
+            this.element.classList.add(CLASS_HAS_FOCUS);
+
+            // Enlarge SVG
+            svgElement.setAttribute('height', '36px');
+            svgElement.setAttribute('width', '30px');
+
+            // Re-adjust positioning
+            this.element.style.left = `${xVal - 3}px`;
+            this.element.style.top = `${yVal - 3}px`;
+        }
     }
 
     /**

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -81,6 +81,8 @@ class Annotator extends EventEmitter {
 
         this.unbindDOMListeners();
         this.unbindCustomListenersOnService();
+
+        this.removeListener('annotationfocus', this.focusAnnotation);
     }
 
     /**
@@ -389,6 +391,28 @@ class Annotator extends EventEmitter {
         this.threads = {};
         this.bindDOMListeners();
         this.bindCustomListenersOnService(this.annotationService);
+
+        this.addListener('annotationfocus', this.focusAnnotation);
+    }
+    /**
+     * Toggles annotation thread specified from
+     *
+     * @param {Object} options - annotation options
+     * @param {Object} options.threadNumber - Annotation thread number
+     * @param {Object} options.page - Annotation location page
+     * @private
+     * @return {void}
+     */
+    focusAnnotation(options) {
+        if (!this.threads[options.page]) {
+            return;
+        }
+
+        this.threads[options.page].forEach((thread) => {
+            if (parseInt(thread.thread, 10) === options.threadNumber) {
+                thread.toggleThreadFocus();
+            }
+        });
     }
 
     /**

--- a/src/lib/annotations/Annotator.scss
+++ b/src/lib/annotations/Annotator.scss
@@ -269,7 +269,9 @@ $avatar-color-9: #f22c44;
         transition: fill .5s;
     }
 
-    &:hover svg {
+    &:hover svg,
+    &.bp-has-focus path,
+    &.bp-has-focus circle {
         fill: $box-blue;
     }
 }

--- a/src/lib/annotations/image/ImageAnnotator.js
+++ b/src/lib/annotations/image/ImageAnnotator.js
@@ -109,6 +109,7 @@ class ImageAnnotator extends Annotator {
         // Set existing thread ID if created with annotations
         if (annotations.length > 0) {
             threadParams.threadID = annotations[0].threadID;
+            threadParams.thread = annotations[0].thread;
         }
 
         thread = new ImagePointThread(threadParams);

--- a/src/lib/icons/placed_annotation_24px.svg
+++ b/src/lib/icons/placed_annotation_24px.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="30" viewBox="0 0 24 30" focusable="false">
+<svg class="icon" width="24" height="30" viewBox="0 0 24 30" focusable="false">
   <g transform="translate(1 1)" fill="none" fill-rule="evenodd">
     <path d="M15 17l-4 4-4-4H1.99C.89 17 0 16.11 0 15V2C0 .895.89 0 1.99 0h18.02C21.11 0 22 .89 22 2v13c0 1.105-.89 2-1.99 2H15z" stroke="#FFF" fill="#0061d5"/>
     <rect fill="#FFF" x="4" y="5" width="14" height="1" rx=".5"/>


### PR DESCRIPTION
- "focus" behavior is specific to the current annotations icon
- Slightly enlarges the icon when 'annotationfocus' event is emitted for a thread number matching the current thread
- Ensuring image point annotations have thread numbers associated with the threads