### PR TITLE
Fix: Load annotator with the correct initial scale

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -61,11 +61,6 @@ class Annotator extends EventEmitter {
         this.isMobile = data.isMobile;
         this.previewUI = data.previewUI;
         this.annotationModeHandlers = [];
-        this.annotatedElement = this.getAnnotatedEl(this.container);
-
-        if (!this.annotatedElement) {
-            throw new Error('No annotatable element found.');
-        }
     }
 
     /**
@@ -91,9 +86,11 @@ class Annotator extends EventEmitter {
     /**
      * Initializes annotator.
      *
+     * @param {number} [initialScale] - The initial scale factor to render the annotations
      * @return {void}
      */
-    init() {
+    init(initialScale = 1) {
+        this.annotatedElement = this.getAnnotatedEl(this.container);
         this.notification = new Notification(this.annotatedElement);
 
         const { apiHost, fileId, token } = this.options;
@@ -110,7 +107,7 @@ class Annotator extends EventEmitter {
             this.setupMobileDialog();
         }
 
-        const scale = annotatorUtil.getScale(this.annotatedElement);
+        const scale = initialScale;
         this.setScale(scale);
         this.setupAnnotations();
         this.showAnnotations();

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -61,6 +61,7 @@ class Annotator extends EventEmitter {
         this.isMobile = data.isMobile;
         this.previewUI = data.previewUI;
         this.annotationModeHandlers = [];
+        this.annotatedElement = this.getAnnotatedEl(this.container);
     }
 
     /**
@@ -89,7 +90,6 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     init() {
-        this.annotatedElement = this.getAnnotatedEl(this.container);
         this.notification = new Notification(this.annotatedElement);
 
         const { apiHost, fileId, token } = this.options;
@@ -106,7 +106,8 @@ class Annotator extends EventEmitter {
             this.setupMobileDialog();
         }
 
-        this.setScale(1);
+        const scale = annotatorUtil.getScale(this.annotatedElement);
+        this.setScale(scale);
         this.setupAnnotations();
         this.showAnnotations();
     }
@@ -236,10 +237,11 @@ class Annotator extends EventEmitter {
      * Sets the zoom scale.
      *
      * @param {number} scale - current zoom scale
-     * @return {void}
+     * @return {Annotator} Annotator instance returned for chaining
      */
     setScale(scale) {
         this.annotatedElement.setAttribute('data-scale', scale);
+        return this;
     }
 
     /**

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -238,7 +238,7 @@ class Annotator extends EventEmitter {
      * Sets the zoom scale.
      *
      * @param {number} scale - current zoom scale
-     * @return {Annotator} Annotator instance returned for chaining
+     * @return {void}
      */
     setScale(scale) {
         this.annotatedElement.setAttribute('data-scale', scale);

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -62,6 +62,10 @@ class Annotator extends EventEmitter {
         this.previewUI = data.previewUI;
         this.annotationModeHandlers = [];
         this.annotatedElement = this.getAnnotatedEl(this.container);
+
+        if (!this.annotatedElement) {
+            throw new Error('No annotatable element found.');
+        }
     }
 
     /**
@@ -241,7 +245,6 @@ class Annotator extends EventEmitter {
      */
     setScale(scale) {
         this.annotatedElement.setAttribute('data-scale', scale);
-        return this;
     }
 
     /**

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -106,8 +106,8 @@ describe('lib/annotations/Annotator', () => {
         });
 
         it('should set scale and setup annotations', () => {
-            annotator.init();
-            expect(stubs.scale).to.be.called;
+            annotator.init(5);
+            expect(stubs.scale).to.be.calledWith(5);
             expect(stubs.setup).to.be.called;
             expect(stubs.show).to.be.called;
             expect(annotator.annotationService).to.not.be.null;

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -96,6 +96,7 @@ describe('lib/annotations/Annotator', () => {
         beforeEach(() => {
             const annotatedEl = document.querySelector('.annotated-element');
             sandbox.stub(annotator, 'getAnnotatedEl').returns(annotatedEl);
+            annotator.annotatedElement = annotatedEl;
 
             stubs.scale = sandbox.stub(annotator, 'setScale');
             stubs.setup = sandbox.stub(annotator, 'setupAnnotations');
@@ -161,6 +162,7 @@ describe('lib/annotations/Annotator', () => {
     describe('once annotator is initialized', () => {
         beforeEach(() => {
             const annotatedEl = document.querySelector('.annotated-element');
+            annotator.annotatedElement = annotatedEl;
             sandbox.stub(annotator, 'getAnnotatedEl').returns(annotatedEl);
             sandbox.stub(annotator, 'setupAnnotations');
             sandbox.stub(annotator, 'showAnnotations');

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -223,7 +223,11 @@ class DocAnnotator extends Annotator {
             }
 
             // Get correct page
-            const { pageEl, page } = annotatorUtil.getPageInfo(event.target);
+            let { pageEl, page } = annotatorUtil.getPageInfo(event.target);
+            if (page === -1) {
+                // The ( .. ) around assignment is required syntax
+                ({ pageEl, page } = annotatorUtil.getPageInfo(window.getSelection().anchorNode));
+            }
 
             // Use highlight module to calculate quad points
             const { highlightEls } = docAnnotatorUtil.getHighlightAndHighlightEls(this.highlighter, pageEl);
@@ -296,7 +300,7 @@ class DocAnnotator extends Annotator {
         } else if (type === TYPES.point) {
             thread = new DocPointThread(threadParams);
         } else {
-            throw new Error(`DocAnnotator: Unknown Annotation Type: ${type}`);
+            throw new Error(`Unhandled document annotation type: ${type}`);
         }
 
         this.addThreadToMap(thread);
@@ -576,13 +580,7 @@ class DocAnnotator extends Annotator {
             return;
         }
 
-        // Determine if mouse is over any highlight dialog currently
-        // and ignore hover events of any highlights below
         const event = this.mouseMoveEvent;
-        if (docAnnotatorUtil.isDialogDataType(event.target)) {
-            return;
-        }
-
         this.mouseMoveEvent = null;
         this.throttleTimer = performance.now();
         // Only filter through highlight threads on the current page

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -223,11 +223,7 @@ class DocAnnotator extends Annotator {
             }
 
             // Get correct page
-            let { pageEl, page } = annotatorUtil.getPageInfo(event.target);
-            if (page === -1) {
-                // The ( .. ) around assignment is required syntax
-                ({ pageEl, page } = annotatorUtil.getPageInfo(window.getSelection().anchorNode));
-            }
+            const { pageEl, page } = annotatorUtil.getPageInfo(event.target);
 
             // Use highlight module to calculate quad points
             const { highlightEls } = docAnnotatorUtil.getHighlightAndHighlightEls(this.highlighter, pageEl);
@@ -580,7 +576,13 @@ class DocAnnotator extends Annotator {
             return;
         }
 
+        // Determine if mouse is over any highlight dialog
+        // and ignore hover events of any highlights below
         const event = this.mouseMoveEvent;
+        if (docAnnotatorUtil.isDialogDataType(event.target)) {
+            return;
+        }
+
         this.mouseMoveEvent = null;
         this.throttleTimer = performance.now();
         // Only filter through highlight threads on the current page

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -345,7 +345,6 @@ class BaseViewer extends EventEmitter {
         document.defaultView.addEventListener('resize', this.debouncedResizeHandler);
 
         this.addListener('load', (event) => {
-            // this.scale set to 1 if event.scale does not exist
             ({ scale: this.scale = 1 } = event);
 
             if (this.annotationsPromise) {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -344,7 +344,10 @@ class BaseViewer extends EventEmitter {
         // Add a resize handler for the window
         document.defaultView.addEventListener('resize', this.debouncedResizeHandler);
 
-        this.addListener('load', () => {
+        this.addListener('load', (event) => {
+            // this.scale set to 1 if event.scale does not exist
+            ({ scale: this.scale = 1 } = event);
+
             if (this.annotationsPromise) {
                 this.annotationsPromise.then(this.loadAnnotator);
             }
@@ -653,6 +656,8 @@ class BaseViewer extends EventEmitter {
             locale: location.locale,
             previewUI: this.previewUI
         });
+
+        this.annotator.setScale(this.scale);
         this.annotator.init();
 
         // Disables controls during point annotation mode

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -656,8 +656,7 @@ class BaseViewer extends EventEmitter {
             previewUI: this.previewUI
         });
 
-        this.annotator.setScale(this.scale);
-        this.annotator.init();
+        this.annotator.init(this.scale);
 
         // Disables controls during point annotation mode
         this.annotator.addListener('annotationmodeenter', this.disableViewerControls);

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -744,10 +744,13 @@ describe('lib/viewers/BaseViewer', () => {
                 }
             };
             base.addListener = sandbox.stub();
+            base.scale = 1;
             base.annotator = {
                 init: sandbox.stub(),
-                addListener: sandbox.stub()
+                addListener: sandbox.stub(),
+                setScale: sandbox.stub()
             };
+            base.annotator.setScale.returns(base.annotator);
             base.annotatorConf = {
                 CONSTRUCTOR: sandbox.stub().returns(base.annotator)
             };
@@ -755,6 +758,7 @@ describe('lib/viewers/BaseViewer', () => {
         });
         it('should initialize the annotator', () => {
             expect(base.annotator.init).to.be.called;
+            expect(base.annotator.setScale).to.be.called;
             expect(base.annotator.addListener).to.be.calledWith('annotationmodeenter', sinon.match.func);
             expect(base.annotator.addListener).to.be.calledWith('annotationmodeexit', sinon.match.func);
             expect(base.annotator.addListener).to.be.calledWith('annotationsfetched', sinon.match.func);

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -744,21 +744,19 @@ describe('lib/viewers/BaseViewer', () => {
                 }
             };
             base.addListener = sandbox.stub();
-            base.scale = 1;
+            base.scale = 1.5;
             base.annotator = {
                 init: sandbox.stub(),
                 addListener: sandbox.stub(),
                 setScale: sandbox.stub()
             };
-            base.annotator.setScale.returns(base.annotator);
             base.annotatorConf = {
                 CONSTRUCTOR: sandbox.stub().returns(base.annotator)
             };
             base.initAnnotations();
         });
         it('should initialize the annotator', () => {
-            expect(base.annotator.init).to.be.called;
-            expect(base.annotator.setScale).to.be.called;
+            expect(base.annotator.init).to.be.calledWith(1.5);
             expect(base.annotator.addListener).to.be.calledWith('annotationmodeenter', sinon.match.func);
             expect(base.annotator.addListener).to.be.calledWith('annotationmodeexit', sinon.match.func);
             expect(base.annotator.addListener).to.be.calledWith('annotationsfetched', sinon.match.func);

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -998,7 +998,8 @@ class DocBaseViewer extends BaseViewer {
             this.loaded = true;
             this.emit('load', {
                 numPages: this.pdfViewer.pagesCount,
-                endProgress: false // Indicate that viewer will end progress later
+                endProgress: false, // Indicate that viewer will end progress later
+                scale: this.pdfViewer.currentScale
             });
         }
     }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1436,7 +1436,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.pagesinitHandler();
             expect(stubs.emit).to.be.calledWith('load', {
                 endProgress: false,
-                numPages: 5
+                numPages: 5,
+                scale: sinon.match.any
             });
             expect(docBase.loaded).to.be.truthy;
         });


### PR DESCRIPTION
Annotator is currently always being loaded with scale 1. When the true scale is set, the annotations are not re-rendered. As a result, annotations on page load will always be the same size.

Proposed changes:
-  annotator.setScale() returns this (annotatorInstance) so that calls can be used in a builder format. ie annotator.setScale().init(), unfortunately prettier formats these calls all on one line. Might be useful to anyone who has forked the repository.
-  Update the viewer scale just before loading the annotations
-  Assign annotatedElement in Annotator constructor rather than init() so that annotatorInstance.setScale(trueScale) can be called before annotator.init(). Init() will render the annotations and require a rescale. As init() appears to be called right after constructing Annotator instances, I do not see an issue with this. In addition, child classes will be able to use this.annotatedElement.