### PR TITLE
Fix: Forcing HD/SD should disable adaptation

### DIFF
--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -216,10 +216,10 @@ class DashViewer extends VideoBaseViewer {
      * Enables or disables automatic adaptation
      *
      * @private
-     * @param {boolean} [adapt] - Enable or disable adaptation
+     * @param {boolean} adapt - Enable or disable adaptation
      * @return {void}
      */
-    enableAdaptation(adapt = true) {
+    enableAdaptation(adapt) {
         this.adapting = adapt;
         this.player.configure({ abr: { enabled: adapt } });
     }
@@ -256,14 +256,16 @@ class DashViewer extends VideoBaseViewer {
 
         switch (quality) {
             case 'hd':
+                this.enableAdaptation(false);
                 this.enableHD();
                 break;
             case 'sd':
+                this.enableAdaptation(false);
                 this.enableSD();
                 break;
             case 'auto':
             default:
-                this.enableAdaptation();
+                this.enableAdaptation(true);
                 break;
         }
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -264,7 +264,7 @@ describe('lib/viewers/media/DashViewer', () => {
     describe('enableAdaptation()', () => {
         it('should configure player to enable adaptation by default', () => {
             stubs.mockPlayer.expects('configure').withArgs({ abr: { enabled: true } });
-            dash.enableAdaptation();
+            dash.enableAdaptation(true);
         });
 
         it('should configure player to disable adaptation', () => {
@@ -277,12 +277,13 @@ describe('lib/viewers/media/DashViewer', () => {
         beforeEach(() => {
             stubs.hd = sandbox.stub(dash, 'enableHD');
             stubs.sd = sandbox.stub(dash, 'enableSD');
-            stubs.auto = sandbox.stub(dash, 'enableAdaptation');
+            stubs.adapt = sandbox.stub(dash, 'enableAdaptation');
         });
 
         it('should enable HD video', () => {
             sandbox.stub(dash.cache, 'get').returns('hd');
             dash.handleQuality();
+            expect(stubs.adapt).to.be.calledWith(false);
             expect(stubs.hd).to.be.called;
             expect(dash.emit).to.be.calledWith('qualitychange', 'hd');
         });
@@ -290,6 +291,7 @@ describe('lib/viewers/media/DashViewer', () => {
         it('should enable SD video', () => {
             sandbox.stub(dash.cache, 'get').returns('sd');
             dash.handleQuality();
+            expect(stubs.adapt).to.be.calledWith(false);
             expect(stubs.sd).to.be.called;
             expect(dash.emit).to.be.calledWith('qualitychange', 'sd');
         });
@@ -297,14 +299,14 @@ describe('lib/viewers/media/DashViewer', () => {
         it('should enable auto video', () => {
             sandbox.stub(dash.cache, 'get').returns('auto');
             dash.handleQuality();
-            expect(stubs.auto).to.be.called;
+            expect(stubs.adapt).to.be.calledWith(true);
             expect(dash.emit).to.be.calledWith('qualitychange', 'auto');
         });
 
         it('should not emit "qualitychange" event if no quality was cached', () => {
             sandbox.stub(dash.cache, 'get');
             dash.handleQuality();
-            expect(stubs.auto).to.be.called;
+            expect(stubs.adapt).to.be.calledWith(true); // default to adapt=true
             expect(dash.emit).to.not.be.called;
         });
     });


### PR DESCRIPTION
Shaka-player changed its behavior when selecting a variant. We now have
to explicitly disable adaptation. See notes below (which also apply to
upgrade from 2.0 to 2.1):

https://github.com/google/shaka-player/blob/master/docs/tutorials/upgrade-v2-0.md

NOTE: From my testing, their example doesn't actually work, and I need
to disable adaptation BEFORE selecting the variant. I filed https://github.com/google/shaka-player/issues/962 on shaka team for this