### PR TITLE
Fix: Only initialize PreviewUI.notification after viewer is loaded

### DIFF
--- a/src/lib/PreviewUI.js
+++ b/src/lib/PreviewUI.js
@@ -117,9 +117,6 @@ class PreviewUI {
         // Setup loading indicator
         this.setupLoading();
 
-        // Setup notification
-        this.notification = new Notification(this.contentContainer);
-
         // Attach keyboard events
         document.addEventListener('keydown', this.keydownHandler);
 
@@ -258,6 +255,9 @@ class PreviewUI {
                 // part of finishLoadingSetup in BaseViewer.js
                 crawler.classList.remove(CLASS_HIDDEN);
             }
+
+            // Setup viewer notification
+            this.notification = new Notification(this.contentContainer);
         }
     }
 

--- a/src/lib/__tests__/PreviewUI-test.js
+++ b/src/lib/__tests__/PreviewUI-test.js
@@ -57,9 +57,6 @@ describe('lib/PreviewUI', () => {
             // Check progress bar
             expect(resultEl).to.contain(constants.SELECTOR_BOX_PREVIEW_PROGRESS_BAR);
 
-            // Check notification
-            expect(resultEl).to.contain('.bp-notification');
-
             // Check loading state
             const loadingWrapperEl = resultEl.querySelector(constants.SELECTOR_BOX_PREVIEW_LOADING_WRAPPER);
             expect(loadingWrapperEl).to.contain(constants.SELECTOR_BOX_PREVIEW_ICON);
@@ -190,10 +187,13 @@ describe('lib/PreviewUI', () => {
         });
 
         describe('hideLoadingIndicator()', () => {
-            it('should hide loading indicator', () => {
+            it('should hide loading indicator and intializes the notification', () => {
                 const contentContainerEl = containerEl.querySelector(constants.SELECTOR_BOX_PREVIEW);
                 ui.hideLoadingIndicator();
                 expect(contentContainerEl).to.have.class(constants.CLASS_PREVIEW_LOADED);
+
+                // Check that notification is initialized
+                expect(contentContainerEl).to.contain('.bp-notification');
             });
 
             it('should remove the hidden class from the crawler', () => {


### PR DESCRIPTION
- The notification object was getting initialized in the viewer container on top of the loading indicator which prevented the download button in the loading indicator from triggering anything