### PR TITLE
Fix: Re-scale annotation canvases on zoom

### DIFF
--- a/src/lib/annotations/MobileAnnotator.scss
+++ b/src/lib/annotations/MobileAnnotator.scss
@@ -194,7 +194,9 @@ $tablet: "(min-width: 768px)";
     width: 100%;
 
     @include border-top-bottom;
+}
 
+.bp-mobile-annotation-dialog .annotation-container {
     @media #{$tablet} {
         left: auto;
         padding: 15px 0;

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -36,7 +36,7 @@ const CLASS_DEFAULT_CURSOR = 'bp-use-default-cursor';
 // Required by rangy highlighter
 const ID_ANNOTATED_ELEMENT = 'bp-rangy-annotated-element';
 
-const annotationLayers = [CLASS_ANNOTATION_LAYER_HIGHLIGHT, CLASS_ANNOTATION_LAYER_DRAW];
+const ANNOTATION_LAYER_CLASSES = [CLASS_ANNOTATION_LAYER_HIGHLIGHT, CLASS_ANNOTATION_LAYER_DRAW];
 
 /**
  * For filtering out and only showing the first thread in a list of threads.
@@ -388,7 +388,7 @@ class DocAnnotator extends Annotator {
      */
     renderAnnotationsOnPage(pageNum) {
         // Scale existing canvases on re-render
-        this.scaleAnnotationCanvases(pageNum, annotationLayers);
+        this.scaleAnnotationCanvases(pageNum);
 
         super.renderAnnotationsOnPage(pageNum);
 
@@ -400,10 +400,17 @@ class DocAnnotator extends Annotator {
         });
     }
 
