### PR TITLE
Fix: Emit scale does not always pass events

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -345,7 +345,9 @@ class BaseViewer extends EventEmitter {
         document.defaultView.addEventListener('resize', this.debouncedResizeHandler);
 
         this.addListener('load', (event) => {
-            ({ scale: this.scale = 1 } = event);
+            if (event && event.scale) {
+                this.scale = event.scale;
+            }
 
             if (this.annotationsPromise) {
                 this.annotationsPromise.then(this.loadAnnotator);

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -284,8 +284,9 @@ describe('lib/viewers/BaseViewer', () => {
             sandbox.stub(document.defaultView, 'addEventListener');
             sandbox.stub(base, 'loadAnnotator');
             base.annotationsPromise = {
-                then: () => {
+                then: (arg) => {
                     expect(base.scale).to.equal(1.5);
+                    expect(arg).to.equal(base.loadAnnotator);
                     done();
                 }
             };
@@ -302,7 +303,8 @@ describe('lib/viewers/BaseViewer', () => {
             sandbox.stub(document.defaultView, 'addEventListener');
             sandbox.stub(base, 'loadAnnotator');
             base.annotationsPromise = {
-                then: () => {
+                then: (arg) => {
+                    expect(arg).to.equal(base.loadAnnotator);
                     done();
                 }
             };

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -285,11 +285,13 @@ describe('lib/viewers/BaseViewer', () => {
             sandbox.stub(base, 'loadAnnotator');
             base.annotationsPromise = {
                 then: () => {
+                    expect(base.scale).to.equal(1.5);
                     done();
                 }
             };
 
             base.addCommonListeners();
+            expect(base.scale).to.equal(1);
             base.emit('load', {
                 scale: 1.5
             });

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -278,6 +278,36 @@ describe('lib/viewers/BaseViewer', () => {
             expect(document.defaultView.addEventListener).to.be.calledWith('resize', base.debouncedResizeHandler);
             expect(base.addListener).to.be.calledWith('load', sinon.match.func);
         });
+
+        it('should load the annotator when load is emitted with scale', (done) => {
+            sandbox.stub(fullscreen, 'addListener');
+            sandbox.stub(document.defaultView, 'addEventListener');
+            sandbox.stub(base, 'loadAnnotator');
+            base.annotationsPromise = {
+                then: () => {
+                    done();
+                }
+            };
+
+            base.addCommonListeners();
+            base.emit('load', {
+                scale: 1.5
+            });
+        });
+
+        it('should load the annotator when load is emitted without an event', (done) => {
+            sandbox.stub(fullscreen, 'addListener');
+            sandbox.stub(document.defaultView, 'addEventListener');
+            sandbox.stub(base, 'loadAnnotator');
+            base.annotationsPromise = {
+                then: () => {
+                    done();
+                }
+            };
+
+            base.addCommonListeners();
+            base.emit('load');
+        });
     });
 
     describe('toggleFullscreen()', () => {


### PR DESCRIPTION
Thanks to @pramodsum for the catch.
Fancy destructure syntax was no good here.