### PR TITLE
Fix: Do not display disabled annotation types on fetch

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -504,7 +504,7 @@ class Annotator extends EventEmitter {
                     return;
                 }
 
-                // Bind events on   valid annotation thread
+                // Bind events on valid annotation thread
                 const thread = this.createAnnotationThread(annotations, firstAnnotation.location, firstAnnotation.type);
                 this.bindCustomListenersOnThread(thread);
             });

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -500,12 +500,13 @@ class Annotator extends EventEmitter {
             Object.keys(threadMap).forEach((threadID) => {
                 const annotations = threadMap[threadID];
                 const firstAnnotation = annotations[0];
-
-                // Bind events on valid annotation thread
-                const thread = this.createAnnotationThread(annotations, firstAnnotation.location, firstAnnotation.type);
-                if (thread) {
-                    this.bindCustomListenersOnThread(thread);
+                if (!firstAnnotation || !this.isModeAnnotatable(firstAnnotation.type)) {
+                    return;
                 }
+
+                // Bind events on   valid annotation thread
+                const thread = this.createAnnotationThread(annotations, firstAnnotation.location, firstAnnotation.type);
+                this.bindCustomListenersOnThread(thread);
             });
 
             this.emit('annotationsfetched');
@@ -603,6 +604,10 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     bindCustomListenersOnThread(thread) {
+        if (!thread) {
+            return;
+        }
+
         // Thread was deleted, remove from thread map
         thread.addListener('threaddeleted', () => {
             const page = thread.location.page || 1;

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -345,6 +345,7 @@ describe('lib/annotations/Annotator', () => {
                 stubs.threadPromise = Promise.resolve(threadMap);
                 stubs.serviceMock.expects('getThreadMap').returns(stubs.threadPromise);
                 sandbox.stub(annotator, 'emit');
+                sandbox.stub(annotator, 'isModeAnnotatable').returns(true);
             });
 
             it('should reset and create a new thread map by fetching annotation data from the server', () => {
@@ -357,7 +358,7 @@ describe('lib/annotations/Annotator', () => {
                 return stubs.threadPromise.then(() => {
                     expect(Object.keys(annotator.threads).length === 0).to.be.true;
                     expect(annotator.createAnnotationThread).to.be.calledTwice;
-                    expect(annotator.bindCustomListenersOnThread).to.be.calledOnce;
+                    expect(annotator.bindCustomListenersOnThread).to.be.calledTwice;
                     expect(result).to.be.an.object;
                 });
             });
@@ -459,6 +460,11 @@ describe('lib/annotations/Annotator', () => {
                 stubs.threadMock.expects('addListener').withArgs('threadcleanup', sinon.match.func);
                 annotator.bindCustomListenersOnThread(stubs.thread);
             });
+
+            it('should do nothing when given thread is empty', () => {
+                expect(annotator.bindCustomListenersOnThread).to.not.throw(undefined);
+                expect(annotator.bindCustomListenersOnThread).to.not.throw(null);
+            })
         });
 
         describe('unbindCustomListenersOnThread()', () => {


### PR DESCRIPTION
This PR uncovered a minor (possible) issue with highlight annotations right now: 

Remove highlights from BoxAnnotations.js. The client side will filter fetched highlight annotations from being displayed but highlight handlers will still be enabled and available.