### PR TITLE
Chore: Remove code supporting token in options object

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -149,7 +149,7 @@ class Preview extends EventEmitter {
      * Primary function for showing a preview of a file.
      *
      * @param {string} fileId - Box File ID
-     * @param {string|Function} token - auth token string or generator function
+     * @param {string|Function} token - Access token string or generator function
      * @param {Object} [options] - Optional preview options
      * @return {void}
      */
@@ -157,8 +157,6 @@ class Preview extends EventEmitter {
         // Save a reference to the options to be used later
         if (typeof token === 'string' || typeof token === 'function') {
             this.previewOptions = Object.assign({}, options, { token });
-        } else if (token) {
-            this.previewOptions = Object.assign({}, token || {});
         } else {
             throw new Error('Missing access token!');
         }

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -128,7 +128,7 @@ describe('lib/Preview', () => {
             const spy = sandbox.spy(preview, 'show');
 
             try {
-                preview.show('file');
+                preview.show('file', {});
             } catch (e) {
                 expect(spy.threw());
                 expect(e.message).to.equal('Missing access token!');


### PR DESCRIPTION
Remove code that supports access token in the options object - this has been deprecated for some time now.