### PR TITLE
Chore: Removing references to annotations from individual viewers

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -545,14 +545,23 @@ class Annotator extends EventEmitter {
      */
     bindPointModeListeners() {
         const pointFunc = this.pointClickHandler.bind(this.annotatedElement);
-        const handler = {
-            type: 'click',
-            func: pointFunc,
-            eventObj: this.annotatedElement
-        };
+        const handlers = [
+            {
+                type: 'mousedown',
+                func: pointFunc,
+                eventObj: this.annotatedElement
+            },
+            {
+                type: 'touchstart',
+                func: pointFunc,
+                eventObj: this.annotatedElement
+            }
+        ];
 
-        handler.eventObj.addEventListener(handler.type, handler.func);
-        this.annotationModeHandlers.push(handler);
+        handlers.forEach((handler) => {
+            handler.eventObj.addEventListener(handler.type, handler.func);
+            this.annotationModeHandlers.push(handler);
+        });
     }
 
     /**
@@ -565,6 +574,7 @@ class Annotator extends EventEmitter {
      */
     pointClickHandler(event) {
         event.stopPropagation();
+        event.preventDefault();
 
         // Determine if a point annotation dialog is already open and close the
         // current open dialog

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -151,7 +151,7 @@ describe('lib/annotations/Annotator', () => {
         });
     });
 
