### PR TITLE
Chore: Hide viewer controls when creating annotations

### DIFF
--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -143,6 +143,7 @@ class AnnotationThread extends EventEmitter {
         tempAnnotationData.modified = tempAnnotationData.created;
         const tempAnnotation = new Annotation(tempAnnotationData);
         this.saveAnnotationToThread(tempAnnotation);
+        this.emit('threadsavedlocally');
 
         // Changing state from pending
         this.state = STATES.hover;

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -465,9 +465,22 @@ describe('lib/annotations/Annotator', () => {
 
         describe('bindCustomListenersOnThread', () => {
             it('should bind custom listeners on the thread', () => {
+                stubs.threadMock.expects('addListener').withArgs('threadsavedlocally', sinon.match.func);
                 stubs.threadMock.expects('addListener').withArgs('threaddeleted', sinon.match.func);
                 stubs.threadMock.expects('addListener').withArgs('threadcleanup', sinon.match.func);
                 annotator.bindCustomListenersOnThread(stubs.thread);
+            });
+        });
+
+        describe('threadDeletedHandler()', () => {
+            it('should exit annotation mode and remove thread from thread map', () => {
+                sandbox.stub(annotator, 'emit');
+                stubs.thread.location = { page: 2 };
+                annotator.addThreadToMap(stubs.thread);
+
+                annotator.threadDeletedHandler(stubs.thread);
+                expect(annotator.threads[2]).to.not.contain(stubs.thread);
+                expect(annotator.emit).to.be.calledWith('annotationmodeexit');
             });
         });
 
@@ -593,6 +606,7 @@ describe('lib/annotations/Annotator', () => {
                 stubs.destroy.returns(false);
                 stubs.getLocation.returns({});
                 stubs.create.returns(stubs.thread);
+                sandbox.stub(annotator, 'emit');
 
                 stubs.threadMock.expects('show');
                 annotator.pointClickHandler(event);
@@ -600,6 +614,7 @@ describe('lib/annotations/Annotator', () => {
                 expect(annotator.getLocationFromEvent).to.be.called;
                 expect(annotator.bindCustomListenersOnThread).to.be.called;
                 expect(annotator.togglePointAnnotationHandler).to.be.called;
+                expect(annotator.emit).to.be.calledWith('annotationmodeenter');
             });
         });
 

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -265,6 +265,8 @@ class DocAnnotator extends Annotator {
      * @return {AnnotationThread} Created annotation thread
      */
     createAnnotationThread(annotations, location, type) {
+        this.emit('annotationmodeexit');
+
         let thread;
         const threadParams = {
             annotatedElement: this.annotatedElement,
@@ -684,8 +686,10 @@ class DocAnnotator extends Annotator {
         // we trigger the create handler instead of the click handler
         if (this.didMouseMove || event.type === 'dblclick') {
             this.highlightCreateHandler(event);
+            this.emit('annotationmodeenter');
         } else {
             this.highlightClickHandler(event);
+            this.emit('annotationmodeexit');
         }
     }
 

--- a/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
+++ b/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
@@ -205,9 +205,13 @@ describe('lib/annotations/doc/DocAnnotator', () => {
             stubs.setupFunc = AnnotationThread.prototype.setup;
             stubs.validateThread = sandbox.stub(annotatorUtil, 'validateThreadParams').returns(true);
             sandbox.stub(annotator, 'handleValidationError');
+            sandbox.stub(annotator, 'emit');
         });
 
         afterEach(() => {
+            // Expect this call no matter the validity of the thread
+            expect(annotator.emit).to.be.calledWith('annotationmodeexit');
+
             Object.defineProperty(AnnotationThread.prototype, 'setup', { value: stubs.setupFunc });
         });
 
@@ -260,7 +264,6 @@ describe('lib/annotations/doc/DocAnnotator', () => {
 
         it('should emit error and return undefined if thread params are invalid', () => {
             stubs.validateThread.returns(false);
-            sandbox.stub(annotator, 'emit');
             const thread = annotator.createAnnotationThread([], {}, TYPES.highlight);
             expect(thread instanceof DocHighlightThread).to.be.false;
             expect(annotator.handleValidationError).to.be.called;
@@ -803,20 +806,23 @@ describe('lib/annotations/doc/DocAnnotator', () => {
         beforeEach(() => {
             stubs.create = sandbox.stub(annotator, 'highlightCreateHandler');
             stubs.click = sandbox.stub(annotator, 'highlightClickHandler');
+            sandbox.stub(annotator, 'emit');
         });
 
-        it('should call highlightCreateHandler if not on mobile, and the user double clicked', () => {
+        it('should call highlightCreateHandler if the user double clicked', () => {
             annotator.highlightMouseupHandler({ type: 'dblclick' });
             expect(stubs.create).to.be.called;
             expect(stubs.click).to.not.be.called;
             expect(annotator.isCreatingHighlight).to.be.false;
+            expect(annotator.emit).to.be.calledWith('annotationmodeenter');
         });
 
-        it('should call highlightClickHandler if not on mobile, and the mouse did not move', () => {
+        it('should call highlightClickHandler if the mouse did not move', () => {
             annotator.highlightMouseupHandler({ x: 0, y: 0 });
             expect(stubs.create).to.not.be.called;
             expect(stubs.click).to.be.called;
             expect(annotator.isCreatingHighlight).to.be.false;
+            expect(annotator.emit).to.be.calledWith('annotationmodeexit');
         });
 
         it('should call highlighter.removeAllHighlghts', () => {

--- a/src/lib/annotations/image/ImageAnnotator.js
+++ b/src/lib/annotations/image/ImageAnnotator.js
@@ -85,6 +85,8 @@ class ImageAnnotator extends Annotator {
      * @return {AnnotationThread} Created annotation thread
      */
     createAnnotationThread(annotations, location, type) {
+        this.emit('annotationmodeexit');
+
         let thread;
 
         // Corrects any image annotation page number to 1 instead of -1

--- a/src/lib/annotations/image/__tests__/ImageAnnotator-test.js
+++ b/src/lib/annotations/image/__tests__/ImageAnnotator-test.js
@@ -79,6 +79,15 @@ describe('lib/annotations/image/ImageAnnotator', () => {
     });
 
     describe('createAnnotationThread()', () => {
+        beforeEach(() => {
+            sandbox.stub(annotator, 'emit');
+        });
+
+        afterEach(() => {
+            // Expect this call no matter the validity of the thread
+            expect(annotator.emit).to.be.calledWith('annotationmodeexit');
+        });
+
         it('should create, add point thread to internal map, and return it', () => {
             sandbox.stub(annotatorUtil, 'validateThreadParams').returns(true);
             sandbox.stub(annotator, 'addThreadToMap');


### PR DESCRIPTION
- This prevents the viewer controls from being displayed in the following situations: 
1) user is creating an annotation and the shared highlight dialog is shown
2) user is adding the first annotation comment to a point annotation
3) user is adding the first annotation comment to a highlight-comment annotation