-    scaleAnnotationCanvases(pageNum, layerClasses) {
+    /**
+     * Scales all annotation canvases for a specified page.
+     *
+     * @override
+     * @param {number} pageNum - Page number
+     * @return {void}
+     */
+    scaleAnnotationCanvases(pageNum) {
         const pageEl = this.annotatedElement.querySelector(`[data-page-number="${pageNum}"]`);
 
-        layerClasses.forEach((annotationLayerClass) => {
+        ANNOTATION_LAYER_CLASSES.forEach((annotationLayerClass) => {
             const annotationLayerEl = pageEl.querySelector(`.${annotationLayerClass}`);
             if (annotationLayerEl) {
                 docAnnotatorUtil.scaleCanvas(pageEl, annotationLayerEl);

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -21,6 +21,7 @@ import {
     PAGE_PADDING_TOP,
     PAGE_PADDING_BOTTOM,
     CLASS_ANNOTATION_LAYER_HIGHLIGHT,
+    CLASS_ANNOTATION_LAYER_DRAW,
     PENDING_STATES
 } from '../annotationConstants';
 
@@ -34,6 +35,8 @@ const CLASS_DEFAULT_CURSOR = 'bp-use-default-cursor';
 
 // Required by rangy highlighter
 const ID_ANNOTATED_ELEMENT = 'bp-rangy-annotated-element';
+
+const annotationLayers = [CLASS_ANNOTATION_LAYER_HIGHLIGHT, CLASS_ANNOTATION_LAYER_DRAW];
 
 /**
  * For filtering out and only showing the first thread in a list of threads.
@@ -384,12 +387,26 @@ class DocAnnotator extends Annotator {
      * @return {void}
      */
     renderAnnotationsOnPage(pageNum) {
+        // Scale existing canvases on re-render
+        this.scaleAnnotationCanvases(pageNum, annotationLayers);
+
         super.renderAnnotationsOnPage(pageNum);
 
         // Destroy current pending highlight annotation
         this.getHighlightThreadsOnPage(pageNum).forEach((thread) => {
             if (annotatorUtil.isPending(thread.state)) {
                 thread.destroy();
+            }
+        });
+    }
+
+    scaleAnnotationCanvases(pageNum, layerClasses) {
+        const pageEl = this.annotatedElement.querySelector(`[data-page-number="${pageNum}"]`);
+
+        layerClasses.forEach((annotationLayerClass) => {
+            const annotationLayerEl = pageEl.querySelector(`.${annotationLayerClass}`);
+            if (annotationLayerEl) {
+                docAnnotatorUtil.scaleCanvas(pageEl, annotationLayerEl);
             }
         });
     }
@@ -485,6 +502,10 @@ class DocAnnotator extends Annotator {
      * @return {void}
      */
     bindCustomListenersOnThread(thread) {
+        if (!thread) {
+            return;
+        }
+
         super.bindCustomListenersOnThread(thread);
 
         // We need to redraw highlights on the page if a thread was deleted

--- a/src/lib/annotations/doc/DocDrawingThread.js
+++ b/src/lib/annotations/doc/DocDrawingThread.js
@@ -1,8 +1,6 @@
 import {
     STATES,
     DRAW_STATES,
-    PAGE_PADDING_TOP,
-    PAGE_PADDING_BOTTOM,
     CLASS_ANNOTATION_LAYER_DRAW,
     CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS
 } from '../annotationConstants';
@@ -127,12 +125,7 @@ class DocDrawingThread extends DrawingThread {
 
         super.saveAnnotation(type, text);
 
-        const drawingAnnotationLayerContext = docAnnotatorUtil.getContext(
-            this.pageEl,
-            CLASS_ANNOTATION_LAYER_DRAW,
-            PAGE_PADDING_TOP,
-            PAGE_PADDING_BOTTOM
-        );
+        const drawingAnnotationLayerContext = docAnnotatorUtil.getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW);
         if (drawingAnnotationLayerContext) {
             const inProgressCanvas = this.drawingContext.canvas;
             const width = parseInt(inProgressCanvas.style.width, 10);
@@ -161,12 +154,7 @@ class DocDrawingThread extends DrawingThread {
         } else {
             const config = { scale: this.lastScaleFactor };
             this.pageEl = docAnnotatorUtil.getPageEl(this.annotatedElement, this.location.page);
-            context = docAnnotatorUtil.getContext(
-                this.pageEl,
-                CLASS_ANNOTATION_LAYER_DRAW,
-                PAGE_PADDING_TOP,
-                PAGE_PADDING_BOTTOM
-            );
+            context = docAnnotatorUtil.getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW);
             this.setContextStyles(config, context);
         }
 
@@ -196,12 +184,7 @@ class DocDrawingThread extends DrawingThread {
         // Set the scale and in-memory context for the pending thread
         this.lastScaleFactor = scale;
         this.pageEl = docAnnotatorUtil.getPageEl(this.annotatedElement, this.location.page);
-        this.drawingContext = docAnnotatorUtil.getContext(
-            this.pageEl,
-            CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS,
-            PAGE_PADDING_TOP,
-            PAGE_PADDING_BOTTOM
-        );
+        this.drawingContext = docAnnotatorUtil.getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS);
 
         const config = { scale };
         this.setContextStyles(config);

--- a/src/lib/annotations/doc/DocHighlightThread.js
+++ b/src/lib/annotations/doc/DocHighlightThread.js
@@ -375,12 +375,7 @@ class DocHighlightThread extends AnnotationThread {
     /* istanbul ignore next */
     draw(fillStyle) {
         const pageEl = this.getPageEl();
-        const context = docAnnotatorUtil.getContext(
-            pageEl,
-            CLASS_ANNOTATION_LAYER_HIGHLIGHT,
-            PAGE_PADDING_TOP,
-            PAGE_PADDING_BOTTOM
-        );
+        const context = docAnnotatorUtil.getContext(pageEl, CLASS_ANNOTATION_LAYER_HIGHLIGHT);
         if (!context) {
             return;
         }

--- a/src/lib/annotations/doc/__tests__/docAnnotatorUtil-test.js
+++ b/src/lib/annotations/doc/__tests__/docAnnotatorUtil-test.js
@@ -1,21 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import {
-    isPresentation,
-    isInDialog,
-    hasActiveDialog,
-    fitDialogHeightInPage,
-    isPointInPolyOpt,
-    isSelectionPresent,
-    convertPDFSpaceToDOMSpace,
-    convertDOMSpaceToPDFSpace,
-    getBrowserCoordinatesFromLocation,
-    getLowerRightCornerOfLastQuadPoint,
-    getTopRightCornerOfLastQuadPoint,
-    isValidSelection,
-    getContext,
-    getPageEl,
-    isDialogDataType
-} from '../docAnnotatorUtil';
+import * as docAnnotatorUtil from '../docAnnotatorUtil';
 import {
     SELECTOR_ANNOTATION_DIALOG,
     SELECTOR_ANNOTATION_CONTAINER,
@@ -25,6 +9,7 @@ import {
 import * as annotatorUtil from '../../annotatorUtil';
 
 const sandbox = sinon.sandbox.create();
+let stubs = {};
 
 describe('lib/annotations/doc/docAnnotatorUtil', () => {
     before(() => {
@@ -38,38 +23,39 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
     afterEach(() => {
         sandbox.verifyAndRestore();
         fixture.cleanup();
+        stubs = {};
     });
 
     describe('isPresentation()', () => {
         it('should return false if annotatedElement is a document', () => {
             const docEl = document.querySelector('.annotatedElement');
-            const result = isPresentation(docEl);
+            const result = docAnnotatorUtil.isPresentation(docEl);
             expect(result).to.be.false;
         });
 
         it('should return true if annotatedElement is a presentation', () => {
             const docEl = document.querySelector('.annotatedElement');
             docEl.classList.add('bp-doc-presentation');
-            const result = isPresentation(docEl);
+            const result = docAnnotatorUtil.isPresentation(docEl);
             expect(result).to.be.true;
         });
     });
 
     describe('isInDialog()', () => {
         it('should return false if no dialog element exists', () => {
-            const result = isInDialog({ clientX: 8, clientY: 8 });
+            const result = docAnnotatorUtil.isInDialog({ clientX: 8, clientY: 8 });
             expect(result).to.be.false;
         });
 
         it('should return true if the event is in the given dialog', () => {
             const dialogEl = document.querySelector(SELECTOR_ANNOTATION_DIALOG);
-            const result = isInDialog({ clientX: 8, clientY: 8 }, dialogEl);
+            const result = docAnnotatorUtil.isInDialog({ clientX: 8, clientY: 8 }, dialogEl);
             expect(result).to.be.true;
         });
 
         it('should return false if the event is in the given dialog', () => {
             const dialogEl = document.querySelector(SELECTOR_ANNOTATION_DIALOG);
-            const result = isInDialog({ clientX: 100, clientY: 100 }, dialogEl);
+            const result = docAnnotatorUtil.isInDialog({ clientX: 100, clientY: 100 }, dialogEl);
             expect(result).to.be.false;
         });
     });
@@ -78,7 +64,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
         it('should return false if no annotation dialog is open', () => {
             const currDialogEl = document.querySelector(SELECTOR_ANNOTATION_DIALOG);
             currDialogEl.classList.add('bp-is-hidden');
-            const result = hasActiveDialog(document);
+            const result = docAnnotatorUtil.hasActiveDialog(document);
             expect(result).to.be.false;
         });
 
@@ -91,7 +77,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
             openDialogEl.classList.add(CLASS_ANNOTATION_DIALOG);
             docEl.appendChild(openDialogEl);
 
-            const result = hasActiveDialog(document);
+            const result = docAnnotatorUtil.hasActiveDialog(document);
             expect(result).to.be.true;
         });
     });
@@ -106,7 +92,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
             const pageHeight = 20;
             const yPos = 5;
 
-            fitDialogHeightInPage(docEl, dialogEl, pageHeight, yPos);
+            docAnnotatorUtil.fitDialogHeightInPage(docEl, dialogEl, pageHeight, yPos);
 
             const annotationsEl = dialogEl.querySelector(SELECTOR_ANNOTATION_CONTAINER);
             expect(annotationsEl.style.maxHeight).to.not.be.undefined;
@@ -116,12 +102,12 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
     describe('isPointInPolyOpt()', () => {
         it('should return true if point is inside polygon', () => {
             const polygon = [[0, 0], [100, 0], [100, 100], [0, 100]];
-            assert.ok(isPointInPolyOpt(polygon, 50, 50));
+            expect(docAnnotatorUtil.isPointInPolyOpt(polygon, 50, 50)).to.be.true;
         });
 
         it('should return false if point is outside polygon', () => {
             const polygon = [[0, 0], [100, 0], [100, 100], [0, 100]];
-            assert.ok(!isPointInPolyOpt(polygon, 120, 50));
+            expect(docAnnotatorUtil.isPointInPolyOpt(polygon, 120, 50)).to.be.false;
         });
     });
 
@@ -132,11 +118,11 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
             range.selectNode(barEl.childNodes[0]);
             const selection = window.getSelection();
             selection.addRange(range);
-            assert.ok(isSelectionPresent());
+            expect(docAnnotatorUtil.isSelectionPresent()).to.be.true;
         });
 
         it('should return false if there is no non-empty selection on the page', () => {
-            assert.ok(!isSelectionPresent());
+            expect(docAnnotatorUtil.isSelectionPresent()).to.be.false;
         });
     });
 
@@ -146,7 +132,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
 
             // 300 * 4/3 * 0.5, 1000 - 300 * 4/3 * 0.5
             const expected = [200, 800];
-            assert.equal(convertPDFSpaceToDOMSpace(coordinates, 1000, 0.5).toString(), expected.toString());
+            expect(docAnnotatorUtil.convertPDFSpaceToDOMSpace(coordinates, 1000, 0.5)).to.deep.equals(expected);
         });
     });
 
@@ -156,7 +142,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
 
             // 400 * 3/4 / 0.5 to fixed 4, (1000 - 400) * 3/4 / 0.5 to fixed 4
             const expected = [Number(600).toFixed(4), Number(900).toFixed(4)];
-            assert.equal(convertDOMSpaceToPDFSpace(coordinates, 1000, 0.5).toString(), expected.toString());
+            expect(docAnnotatorUtil.convertDOMSpaceToPDFSpace(coordinates, 1000, 0.5)).to.deep.equals(expected);
         });
     });
 
@@ -175,20 +161,20 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
             annotatedEl.style.height = '1030px';
             annotatedEl.style.width = '600px';
 
-            assert.equal(getBrowserCoordinatesFromLocation(location, annotatedEl).toString(), [400, 600].toString());
+            expect(docAnnotatorUtil.getBrowserCoordinatesFromLocation(location, annotatedEl)).to.deep.equals([400, 600]);
         });
     });
 
     describe('getLowerRightCornerOfLastQuadPoint()', () => {
         const quadPoints = [[0, 10, 10, 10, 10, 20, 0, 20], [0, 0, 10, 0, 10, 10, 0, 10]];
 
-        assert.equal(getLowerRightCornerOfLastQuadPoint(quadPoints).toString(), [10, 0].toString());
+        expect(docAnnotatorUtil.getLowerRightCornerOfLastQuadPoint(quadPoints)).to.deep.equals([10, 0]);
     });
 
     describe('getTopRightCornerOfLastQuadPoint()', () => {
         const quadPoints = [[0, 10, 10, 10, 10, 20, 0, 20], [0, 0, 10, 0, 10, 10, 0, 10]];
 
-        assert.equal(getTopRightCornerOfLastQuadPoint(quadPoints).toString(), [0, 0].toString());
+        expect(docAnnotatorUtil.getTopRightCornerOfLastQuadPoint(quadPoints)).to.deep.equals([0, 0]);
     });
 
     describe('isValidSelection', () => {
@@ -198,7 +184,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
                 isCollapsed: false,
                 toString: () => 'I am valid!'
             };
-            expect(isValidSelection(selection)).to.be.false;
+            expect(docAnnotatorUtil.isValidSelection(selection)).to.be.false;
         });
 
         it('should return false if the selection isn\'t collapsed', () => {
@@ -207,7 +193,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
                 isCollapsed: true,
                 toString: () => 'I am valid!'
             };
-            expect(isValidSelection(selection)).to.be.false;
+            expect(docAnnotatorUtil.isValidSelection(selection)).to.be.false;
         });
 
         it('should return false if the selection is empty', () => {
@@ -216,7 +202,7 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
                 isCollapsed: false,
                 toString: () => ''
             };
-            expect(isValidSelection(selection)).to.be.false;
+            expect(docAnnotatorUtil.isValidSelection(selection)).to.be.false;
         });
 
         it('should return true if the selection is valid', () => {
@@ -225,57 +211,95 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
                 isCollapsed: false,
                 toString: () => 'I am valid!'
             };
-            expect(isValidSelection(selection)).to.be.true;
+            expect(docAnnotatorUtil.isValidSelection(selection)).to.be.true;
+        });
+    });
+
+    describe('scaleCanvas()', () => {
+        const width = 100;
+        const height = 200;
+
+        // PAGE_PADDING_TOP + PAGE_PADDING_BOTTOM
+        const pagePadding = 30;
+
+        beforeEach(() => {
+            stubs.annotationLayer = document.createElement('canvas');
+            stubs.pageEl = {
+                getBoundingClientRect: sandbox.stub().returns({
+                    width,
+                    height
+                })
+            };
+
+            stubs.canvasHeight = height - pagePadding;
+        });
+
+        it('should adjust canvas height and width and return the scaled canvas', () => {
+            const scaledCanvas = docAnnotatorUtil.scaleCanvas(stubs.pageEl, stubs.annotationLayer);
+            expect(scaledCanvas.width).equals(width);
+            expect(scaledCanvas.height).equals(stubs.canvasHeight);
+            expect(scaledCanvas.style.width).not.equals(`${width}px`);
+            expect(scaledCanvas.style.height).not.equals(`${height}px`);
+        });
+
+        it('should add style height & width if device pixel ratio is not 1', () => {
+            const pxRatio = 2;
+            window.devicePixelRatio = pxRatio;
+
+            const scaledCanvas = docAnnotatorUtil.scaleCanvas(stubs.pageEl, stubs.annotationLayer);
+
+            expect(scaledCanvas.width).equals(width * pxRatio);
+            expect(scaledCanvas.height).equals(stubs.canvasHeight * pxRatio);
+            expect(scaledCanvas.style.width).equals(`${width}px`);
+            expect(scaledCanvas.style.height).equals(`${stubs.canvasHeight}px`);
         });
     });
 
     describe('getContext()', () => {
-        it('should return null if there is no pageEl', () => {
-            const result = getContext(null, 'random-class-name', 0, 0);
-            expect(result).to.equal(null);
-        });
-
-        it('should not insert into the pageEl if the annotationLayerEl already exists', () => {
-            const annotationLayer = {
+        beforeEach(() => {
+            stubs.annotationLayer = {
                 width: 0,
                 height: 0,
-                getContext: sandbox.stub().returns('2d context')
-            };
-            const pageEl = {
-                querySelector: sandbox.stub().returns(annotationLayer),
-                getBoundingClientRect: sandbox.stub(),
-                insertBefore: sandbox.stub()
-            };
-
-            getContext(pageEl, 'random-class-name');
-            expect(annotationLayer.getContext).to.be.called;
-            expect(pageEl.insertBefore).to.not.be.called;
-        });
-
-        it('should insert into the pageEl if the annotationLayerEl does not exist', () => {
-            const annotationLayer = {
-                width: 0,
-                height: 0,
-                getContext: sandbox.stub().returns({
-                    scale: sandbox.stub()
-                }),
+                getContext: sandbox.stub().returns('2d context'),
                 classList: {
                     add: sandbox.stub()
                 },
                 style: {}
             };
-            const pageEl = {
-                querySelector: sandbox.stub().returns(undefined),
-                getBoundingClientRect: sandbox.stub().returns({ width: 0, height: 0 }),
+
+            stubs.pageEl = {
+                querySelector: sandbox.stub(),
+                getBoundingClientRect: sandbox.stub(),
                 insertBefore: sandbox.stub()
             };
-            const docStub = sandbox.stub(document, 'createElement').returns(annotationLayer);
 
-            getContext(pageEl, 'random-class-name', 0, 0);
+            sandbox.stub(docAnnotatorUtil, 'scaleCanvas').returns(stubs.annotationLayer);
+        });
+
+        it('should return null if there is no pageEl', () => {
+            const result = docAnnotatorUtil.getContext(null, 'random-class-name', 0, 0);
+            expect(result).to.equal(null);
+        });
+
+        it('should not insert into the pageEl if the annotationLayerEl already exists', () => {
+            stubs.pageEl.querySelector.returns(stubs.annotationLayer);
+            docAnnotatorUtil.getContext(stubs.pageEl, 'random-class-name');
+            expect(stubs.annotationLayer.getContext).to.be.called;
+            expect(stubs.pageEl.insertBefore).to.not.be.called;
+        });
+
+        it('should insert into the pageEl if the annotationLayerEl does not exist', () => {
+            stubs.annotationLayer.getContext.returns({
+                scale: sandbox.stub()
+            });
+            stubs.pageEl.getBoundingClientRect.returns({ width: 0, height: 0 });
+            const docStub = sandbox.stub(document, 'createElement').returns(stubs.annotationLayer);
+
+            docAnnotatorUtil.getContext(stubs.pageEl, 'random-class-name', 0, 0);
             expect(docStub).to.be.called;
-            expect(annotationLayer.getContext).to.be.called;
-            expect(annotationLayer.classList.add).to.be.called;
-            expect(pageEl.insertBefore).to.be.called;
+            expect(stubs.annotationLayer.getContext).to.be.called;
+            expect(stubs.annotationLayer.classList.add).to.be.called;
+            expect(stubs.pageEl.insertBefore).to.be.called;
         });
     });
 
@@ -286,20 +310,20 @@ describe('lib/annotations/doc/docAnnotatorUtil', () => {
             const truePageEl = document.querySelector(`.page[data-page-number="${page}"]`);
             docEl.appendChild(truePageEl);
 
-            const pageEl = getPageEl(docEl, page);
-            assert.equal(pageEl, truePageEl);
+            const pageEl = docAnnotatorUtil.getPageEl(docEl, page);
+            expect(pageEl).equals(truePageEl);
         });
     });
 
     describe('isDialogDataType()', () => {
         it('should return true if the mouse event occured in a highlight dialog', () => {
             sandbox.stub(annotatorUtil, 'findClosestDataType').returns(DATA_TYPE_ANNOTATION_DIALOG);
-            expect(isDialogDataType({})).to.be.true;
+            expect(docAnnotatorUtil.isDialogDataType({})).to.be.true;
         });
 
         it('should return false if the mouse event occured outside a highlight dialog', () => {
             sandbox.stub(annotatorUtil, 'findClosestDataType').returns('something');
-            expect(isDialogDataType({})).to.be.false;
+            expect(docAnnotatorUtil.isDialogDataType({})).to.be.false;
         });
     });
 });

