### PR TITLE
Fix: Create annotation in API using thread rather than threadNumber

### DIFF
--- a/src/lib/annotations/AnnotationService.js
+++ b/src/lib/annotations/AnnotationService.js
@@ -86,8 +86,12 @@ class AnnotationService extends EventEmitter {
                         threadID: annotation.threadID
                     },
                     message: annotation.text,
-                    threadNumber: annotation.threadNumber
+                    thread: annotation.threadNumber
                 })
+                // NOTE: Ensure that threadNumbers are sent to the API as
+                // thread, else the API created annotation will have an
+                // incremented threadNumber. This is due to the naming system
+                // in the annotations API
             })
                 .then((response) => response.json())
                 .then((data) => {


### PR DESCRIPTION
- The annotations API refers to thread numbers as thread, therefore any create API request MUST provide the threadNumber as thread as to avoid adding the new annotation to it's own thread and incrementing the threadNumber
- Any annotation created since https://github.com/box/box-content-preview/pull/241 in [v1.3.0](https://github.com/box/box-content-preview/releases/tag/v1.3.0) will not have the correct thread number associated with it. Instead each annotation will have a unique thread number. This will be fixed in v1.7.0