### PR TITLE
Fix: annotation handler rebinding

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -547,16 +547,15 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     bindPointModeListeners() {
-        const pointFunc = this.pointClickHandler.bind(this.annotatedElement);
         const handlers = [
             {
                 type: 'mousedown',
-                func: pointFunc,
+                func: this.pointClickHandler,
                 eventObj: this.annotatedElement
             },
             {
                 type: 'touchstart',
-                func: pointFunc,
+                func: this.pointClickHandler,
                 eventObj: this.annotatedElement
             }
         ];
@@ -618,26 +617,23 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        const startCallback = drawingThread.handleStart.bind(drawingThread);
-        const stopCallback = drawingThread.handleStop.bind(drawingThread);
-        const moveCallback = drawingThread.handleMove.bind(drawingThread);
         /* eslint-disable require-jsdoc */
         const locationFunction = (event) => this.getLocationFromEvent(event, TYPES.point);
         /* eslint-enable require-jsdoc */
         const handlers = [
             {
                 type: 'mousemove',
-                func: annotatorUtil.eventToLocationHandler(locationFunction, moveCallback),
+                func: annotatorUtil.eventToLocationHandler(locationFunction, drawingThread.handleMove),
                 eventObj: this.annotatedElement
             },
             {
                 type: 'mousedown',
-                func: annotatorUtil.eventToLocationHandler(locationFunction, startCallback),
+                func: annotatorUtil.eventToLocationHandler(locationFunction, drawingThread.handleStart),
                 eventObj: this.annotatedElement
             },
             {
                 type: 'mouseup',
-                func: annotatorUtil.eventToLocationHandler(locationFunction, stopCallback),
+                func: annotatorUtil.eventToLocationHandler(locationFunction, drawingThread.handleStop),
                 eventObj: this.annotatedElement
             }
         ];

--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -7,7 +7,7 @@ const ANNOTATORS = [
         NAME: 'Document',
         CONSTRUCTOR: DocAnnotator,
         VIEWER: ['Document', 'Presentation'],
-        TYPE: [TYPES.point, TYPES.highlight]
+        TYPE: [TYPES.point, TYPES.highlight, TYPES.draw]
     },
     {
         NAME: 'Image',

--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -7,7 +7,7 @@ const ANNOTATORS = [
         NAME: 'Document',
         CONSTRUCTOR: DocAnnotator,
         VIEWER: ['Document', 'Presentation'],
-        TYPE: [TYPES.point, TYPES.highlight, TYPES.draw]
+        TYPE: [TYPES.point, TYPES.highlight]
     },
     {
         NAME: 'Image',

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -503,10 +503,8 @@ describe('lib/annotations/Annotator', () => {
             it('should bind point mode click handler', () => {
                 sandbox.stub(annotator.annotatedElement, 'addEventListener');
                 sandbox.stub(annotator.annotatedElement, 'removeEventListener');
-                sandbox.stub(annotator.pointClickHandler, 'bind', () => annotator.pointClickHandler);
 
                 annotator.bindPointModeListeners();
-                expect(annotator.pointClickHandler.bind).to.be.called;
                 expect(annotator.annotatedElement.addEventListener).to.be.calledWith(
                     'mousedown',
                     annotator.pointClickHandler
@@ -521,11 +519,9 @@ describe('lib/annotations/Annotator', () => {
         describe('unbindModeListeners()', () => {
             it('should unbind point mode click handler', () => {
                 sandbox.stub(annotator.annotatedElement, 'removeEventListener');
-                sandbox.stub(annotator.pointClickHandler, 'bind', () => annotator.pointClickHandler);
 
                 annotator.bindPointModeListeners();
                 annotator.unbindModeListeners();
-                expect(annotator.pointClickHandler.bind).to.be.called;
                 expect(annotator.annotatedElement.removeEventListener).to.be.calledWith(
                     'mousedown',
                     annotator.pointClickHandler
@@ -669,16 +665,10 @@ describe('lib/annotations/Annotator', () => {
                 sandbox.stub(annotator.annotatedElement, 'addEventListener');
                 sandbox.stub(annotator.annotatedElement, 'removeEventListener');
                 sandbox.stub(annotator, 'isInDrawMode').returns(true);
-                sandbox.stub(drawingThread.handleStart, 'bind', () => drawingThread.pointClickHandler);
-                sandbox.stub(drawingThread.handleStop, 'bind', () => drawingThread.pointClickHandler);
-                sandbox.stub(drawingThread.handleMove, 'bind', () => drawingThread.pointClickHandler);
                 sandbox.stub(annotatorUtil, 'eventToLocationHandler').returns(locationHandler);
 
                 annotator.bindDrawModeListeners(drawingThread, postButtonEl);
 
-                expect(drawingThread.handleStart.bind).to.be.called;
-                expect(drawingThread.handleStop.bind).to.be.called;
-                expect(drawingThread.handleMove.bind).to.be.called;
                 expect(annotator.annotatedElement.addEventListener).to.be.calledWith(
                     sinon.match.string,
                     locationHandler

--- a/src/lib/annotations/drawing/DrawingThread.js
+++ b/src/lib/annotations/drawing/DrawingThread.js
@@ -38,7 +38,11 @@ class DrawingThread extends AnnotationThread {
      */
     constructor(data) {
         super(data);
+
         this.render = this.render.bind(this);
+        this.handleStart = this.handleStart.bind(this);
+        this.handleMove = this.handleMove.bind(this);
+        this.handleStop = this.handleStop.bind(this);
     }
 
     /**


### PR DESCRIPTION
I previously (unnecessarily) bound pointClickHandler to the wrong object. Also moving DrawingThread handler bindings to the constructor.