--- a/src/lib/annotations/doc/docAnnotatorUtil.js
+++ b/src/lib/annotations/doc/docAnnotatorUtil.js
@@ -357,6 +357,31 @@ export function isValidSelection(selection) {
 }
 
 /**
+ * Scales the canvas an annotation should be drawn on
+ *
+ * @param {HTMLElement} pageEl - The DOM element for the current page
+ * @param {HTMLElement} annotationLayerEl - The annotation canvas layer
+ * @return {HTMLElement} The scaled annotation canvas layer
+ */
+export function scaleCanvas(pageEl, annotationLayerEl) {
+    const pageDimensions = pageEl.getBoundingClientRect();
+    const pxRatio = window.devicePixelRatio || 1;
+    const width = pageDimensions.width;
+    const height = pageDimensions.height - PAGE_PADDING_TOP - PAGE_PADDING_BOTTOM;
+
+    const scaledCanvas = annotationLayerEl;
+    scaledCanvas.width = pxRatio * width;
+    scaledCanvas.height = pxRatio * height;
+
+    if (pxRatio !== 1) {
+        scaledCanvas.style.width = `${width}px`;
+        scaledCanvas.style.height = `${height}px`;
+    }
+
+    return scaledCanvas;
+}
+
+/**
  * Gets the context an annotation should be drawn on.
  *
  * @param {HTMLElement} pageEl - The DOM element for the current page
@@ -365,41 +390,23 @@ export function isValidSelection(selection) {
  * @param {number} [paddingBottom] - The bottom padding of each page element
  * @return {RenderingContext|null} Context or null if no page element was given
  */
