### PR TITLE
Fix: Fix release script after GitHub release

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -177,6 +177,8 @@ push_new_release() {
     echo "Pushing new GitHub release"
     echo "----------------------------------------------------------------------"
     ./node_modules/.bin/conventional-github-releaser
+
+    return 0
 }
 
 


### PR DESCRIPTION
GitHub releaser script output was interpreted as an error response - we explicitly return 0 with success.