### PR TITLE
New: Separate create and view permissions for annotations

### DIFF
--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -50,6 +50,7 @@ class AnnotationThread extends EventEmitter {
         this.type = data.type;
         this.locale = data.locale;
         this.isMobile = data.isMobile;
+        this.permissions = data.permissions;
 
         this.setup();
     }

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -552,8 +552,7 @@ class Annotator extends EventEmitter {
                 const annotations = threadMap[threadID];
                 const firstAnnotation = annotations[0];
 
-                const isModeEnabled = this.isModeAnnotatable(firstAnnotation.type);
-                if (!firstAnnotation || !isModeEnabled) {
+                if (!firstAnnotation || !this.isModeAnnotatable(firstAnnotation.type)) {
                     return;
                 }
 

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -292,7 +292,8 @@ class DocAnnotator extends Annotator {
             isMobile: this.isMobile,
             locale: this.locale,
             location,
-            type
+            type,
+            permissions: this.permissions
         };
 
         // Set existing thread ID if created with annotations
@@ -455,10 +456,6 @@ class DocAnnotator extends Annotator {
 
         this.annotatedElement.addEventListener('mouseup', this.highlightMouseupHandler);
 
-        if (!this.canAnnotate) {
-            return;
-        }
-
         if (this.hasTouch && this.isMobile) {
             document.addEventListener('selectionchange', this.onSelectionChange);
             this.annotatedElement.addEventListener('touchstart', this.drawingSelectionHandler);
@@ -488,7 +485,7 @@ class DocAnnotator extends Annotator {
             this.highlightThrottleHandle = null;
         }
 
-        if (!this.canAnnotate) {
+        if (!this.permissions.canAnnotate) {
             return;
         }
 

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -485,10 +485,6 @@ class DocAnnotator extends Annotator {
             this.highlightThrottleHandle = null;
         }
 
-        if (!this.permissions.canAnnotate) {
-            return;
-        }
-
         if (this.hasTouch && this.isMobile) {
             document.removeEventListener('selectionchange', this.onSelectionChange);
             this.annotatedElement.removeEventListener('touchstart', this.drawingSelectionHandler);

--- a/src/lib/annotations/doc/DocHighlightDialog.js
+++ b/src/lib/annotations/doc/DocHighlightDialog.js
@@ -295,7 +295,7 @@ class DocHighlightDialog extends AnnotationDialog {
 
             if (!this.canAnnotate) {
                 // Hide all action buttons if user cannot annotate
-                const highlightButtons = this.highlightDialogEl.querySelector(`.${constants.CLASS_HIGHLIGHT_BTNS}`);
+                const highlightButtons = this.highlightDialogEl.querySelector(constants.SELECTOR_HIGHLIGHT_BTNS);
                 annotatorUtil.hideElement(highlightButtons);
             } else if (annotations[0].permissions && !annotations[0].permissions.can_delete) {
                 // Hide delete button on plain highlights if user doesn't have permissions

--- a/src/lib/annotations/doc/DocHighlightDialog.js
+++ b/src/lib/annotations/doc/DocHighlightDialog.js
@@ -19,7 +19,7 @@ class DocHighlightDialog extends AnnotationDialog {
     // Public
     //--------------------------------------------------------------------------
 
-    /** 
+    /**
      * Saves an annotation with the associated text or blank if only
      * highlighting. Only adds an annotation to the dialog if it contains text.
      * The annotation is still added to the thread on the server side.
@@ -67,7 +67,7 @@ class DocHighlightDialog extends AnnotationDialog {
 
     /**
      * Set the state of the dialog so comments are hidden, if they're currently shown.
-     * 
+     *
      * @public
      * @return {void}
      */
@@ -293,9 +293,12 @@ class DocHighlightDialog extends AnnotationDialog {
             ]);
             annotatorUtil.showElement(highlightLabelEl);
 
-            // Hide delete button on plain highlights if user doesn't have
-            // permissions
-            if (annotations[0].permissions && !annotations[0].permissions.can_delete) {
+            if (!this.canAnnotate) {
+                // Hide all action buttons if user cannot annotate
+                const highlightButtons = this.highlightDialogEl.querySelector(`.${constants.CLASS_HIGHLIGHT_BTNS}`);
+                annotatorUtil.hideElement(highlightButtons);
+            } else if (annotations[0].permissions && !annotations[0].permissions.can_delete) {
+                // Hide delete button on plain highlights if user doesn't have permissions
                 const addHighlightBtn = this.highlightDialogEl.querySelector(constants.SELECTOR_ADD_HIGHLIGHT_BTN);
                 annotatorUtil.hideElement(addHighlightBtn);
             }
@@ -306,7 +309,7 @@ class DocHighlightDialog extends AnnotationDialog {
             this.addAnnotationElement(annotation);
         });
 
-        if (!this.isMobile) {
+        if (!this.isMobile && this.canAnnotate) {
             this.bindDOMListeners();
         }
     }

--- a/src/lib/annotations/doc/DocHighlightThread.js
+++ b/src/lib/annotations/doc/DocHighlightThread.js
@@ -273,7 +273,7 @@ class DocHighlightThread extends AnnotationThread {
             annotations: this.annotations,
             locale: this.locale,
             location: this.location,
-            canAnnotate: this.annotationService.canAnnotate
+            canAnnotate: this.permissions.canAnnotate
         });
 
         // Ensures that previously created annotations have the right type

--- a/src/lib/annotations/doc/DocPointThread.js
+++ b/src/lib/annotations/doc/DocPointThread.js
@@ -24,7 +24,7 @@ class DocPointThread extends AnnotationThread {
      */
     showDialog() {
         // Don't show dialog if user can annotate and there is a current selection
-        if (this.annotationService.canAnnotate && docAnnotatorUtil.isSelectionPresent()) {
+        if (this.permissions.canAnnotate && docAnnotatorUtil.isSelectionPresent()) {
             return;
         }
 
@@ -78,7 +78,7 @@ class DocPointThread extends AnnotationThread {
             annotations: this.annotations,
             locale: this.locale,
             location: this.location,
-            canAnnotate: this.annotationService.canAnnotate
+            canAnnotate: this.permissions.canAnnotate
         });
     }
 }

--- a/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
+++ b/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
@@ -556,7 +556,7 @@ describe('lib/annotations/doc/DocAnnotator', () => {
         });
 
         it('should bind selectionchange event, on the document, if on mobile and can annotate', () => {
-            annotator.annotationService.canAnnotate = true;
+            annotator.permissions.canAnnotate = true;
             annotator.isMobile = true;
             annotator.hasTouch = true;
             const docListen = sandbox.spy(document, 'addEventListener');
@@ -616,7 +616,7 @@ describe('lib/annotations/doc/DocAnnotator', () => {
         });
 
         it('should unbind selectionchange event, on the document, if on mobile, has touch and can annotate', () => {
-            annotator.annotationService.canAnnotate = true;
+            annotator.permissions.canAnnotate = true;
             annotator.isMobile = true;
             annotator.hasTouch = true;
             const docStopListen = sandbox.spy(document, 'removeEventListener');

--- a/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
+++ b/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
@@ -530,19 +530,6 @@ describe('lib/annotations/doc/DocAnnotator', () => {
             stubs.elMock = sandbox.mock(annotator.annotatedElement);
         });
 
-        it('shouldn\'t bind DOM listeners if user cannot annotate except mouseup', () => {
-            annotator.canAnnotate = false;
-
-            stubs.elMock.expects('addEventListener').withArgs('mouseup', sinon.match.func);
-            stubs.elMock.expects('addEventListener').withArgs('dblclick', sinon.match.func).never();
-            stubs.elMock.expects('addEventListener').withArgs('mousedown', sinon.match.func).never();
-            stubs.elMock.expects('addEventListener').withArgs('contextmenu', sinon.match.func).never();
-            stubs.elMock.expects('addEventListener').withArgs('mousemove', sinon.match.func).never();
-            stubs.elMock.expects('addEventListener').withArgs('touchstart', sinon.match.func).never();
-            stubs.elMock.expects('addEventListener').withArgs('click', sinon.match.func).never();
-            annotator.bindDOMListeners();
-        });
-
         it('should bind DOM listeners if user can annotate', () => {
             annotator.canAnnotate = true;
 
@@ -576,18 +563,6 @@ describe('lib/annotations/doc/DocAnnotator', () => {
             };
             stubs.elMock = sandbox.mock(annotator.annotatedElement);
             annotator.highlightMousemoveHandler = () => {};
-        });
-
-        it('should not unbind DOM listeners if user cannot annotate except mouseup', () => {
-            annotator.canAnnotate = false;
-
-            stubs.elMock.expects('removeEventListener').withArgs('mouseup', sinon.match.func);
-            stubs.elMock.expects('removeEventListener').withArgs('mousedown', sinon.match.func).never();
-            stubs.elMock.expects('removeEventListener').withArgs('contextmenu', sinon.match.func).never();
-            stubs.elMock.expects('removeEventListener').withArgs('mousemove', sinon.match.func).never();
-            stubs.elMock.expects('removeEventListener').withArgs('dblclick', sinon.match.func).never();
-            stubs.elMock.expects('removeEventListener').withArgs('click', sinon.match.func).never();
-            annotator.unbindDOMListeners();
         });
 
         it('should unbind DOM listeners if user can annotate', () => {

--- a/src/lib/annotations/doc/__tests__/DocHighlightDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/DocHighlightDialog-test.js
@@ -399,7 +399,20 @@ describe('lib/annotations/doc/DocHighlightDialog', () => {
             expect(stubs.show).to.be.called;
         });
 
-        it('should hide delete button on plain highlights if user does not have permissions', () => {
+        it('should hide all buttons on plain highlights if user does not have canAnnotate permissions', () => {
+            sandbox.stub(annotatorUtil, 'isPlainHighlight').returns(true);
+            dialog.canAnnotate = false;
+
+            dialog.setup([stubs.annotation]);
+            const highlightLabelEl = dialog.highlightDialogEl.querySelector(`.${CLASS_HIGHLIGHT_LABEL}`);
+            const highlightBtns = dialog.highlightDialogEl.querySelector(constants.SELECTOR_HIGHLIGHT_BTNS);
+            const addHighlightBtn = dialog.highlightDialogEl.querySelector(constants.SELECTOR_ADD_HIGHLIGHT_BTN);
+            expect(stubs.show).to.be.calledWith(highlightLabelEl);
+            expect(stubs.hide).to.be.calledWith(highlightBtns);
+            expect(stubs.hide).to.not.be.calledWith(addHighlightBtn);
+        });
+
+        it('should hide delete button on plain highlights if user does not have delete permissions', () => {
             sandbox.stub(annotatorUtil, 'isPlainHighlight').returns(true);
             stubs.annotation.permissions.can_delete = false;
 

--- a/src/lib/annotations/doc/__tests__/DocHighlightThread-test.js
+++ b/src/lib/annotations/doc/__tests__/DocHighlightThread-test.js
@@ -33,7 +33,11 @@ describe('lib/annotations/doc/DocHighlightThread', () => {
             fileVersionId: 1,
             location: {},
             threadID: 2,
-            type: 'highlight'
+            type: 'highlight',
+            permissions: {
+                canAnnotate: true,
+                canViewAllAnnotations: true
+            }
         });
         highlightThread.dialog.setup([]);
     });
@@ -151,7 +155,11 @@ describe('lib/annotations/doc/DocHighlightThread', () => {
                 fileVersionId: 1,
                 location: {},
                 threadID: 2,
-                type: 'highlight'
+                type: 'highlight',
+                permissions: {
+                    canAnnotate: true,
+                    canViewAllAnnotations: true
+                }
             });
             plainHighlightThread.dialog.setup([]);
 
@@ -178,7 +186,11 @@ describe('lib/annotations/doc/DocHighlightThread', () => {
                 fileVersionId: 1,
                 location: {},
                 threadID: 2,
-                type: 'highlight'
+                type: 'highlight',
+                permissions: {
+                    canAnnotate: true,
+                    canViewAllAnnotations: true
+                }
             });
 
             Object.defineProperty(Object.getPrototypeOf(DocHighlightThread.prototype), 'deleteAnnotation', {

--- a/src/lib/annotations/doc/__tests__/DocPointThread-test.js
+++ b/src/lib/annotations/doc/__tests__/DocPointThread-test.js
@@ -24,7 +24,10 @@ describe('lib/annotations/doc/DocPointThread', () => {
             fileVersionId: 1,
             location: {},
             threadID: 2,
-            type: 'point'
+            type: 'point',
+            permissions: {
+                canAnnotate: true
+            }
         });
     });
 
@@ -35,7 +38,6 @@ describe('lib/annotations/doc/DocPointThread', () => {
 
     describe('showDialog', () => {
         it('should not call parent showDialog if user can annotate and there is a selection present', () => {
-            pointThread.permissions.canAnnotate = true;
             sandbox.stub(docAnnotatorUtil, 'isSelectionPresent').returns(true);
 
             // This stubs out a parent method by forcing the method we care about
@@ -62,7 +64,6 @@ describe('lib/annotations/doc/DocPointThread', () => {
         });
 
         it('should call parent showDialog if there isn\'t a selection present', () => {
-            pointThread.permissions.canAnnotate = true;
             sandbox.stub(docAnnotatorUtil, 'isSelectionPresent').returns(false);
             Object.defineProperty(Object.getPrototypeOf(DocPointThread.prototype), 'showDialog', {
                 value: sandbox.stub()

--- a/src/lib/annotations/doc/__tests__/DocPointThread-test.js
+++ b/src/lib/annotations/doc/__tests__/DocPointThread-test.js
@@ -35,7 +35,7 @@ describe('lib/annotations/doc/DocPointThread', () => {
 
     describe('showDialog', () => {
         it('should not call parent showDialog if user can annotate and there is a selection present', () => {
-            pointThread.annotationService.canAnnotate = true;
+            pointThread.permissions.canAnnotate = true;
             sandbox.stub(docAnnotatorUtil, 'isSelectionPresent').returns(true);
 
             // This stubs out a parent method by forcing the method we care about
@@ -51,7 +51,7 @@ describe('lib/annotations/doc/DocPointThread', () => {
         });
 
         it('should call parent showDialog if user can\'t annotate', () => {
-            pointThread.annotationService.canAnnotate = false;
+            pointThread.permissions.canAnnotate = false;
             Object.defineProperty(Object.getPrototypeOf(DocPointThread.prototype), 'showDialog', {
                 value: sandbox.stub()
             });
@@ -62,7 +62,7 @@ describe('lib/annotations/doc/DocPointThread', () => {
         });
 
         it('should call parent showDialog if there isn\'t a selection present', () => {
-            pointThread.annotationService.canAnnotate = true;
+            pointThread.permissions.canAnnotate = true;
             sandbox.stub(docAnnotatorUtil, 'isSelectionPresent').returns(false);
             Object.defineProperty(Object.getPrototypeOf(DocPointThread.prototype), 'showDialog', {
                 value: sandbox.stub()

--- a/src/lib/annotations/image/ImageAnnotator.js
+++ b/src/lib/annotations/image/ImageAnnotator.js
@@ -116,7 +116,8 @@ class ImageAnnotator extends Annotator {
             isMobile: this.isMobile,
             locale: this.locale,
             location: fixedLocation,
-            type
+            type,
+            permissions: this.permissions
         };
 
         if (!annotatorUtil.validateThreadParams(threadParams)) {

--- a/src/lib/annotations/image/ImagePointThread.js
+++ b/src/lib/annotations/image/ImagePointThread.js
@@ -57,7 +57,7 @@ class ImagePointThread extends AnnotationThread {
             annotations: this.annotations,
             location: this.location,
             locale: this.locale,
-            canAnnotate: this.annotationService.canAnnotate
+            canAnnotate: this.permissions.canAnnotate
         });
     }
 }

--- a/src/lib/annotations/image/__tests__/ImagePointThread-test.js
+++ b/src/lib/annotations/image/__tests__/ImagePointThread-test.js
@@ -23,7 +23,10 @@ describe('lib/annotations/image/ImagePointThread', () => {
             fileVersionId: 1,
             location: {},
             threadID: 2,
-            type: 'point'
+            type: 'point',
+            permissions: {
+                canAnnotate: true
+            }
         });
 
         thread.dialog = {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -680,17 +680,17 @@ class BaseViewer extends EventEmitter {
      */
     initAnnotations() {
         const { apiHost, container, file, location, token } = this.options;
-        const { id: fileId, file_version: { id: fileVersionId } } = file;
+        const { id: fileId, file_version: { id: fileVersionId }, permissions } = file;
 
         // Construct and init annotator
         this.annotator = new this.annotatorConf.CONSTRUCTOR({
-            canAnnotate: this.canAnnotate,
             container,
             options: {
                 annotator: this.annotatorConf,
                 apiHost,
                 fileId,
-                token
+                token,
+                permissions
             },
             fileVersionId,
             isMobile: this.isMobile,


### PR DESCRIPTION
Enables annotations to be shown in a view-only setting with the correct scopes

Annotations permissions will be as follows:
- can_annotate - whether a user can add any new annotations
- can_view_annotations_all - whether a user can view all annotations
- can_view_annotations_self - whether a user can view their own annotations (The API should return only the current user's annotations for this scope)