### PR TITLE
Multi audio

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -88,6 +88,10 @@ of=of
 subtitles=Subtitles
 # Label for turning off subtitles in media player
 off=Off
+# Label for audio tracks in media player
+media_audio=Audio
+# Label for alternate audio tracks in media player
+track=Track
 
 
 # 3D Preview

--- a/src/lib/viewers/media/MediaControls.js
+++ b/src/lib/viewers/media/MediaControls.js
@@ -180,6 +180,16 @@ class MediaControls extends EventEmitter {
     }
 
     /**
+     * Audio-track handler
+     *
+     * @private
+     * @return {void}
+     */
+    handleAudioTrack() {
+        this.emit('audiochange');
+    }
+
+    /**
      * Attaches settings menu
      *
      * @private
@@ -876,6 +886,17 @@ class MediaControls extends EventEmitter {
     initSubtitles(subtitles, language) {
         this.settings.addListener('subtitles', this.handleSubtitle);
         this.settings.loadSubtitles(subtitles, language);
+    }
+
+    /**
+     * Takes a list of audio tracks and populates the settings menu
+     *
+     * @param {Array} audioLanguages - An ordered list of languages of the audio tracks
+     * @return {void}
+     */
+    initAlternateAudio(audioLanguages) {
+        this.settings.addListener('audiotracks', this.handleAudioTrack);
+        this.settings.loadAlternateAudio(audioLanguages);
     }
 }
 

--- a/src/lib/viewers/media/Settings.scss
+++ b/src/lib/viewers/media/Settings.scss
@@ -39,15 +39,18 @@ $item-hover-color: #f6fafd;
 .bp-media-settings-menu-quality,
 .bp-media-settings-menu-speed,
 .bp-media-settings-menu-subtitles,
+.bp-media-settings-menu-audiotracks,
 .bp-media-settings-show-speed .bp-media-settings-menu-main,
 .bp-media-settings-show-quality .bp-media-settings-menu-main,
-.bp-media-settings-show-subtitles .bp-media-settings-menu-main {
+.bp-media-settings-show-subtitles .bp-media-settings-menu-main,
+.bp-media-settings-show-audiotracks .bp-media-settings-menu-main {
     display: none;
 }
 
 .bp-media-settings-show-speed .bp-media-settings-menu-speed,
 .bp-media-settings-show-quality .bp-media-settings-menu-quality,
-.bp-media-settings-show-subtitles .bp-media-settings-menu-subtitles {
+.bp-media-settings-show-subtitles .bp-media-settings-menu-subtitles,
+.bp-media-settings-show-audiotracks .bp-media-settings-menu-audiotracks {
     display: table;
 }
 
@@ -55,7 +58,8 @@ $item-hover-color: #f6fafd;
 .bp-media-mp4,
 .bp-media-mp3 {
     .bp-media-settings-item-quality,
-    .bp-media-settings-item-subtitles {
+    .bp-media-settings-item-subtitles,
+    .bp-media-settings-item-audiotracks {
         display: none;
     }
 }
@@ -99,6 +103,13 @@ $item-hover-color: #f6fafd;
 .bp-media-settings-item-subtitles,
 .bp-media-settings-menu-subtitles {
     .bp-media-settings-subtitles-unavailable & {
+        display: none;
+    }
+}
+
+.bp-media-settings-item-audiotracks,
+.bp-media-settings-menu-audiotracks {
+    .bp-media-settings-audiotracks-unavailable & {
         display: none;
     }
 }

--- a/src/lib/viewers/media/__tests__/MediaControls-test.js
+++ b/src/lib/viewers/media/__tests__/MediaControls-test.js
@@ -1021,5 +1021,17 @@ describe('lib/viewers/media/MediaControls', () => {
             expect(mediaControls.settings.loadSubtitles).to.be.calledWith(subs);
         });
     });
+
+    describe('initAlternateAudio()', () => {
+        it('should load alternate audio', () => {
+            sandbox.stub(mediaControls.settings, 'loadAlternateAudio');
+            const audios = [
+                { language: 'eng', role: 'audio0' },
+                { language: 'rus', role: 'audio1' }
+            ];
+            mediaControls.initAlternateAudio(audios);
+        expect(mediaControls.settings.loadAlternateAudio).to.be.calledWith(audios);
+        });
+    });
 });
 /* eslint-enable no-unused-expressions */

