### PR TITLE
Update: Allow passed in collections to be of file objects

### DIFF
--- a/src/lib/__tests__/tokens-test.js
+++ b/src/lib/__tests__/tokens-test.js
@@ -5,19 +5,45 @@ describe('lib/tokens', () => {
         return Promise.resolve('token');
     }
 
-    function mapTokenFunction(ids) {
-        return Promise.resolve({
-            [ids[0]]: 'token1',
-            [ids[1]]: 'token2'
-        });
+    function mapIdTokenFunction(ids) {
+        if (ids.length > 1) {
+            return Promise.resolve({
+                [ids[0].replace('file_', '')]: 'token1',
+                [ids[1].replace('file_', '')]: 'token2'
+            });
+        } else {
+            return Promise.resolve({
+                [ids[0].replace('file_', '')]: 'token1'
+            });
+        }
+    }
+
+    function mapTypedIdTokenFunction(ids) {
+        if (ids.length > 1) {
+            return Promise.resolve({
+                [ids[0]]: 'token1',
+                [ids[1]]: 'token2'
+            });
+        } else {
+            return Promise.resolve({
+                [ids[0]]: 'token1'
+            });
+        }
     }
 
     describe('getTokens', () => {
         it('should throw an error when no id provided', () => {
             return getTokens(null, 'token').should.be.rejectedWith(Error);
         });
-        it('should throw an error when no token provided', () => {
-            return getTokens('123').should.be.rejectedWith(Error);
+        it('should use undefined token when no token provided', () => {
+            return getTokens('123').then((data) => {
+                assert.equal(undefined, data['123']);
+            });
+        });
+        it('should use null token when null token provided', () => {
+            return getTokens('123', null).then((data) => {
+                assert.equal(null, data['123']);
+            });
         });
         it('should create id token map with string token and string id', () => {
             return getTokens('123', 'token').then((data) => {
@@ -42,18 +68,29 @@ describe('lib/tokens', () => {
             });
         });
         it('should create id token map with function token that returns map and string id', () => {
-            return getTokens('123', mapTokenFunction).then((data) => {
+            return getTokens('123', mapIdTokenFunction).then((data) => {
                 assert.equal('token1', data['123']);
             });
         });
         it('should create id token map with function token that returns map and array of string ids', () => {
-            return getTokens(['123', '456'], mapTokenFunction).then((data) => {
+            return getTokens(['123', '456'], mapIdTokenFunction).then((data) => {
+                assert.equal('token1', data['123']);
+                assert.equal('token2', data['456']);
+            });
+        });
+        it('should create id token map with function token that returns map and string typed id', () => {
+            return getTokens('123', mapTypedIdTokenFunction).then((data) => {
+                assert.equal('token1', data['123']);
+            });
+        });
+        it('should create id token map with function token that returns map and array of string typed ids', () => {
+            return getTokens(['123', '456'], mapTypedIdTokenFunction).then((data) => {
                 assert.equal('token1', data['123']);
                 assert.equal('token2', data['456']);
             });
         });
         it('should throw an error when not all tokens could be fetched', () => {
-            return getTokens(['123', '456', '789'], mapTokenFunction).should.be.rejectedWith(Error);
+            return getTokens(['123', '456', '789'], mapIdTokenFunction).should.be.rejectedWith(Error);
         });
     });
 });


### PR DESCRIPTION
Allows tokens to be null or undefined. Useful when the passed in file or collection has well formed file objects. This is for offline use case or the use case where the parent project (like ContentExplorer UI Element) has already made the call.

Also changes the token getter to pass in typed ids for files and handle cases when typed ids are returned from the token service to make it consistent with other UI Elements. Since all the UI elements can either be requesting `folder` or `file` ids, the token service needs to know what type of id we are sending it, as such either `file_` or `folder_` is prefixed to all the ids. Likewise the token service can/will return typed ids after fetching tokens. So it needs to be mapped back to what preview wants.