### PR TITLE
New: Support well-formed file object in show()

### DIFF
--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -23,7 +23,7 @@ describe('lib/file', () => {
         it('should return the correct api url', () => {
             assert.equal(
                 getURL('id', 'api'),
-                'api/2.0/files/id?fields=permissions,shared_link,sha1,file_version,name,size,extension,representations,watermark_info,authenticated_download_url'
+                'api/2.0/files/id?fields=id,permissions,shared_link,sha1,file_version,name,size,extension,representations,watermark_info,authenticated_download_url'
             );
         });
     });
@@ -89,18 +89,20 @@ describe('lib/file', () => {
     });
 
     describe('checkFileValid()', () => {
-        it('should return false if file is null', () => {
-            const file = null;
+        it('should return false if file is null or undefined or not an object', () => {
+            let file = null;
             assert.notOk(checkFileValid(file));
-        });
 
-        it('should return false if file is null', () => {
-            const file = undefined;
+            file = undefined;
+            assert.notOk(checkFileValid(file));
+
+            file = 'string';
             assert.notOk(checkFileValid(file));
         });
 
         it('should return true if file has all the appropratie properties', () => {
             const file = {
+                id: '123',
                 permissions: {},
                 shared_link: 'blah',
                 sha1: 'blah',

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -1,9 +1,10 @@
 import { ORIGINAL_REP_NAME } from './constants';
 
-// List of Box Content API fields that the Preview SDK requires for every file. Updating this list is most likely
+// List of Box Content API fields that the Preview library requires for every file. Updating this list is most likely
 // a breaking change and should be done with care. Clients that leverage functionality dependent on this format
 // (e.g. Box.Preview.updateFileCache()) will need to be updated if this list is modified.
 const FILE_FIELDS = [
+    'id',
     'permissions',
     'shared_link',
     'sha1',
@@ -84,14 +85,14 @@ export function checkFeature(viewer, primary, secondary) {
 }
 
 /**
- * Checks whether file metadata is valid by checking whether each property
+ * Checks whether Box File object is valid by checking whether each property
  * in FIELDS on the specified file object is defined.
  *
- * @param {Object} file - Box file metadata to check
- * @return {boolean} Whether or not file metadata structure is valid
+ * @param {Object} file - Box File object to check
+ * @return {boolean} Whether or not file object structure is valid
  */
 export function checkFileValid(file) {
-    if (!file) {
+    if (!file || typeof file !== 'object') {
         return false;
     }
 


### PR DESCRIPTION
- Partially reverts changes from #24 and will enable #326
- Adds 'id' to FILE_FIELDS since we use that to validate the file object passed in