--- a/src/lib/viewers/media/__tests__/Settings-test.js
+++ b/src/lib/viewers/media/__tests__/Settings-test.js
@@ -765,6 +765,51 @@ describe('lib/viewers/media/Settings', () => {
         });
     });
 
+    describe('loadAlternateAudio()', () => {
+        it('Should load all audio tracks and make them available', () => {
+            const audioMenu = settings.settingsEl.querySelector('.bp-media-settings-menu-audiotracks');
+            sandbox.stub(settings, 'chooseOption');
+
+            settings.loadAlternateAudio(['English', 'Russian', 'Spanish']);
+
+            expect(settings.chooseOption).to.be.calledWith('audiotracks', '0');
+            expect(audioMenu.children.length).to.equal(4); // Three languages, and back to main menu
+            expect(settings.containerEl).to.not.have.class('bp-media-settings-audiotracks-unavailable');
+        });
+
+        it('Should reset menu dimensions after loading', () => {
+            sandbox.stub(settings, 'setMenuContainerDimensions');
+
+            settings.loadAlternateAudio(['English', 'Russian', 'Spanish']);
+
+            expect(settings.setMenuContainerDimensions).to.be.calledWith(settings.settingsEl.firstChild);
+        });
+
+        it('Should not list language for "und" language code', () => {
+            const audioMenu = settings.settingsEl.querySelector('.bp-media-settings-menu-audiotracks');
+
+            settings.loadAlternateAudio(['English', 'und']);
+
+            const audio0 = audioMenu.querySelector('[data-value="0"]').querySelector('.bp-media-settings-value');
+            const audio1 = audioMenu.querySelector('[data-value="1"]').querySelector('.bp-media-settings-value');
+            expect(audio0.innerHTML).to.equal('Track 1 (English)');
+            expect(audio1.innerHTML).to.equal('Track 2');
+        });
+
+        it('Should escape audio languages and roles', () => {
+            const audioMenu = settings.settingsEl.querySelector('.bp-media-settings-menu-audiotracks');
+
+            // There shouldn't be a way to get such inputs into this method in normal use case anyway
+            // because it goes through multiple levels of sanitization, but just in case...
+            settings.loadAlternateAudio(['English', '<badboy>']);
+
+            const audio0 = audioMenu.querySelector('[data-value="0"]').querySelector('.bp-media-settings-value');
+            const audio1 = audioMenu.querySelector('[data-value="1"]').querySelector('.bp-media-settings-value');
+            expect(audio0.innerHTML).to.equal('Track 1 (English)');
+            expect(audio1.innerHTML).to.equal('Track 2 (&lt;badboy&gt;)');
+        });
+    });
+
     describe('hasSubtitles()', () => {
         it('Should be false before loading subtitles', () => {
             expect(settings.hasSubtitles()).to.be.false;


### PR DESCRIPTION
    New: Support multiple audio tracks

    This commit adds support for selection of different audio tracks when
    available in the manifest. It selects based on a combination of the
    language and "role" of the audio track. This combination should be
    unique in order to unambiguously select audio tracks - roles are made
    unique by the backend, as audio0, audio1, etc.

    One thing to be careful of in all this is how this interacts with
    selecting HD/SD video. Previous implementation would cache the HD/SD
    variant to switch to. Now, there are multiple HD variants and multiple
    SD variants, because the HD stream could have different audio. Thus this
    required some refactoring of how we pick the HD/SD streams, so that we
    maintain the same audio stream while changing video quality. In the
    process, I've also fixed a bug in how we size the video for audio-only
    representations (before, the size would end up being so small that the
    play button icon would leak into the controls).