-export function getContext(pageEl, annotationLayerClass, paddingTop, paddingBottom) {
+export function getContext(pageEl, annotationLayerClass) {
     if (!pageEl) {
         return null;
     }
 
-    let annotationLayerEl = pageEl.querySelector(`.${annotationLayerClass}`);
-    let context;
     // Create annotation layer if one does not exist (e.g. first load or page resize)
+    let annotationLayerEl = pageEl.querySelector(`.${annotationLayerClass}`);
     if (!annotationLayerEl) {
         annotationLayerEl = document.createElement('canvas');
         annotationLayerEl.classList.add(annotationLayerClass);
-        const pageDimensions = pageEl.getBoundingClientRect();
-        const pagePaddingTop = paddingTop || 0;
-        const pagePaddingBottom = paddingBottom || 0;
-        const pxRatio = window.devicePixelRatio || 1;
-        const width = pageDimensions.width;
-        const height = pageDimensions.height - pagePaddingTop - pagePaddingBottom;
-
-        annotationLayerEl.width = pxRatio * width;
-        annotationLayerEl.height = pxRatio * height;
-        context = annotationLayerEl.getContext('2d');
-
-        if (pxRatio !== 1) {
-            annotationLayerEl.style.width = `${width}px`;
-            annotationLayerEl.style.height = `${height}px`;
-            context.scale(pxRatio, pxRatio);
-        }
+        annotationLayerEl = scaleCanvas(pageEl, annotationLayerEl);
 
         const textLayerEl = pageEl.querySelector('.textLayer');
         pageEl.insertBefore(annotationLayerEl, textLayerEl);
-    } else {
-        context = annotationLayerEl.getContext('2d');
     }
 
-    return context;
+    return annotationLayerEl.getContext('2d');
 }
 
 /**


### PR DESCRIPTION
- Fixes the bug where the annotations canvas fails to re-render on zoom which results in highlights and drawings being incorrectly positioned
- Includes a CSS fix for highlight create dialog on mobile