-    describe('setupAnnotations', () => {
+    describe('setupAnnotations()', () => {
         it('should initialize thread map and bind DOM listeners', () => {
             sandbox.stub(annotator, 'bindDOMListeners');
             sandbox.stub(annotator, 'bindCustomListenersOnService');
@@ -341,7 +341,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('fetchAnnotations', () => {
+        describe('fetchAnnotations()', () => {
             beforeEach(() => {
                 annotator.annotationService = {
                     getThreadMap: () => {}
@@ -380,7 +380,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('bindCustomListenersOnService', () => {
+        describe('bindCustomListenersOnService()', () => {
             it('should do nothing if the service does not exist', () => {
                 annotator.annotationService = {
                     addListener: sandbox.stub()
@@ -438,7 +438,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('unbindCustomListenersOnService', () => {
+        describe('unbindCustomListenersOnService()', () => {
             it('should do nothing if the service does not exist', () => {
                 annotator.annotationService = {
                     removeListener: sandbox.stub()
@@ -463,7 +463,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('bindCustomListenersOnThread', () => {
+        describe('bindCustomListenersOnThread()', () => {
             it('should bind custom listeners on the thread', () => {
                 stubs.threadMock.expects('addListener').withArgs('threaddeleted', sinon.match.func);
                 stubs.threadMock.expects('addListener').withArgs('threadcleanup', sinon.match.func);
@@ -471,7 +471,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('unbindCustomListenersOnThread', () => {
+        describe('unbindCustomListenersOnThread()', () => {
             it('should unbind custom listeners from the thread', () => {
                 stubs.threadMock.expects('removeAllListeners').withArgs('threaddeleted');
                 stubs.threadMock.expects('removeAllListeners').withArgs('threadcleanup');
@@ -479,7 +479,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('bindPointModeListeners', () => {
+        describe('bindPointModeListeners()', () => {
             it('should bind point mode click handler', () => {
                 sandbox.stub(annotator.annotatedElement, 'addEventListener');
                 sandbox.stub(annotator.annotatedElement, 'removeEventListener');
@@ -488,7 +488,11 @@ describe('lib/annotations/Annotator', () => {
                 annotator.bindPointModeListeners();
                 expect(annotator.pointClickHandler.bind).to.be.called;
                 expect(annotator.annotatedElement.addEventListener).to.be.calledWith(
-                    'click',
+                    'mousedown',
+                    annotator.pointClickHandler
+                );
+                expect(annotator.annotatedElement.addEventListener).to.be.calledWith(
+                    'touchstart',
                     annotator.pointClickHandler
                 );
             });
@@ -503,7 +507,11 @@ describe('lib/annotations/Annotator', () => {
                 annotator.unbindModeListeners();
                 expect(annotator.pointClickHandler.bind).to.be.called;
                 expect(annotator.annotatedElement.removeEventListener).to.be.calledWith(
-                    'click',
+                    'mousedown',
+                    annotator.pointClickHandler
+                );
+                expect(annotator.annotatedElement.removeEventListener).to.be.calledWith(
+                    'touchstart',
                     annotator.pointClickHandler
                 );
             });
@@ -542,7 +550,8 @@ describe('lib/annotations/Annotator', () => {
 
         describe('pointClickHandler()', () => {
             const event = {
-                stopPropagation: () => {}
+                stopPropagation: () => {},
+                preventDefault: () => {}
             };
 
             beforeEach(() => {
@@ -603,7 +612,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('bindDrawModeListeners', () => {
+        describe('bindDrawModeListeners()', () => {
             it('should do nothing if neither a thread nor a post button is not provided', () => {
                 const drawingThread = {
                     handleStart: () => {},
@@ -661,7 +670,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('addToThreadMap', () => {
+        describe('addToThreadMap()', () => {
             it('should add valid threads to the thread map', () => {
                 stubs.thread.location = { page: 2 };
                 stubs.thread2.location = { page: 3 };
@@ -684,7 +693,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('isInPointMode', () => {
+        describe('isInPointMode()', () => {
             it('should return whether the annotator is in point mode or not', () => {
                 annotator.annotatedElement.classList.add(CLASS_ANNOTATION_POINT_MODE);
                 expect(annotator.isInPointMode()).to.be.true;
@@ -694,7 +703,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('isInDrawMode', () => {
+        describe('isInDrawMode()', () => {
             it('should return whether the annotator is in draw mode or not', () => {
                 annotator.annotatedElement.classList.add(CLASS_ANNOTATION_DRAW_MODE);
                 expect(annotator.isInDrawMode()).to.be.true;
@@ -704,7 +713,7 @@ describe('lib/annotations/Annotator', () => {
             });
         });
 
-        describe('destroyPendingThreads', () => {
+        describe('destroyPendingThreads()', () => {
             beforeEach(() => {
                 stubs.thread = {
                     location: { page: 2 },

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -174,16 +174,24 @@ class DocAnnotator extends Annotator {
         let location = null;
         const zoomScale = annotatorUtil.getScale(this.annotatedElement);
 
+        let clientEvent = event;
+        if (this.isMobile) {
+            if (!event.targetTouches || event.targetTouches.length === 0) {
+                return location;
+            }
+            clientEvent = event.targetTouches[0];
+        }
+
+        // If click isn't on a page, ignore
+        const eventTarget = clientEvent.target;
+        const { pageEl, page } = annotatorUtil.getPageInfo(eventTarget);
+        if (!pageEl) {
+            return location;
+        }
+
         if (annotationType === TYPES.point) {
             // If there is a selection, ignore
             if (docAnnotatorUtil.isSelectionPresent()) {
-                return location;
-            }
-
-            // If click isn't on a page, ignore
-            const eventTarget = event.target;
-            const { pageEl, page } = annotatorUtil.getPageInfo(eventTarget);
-            if (!pageEl) {
                 return location;
             }
 
@@ -198,15 +206,23 @@ class DocAnnotator extends Annotator {
             const pageWidth = pageDimensions.width;
             const pageHeight = pageDimensions.height - PAGE_PADDING_TOP - PAGE_PADDING_BOTTOM;
             const browserCoordinates = [
-                event.clientX - pageDimensions.left,
-                event.clientY - pageDimensions.top - PAGE_PADDING_TOP
+                clientEvent.clientX - pageDimensions.left,
+                clientEvent.clientY - pageDimensions.top - PAGE_PADDING_TOP
             ];
+            let [x, y] = browserCoordinates;
+
+            // Do not create annotation if event doesn't have coordinates
+            if (isNaN(x) || isNaN(y)) {
+                this.emit('annotationerror', __('annotations_create_error'));
+                return location;
+            }
+
             const pdfCoordinates = docAnnotatorUtil.convertDOMSpaceToPDFSpace(
                 browserCoordinates,
                 pageHeight,
                 zoomScale
             );
-            const [x, y] = pdfCoordinates;
+            [x, y] = pdfCoordinates;
 
             // We save the dimensions of the annotated element scaled to 100%
             // so we can compare to the annotated element during render time
@@ -221,9 +237,6 @@ class DocAnnotator extends Annotator {
             if (!this.highlighter || !this.highlighter.highlights.length) {
                 return location;
             }
-
-            // Get correct page
-            const { pageEl, page } = annotatorUtil.getPageInfo(event.target);
 
             // Use highlight module to calculate quad points
             const { highlightEls } = docAnnotatorUtil.getHighlightAndHighlightEls(this.highlighter, pageEl);

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -439,9 +439,6 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             stubs.nextPage = sandbox.stub(presentation, 'nextPage');
             stubs.previousPage = sandbox.stub(presentation, 'previousPage');
             stubs.checkOverflow = sandbox.stub(presentation, 'checkOverflow').returns(false);
-            presentation.annotator = {
-                isInDialogOnPage: sandbox.stub().returns(false)
-            };
             presentation.event = {
                 deltaY: 5,
                 deltaX: -0

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -285,11 +285,6 @@ class ImageBaseViewer extends BaseViewer {
      * @return {void}
      */
     handleMouseUp(event) {
-        // Ignore zoom/pan mouse events if in annotation mode
-        if (this.annotator && this.annotator.isInPointMode()) {
-            return;
-        }
-
         const { button, ctrlKey, metaKey } = event;
 
         // If this is not a left click, then ignore
@@ -342,22 +337,6 @@ class ImageBaseViewer extends BaseViewer {
         if (!this.isMobile) {
             this.updateCursor();
         }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    getAnnotationModeClickHandler(mode) {
-        if (!mode || !this.isAnnotatable(mode)) {
-            return null;
-        }
-
-        const eventName = `toggle${mode}annotationmode`;
-        return () => {
-            this.imageEl.classList.remove(CSS_CLASS_ZOOMABLE);
-            this.imageEl.classList.remove(CSS_CLASS_PANNABLE);
-            this.emit(eventName);
-        };
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -77,7 +77,7 @@ class ImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     updatePannability() {
-        if (!this.imageEl || (this.annotator && this.annotator.isInPointMode())) {
+        if (!this.imageEl) {
             return;
         }
 

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -475,38 +475,6 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         });
     });
 
-    describe('getAnnotationModeClickHandler()', () => {
-        beforeEach(() => {
-            stubs.isAnnotatable = sandbox.stub(imageBase, 'isAnnotatable').returns(false);
-        });
-
-        it('should return null if you cannot annotate', () => {
-            const handler = imageBase.getAnnotationModeClickHandler('point');
-            expect(stubs.isAnnotatable).to.be.called;
-            expect(handler).to.equal(null);
-        });
-
-        it('should return the toggle point mode handler', () => {
-            stubs.isAnnotatable.returns(true);
-            stubs.emitter = sandbox.stub(imageBase, 'emit');
-            imageBase.annotator = {
-                togglePointAnnotationHandler: () => {}
-            };
-            imageBase.imageEl.classList.add(CSS_CLASS_PANNABLE);
-            imageBase.imageEl.classList.add(CSS_CLASS_ZOOMABLE);
-
-            const handler = imageBase.getAnnotationModeClickHandler('point');
-            expect(stubs.isAnnotatable).to.be.called;
-            expect(handler).to.be.a('function');
-
-            handler(event);
-
-            expect(imageBase.imageEl).to.not.have.class(CSS_CLASS_PANNABLE);
-            expect(imageBase.imageEl).to.not.have.class(CSS_CLASS_ZOOMABLE);
-            expect(imageBase.emit).to.have.been.calledWith('togglepointannotationmode');
-        });
-    });
-
     describe('finishLoading()', () => {
         beforeEach(() => {
             imageBase.loaded = false;


### PR DESCRIPTION
- Use touchstart and mousedown to trigger the creation of point annotations
- Swap out event with touchEvent if the user is on a mobile device