### PR TITLE
Fix: scale being unbound when annotating

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -77,6 +77,7 @@ class Annotator extends EventEmitter {
 
         this.unbindDOMListeners();
         this.unbindCustomListenersOnService();
+        this.removeListener('scaleAnnotations', this.scaleAnnotations);
     }
 
     /**
@@ -384,6 +385,7 @@ class Annotator extends EventEmitter {
         this.threads = {};
         this.bindDOMListeners();
         this.bindCustomListenersOnService(this.annotationService);
+        this.addListener('scaleAnnotations', this.scaleAnnotations);
     }
 
     /**
@@ -420,9 +422,7 @@ class Annotator extends EventEmitter {
      *
      * @return {void}
      */
-    bindDOMListeners() {
-        this.addListener('scaleAnnotations', this.scaleAnnotations);
-    }
+    bindDOMListeners() {}
 
     /**
      * Unbinds DOM event listeners. Can be overridden by any annotator that
@@ -432,9 +432,7 @@ class Annotator extends EventEmitter {
      * @protected
      * @return {void}
      */
-    unbindDOMListeners() {
-        this.removeListener('scaleAnnotations', this.scaleAnnotations);
-    }
+    unbindDOMListeners() {}
 
     /**
      * Binds custom event listeners for the Annotation Service.

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -93,12 +93,14 @@ describe('lib/annotations/Annotator', () => {
             const unbindCustomStub = sandbox.stub(annotator, 'unbindCustomListenersOnThread');
             const unbindDOMStub = sandbox.stub(annotator, 'unbindDOMListeners');
             const unbindCustomListenersOnService = sandbox.stub(annotator, 'unbindCustomListenersOnService');
+            const unbindScaleListener = sandbox.stub(annotator, 'removeListener');
 
             annotator.destroy();
 
             expect(unbindCustomStub).to.be.calledWith(stubs.thread);
             expect(unbindDOMStub).to.be.called;
             expect(unbindCustomListenersOnService).to.be.called;
+            expect(unbindScaleListener).to.be.calledWith('scaleAnnotations', sinon.match.func);
         });
     });
 
@@ -166,6 +168,7 @@ describe('lib/annotations/Annotator', () => {
             expect(Object.keys(annotator.threads).length === 0).to.be.true;
             expect(annotator.bindDOMListeners).to.be.called;
             expect(annotator.bindCustomListenersOnService).to.be.called;
+            expect(annotator.addListener).to.be.calledWith('scaleAnnotations', sinon.match.func);
         });
     });
 
@@ -381,22 +384,6 @@ describe('lib/annotations/Annotator', () => {
                 return stubs.threadPromise.then(() => {
                     expect(annotator.emit).to.be.calledWith('annotationsfetched');
                 });
-            });
-        });
-
-        describe('bindDOMListeners()', () => {
-            it('should add a listener for scaling the annotator', () => {
-                sandbox.stub(annotator, 'addListener');
-                annotator.bindDOMListeners();
-                expect(annotator.addListener).to.be.calledWith('scaleAnnotations', sinon.match.func);
-            });
-        });
-
-        describe('unbindDOMListeners()', () => {
-            it('should add a listener for scaling the annotator', () => {
-                sandbox.stub(annotator, 'removeListener');
-                annotator.unbindDOMListeners();
-                expect(annotator.removeListener).to.be.calledWith('scaleAnnotations', sinon.match.func);
             });
         });
 


### PR DESCRIPTION
Bug: open a file with annotations,
click point mode and change the browser window size and the annotations will not redraw.

Cause: unbindDOMModeListeners is being called on entering annotation mode. This method removes the scale listener.