### PR TITLE
Chore: Rsync.plugin should update files rather than delete and replace

### DIFF
--- a/build/RsyncPlugin.js
+++ b/build/RsyncPlugin.js
@@ -10,7 +10,7 @@ RsyncPlugin.prototype.apply = function rsync(compiler) {
     compiler.plugin('done', () => {
         console.log('');
         console.log(`🔄 🔄 🔄  Rsync starting for ${this.source} 🔄 🔄 🔄`);
-        execSync(`rsync -avz --delete --exclude=".*" "${this.source}" "${this.destination}"`, { stdio: [0, 1, 2] });
+        execSync(`rsync -avz --update --exclude=".*" "${this.source}" "${this.destination}"`, { stdio: [0, 1, 2] });
     });
 };
 


### PR DESCRIPTION
- This is so that annotations.js/annotations.css and
  preview.js/preview.css can be synced from separate 
  repositories simultaneously