### PR TITLE
New: Emit annotation thread events to the viewer and beyond

### DIFF
--- a/src/lib/annotations/AnnotationModeController.js
+++ b/src/lib/annotations/AnnotationModeController.js
@@ -109,7 +109,7 @@ class AnnotationModeController extends EventEmitter {
 
         // TODO (@minhnguyen): Move annotator.bindCustomListenersOnThread logic to AnnotationModeController
         this.annotator.bindCustomListenersOnThread(thread);
-        thread.addListener('annotationevent', (data) => {
+        thread.addListener('threadevent', (data) => {
             this.handleAnnotationEvent(thread, data);
         });
     }
@@ -127,7 +127,6 @@ class AnnotationModeController extends EventEmitter {
         }
 
         thread.removeAllListeners('threadevent');
-        thread.removeAllListeners('annotationevent');
     }
 
     /**

--- a/src/lib/annotations/AnnotationModeController.js
+++ b/src/lib/annotations/AnnotationModeController.js
@@ -126,9 +126,7 @@ class AnnotationModeController extends EventEmitter {
             return;
         }
 
-        thread.removeAllListeners('threaddeleted');
-        thread.removeAllListeners('threadcleanup');
-        thread.removeAllListeners('annotationsaved');
+        thread.removeAllListeners('threadevent');
         thread.removeAllListeners('annotationevent');
     }
 

--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -172,7 +172,9 @@ class AnnotationThread extends EventEmitter {
         // Ignore if no corresponding annotation exists in thread or user doesn't have permissions
         const annotation = this.annotations.find((annot) => annot.annotationID === annotationID);
         if (!annotation || (annotation.permissions && !annotation.permissions.can_delete)) {
-            return Promise.resolve();
+            // Broadcast error
+            this.emit(THREAD_EVENT.deleteError);
+            return Promise.reject();
         }
 
         // Delete annotation on client

--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -4,7 +4,13 @@ import Annotation from './Annotation';
 import AnnotationService from './AnnotationService';
 import * as annotatorUtil from './annotatorUtil';
 import { ICON_PLACED_ANNOTATION } from '../icons/icons';
-import { STATES, TYPES, CLASS_ANNOTATION_POINT_MARKER, DATA_TYPE_ANNOTATION_INDICATOR } from './annotationConstants';
+import {
+    STATES,
+    TYPES,
+    CLASS_ANNOTATION_POINT_MARKER,
+    DATA_TYPE_ANNOTATION_INDICATOR,
+    THREAD_EVENT
+} from './annotationConstants';
 
 @autobind
 class AnnotationThread extends EventEmitter {
@@ -77,7 +83,7 @@ class AnnotationThread extends EventEmitter {
             this.element = null;
         }
 
-        this.emit('threaddeleted');
+        this.emit(THREAD_EVENT.threadDelete);
     }
 
     /**
@@ -157,7 +163,7 @@ class AnnotationThread extends EventEmitter {
                 this.deleteAnnotation(tempAnnotationID, /* useServer */ false);
 
                 // Broadcast error
-                this.emit('annotationcreateerror');
+                this.emit(THREAD_EVENT.createError);
             });
     }
 
@@ -217,12 +223,15 @@ class AnnotationThread extends EventEmitter {
 
                     // Broadcast thread cleanup if needed
                     if (this.annotations.length === 0) {
-                        this.emit('threadcleanup');
+                        this.emit(THREAD_EVENT.threadCleanup);
                     }
+
+                    // Broadcast annotation deletion event
+                    this.emit(THREAD_EVENT.delete);
                 })
                 .catch(() => {
                     // Broadcast error
-                    this.emit('annotationdeleteerror');
+                    this.emit(THREAD_EVENT.deleteError);
                 });
         }
     }
@@ -416,7 +425,32 @@ class AnnotationThread extends EventEmitter {
         if (!annotatorUtil.isPending(this.state)) {
             return;
         }
+
+        this.emit(THREAD_EVENT.cancel);
         this.destroy();
+    }
+
+    /**
+     * Generate threadData with relevant information to be emitted with an
+     * annotation thread event
+     *
+     * @protected
+     * @return {Object} threadData - Annotation event thread data
+     */
+    getThreadEventData() {
+        const threadData = {
+            type: this.type,
+            threadID: this.threadID
+        };
+
+        if (this.annotationService.user.id > 0) {
+            threadData.userId = this.annotationService.user.id;
+        }
+        if (this.threadNumber) {
+            threadData.threadNumber = this.threadNumber;
+        }
+
+        return threadData;
     }
 
     //--------------------------------------------------------------------------
@@ -445,6 +479,7 @@ class AnnotationThread extends EventEmitter {
         // Set threadNumber if the savedAnnotation is the first annotation of the thread
         if (!this.threadNumber && savedAnnotation && savedAnnotation.threadNumber) {
             this.threadNumber = savedAnnotation.threadNumber;
+            this.emit(THREAD_EVENT.save);
         }
 
         if (this.dialog) {
@@ -457,8 +492,6 @@ class AnnotationThread extends EventEmitter {
             this.dialog.addAnnotation(savedAnnotation);
             this.dialog.removeAnnotation(tempAnnotation.annotationID);
         }
-
-        this.emit('annotationsaved');
     }
 
     /**
@@ -503,6 +536,10 @@ class AnnotationThread extends EventEmitter {
         if (this.dialog) {
             this.dialog.addAnnotation(annotation);
         }
+
+        if (this.annotations.length > 1) {
+            this.emit(THREAD_EVENT.save);
+        }
     }
 
     /**
@@ -545,6 +582,21 @@ class AnnotationThread extends EventEmitter {
      */
     deleteAnnotationWithID(data) {
         this.deleteAnnotation(data.annotationID);
+    }
+
+    /**
+     * Emits a generic viewer event
+     *
+     * @private
+     * @emits viewerevent
+     * @param {string} event - Event name
+     * @param {Object} data - Event data
+     * @return {void}
+     */
+    emit(event) {
+        const threadData = this.getThreadEventData();
+        super.emit(event, threadData);
+        super.emit('threadevent', { event, data: threadData });
     }
 }
 

--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -603,13 +603,13 @@ class AnnotationThread extends EventEmitter {
      * @private
      * @emits viewerevent
      * @param {string} event - Event name
-     * @param {Object} data - Event data
+     * @param {Object} eventData - Event data
      * @return {void}
      */
-    emit(event) {
+    emit(event, eventData) {
         const threadData = this.getThreadEventData();
-        super.emit(event, threadData);
-        super.emit('threadevent', { event, data: threadData });
+        super.emit(event, { data: threadData, eventData });
+        super.emit('threadevent', { event, data: threadData, eventData });
     }
 }
 

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -668,7 +668,7 @@ class Annotator extends EventEmitter {
         if (!service || !(service instanceof AnnotationService)) {
             return;
         }
-        service.removeAllListeners(ANNOTATOR_EVENT.error);
+        service.removeListener(ANNOTATOR_EVENT.error, this.handleServiceEvents);
     }
 
     /**
@@ -694,7 +694,7 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     unbindCustomListenersOnThread(thread) {
-        thread.removeAllListeners('threadevent');
+        thread.removeListener('threadevent', this.handleAnnotationThreadEvents);
     }
 
     /**

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -104,7 +104,7 @@ class Annotator extends EventEmitter {
 
         this.unbindDOMListeners();
         this.unbindCustomListenersOnService();
-        this.removeListener('scaleannotations', this.scaleAnnotations);
+        this.removeListener(ANNOTATOR_EVENT.scale, this.scaleAnnotations);
     }
 
     /**
@@ -539,7 +539,7 @@ class Annotator extends EventEmitter {
         this.threads = {};
         this.bindDOMListeners();
         this.bindCustomListenersOnService(this.annotationService);
-        this.addListener('scaleannotations', this.scaleAnnotations);
+        this.addListener(ANNOTATOR_EVENT.scale, this.scaleAnnotations);
     }
 
     /**
@@ -620,7 +620,7 @@ class Annotator extends EventEmitter {
         }
 
         /* istanbul ignore next */
-        service.addListener('annotatorerror', this.handleServiceEvents);
+        service.addListener(ANNOTATOR_EVENT.error, this.handleServiceEvents);
     }
 
     /**
@@ -668,7 +668,7 @@ class Annotator extends EventEmitter {
         if (!service || !(service instanceof AnnotationService)) {
             return;
         }
-        service.removeAllListeners('annotatorerror');
+        service.removeAllListeners(ANNOTATOR_EVENT.error);
     }
 
     /**
@@ -949,6 +949,10 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     handleAnnotationThreadEvents(data) {
+        if (!data.data || !data.data.threadID) {
+            return;
+        }
+
         const thread = this.getThreadByID(data.data.threadID);
         if (!thread) {
             return;

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -19,11 +19,10 @@ import {
     SELECTOR_ANNOTATION_BUTTON_DRAW_POST,
     SELECTOR_ANNOTATION_BUTTON_DRAW_UNDO,
     SELECTOR_ANNOTATION_BUTTON_DRAW_REDO,
-    TYPES
+    TYPES,
+    THREAD_EVENT,
+    ANNOTATOR_EVENT
 } from './annotationConstants';
-
-const MODE_ENTER = 'annotationmodeenter';
-const MODE_EXIT = 'annotationmodeexit';
 
 @autobind
 class Annotator extends EventEmitter {
@@ -105,7 +104,7 @@ class Annotator extends EventEmitter {
 
         this.unbindDOMListeners();
         this.unbindCustomListenersOnService();
-        this.removeListener('scaleAnnotations', this.scaleAnnotations);
+        this.removeListener('scaleannotations', this.scaleAnnotations);
     }
 
     /**
@@ -407,7 +406,7 @@ class Annotator extends EventEmitter {
             return;
         } else if (this.isInAnnotationMode(mode)) {
             this.currentAnnotationMode = null;
-            this.emit(MODE_EXIT);
+            this.emit(ANNOTATOR_EVENT.modeExit, { mode });
         }
 
         this.annotatedElement.classList.remove(CLASS_ANNOTATION_MODE);
@@ -441,7 +440,7 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     enableAnnotationMode(mode, buttonEl) {
-        this.emit(MODE_ENTER, mode);
+        this.emit(ANNOTATOR_EVENT.modeEnter, { mode });
         this.annotatedElement.classList.add(CLASS_ANNOTATION_MODE);
         if (buttonEl) {
             buttonEl.classList.add(CLASS_ACTIVE);
@@ -540,7 +539,7 @@ class Annotator extends EventEmitter {
         this.threads = {};
         this.bindDOMListeners();
         this.bindCustomListenersOnService(this.annotationService);
-        this.addListener('scaleAnnotations', this.scaleAnnotations);
+        this.addListener('scaleannotations', this.scaleAnnotations);
     }
 
     /**
@@ -585,7 +584,7 @@ class Annotator extends EventEmitter {
                 }
             });
 
-            this.emit('annotationsfetched');
+            this.emit(ANNOTATOR_EVENT.fetch);
         });
     }
 
@@ -654,7 +653,7 @@ class Annotator extends EventEmitter {
         }
 
         if (errorMessage) {
-            this.emit('annotatorerror', errorMessage);
+            this.emit(ANNOTATOR_EVENT.error, errorMessage);
         }
     }
 
@@ -684,17 +683,7 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        // Thread was deleted, remove from thread map
-        thread.addListener('threaddeleted', () => {
-            this.removeThreadFromMap(thread);
-        });
-
-        // Thread should be cleaned up, unbind listeners - we don't do this
-        // in threaddeleted listener since thread may still need to respond
-        // to error messages
-        thread.addListener('threadcleanup', () => {
-            this.unbindCustomListenersOnThread(thread);
-        });
+        thread.addListener('threadevent', this.handleAnnotationThreadEvents);
     }
 
     /**
@@ -705,9 +694,7 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     unbindCustomListenersOnThread(thread) {
-        thread.removeAllListeners('threaddeleted');
-        thread.removeAllListeners('threadcleanup');
-        thread.removeAllListeners('annotationsaved');
+        thread.removeAllListeners('threadevent');
         thread.removeAllListeners('annotationevent');
     }
 
@@ -755,7 +742,6 @@ class Annotator extends EventEmitter {
     pointClickHandler(event) {
         event.stopPropagation();
         event.preventDefault();
-        this.emit(MODE_EXIT);
 
         // Determine if a point annotation dialog is already open and close the
         // current open dialog
@@ -784,6 +770,8 @@ class Annotator extends EventEmitter {
             // Bind events on thread
             this.bindCustomListenersOnThread(thread);
         }
+
+        this.emit(THREAD_EVENT.pending, thread.getThreadEventData());
     }
 
     /**
@@ -876,6 +864,7 @@ class Annotator extends EventEmitter {
         this.setScale(data.scale);
         this.rotateAnnotations(data.rotationAngle, data.pageNum);
     }
+
     /**
      * Gets threads on page
      *
@@ -889,6 +878,25 @@ class Annotator extends EventEmitter {
         }
 
         return this.threads[page];
+    }
+
+    /**
+     * Gets thread specified by threadID
+     *
+     * @private
+     * @param {number} threadID - Thread ID
+     * @return {AnnotationThread} Annotation thread specified by threadID
+     */
+    getThreadByID(threadID) {
+        let thread = null;
+        Object.keys(this.threads).forEach((page) => {
+            const pageThreads = this.getThreadsOnPage(page);
+            if (threadID in pageThreads) {
+                thread = pageThreads[threadID];
+            }
+        });
+
+        return thread;
     }
 
     /**
@@ -927,8 +935,40 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        this.emit('annotatorerror', __('annotations_load_error'));
+        this.emit(ANNOTATOR_EVENT.error, __('annotations_load_error'));
         this.validationErrorEmitted = true;
+    }
+
+    /**
+     * Handles annotation thread events and emits them to the viewer
+     *
+     * @private
+     * @param {Object} [data] - Annotation thread event data
+     * @param {string} [data.event] - Annotation thread event
+     * @param {string} [data.data] - Annotation thread event data
+     * @return {void}
+     */
+    handleAnnotationThreadEvents(data) {
+        const thread = this.getThreadByID(data.data.threadID);
+        if (!thread) {
+            return;
+        }
+
+        switch (data.event) {
+            case THREAD_EVENT.threadCleanup:
+                // Thread should be cleaned up, unbind listeners - we
+                // don't do this in annotationdelete listener since thread
+                // may still need to respond to error messages
+                this.unbindCustomListenersOnThread(thread);
+                break;
+            case THREAD_EVENT.threadDelete:
+                // Thread was deleted, remove from thread map
+                this.removeThreadFromMap(thread);
+                this.emit(data.event, data.data);
+                break;
+            default:
+                this.emit(data.event, data.data);
+        }
     }
 
     /**
@@ -947,6 +987,7 @@ class Annotator extends EventEmitter {
             event,
             data,
             annotatorName: annotator ? annotator.NAME : '',
+            fileVersionId: this.fileVersionId,
             fileId
         });
     }

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -695,7 +695,6 @@ class Annotator extends EventEmitter {
      */
     unbindCustomListenersOnThread(thread) {
         thread.removeAllListeners('threadevent');
-        thread.removeAllListeners('annotationevent');
     }
 
     /**

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -969,6 +969,14 @@ class Annotator extends EventEmitter {
                 this.removeThreadFromMap(thread);
                 this.emit(data.event, data.data);
                 break;
+            case THREAD_EVENT.deleteError:
+                this.emit(ANNOTATOR_EVENT.error, __('annotations_delete_error'));
+                this.emit(data.event, data.data);
+                break;
+            case THREAD_EVENT.createError:
+                this.emit(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+                this.emit(data.event, data.data);
+                break;
             default:
                 this.emit(data.event, data.data);
         }

--- a/src/lib/annotations/__tests__/AnnotationModeController-test.js
+++ b/src/lib/annotations/__tests__/AnnotationModeController-test.js
@@ -127,7 +127,6 @@ describe('lib/annotations/AnnotationModeController', () => {
 
             annotationModeController.unbindCustomListenersOnThread(thread);
             expect(thread.removeAllListeners).to.be.calledWith('threadevent');
-            expect(thread.removeAllListeners).to.be.calledWith('annotationevent');
         });
     });
 

--- a/src/lib/annotations/__tests__/AnnotationModeController-test.js
+++ b/src/lib/annotations/__tests__/AnnotationModeController-test.js
@@ -126,7 +126,8 @@ describe('lib/annotations/AnnotationModeController', () => {
             };
 
             annotationModeController.unbindCustomListenersOnThread(thread);
-            expect(thread.removeAllListeners).to.have.callCount(4);
+            expect(thread.removeAllListeners).to.be.calledWith('threadevent');
+            expect(thread.removeAllListeners).to.be.calledWith('annotationevent');
         });
     });
 

--- a/src/lib/annotations/__tests__/AnnotationThread-test.js
+++ b/src/lib/annotations/__tests__/AnnotationThread-test.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-expressions */
+import EventEmitter from 'events';
 import AnnotationThread from '../AnnotationThread';
 import Annotation from '../Annotation';
 import * as annotatorUtil from '../annotatorUtil';
@@ -7,7 +8,8 @@ import {
     TYPES,
     CLASS_ANNOTATION_POINT_MARKER,
     DATA_TYPE_ANNOTATION_INDICATOR,
-    CLASS_HIDDEN
+    CLASS_HIDDEN,
+    THREAD_EVENT
 } from '../annotationConstants';
 
 let thread;
@@ -70,7 +72,7 @@ describe('lib/annotations/AnnotationThread', () => {
             thread.destroy();
             expect(stubs.unbindCustom).to.be.called;
             expect(stubs.unbindDOM).to.be.called;
-            expect(stubs.emit).to.be.calledWith('threaddeleted');
+            expect(stubs.emit).to.be.calledWith(THREAD_EVENT.threadDelete);
         });
 
         it('should not destroy the dialog on mobile', () => {
@@ -141,6 +143,7 @@ describe('lib/annotations/AnnotationThread', () => {
                 type: 'point'
             });
 
+            sandbox.stub(thread, 'getThreadEventData').returns({});
             stubs.create = sandbox.stub(annotationService, 'create');
         });
 
@@ -162,15 +165,18 @@ describe('lib/annotations/AnnotationThread', () => {
 
         it('should delete the temporary annotation and broadcast an error if there was an error saving', (done) => {
             stubs.create.returns(Promise.reject());
-            stubs.delete = sandbox.stub(thread, 'deleteAnnotation');
+            stubs.handleError = sandbox.stub(thread, 'handleThreadSaveError');
+            stubs.serverSave = sandbox.stub(thread, 'updateTemporaryAnnotation');
 
-            thread.on('annotationcreateerror', () => {
-                expect(stubs.delete).to.be.called;
+            const promise = thread.saveAnnotation('point', 'blah');
+            promise.should.be.fulfilled.then(() => {
+                expect(stubs.handleError).to.be.called;
                 done();
+            }).catch(() => {
+                Assert.fail();
             });
-
-            thread.saveAnnotation('point', 'blah');
             expect(stubs.create).to.be.called;
+            expect(stubs.serverSave).to.not.be.called;
         });
     });
 
@@ -195,6 +201,7 @@ describe('lib/annotations/AnnotationThread', () => {
 
             stubs.create = sandbox.stub(annotationService, 'create');
             stubs.saveAnnotationToThread = sandbox.stub(thread, 'saveAnnotationToThread');
+            sandbox.stub(thread, 'getThreadEventData').returns({});
         });
 
         it('should save annotation to thread if it does not exist in annotations array', () => {
@@ -219,9 +226,10 @@ describe('lib/annotations/AnnotationThread', () => {
         });
 
         it('should emit an annotationsaved event on success', (done) => {
-            const serverAnnotation = 'real annotation';
+            const serverAnnotation = { threadNumber: 1 };
             const tempAnnotation = serverAnnotation;
-            thread.addListener('annotationsaved', () => {
+            thread.threadNumber = undefined;
+            thread.addListener(THREAD_EVENT.save, () => {
                 expect(stubs.saveAnnotationToThread).to.be.called;
                 done();
             });
@@ -276,16 +284,22 @@ describe('lib/annotations/AnnotationThread', () => {
             };
             stubs.dialogMock = sandbox.mock(thread.dialog);
 
-            stubs.delete = sandbox.stub(annotationService, 'delete');
             stubs.isPlain = sandbox.stub(annotatorUtil, 'isPlainHighlight');
             stubs.cancel = sandbox.stub(thread, 'cancelFirstComment');
             stubs.destroy = sandbox.stub(thread, 'destroy');
+            thread.annotationService.user = {
+                id: 1
+            };
+            sandbox.stub(thread, 'getThreadEventData').returns({
+                threadNumber: 1
+            });
         });
 
         it('should destroy the thread if the deleted annotation was the last annotation in the thread', () => {
             thread.isMobile = false;
             stubs.dialogMock.expects('removeAnnotation').never();
             stubs.dialogMock.expects('hideMobileDialog').never();
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.deleteAnnotation('someID', false);
             expect(stubs.destroy).to.be.called;
         });
@@ -294,6 +308,7 @@ describe('lib/annotations/AnnotationThread', () => {
             thread.isMobile = true;
             stubs.dialogMock.expects('removeAnnotation');
             stubs.dialogMock.expects('hideMobileDialog');
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.deleteAnnotation('someID', false);
         });
 
@@ -301,40 +316,49 @@ describe('lib/annotations/AnnotationThread', () => {
             // Add another annotation to thread so 'someID' isn't the only annotation
             thread.annotations.push(stubs.annotation2);
             stubs.dialogMock.expects('removeAnnotation').withArgs('someID');
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.deleteAnnotation('someID', false);
         });
 
         it('should make a server call to delete an annotation with the specified ID if useServer is true', () => {
-            stubs.delete.returns(Promise.resolve());
-            thread.deleteAnnotation('someID', true);
-            expect(stubs.delete).to.be.calledWith('someID');
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
+            const promise = thread.deleteAnnotation('someID');
+            promise.should.be.fulfilled.then(() => {
+                expect(stubs.emit).to.not.be.calledWith(THREAD_EVENT.threadCleanup);
+                expect(stubs.emit).to.be.calledWith(THREAD_EVENT.delete);
+                done();
+            }).catch(() => {
+                Assert.fail();
+            });
+            expect(annotationService.delete).to.be.calledWith('someID');
         });
 
-        it('should make also delete blank highlight comment from the server when removing the last comment on a highlight thread', () => {
+        it('should also delete blank highlight comment from the server when removing the last comment on a highlight thread', () => {
             stubs.annotation2.permissions.can_delete = false;
             thread.annotations.push(stubs.annotation2);
             stubs.isPlain.returns(true);
-            stubs.delete.returns(Promise.resolve());
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.deleteAnnotation('someID', true);
-            expect(stubs.delete).to.be.calledWith('someID');
+            expect(annotationService.delete).to.be.calledWith('someID');
         });
 
         it('should not make a server call to delete an annotation with the specified ID if useServer is false', () => {
-            stubs.delete.returns(Promise.resolve());
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.deleteAnnotation('someID', false);
-            expect(stubs.delete).to.not.be.called;
+            expect(annotationService.delete).to.not.be.called;
         });
 
         it('should broadcast an error if there was an error deleting from server', (done) => {
-            stubs.delete.returns(Promise.reject());
+            sandbox.stub(annotationService, 'delete').returns(Promise.reject());
             thread.on('annotationdeleteerror', () => {
                 done();
             });
             thread.deleteAnnotation('someID', true);
-            expect(stubs.delete).to.be.called;
+            expect(annotationService.delete).to.be.called;
         });
 
         it('should toggle highlight dialogs with the delete of the last comment if user does not have permission to delete the entire annotation', () => {
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
             thread.annotations.push(stubs.annotation2);
             stubs.isPlain.returns(true);
             thread.deleteAnnotation('someID', false);
@@ -346,7 +370,15 @@ describe('lib/annotations/AnnotationThread', () => {
             stubs.annotation2.permissions.can_delete = true;
             thread.annotations.push(stubs.annotation2);
             stubs.isPlain.returns(true);
-            thread.deleteAnnotation('someID', false);
+            sandbox.stub(annotationService, 'delete').returns(Promise.resolve());
+            const promise = thread.deleteAnnotation('someID');
+            promise.should.be.fulfilled.then(() => {
+                expect(stubs.emit).to.be.calledWith(THREAD_EVENT.threadCleanup);
+                expect(stubs.emit).to.be.calledWith(THREAD_EVENT.delete);
+                done();
+            }).catch(() => {
+                Assert.fail();
+            });
             expect(stubs.cancel).to.not.be.called;
             expect(stubs.destroy).to.be.called;
         });
@@ -585,17 +617,54 @@ describe('lib/annotations/AnnotationThread', () => {
             thread.isMobile = true;
             thread.cancelUnsavedAnnotation();
             expect(thread.destroy).to.be.called;
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
 
             // 'pending' state
             thread.isMobile = false;
             thread.state = STATES.pending;
             thread.cancelUnsavedAnnotation();
             expect(thread.destroy).to.be.called;
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
 
             // 'pending-active' state
             thread.state = STATES.pending_active;
             thread.cancelUnsavedAnnotation();
             expect(thread.destroy).to.be.called;
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
+        });
+    });
+
+    describe('getThreadEventData()', () => {
+        it('should return thread type and threadID', () => {
+            thread.annotationService.user = { id: -1 };
+            thread.threadNumber = undefined;
+            const data = thread.getThreadEventData();
+            expect(data).to.deep.equal({
+                type: thread.type,
+                threadID: thread.threadID
+            });
+        });
+
+        it('should also return annotator\'s user id', () => {
+            thread.annotationService.user = { id: 1 };
+            thread.threadNumber = undefined;
+            const data = thread.getThreadEventData();
+            expect(data).to.deep.equal({
+                type: thread.type,
+                threadID: thread.threadID,
+                userId: 1
+            });
+        });
+
+        it('should return thread type and threadID', () => {
+            thread.annotationService.user = { id: -1 };
+            thread.threadNumber = 1;
+            const data = thread.getThreadEventData();
+            expect(data).to.deep.equal({
+                type: thread.type,
+                threadID: thread.threadID,
+                threadNumber: 1
+            });
         });
     });
 
@@ -698,6 +767,15 @@ describe('lib/annotations/AnnotationThread', () => {
             sandbox.stub(thread, 'deleteAnnotation');
             thread.deleteAnnotationWithID({ annotationID: 1 });
             expect(thread.deleteAnnotation).to.be.calledWith(1);
+        });
+    });
+
+    describe('handleThreadSaveError()', () => {
+        it('should delete temp annotation and emit event', () => {
+            sandbox.stub(thread, 'deleteAnnotation');
+            thread.handleThreadSaveError(1);
+            expect(thread.deleteAnnotation).to.be.calledWith(1, false);
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.createError);
         });
     });
 });

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -620,7 +620,6 @@ describe('lib/annotations/Annotator', () => {
         describe('unbindCustomListenersOnThread()', () => {
             it('should unbind custom listeners from the thread', () => {
                 stubs.threadMock.expects('removeAllListeners').withArgs('threadevent');
-                stubs.threadMock.expects('removeAllListeners').withArgs('annotationevent');
                 annotator.unbindCustomListenersOnThread(stubs.thread);
             });
         });

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -51,7 +51,7 @@ describe('lib/annotations/Annotator', () => {
             hide: () => {},
             addListener: () => {},
             unbindCustomListenersOnThread: () => {},
-            removeAllListeners: () => {},
+            removeListener: () => {},
             scrollIntoView: () => {},
             getThreadEventData: () => {},
             type: 'type'
@@ -204,6 +204,10 @@ describe('lib/annotations/Annotator', () => {
             annotator.addThreadToMap(stubs.thread3);
 
             annotator.init();
+        });
+
+        afterEach(() => {
+            annotator.threads = {};
         });
 
         describe('hideAnnotations()', () => {
@@ -604,7 +608,7 @@ describe('lib/annotations/Annotator', () => {
                     canAnnotate: true,
                     canDelete: true
                 });
-                const removeListenerStub = sandbox.stub(annotator.annotationService, 'removeAllListeners');
+                const removeListenerStub = sandbox.stub(annotator.annotationService, 'removeListener');
 
                 annotator.unbindCustomListenersOnService();
                 expect(removeListenerStub).to.be.called;
@@ -625,7 +629,7 @@ describe('lib/annotations/Annotator', () => {
 
         describe('unbindCustomListenersOnThread()', () => {
             it('should unbind custom listeners from the thread', () => {
-                stubs.threadMock.expects('removeAllListeners').withArgs('threadevent');
+                stubs.threadMock.expects('removeListener').withArgs('threadevent');
                 annotator.unbindCustomListenersOnThread(stubs.thread);
             });
         });

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -1031,6 +1031,32 @@ describe('lib/annotations/Annotator', () => {
                 expect(stubs.unbind).to.not.be.called;
             });
 
+            it('should emit delete error notification event', () => {
+                stubs.getThread.returns(stubs.thread);
+                const data = {
+                    event: THREAD_EVENT.deleteError,
+                    data: { threadID: 1 }
+                };
+                annotator.handleAnnotationThreadEvents(data);
+                expect(stubs.emit).to.be.calledWith(data.event, data.data);
+                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, __('annotations_delete_error'));
+                expect(stubs.unbind).to.not.be.called;
+                expect(stubs.remove).to.not.be.called;
+            });
+
+            it('should emit save error notification event', () => {
+                stubs.getThread.returns(stubs.thread);
+                const data = {
+                    event: THREAD_EVENT.createError,
+                    data: { threadID: 1 }
+                };
+                annotator.handleAnnotationThreadEvents(data);
+                expect(stubs.emit).to.be.calledWith(data.event, data.data);
+                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+                expect(stubs.unbind).to.not.be.called;
+                expect(stubs.remove).to.not.be.called;
+            });
+
             it('should emit thread event', () => {
                 stubs.getThread.returns(stubs.thread);
                 const data = {

--- a/src/lib/annotations/annotationConstants.js
+++ b/src/lib/annotations/annotationConstants.js
@@ -109,7 +109,8 @@ export const ANNOTATOR_EVENT = {
     modeEnter: 'annotationmodeenter',
     modeExit: 'annotationmodeexit',
     fetch: 'annotationsfetched',
-    error: 'annotationerror'
+    error: 'annotationerror',
+    scale: 'scaleannotations'
 };
 
 export const THREAD_EVENT = {

--- a/src/lib/annotations/annotationConstants.js
+++ b/src/lib/annotations/annotationConstants.js
@@ -105,6 +105,25 @@ export const HIGHLIGHT_FILL = {
     erase: 'rgba(255, 245, 132, 1)'
 };
 
+export const ANNOTATOR_EVENT = {
+    modeEnter: 'annotationmodeenter',
+    modeExit: 'annotationmodeexit',
+    fetch: 'annotationsfetched',
+    error: 'annotationerror'
+};
+
+export const THREAD_EVENT = {
+    pending: 'annotationpending',
+    threadSave: 'annotationthreadsaved',
+    threadDelete: 'annotationthreaddeleted',
+    threadCleanup: 'annotationthreadcleanup',
+    save: 'annotationsaved',
+    delete: 'annotationdeleted',
+    deleteError: 'annotationdeleteerror',
+    cancel: 'annotationcanceled',
+    createError: 'annotationcreateerror'
+};
+
 export const PAGE_PADDING_TOP = 15;
 export const PAGE_PADDING_BOTTOM = 15;
 

--- a/src/lib/annotations/doc/CreateHighlightDialog.js
+++ b/src/lib/annotations/doc/CreateHighlightDialog.js
@@ -26,8 +26,10 @@ const COMMENT_BUTTON_TEMPLATE = `
 
 /**
  * Events emitted by this component.
+ * TODO(@spramod): Evaluate if these events need to be propogated to viewer
  */
 export const CreateEvents = {
+    init: 'init_highlight_create',
     plain: 'plain_highlight_create',
     comment: 'comment_highlight_edit',
     commentPost: 'comment_highlight_post'
@@ -156,6 +158,7 @@ class CreateHighlightDialog extends EventEmitter {
         this.setButtonVisibility(true);
 
         showElement(this.containerEl);
+        this.emit(CreateEvents.init);
     }
 
     /**

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -129,10 +129,6 @@ class DocAnnotator extends Annotator {
             allowHighlight: this.plainHighlightEnabled
         });
 
-        this.createHighlightDialog.addListener(CreateEvents.init, () => {
-            this.emit(THREAD_EVENT.pending, TYPES.highlight);
-        });
-
         if (this.commentHighlightEnabled) {
             this.highlightCurrentSelection = this.highlightCurrentSelection.bind(this);
             this.createHighlightDialog.addListener(CreateEvents.comment, this.highlightCurrentSelection);
@@ -177,6 +173,10 @@ class DocAnnotator extends Annotator {
 
         // Allow rangy to highlight this
         this.annotatedElement.id = ID_ANNOTATED_ELEMENT;
+
+        this.createHighlightDialog.addListener(CreateEvents.init, () =>
+            this.emit(THREAD_EVENT.pending, TYPES.highlight)
+        );
     }
 
     //--------------------------------------------------------------------------
@@ -1027,6 +1027,10 @@ class DocAnnotator extends Annotator {
      * @return {void}
      */
     handleAnnotationThreadEvents(data) {
+        if (!data.data || !data.data.threadID) {
+            return;
+        }
+
         const thread = this.getThreadByID(data.data.threadID);
         if (!thread) {
             return;

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -174,6 +174,10 @@ class DocAnnotator extends Annotator {
         // Allow rangy to highlight this
         this.annotatedElement.id = ID_ANNOTATED_ELEMENT;
 
+        if (!this.createHighlightDialog) {
+            return;
+        }
+
         this.createHighlightDialog.addListener(CreateEvents.init, () =>
             this.emit(THREAD_EVENT.pending, TYPES.highlight)
         );

--- a/src/lib/annotations/doc/DocDrawingThread.js
+++ b/src/lib/annotations/doc/DocDrawingThread.js
@@ -75,9 +75,7 @@ class DocDrawingThread extends DrawingThread {
                 dimensions: location.dimensions
             };
             this.checkAndHandleScaleUpdate();
-            this.emit('annotationevent', {
-                type: 'locationassigned'
-            });
+            this.emit('locationassigned');
         }
 
         this.drawingFlag = DRAW_STATES.drawing;
@@ -198,16 +196,8 @@ class DocDrawingThread extends DrawingThread {
             return;
         }
 
-        this.dialog.addListener('annotationcreate', () => {
-            this.emit('annotationevent', {
-                type: 'softcommit'
-            });
-        });
-        this.dialog.addListener('annotationdelete', () => {
-            this.emit('annotationevent', {
-                type: 'dialogdelete'
-            });
-        });
+        this.dialog.addListener('annotationcreate', () => this.emit('softcommit'));
+        this.dialog.addListener('annotationdelete', () => this.emit('dialogdelete'));
     }
 
     /**
@@ -267,10 +257,7 @@ class DocDrawingThread extends DrawingThread {
      */
     onPageChange(location) {
         this.handleStop();
-        this.emit('annotationevent', {
-            type: 'softcommit',
-            location
-        });
+        this.emit('softcommit', { location });
     }
 
     /**

--- a/src/lib/annotations/doc/__tests__/CreateHighlightDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/CreateHighlightDialog-test.js
@@ -101,8 +101,10 @@ describe('lib/annotations/doc/CreateHighlightDialog', () => {
         });
 
         it('should remove the hidden class from the UI element', () => {
+            const emit = sandbox.stub(dialog, 'emit');
             dialog.show();
             expect(dialog.containerEl.classList.contains(CLASS_HIDDEN)).to.be.false;
+            expect(emit).to.be.calledWith(CreateEvents.init);
         });
     });
 

--- a/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
+++ b/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
@@ -71,6 +71,7 @@ describe('lib/annotations/doc/DocAnnotator', () => {
 
     afterEach(() => {
         sandbox.verifyAndRestore();
+        annotator.threads = {};
         if (typeof annotator.destroy === 'function') {
             annotator.destroy();
             annotator = null;

--- a/src/lib/annotations/doc/__tests__/DocDrawingThread-test.js
+++ b/src/lib/annotations/doc/__tests__/DocDrawingThread-test.js
@@ -9,7 +9,7 @@ import {
     STATES
 } from '../../annotationConstants';
 
-let docDrawingThread;
+let thread;
 let stubs;
 const sandbox = sinon.sandbox.create();
 
@@ -20,63 +20,69 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
 
     beforeEach(() => {
         fixture.load('annotations/doc/__tests__/DocDrawingThread-test.html');
-        docDrawingThread = new DocDrawingThread({});
-        docDrawingThread.location = {
+        thread = new DocDrawingThread({
+            annotationService: {
+                user: {
+                    id: -1
+                }
+            }
+        });
+        thread.location = {
             x: 0,
             y: 0,
-            page: docDrawingThread.page
+            page: thread.page
         };
+        sandbox.stub(thread, 'getThreadEventData');
         stubs = {};
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
-        docDrawingThread.destroy();
-        docDrawingThread = null;
+        thread.destroy();
+        thread = null;
     });
 
     describe('handleMove()', () => {
         beforeEach(() => {
-            docDrawingThread.drawingFlag = DRAW_STATES.drawing;
-            docDrawingThread.pageEl = document.querySelector('.page-element');
-            docDrawingThread.page = docDrawingThread.pageEl.getAttribute('page');
-            docDrawingThread.pendingPath = {
+            thread.drawingFlag = DRAW_STATES.drawing;
+            thread.pageEl = document.querySelector('.page-element');
+            thread.page = thread.pageEl.getAttribute('page');
+            thread.pendingPath = {
                 addCoordinate: sandbox.stub(),
                 isEmpty: sandbox.stub()
             };
 
-            sandbox.stub(docAnnotatorUtil, 'getBrowserCoordinatesFromLocation')
-                   .returns([location.x, location.y]);
+            sandbox.stub(docAnnotatorUtil, 'getBrowserCoordinatesFromLocation').returns([location.x, location.y]);
         });
 
         it("should not add a coordinate when the state is not 'draw'", () => {
-            docDrawingThread.drawingFlag = DRAW_STATES.idle;
-            docDrawingThread.handleMove(docDrawingThread.location);
+            thread.drawingFlag = DRAW_STATES.idle;
+            thread.handleMove(thread.location);
 
-            expect(docDrawingThread.pendingPath.addCoordinate).to.not.be.called;
+            expect(thread.pendingPath.addCoordinate).to.not.be.called;
         });
 
         it("should add a coordinate frame when the state is 'draw'", () => {
-            sandbox.stub(docDrawingThread, 'hasPageChanged').returns(false);
-            docDrawingThread.handleMove(docDrawingThread.location);
+            sandbox.stub(thread, 'hasPageChanged').returns(false);
+            thread.handleMove(thread.location);
 
-            expect(docDrawingThread.hasPageChanged).to.be.called;
-            expect(docDrawingThread.pendingPath.addCoordinate).to.be.called;
+            expect(thread.hasPageChanged).to.be.called;
+            expect(thread.pendingPath.addCoordinate).to.be.called;
         });
 
         it('should do nothing when location is empty', () => {
-            sandbox.stub(docDrawingThread, 'hasPageChanged').returns(false);
+            sandbox.stub(thread, 'hasPageChanged').returns(false);
 
-            docDrawingThread.handleMove(undefined);
-            expect(docDrawingThread.hasPageChanged).to.not.be.called;
+            thread.handleMove(undefined);
+            expect(thread.hasPageChanged).to.not.be.called;
         });
 
         it('should only handle page change when the page changes', () => {
-            sandbox.stub(docDrawingThread, 'hasPageChanged').returns(true);
-            sandbox.stub(docDrawingThread, 'onPageChange');
+            sandbox.stub(thread, 'hasPageChanged').returns(true);
+            sandbox.stub(thread, 'onPageChange');
 
-            docDrawingThread.handleMove({page: 1});
-            expect(docDrawingThread.onPageChange).to.be.called;
+            thread.handleMove({page: 1});
+            expect(thread.onPageChange).to.be.called;
         })
     });
 
@@ -86,114 +92,114 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
             const context = "I'm a real context";
 
             sandbox.stub(window, 'requestAnimationFrame');
-            sandbox.stub(docDrawingThread, 'checkAndHandleScaleUpdate');
-            sandbox.stub(docDrawingThread, 'hasPageChanged').returns(false);
+            sandbox.stub(thread, 'checkAndHandleScaleUpdate');
+            sandbox.stub(thread, 'hasPageChanged').returns(false);
             sandbox.stub(docAnnotatorUtil, 'getPageEl')
                    .returns(context);
 
-            docDrawingThread.drawingFlag = DRAW_STATES.idle;
-            docDrawingThread.pendingPath = undefined;
-            docDrawingThread.handleStart(docDrawingThread.location);
+            thread.drawingFlag = DRAW_STATES.idle;
+            thread.pendingPath = undefined;
+            thread.handleStart(thread.location);
 
             expect(window.requestAnimationFrame).to.be.called;
-            expect(docDrawingThread.drawingFlag).to.equal(DRAW_STATES.drawing);
-            expect(docDrawingThread.hasPageChanged).to.be.called;
-            expect(docDrawingThread.pendingPath).to.be.an.instanceof(DrawingPath);
+            expect(thread.drawingFlag).to.equal(DRAW_STATES.drawing);
+            expect(thread.hasPageChanged).to.be.called;
+            expect(thread.pendingPath).to.be.an.instanceof(DrawingPath);
         });
 
         it('should commit the thread when the page changes', () => {
-            sandbox.stub(docDrawingThread, 'hasPageChanged').returns(true);
-            sandbox.stub(docDrawingThread, 'checkAndHandleScaleUpdate');
-            sandbox.stub(docDrawingThread, 'onPageChange');
+            sandbox.stub(thread, 'hasPageChanged').returns(true);
+            sandbox.stub(thread, 'checkAndHandleScaleUpdate');
+            sandbox.stub(thread, 'onPageChange');
 
-            docDrawingThread.pendingPath = undefined;
-            docDrawingThread.location = {};
-            docDrawingThread.handleStart(docDrawingThread.location);
+            thread.pendingPath = undefined;
+            thread.location = {};
+            thread.handleStart(thread.location);
 
-            expect(docDrawingThread.hasPageChanged).to.be.called;
-            expect(docDrawingThread.onPageChange).to.be.called;
-            expect(docDrawingThread.checkAndHandleScaleUpdate).to.not.be.called;
+            expect(thread.hasPageChanged).to.be.called;
+            expect(thread.onPageChange).to.be.called;
+            expect(thread.checkAndHandleScaleUpdate).to.not.be.called;
         });
 
     });
 
     describe('handleStop()', () => {
         beforeEach(() => {
-            stubs.emitAvailableActions = sandbox.stub(docDrawingThread, 'emitAvailableActions');
-            stubs.updateBoundary = sandbox.stub(docDrawingThread, 'updateBoundary');
-            stubs.setBoundary = sandbox.stub(docDrawingThread, 'setBoundary');
-            stubs.drawBoundary = sandbox.stub(docDrawingThread, 'drawBoundary');
-            stubs.createDialog = sandbox.stub(docDrawingThread, 'createDialog');
-            docDrawingThread.drawingFlag = DRAW_STATES.drawing;
-            docDrawingThread.pendingPath = {
+            stubs.emitAvailableActions = sandbox.stub(thread, 'emitAvailableActions');
+            stubs.updateBoundary = sandbox.stub(thread, 'updateBoundary');
+            stubs.setBoundary = sandbox.stub(thread, 'setBoundary');
+            stubs.drawBoundary = sandbox.stub(thread, 'drawBoundary');
+            stubs.createDialog = sandbox.stub(thread, 'createDialog');
+            thread.drawingFlag = DRAW_STATES.drawing;
+            thread.pendingPath = {
                 isEmpty: () => false
             };
-            docDrawingThread.pathContainer = {
+            thread.pathContainer = {
                 insert: sandbox.stub()
             };
         })
         it("should set the state to 'idle' and clear the pendingPath", () => {
-            docDrawingThread.handleStop();
+            thread.handleStop();
 
             expect(stubs.emitAvailableActions).to.be.called;
             expect(stubs.updateBoundary).to.be.called;
             expect(stubs.setBoundary).to.be.called;
             expect(stubs.drawBoundary).to.be.called;
             expect(stubs.createDialog).to.be.called;
-            expect(docDrawingThread.pathContainer.insert).to.be.called;
-            expect(docDrawingThread.drawingFlag).to.equal(DRAW_STATES.idle);
-            expect(docDrawingThread.pendingPath).to.be.null;
+            expect(thread.pathContainer.insert).to.be.called;
+            expect(thread.drawingFlag).to.equal(DRAW_STATES.idle);
+            expect(thread.pendingPath).to.be.null;
         });
 
         it('should not create a dialog if one already exists', () => {
-            docDrawingThread.dialog = {
+            thread.dialog = {
                 value: 'non-empty',
                 removeAllListeners: () => {},
                 destroy: () => {},
                 isVisible: () => false
             }
 
-            docDrawingThread.handleStop();
+            thread.handleStop();
             expect(stubs.createDialog).to.not.be.called;
         });
     });
 
     describe('onPageChange()', () => {
         it('should emit an annotationevent of type pagechanged and stop a pending drawing', (done) =>{
-            sandbox.stub(docDrawingThread, 'handleStop');
-            docDrawingThread.addListener('annotationevent', (data) => {
-                expect(docDrawingThread.handleStop).to.be.called;
-                expect(data.type).to.equal('softcommit');
+            sandbox.stub(thread, 'handleStop');
+            const location = 'location';
+            thread.addListener('annotationevent', (data) => {
                 done();
             });
 
-            docDrawingThread.onPageChange();
+            thread.onPageChange(location);
+            expect(thread.handleStop).to.be.called;
         });
     });
 
     describe('checkAndHandleScaleUpdate()', () => {
         it('should update the drawing information when the scale has changed', () => {
-            sandbox.stub(docDrawingThread, 'setContextStyles');
+            sandbox.stub(thread, 'setContextStyles');
             sandbox.stub(annotatorUtil, 'getScale').returns(1.4);
             sandbox.stub(docAnnotatorUtil, 'getPageEl');
             sandbox.stub(docAnnotatorUtil, 'getContext');
-            docDrawingThread.lastScaleFactor = 1.1;
-            docDrawingThread.location = {
+            thread.lastScaleFactor = 1.1;
+            thread.location = {
                 page: 1
             };
-            docDrawingThread.checkAndHandleScaleUpdate();
-            expect(docDrawingThread.lastScaleFactor).to.equal(1.4);
+            thread.checkAndHandleScaleUpdate();
+            expect(thread.lastScaleFactor).to.equal(1.4);
             expect(annotatorUtil.getScale).to.be.called;
             expect(docAnnotatorUtil.getPageEl).to.be.called;
             expect(docAnnotatorUtil.getContext).to.be.called;
-            expect(docDrawingThread.setContextStyles).to.be.called;
+            expect(thread.setContextStyles).to.be.called;
         });
 
         it('should do nothing when the scale has not changed', () => {
             sandbox.stub(annotatorUtil, 'getScale').returns(1.4);
             sandbox.stub(docAnnotatorUtil, 'getPageEl');
-            docDrawingThread.lastScaleFactor = 1.4;
-            docDrawingThread.checkAndHandleScaleUpdate();
+            thread.lastScaleFactor = 1.4;
+            thread.checkAndHandleScaleUpdate();
             expect(annotatorUtil.getScale).to.be.called;
             expect(docAnnotatorUtil.getPageEl).to.not.be.called;
         });
@@ -201,8 +207,8 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
 
     describe('reconstructBrowserCoordFromLocation()', () => {
         it('should return a browser coordinate when the DocDrawingThread has been assigned a page', () => {
-            docDrawingThread.pageEl = 'has been set';
-            docDrawingThread.location = {
+            thread.pageEl = 'has been set';
+            thread.location = {
                 dimensions: 'has been set'
             };
             const documentLocation = {
@@ -211,7 +217,7 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
             };
 
             sandbox.stub(docAnnotatorUtil, 'getBrowserCoordinatesFromLocation').returns([3,4]);
-            const returnValue = docDrawingThread.reconstructBrowserCoordFromLocation(documentLocation);
+            const returnValue = thread.reconstructBrowserCoordFromLocation(documentLocation);
 
             expect(returnValue).to.deep.equal({
                 x: 3,
@@ -224,9 +230,9 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
         const resetValue = AnnotationThread.prototype.saveAnnotation;
 
         beforeEach(() => {
-            stubs.setBoundary = sandbox.stub(docDrawingThread, 'setBoundary');
-            stubs.show = sandbox.stub(docDrawingThread, 'show');
-            stubs.createDialog = sandbox.stub(docDrawingThread, 'createDialog');
+            stubs.setBoundary = sandbox.stub(thread, 'setBoundary');
+            stubs.show = sandbox.stub(thread, 'show');
+            stubs.createDialog = sandbox.stub(thread, 'createDialog');
             Object.defineProperty(AnnotationThread.prototype, 'saveAnnotation', { value: sandbox.stub() });
         });
 
@@ -235,19 +241,19 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
         });
 
         it('should clean up without committing when there are no paths to be saved', () => {
-            sandbox.stub(docDrawingThread, 'reset');
-            sandbox.stub(docDrawingThread.pathContainer, 'isEmpty').returns(true);
+            sandbox.stub(thread, 'reset');
+            sandbox.stub(thread.pathContainer, 'isEmpty').returns(true);
 
-            docDrawingThread.saveAnnotation('draw');
-            expect(docDrawingThread.pathContainer.isEmpty).to.be.called;
+            thread.saveAnnotation('draw');
+            expect(thread.pathContainer.isEmpty).to.be.called;
             expect(AnnotationThread.prototype.saveAnnotation).to.not.be.called;
-            expect(docDrawingThread.reset).to.be.called;
+            expect(thread.reset).to.be.called;
             expect(stubs.show).to.not.be.called;
             expect(stubs.createDialog).to.not.be.called;
         });
 
         it('should clean up and commit in-progress drawings when there are paths to be saved', () => {
-            docDrawingThread.drawingContext = {
+            thread.drawingContext = {
                 canvas: {
                     style: {
                         width: 10,
@@ -259,11 +265,11 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
                 clearRect: sandbox.stub()
             };
 
-            sandbox.stub(docDrawingThread.pathContainer, 'isEmpty').returns(false);
+            sandbox.stub(thread.pathContainer, 'isEmpty').returns(false);
 
-            docDrawingThread.saveAnnotation('draw');
-            expect(docDrawingThread.pathContainer.isEmpty).to.be.called;
-            expect(docDrawingThread.drawingContext.clearRect).to.be.called;
+            thread.saveAnnotation('draw');
+            expect(thread.pathContainer.isEmpty).to.be.called;
+            expect(thread.drawingContext.clearRect).to.be.called;
             expect(AnnotationThread.prototype.saveAnnotation).to.be.called;
             expect(stubs.show).to.be.called;
             expect(stubs.setBoundary).to.be.called;
@@ -273,7 +279,7 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
 
     describe('hasPageChanged()', () => {
         it('should return false when there is no location', () => {
-            const value = docDrawingThread.hasPageChanged(undefined);
+            const value = thread.hasPageChanged(undefined);
             expect(value).to.be.falsy;
         });
 
@@ -281,67 +287,67 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
             const location = {
                 page: undefined
             };
-            const value = docDrawingThread.hasPageChanged(location);
+            const value = thread.hasPageChanged(location);
             expect(value).to.be.falsy;
         });
 
         it('should return false when the given location page is the same as the thread location', () => {
-            docDrawingThread.location = {
+            thread.location = {
                 page: 2
             };
             const location = {
-                page: docDrawingThread.location.page
+                page: thread.location.page
             };
-            const value = docDrawingThread.hasPageChanged(location);
+            const value = thread.hasPageChanged(location);
             expect(value).to.be.falsy;
         });
 
         it('should return true when the given location page is different from the thread location', () => {
-            docDrawingThread.location = {
+            thread.location = {
                 page: 2
             };
             const location = {
-                page: (docDrawingThread.location.page + 1)
+                page: (thread.location.page + 1)
             };
-            const value = docDrawingThread.hasPageChanged(location);
+            const value = thread.hasPageChanged(location);
             expect(value).to.be.true;
         });
     });
 
     describe('show()', () => {
         beforeEach(() => {
-            sandbox.stub(docDrawingThread, 'selectContext');
-            sandbox.stub(docDrawingThread, 'draw');
-            docDrawingThread.pathContainer = {
+            sandbox.stub(thread, 'selectContext');
+            sandbox.stub(thread, 'draw');
+            thread.pathContainer = {
                 applyToItems: sandbox.stub()
             };
 
-            docDrawingThread.annotatedElement = 'annotatedEl';
-            docDrawingThread.location = 'loc';
+            thread.annotatedElement = 'annotatedEl';
+            thread.location = 'loc';
         });
 
         it('should do nothing when no element is assigned to the DocDrawingThread', () => {
-            docDrawingThread.annotatedElement = undefined;
-            docDrawingThread.show();
-            expect(docDrawingThread.selectContext).to.not.be.called;
+            thread.annotatedElement = undefined;
+            thread.show();
+            expect(thread.selectContext).to.not.be.called;
         });
 
         it('should do nothing when no location is assigned to the DocDrawingThread', () => {
-            docDrawingThread.location = undefined;
-            docDrawingThread.show();
-            expect(docDrawingThread.selectContext).to.not.be.called;
+            thread.location = undefined;
+            thread.show();
+            expect(thread.selectContext).to.not.be.called;
         });
 
         it('should draw the paths in the thread', () => {
-            docDrawingThread.state = 'not pending';
-            docDrawingThread.show();
-            expect(docDrawingThread.selectContext).to.be.called;
-            expect(docDrawingThread.draw).to.be.called;
+            thread.state = 'not pending';
+            thread.show();
+            expect(thread.selectContext).to.be.called;
+            expect(thread.draw).to.be.called;
         });
 
         it('should draw the boundary when a dialog exists and is visible', () => {
-            sandbox.stub(docDrawingThread, 'drawBoundary');
-            docDrawingThread.dialog = {
+            sandbox.stub(thread, 'drawBoundary');
+            thread.dialog = {
                 isVisible: sandbox.stub().returns(true),
                 destroy: () => {},
                 removeAllListeners: () => {},
@@ -349,23 +355,23 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
                 show: sandbox.stub()
             }
 
-            docDrawingThread.show();
-            expect(docDrawingThread.dialog.isVisible).to.be.called;
-            expect(docDrawingThread.drawBoundary).to.be.called;
-            expect(docDrawingThread.dialog.show).to.be.called;
+            thread.show();
+            expect(thread.dialog.isVisible).to.be.called;
+            expect(thread.drawBoundary).to.be.called;
+            expect(thread.dialog.show).to.be.called;
         })
     });
 
     describe('selectContext()', () => {
         beforeEach(() => {
-            sandbox.stub(docDrawingThread, 'checkAndHandleScaleUpdate');
-            sandbox.stub(docDrawingThread, 'setContextStyles');
+            sandbox.stub(thread, 'checkAndHandleScaleUpdate');
+            sandbox.stub(thread, 'setContextStyles');
             stubs.context = sandbox.stub(docAnnotatorUtil, 'getContext');
         });
 
         it('should return the pending drawing context when the state is pending', () => {
-            docDrawingThread.state = STATES.pending;
-            docDrawingThread.drawingContext = {
+            thread.state = STATES.pending;
+            thread.drawingContext = {
                 clearRect: sandbox.stub(),
                 canvas: {
                     height: 100,
@@ -373,10 +379,10 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
                 }
             };
 
-            const retValue = docDrawingThread.selectContext();
-            expect(docDrawingThread.checkAndHandleScaleUpdate).to.be.called;
+            const retValue = thread.selectContext();
+            expect(thread.checkAndHandleScaleUpdate).to.be.called;
             expect(docAnnotatorUtil.getContext).to.not.be.called;
-            expect(retValue).to.deep.equal(docDrawingThread.drawingContext);
+            expect(retValue).to.deep.equal(thread.drawingContext);
         });
 
         it('should set and return the concrete context when the state is not pending', () => {
@@ -389,27 +395,27 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
             };
 
             stubs.context.returns(concreteContext);
-            docDrawingThread.state = STATES.idle;
+            thread.state = STATES.idle;
 
-            const retValue = docDrawingThread.selectContext();
-            expect(docDrawingThread.checkAndHandleScaleUpdate).to.be.called;
-            expect(docDrawingThread.setContextStyles).to.be.called;
+            const retValue = thread.selectContext();
+            expect(thread.checkAndHandleScaleUpdate).to.be.called;
+            expect(thread.setContextStyles).to.be.called;
             expect(docAnnotatorUtil.getContext).to.be.called;
-            expect(retValue).to.deep.equal(docDrawingThread.concreteContext);
+            expect(retValue).to.deep.equal(thread.concreteContext);
         });
     });
 
     describe('getBrowserRectangularBoundary()', () => {
         it('should return null when no thread has not been assigned a location', () => {
-            docDrawingThread.location = undefined;
+            thread.location = undefined;
 
-            const value = docDrawingThread.getBrowserRectangularBoundary();
+            const value = thread.getBrowserRectangularBoundary();
             expect(value).to.be.null;
         });
 
         it('should return a starting coordinate along with a height and width', () => {
-            docDrawingThread.pageEl = 'page';
-            docDrawingThread.location = {
+            thread.pageEl = 'page';
+            thread.location = {
                 dimensions: 'not empty'
             };
 
@@ -418,7 +424,7 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
             stubs.getBrowserCoordinates.onCall(0).returns([5, 5]);
             stubs.getBrowserCoordinates.onCall(1).returns([50, 45]);
 
-            const value = docDrawingThread.getBrowserRectangularBoundary();
+            const value = thread.getBrowserRectangularBoundary();
             expect(stubs.createLocation).to.be.called.twice;
             expect(stubs.getBrowserCoordinates).to.be.called.twice;
             expect(value).to.deep.equal([5, 5, 45, 40]);
@@ -431,23 +437,24 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
                 destroy: sandbox.stub()
             };
 
-            sandbox.stub(docDrawingThread, 'bindCustomListenersOnDialog');
-            docDrawingThread.dialog = existingDialog;
-            docDrawingThread.annotationService = {
-                canAnnotate: true
+            sandbox.stub(thread, 'bindCustomListenersOnDialog');
+            thread.dialog = existingDialog;
+            thread.annotationService = {
+                canAnnotate: true,
+                user: { id: -1 }
             };
 
-            docDrawingThread.createDialog();
+            thread.createDialog();
 
             expect(existingDialog.destroy).to.be.called;
-            expect(docDrawingThread.dialog instanceof DocDrawingDialog).to.be.truthy;
-            expect(docDrawingThread.bindCustomListenersOnDialog).to.be.called;
+            expect(thread.dialog instanceof DocDrawingDialog).to.be.truthy;
+            expect(thread.bindCustomListenersOnDialog).to.be.called;
         });
     });
 
     describe('bindCustomListenersOnDialog', () => {
         it('should bind listeners on the dialog', () => {
-            docDrawingThread.dialog = {
+            thread.dialog = {
                 addListener: sandbox.stub(),
                 removeAllListeners: sandbox.stub(),
                 hide: sandbox.stub(),
@@ -455,9 +462,9 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
                 isVisible: sandbox.stub()
             };
 
-            docDrawingThread.bindCustomListenersOnDialog();
-            expect(docDrawingThread.dialog.addListener).to.be.calledWith('annotationcreate', sinon.match.func);
-            expect(docDrawingThread.dialog.addListener).to.be.calledWith('annotationdelete', sinon.match.func);
+            thread.bindCustomListenersOnDialog();
+            expect(thread.dialog.addListener).to.be.calledWith('annotationcreate', sinon.match.func);
+            expect(thread.dialog.addListener).to.be.calledWith('annotationdelete', sinon.match.func);
         });
     });
 });

--- a/src/lib/annotations/doc/__tests__/DocDrawingThread-test.js
+++ b/src/lib/annotations/doc/__tests__/DocDrawingThread-test.js
@@ -168,7 +168,7 @@ describe('lib/annotations/doc/DocDrawingThread', () => {
         it('should emit an annotationevent of type pagechanged and stop a pending drawing', (done) =>{
             sandbox.stub(thread, 'handleStop');
             const location = 'location';
-            thread.addListener('annotationevent', (data) => {
+            thread.addListener('threadevent', (data) => {
                 done();
             });
 

--- a/src/lib/annotations/drawing/DrawingModeController.js
+++ b/src/lib/annotations/drawing/DrawingModeController.js
@@ -176,7 +176,8 @@ class DrawingModeController extends AnnotationModeController {
      * @return {void}
      */
     handleAnnotationEvent(thread, data = {}) {
-        switch (data.type) {
+        const { eventData } = data;
+        switch (data.event) {
             case 'locationassigned':
                 // Register the thread to the threadmap when a starting location is assigned. Should only occur once.
                 this.annotator.addThreadToMap(thread);
@@ -190,8 +191,8 @@ class DrawingModeController extends AnnotationModeController {
                 this.bindModeListeners();
 
                 // Given a location (page change) start drawing at the provided location
-                if (data.location) {
-                    this.currentThread.handleStart(data.location);
+                if (eventData && eventData.location) {
+                    this.currentThread.handleStart(eventData.location);
                 }
 
                 break;
@@ -210,7 +211,7 @@ class DrawingModeController extends AnnotationModeController {
 
                 break;
             case 'availableactions':
-                this.updateUndoRedoButtonEls(data.undo, data.redo);
+                this.updateUndoRedoButtonEls(eventData.undo, eventData.redo);
                 break;
             default:
         }

--- a/src/lib/annotations/drawing/DrawingModeController.js
+++ b/src/lib/annotations/drawing/DrawingModeController.js
@@ -129,8 +129,9 @@ class DrawingModeController extends AnnotationModeController {
      *
      * @inheritdoc
      * @protected
-     * @return {Array} An array where each element is an object containing the object that will emit the event,
-     *                 the type of events to listen for, and the callback
+     * @return {Array} An array where each element is an object containing
+     * the object that will emit the event, the type of events to listen
+     * for, and the callback
      */
     setupHandlers() {
         /* eslint-disable require-jsdoc */

--- a/src/lib/annotations/drawing/DrawingModeController.js
+++ b/src/lib/annotations/drawing/DrawingModeController.js
@@ -93,7 +93,7 @@ class DrawingModeController extends AnnotationModeController {
 
         // On save, add the thread to the Rbush, on delete, remove it from the Rbush
         thread.addListener('annotationsaved', () => this.registerThread(thread));
-        thread.addListener('threaddeleted', () => this.unregisterThread(thread));
+        thread.addListener('annotationdelete', () => this.unregisterThread(thread));
     }
 
     /**

--- a/src/lib/annotations/drawing/DrawingThread.js
+++ b/src/lib/annotations/drawing/DrawingThread.js
@@ -7,7 +7,8 @@ import {
     DRAW_RENDER_THRESHOLD,
     DRAW_BASE_LINE_WIDTH,
     DRAW_BORDER_OFFSET,
-    DRAW_DASHED_SPACING
+    DRAW_DASHED_SPACING,
+    THREAD_EVENT
 } from '../annotationConstants';
 
 class DrawingThread extends AnnotationThread {
@@ -97,7 +98,7 @@ class DrawingThread extends AnnotationThread {
 
         super.destroy();
         this.reset();
-        this.emit('threadcleanup');
+        this.emit(THREAD_EVENT.threadCleanup);
     }
 
     /**

--- a/src/lib/annotations/drawing/DrawingThread.js
+++ b/src/lib/annotations/drawing/DrawingThread.js
@@ -68,9 +68,7 @@ class DrawingThread extends AnnotationThread {
         // Recreate stored paths
         if (this.location && this.location.paths) {
             this.setBoundary();
-            this.emit('annotationevent', {
-                type: 'locationassigned'
-            });
+            this.emit('locationassigned');
 
             this.location.paths.forEach((drawingPathData) => {
                 const pathInstance = new DrawingPath(drawingPathData);
@@ -287,8 +285,7 @@ class DrawingThread extends AnnotationThread {
      */
     emitAvailableActions() {
         const availableActions = this.pathContainer.getNumberOfItems();
-        this.emit('annotationevent', {
-            type: 'availableactions',
+        this.emit('availableactions', {
             undo: availableActions.undoCount,
             redo: availableActions.redoCount
         });

--- a/src/lib/annotations/drawing/__tests__/DrawingModeController-test.js
+++ b/src/lib/annotations/drawing/__tests__/DrawingModeController-test.js
@@ -167,7 +167,7 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             };
 
             drawingModeController.handleAnnotationEvent(thread, {
-                type: 'locationassigned'
+                event: 'locationassigned'
             });
             expect(drawingModeController.annotator.addThreadToMap).to.be.called;
         });
@@ -181,7 +181,7 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             sandbox.stub(drawingModeController, 'unbindModeListeners');
             sandbox.stub(drawingModeController, 'bindModeListeners');
             drawingModeController.handleAnnotationEvent(thread, {
-                type: 'softcommit'
+                event: 'softcommit'
             });
             expect(drawingModeController.unbindModeListeners).to.be.called;
             expect(drawingModeController.bindModeListeners).to.be.called;
@@ -197,8 +197,10 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
                 handleStart: sandbox.stub()
             };
             const data = {
-                type: 'softcommit',
-                location: 'not empty'
+                event: 'softcommit',
+                eventData: {
+                    location: 'not empty'
+                }
             };
             sandbox.stub(drawingModeController, 'unbindModeListeners');
             sandbox.stub(drawingModeController, 'bindModeListeners', () => {
@@ -209,7 +211,7 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             expect(thread1.saveAnnotation).to.be.called;
             expect(drawingModeController.unbindModeListeners).to.be.called;
             expect(drawingModeController.bindModeListeners).to.be.called;
-            expect(thread2.handleStart).to.be.calledWith(data.location);
+            expect(thread2.handleStart).to.be.calledWith(data.eventData.location);
         });
 
         it('should update undo and redo buttons on availableactions', () => {
@@ -217,9 +219,11 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             sandbox.stub(drawingModeController, 'updateUndoRedoButtonEls');
 
             drawingModeController.handleAnnotationEvent(thread, {
-                type: 'availableactions',
-                undo: 1,
-                redo: 2
+                event: 'availableactions',
+                eventData: {
+                    undo: 1,
+                    redo: 2
+                }
             });
             expect(drawingModeController.updateUndoRedoButtonEls).to.be.calledWith(1, 2);
         });
@@ -233,7 +237,7 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             sandbox.stub(drawingModeController, 'unbindModeListeners');
             sandbox.stub(drawingModeController, 'bindModeListeners');
             drawingModeController.handleAnnotationEvent(thread, {
-                type: 'dialogdelete'
+                event: 'dialogdelete'
             });
             expect(thread.destroy).to.be.called;
             expect(drawingModeController.unbindModeListeners).to.be.called;
@@ -250,7 +254,7 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
             };
 
             drawingModeController.handleAnnotationEvent(thread, {
-                type: 'dialogdelete'
+                event: 'dialogdelete'
             });
             expect(thread.deleteThread).to.be.called;
             expect(drawingModeController.threads.search).to.be.called;

--- a/src/lib/annotations/drawing/__tests__/DrawingModeController-test.js
+++ b/src/lib/annotations/drawing/__tests__/DrawingModeController-test.js
@@ -98,7 +98,8 @@ describe('lib/annotations/drawing/DrawingModeController', () => {
 
             drawingModeController.bindCustomListenersOnThread(thread);
             expect(stubs.super).to.be.called;
-            expect(thread.addListener).to.be.called.twice;
+            expect(thread.addListener).to.be.calledWith('annotationsaved');
+            expect(thread.addListener).to.be.calledWith('annotationdelete');
         });
     });
 

--- a/src/lib/annotations/drawing/__tests__/DrawingThread-test.js
+++ b/src/lib/annotations/drawing/__tests__/DrawingThread-test.js
@@ -4,7 +4,7 @@ import {
     STATES
 } from '../../annotationConstants'
 
-let drawingThread;
+let thread;
 let stubs;
 const sandbox = sinon.sandbox.create();
 
@@ -15,7 +15,7 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
     beforeEach(() => {
         stubs = {};
-        drawingThread = new DrawingThread({
+        thread = new DrawingThread({
             annotatedElement: document.querySelector('.annotated-element'),
             annotations: [],
             annotationService: new AnnotationService({
@@ -34,63 +34,65 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
     afterEach(() => {
         sandbox.verifyAndRestore();
-        drawingThread = null;
+        thread = null;
     });
 
     describe('destroy()', () => {
         beforeEach(() => {
-            drawingThread.state = STATES.pending;
+            thread.state = STATES.pending;
         });
 
         it('should clean up drawings', () => {
             sandbox.stub(window, 'cancelAnimationFrame');
-            sandbox.stub(drawingThread, 'reset');
+            sandbox.stub(thread, 'reset');
+            sandbox.stub(thread, 'emit');
 
-            drawingThread.lastAnimationRequestId = 1;
-            drawingThread.drawingContext = {
+            thread.lastAnimationRequestId = 1;
+            thread.drawingContext = {
                 clearRect: sandbox.stub(),
                 canvas: {
                     width: 100,
                     height: 100
                 }
             };
-            drawingThread.destroy();
+            thread.destroy();
 
             expect(window.cancelAnimationFrame).to.be.calledWith(1);
-            expect(drawingThread.reset).to.be.called;
+            expect(thread.reset).to.be.called;
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.threadCleanup);
         })
     });
 
     describe('reset()', () => {
         it('should clear the boundary', () => {
-            sandbox.stub(drawingThread, 'clearBoundary');
-            drawingThread.reset();
-            expect(drawingThread.clearBoundary).to.be.called;
+            sandbox.stub(thread, 'clearBoundary');
+            thread.reset();
+            expect(thread.clearBoundary).to.be.called;
         });
     })
 
     describe('deleteThread()', () => {
         it('should delete all attached annotations, clear the drawn rectangle, and call destroy', () => {
-            sandbox.stub(drawingThread, 'getBrowserRectangularBoundary').returns(['a', 'b', 'c', 'd']);
-            sandbox.stub(drawingThread, 'deleteAnnotationWithID');
-            sandbox.stub(drawingThread, 'clearBoundary');
-            drawingThread.concreteContext = {
+            sandbox.stub(thread, 'getBrowserRectangularBoundary').returns(['a', 'b', 'c', 'd']);
+            sandbox.stub(thread, 'deleteAnnotationWithID');
+            sandbox.stub(thread, 'clearBoundary');
+            thread.concreteContext = {
                 clearRect: sandbox.stub()
             };
-            drawingThread.annotations = ['annotation'];
+            thread.annotations = ['annotation'];
 
 
-            drawingThread.deleteThread();
-            expect(drawingThread.getBrowserRectangularBoundary).to.be.called;
-            expect(drawingThread.concreteContext.clearRect).to.be.called;
-            expect(drawingThread.clearBoundary).to.be.called;
-            expect(drawingThread.deleteAnnotationWithID).to.be.calledWith('annotation');
+            thread.deleteThread();
+            expect(thread.getBrowserRectangularBoundary).to.be.called;
+            expect(thread.concreteContext.clearRect).to.be.called;
+            expect(thread.clearBoundary).to.be.called;
+            expect(thread.deleteAnnotationWithID).to.be.calledWith('annotation');
         });
     });
 
     describe('setContextStyles()', () => {
         it('should set configurable context properties', () => {
-            drawingThread.drawingContext = {
+            thread.drawingContext = {
                 lineCap: 'not set',
                 lineJoin: 'not set',
                 strokeStyle: 'no color',
@@ -102,71 +104,71 @@ describe('lib/annotations/drawing/DrawingThread', () => {
                 color: 'blue'
             };
 
-            drawingThread.setContextStyles(config);
+            thread.setContextStyles(config);
 
-            assert.deepEqual(drawingThread.drawingContext, {
+            assert.deepEqual(thread.drawingContext, {
                 lineCap: 'round',
                 lineJoin: 'round',
                 strokeStyle: 'blue',
-                lineWidth: drawingThread.drawingContext.lineWidth
+                lineWidth: thread.drawingContext.lineWidth
             });
 
-            assert.ok(drawingThread.drawingContext.lineWidth % config.scale == 0);
+            assert.ok(thread.drawingContext.lineWidth % config.scale == 0);
         })
     });
 
     describe('render()', () => {
         beforeEach(() => {
-            sandbox.stub(drawingThread, 'draw');
+            sandbox.stub(thread, 'draw');
         });
 
         it('should draw the pending path when the context is not empty', () => {
             const timeStamp = 20000;
-            drawingThread.render(timeStamp);
-            expect(drawingThread.draw).to.be.called;
+            thread.render(timeStamp);
+            expect(thread.draw).to.be.called;
         });
 
         it('should do nothing when the timeElapsed is less than the refresh rate', () => {
             const timeStamp = 100;
-            drawingThread.lastRenderTimestamp = 100;
-            drawingThread.render(timeStamp);
-            expect(drawingThread.draw).to.not.be.called;
+            thread.lastRenderTimestamp = 100;
+            thread.render(timeStamp);
+            expect(thread.draw).to.not.be.called;
         });
     });
 
     describe('setup()', () => {
         beforeEach(() => {
-            stubs.createDialog = sandbox.stub(drawingThread, 'createDialog');
+            stubs.createDialog = sandbox.stub(thread, 'createDialog');
         });
 
         it('should set the state to be pending when there are no saved annotations', () => {
-            drawingThread.annotations = [];
-            drawingThread.setup();
-            expect(drawingThread.state).to.equal(STATES.pending);
+            thread.annotations = [];
+            thread.setup();
+            expect(thread.state).to.equal(STATES.pending);
             expect(stubs.createDialog).to.not.be.called;
         });
 
         it('should set the state to be inactive and create a dialog when there are saved annotations', () => {
-            drawingThread.annotations = ['not empty'];
-            drawingThread.setup();
-            expect(drawingThread.state).to.equal(STATES.inactive);
+            thread.annotations = ['not empty'];
+            thread.setup();
+            expect(thread.state).to.equal(STATES.inactive);
             expect(stubs.createDialog).to.be.called;
         });
     });
 
     describe('undo()', () => {
         beforeEach(() => {
-            stubs.draw = sandbox.stub(drawingThread, 'draw');
-            stubs.updateBoundary = sandbox.stub(drawingThread, 'updateBoundary');
-            stubs.setBoundary = sandbox.stub(drawingThread, 'setBoundary');
-            stubs.drawBoundary = sandbox.stub(drawingThread, 'drawBoundary');
-            stubs.emitAvailableActions = sandbox.stub(drawingThread, 'emitAvailableActions');
-            stubs.containerUndo = sandbox.stub(drawingThread.pathContainer, 'undo');
+            stubs.draw = sandbox.stub(thread, 'draw');
+            stubs.updateBoundary = sandbox.stub(thread, 'updateBoundary');
+            stubs.setBoundary = sandbox.stub(thread, 'setBoundary');
+            stubs.drawBoundary = sandbox.stub(thread, 'drawBoundary');
+            stubs.emitAvailableActions = sandbox.stub(thread, 'emitAvailableActions');
+            stubs.containerUndo = sandbox.stub(thread.pathContainer, 'undo');
         });
 
         it('should do nothing when the path container fails to undo', () => {
             stubs.containerUndo.returns(false);
-            drawingThread.undo();
+            thread.undo();
             expect(stubs.containerUndo).to.be.called;
             expect(stubs.draw).to.not.be.called;
             expect(stubs.emitAvailableActions).to.not.be.called;
@@ -177,7 +179,7 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
         it('should draw when the path container indicates a successful undo', () => {
             stubs.containerUndo.returns(true);
-            drawingThread.undo();
+            thread.undo();
             expect(stubs.containerUndo).to.be.called;
             expect(stubs.draw).to.be.called;
             expect(stubs.emitAvailableActions).to.be.called;
@@ -189,14 +191,14 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
     describe('redo()', () => {
         beforeEach(() => {
-            stubs.draw = sandbox.stub(drawingThread, 'draw');
-            stubs.emitAvailableActions = sandbox.stub(drawingThread, 'emitAvailableActions');
-            stubs.containerRedo = sandbox.stub(drawingThread.pathContainer, 'redo');
+            stubs.draw = sandbox.stub(thread, 'draw');
+            stubs.emitAvailableActions = sandbox.stub(thread, 'emitAvailableActions');
+            stubs.containerRedo = sandbox.stub(thread.pathContainer, 'redo');
         });
 
         it('should do nothing when the path container fails to redo', () => {
             stubs.containerRedo.returns(false);
-            drawingThread.redo();
+            thread.redo();
             expect(stubs.containerRedo).to.be.called;
             expect(stubs.draw).to.not.be.called;
             expect(stubs.emitAvailableActions).to.not.be.called;
@@ -204,7 +206,7 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
         it('should draw when the path container indicates a successful redo', () => {
             stubs.containerRedo.returns(true);
-            drawingThread.redo();
+            thread.redo();
             expect(stubs.containerRedo).to.be.called;
             expect(stubs.draw).to.be.called;
             expect(stubs.emitAvailableActions).to.be.called;
@@ -215,13 +217,13 @@ describe('lib/annotations/drawing/DrawingThread', () => {
         let context;
 
         beforeEach(() => {
-            drawingThread.pendingPath = {
+            thread.pendingPath = {
                 isEmpty: sandbox.stub(),
                 drawPath: sandbox.stub()
             };
-            stubs.applyToItems = sandbox.stub(drawingThread.pathContainer, 'applyToItems');
-            stubs.pendingEmpty = drawingThread.pendingPath.isEmpty;
-            stubs.pendingDraw = drawingThread.pendingPath.drawPath;
+            stubs.applyToItems = sandbox.stub(thread.pathContainer, 'applyToItems');
+            stubs.pendingEmpty = thread.pendingPath.isEmpty;
+            stubs.pendingDraw = thread.pendingPath.drawPath;
             context = {
                 clearRect: sandbox.stub(),
                 beginPath: sandbox.stub(),
@@ -235,15 +237,15 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
         it('should do nothing when context is null or undefined', () => {
             context = undefined;
-            drawingThread.draw(context);
+            thread.draw(context);
             context = null;
-            drawingThread.draw(context);
+            thread.draw(context);
             expect(stubs.applyToItems).to.not.be.called;
         });
 
         it('should draw the items in the path container when given a valid context', () => {
             stubs.pendingEmpty.returns(false);
-            drawingThread.draw(context);
+            thread.draw(context);
             expect(context.beginPath).to.be.called;
             expect(stubs.applyToItems).to.be.called;
             expect(stubs.pendingEmpty).to.be.called;
@@ -252,19 +254,19 @@ describe('lib/annotations/drawing/DrawingThread', () => {
         });
 
         it('should clear the canvas when the flag is true', () => {
-            drawingThread.draw(context, true);
+            thread.draw(context, true);
             expect(context.clearRect).to.be.called;
         });
 
         it('should not clear the canvas when the flag is true', () => {
-            drawingThread.draw(context, false);
+            thread.draw(context, false);
             expect(context.clearRect).to.not.be.called;
         });
     });
 
     describe('emitAvailableActions()', () => {
         afterEach(() => {
-            drawingThread.removeAllListeners('annotationevent');
+            thread.removeAllListeners('annotationevent');
         });
 
         it('should trigger an annotationevent with the number of available undo and redo actions', (done) => {
@@ -272,34 +274,34 @@ describe('lib/annotations/drawing/DrawingThread', () => {
                 undoCount: 3,
                 redoCount: 2
             };
-            sandbox.stub(drawingThread.pathContainer, 'getNumberOfItems').returns(numItems);
-            drawingThread.addListener('annotationevent', (data) => {
+            sandbox.stub(thread.pathContainer, 'getNumberOfItems').returns(numItems);
+            thread.addListener('annotationevent', (data) => {
                 expect(data.type).to.equal('availableactions');
                 expect(data.undo).to.equal(numItems.undoCount);
                 expect(data.redo).to.equal(numItems.redoCount);
                 done();
             });
 
-            drawingThread.emitAvailableActions();
+            thread.emitAvailableActions();
         });
     });
 
     describe('drawBoundary()', () => {
         beforeEach(() => {
-            stubs.getBrowserRectangularBoundary = sandbox.stub(drawingThread, 'getBrowserRectangularBoundary');
+            stubs.getBrowserRectangularBoundary = sandbox.stub(thread, 'getBrowserRectangularBoundary');
         });
 
         it('should do nothing when the location has no page', () => {
-            drawingThread.location = {
+            thread.location = {
                 page: undefined
             };
 
-            drawingThread.drawBoundary();
+            thread.drawBoundary();
             expect(stubs.getBrowserRectangularBoundary).to.not.be.called;
         });
 
         it('should draw the boundary of the saved path', () => {
-            drawingThread.drawingContext = {
+            thread.drawingContext = {
                 save: sandbox.stub(),
                 beginPath: sandbox.stub(),
                 setLineDash: sandbox.stub(),
@@ -308,49 +310,49 @@ describe('lib/annotations/drawing/DrawingThread', () => {
                 restore: sandbox.stub()
             };
             stubs.getBrowserRectangularBoundary.returns([1,2,5,6]);
-            drawingThread.location = { page: 1 };
+            thread.location = { page: 1 };
 
-            drawingThread.drawBoundary();
+            thread.drawBoundary();
             expect(stubs.getBrowserRectangularBoundary).to.be.called;
-            expect(drawingThread.drawingContext.save).to.be.called;
-            expect(drawingThread.drawingContext.beginPath).to.be.called;
-            expect(drawingThread.drawingContext.setLineDash).to.be.called;
-            expect(drawingThread.drawingContext.rect).to.be.called;
-            expect(drawingThread.drawingContext.stroke).to.be.called;
-            expect(drawingThread.drawingContext.restore).to.be.called;
+            expect(thread.drawingContext.save).to.be.called;
+            expect(thread.drawingContext.beginPath).to.be.called;
+            expect(thread.drawingContext.setLineDash).to.be.called;
+            expect(thread.drawingContext.rect).to.be.called;
+            expect(thread.drawingContext.stroke).to.be.called;
+            expect(thread.drawingContext.restore).to.be.called;
         })
     });
 
     describe('setBoundary()', () => {
         it('should do nothing when no drawingPaths have been saved', () => {
-            drawingThread.location = {};
+            thread.location = {};
 
-            drawingThread.setBoundary();
-            expect(drawingThread.minX).to.be.undefined;
-            expect(drawingThread.maxX).to.be.undefined;
-            expect(drawingThread.minY).to.be.undefined;
-            expect(drawingThread.maxY).to.be.undefined;
+            thread.setBoundary();
+            expect(thread.minX).to.be.undefined;
+            expect(thread.maxX).to.be.undefined;
+            expect(thread.minY).to.be.undefined;
+            expect(thread.maxY).to.be.undefined;
         });
 
         it('should set the boundary when the location has been assigned', () => {
-            drawingThread.location = {
+            thread.location = {
                 minX: 5,
                 minY: 6,
                 maxX: 7,
                 maxY: 8
             };
 
-            drawingThread.setBoundary();
-            expect(drawingThread.minX).to.equal(drawingThread.location.minX);
-            expect(drawingThread.maxX).to.equal(drawingThread.location.maxX);
-            expect(drawingThread.minY).to.equal(drawingThread.location.minY);
-            expect(drawingThread.maxY).to.equal(drawingThread.location.maxY);
+            thread.setBoundary();
+            expect(thread.minX).to.equal(thread.location.minX);
+            expect(thread.maxX).to.equal(thread.location.maxX);
+            expect(thread.minY).to.equal(thread.location.minY);
+            expect(thread.maxY).to.equal(thread.location.maxY);
         });
     });
 
     describe('clearBoundary()', () => {
         it('should clear the drawing context and hide any dialog', () => {
-            drawingThread.drawingContext = {
+            thread.drawingContext = {
                 canvas: {
                     width: 100,
                     height: 100
@@ -358,17 +360,17 @@ describe('lib/annotations/drawing/DrawingThread', () => {
                 clearRect: sandbox.stub()
             };
 
-            drawingThread.dialog = {
+            thread.dialog = {
                 isVisible: sandbox.stub().returns(true),
                 hide: sandbox.stub(),
                 destroy: () => {},
                 removeAllListeners: () => {}
             };
 
-            drawingThread.clearBoundary();
-            expect(drawingThread.drawingContext.clearRect).to.be.called;
-            expect(drawingThread.dialog.isVisible).to.be.called;
-            expect(drawingThread.dialog.hide).to.be.called;
+            thread.clearBoundary();
+            expect(thread.drawingContext.clearRect).to.be.called;
+            expect(thread.dialog.isVisible).to.be.called;
+            expect(thread.dialog.hide).to.be.called;
         });
     });
 });

--- a/src/lib/annotations/drawing/__tests__/DrawingThread-test.js
+++ b/src/lib/annotations/drawing/__tests__/DrawingThread-test.js
@@ -1,7 +1,8 @@
 import DrawingThread from '../DrawingThread';
 import AnnotationService from '../../AnnotationService';
 import {
-    STATES
+    STATES,
+    THREAD_EVENT
 } from '../../annotationConstants'
 
 let thread;
@@ -266,7 +267,7 @@ describe('lib/annotations/drawing/DrawingThread', () => {
 
     describe('emitAvailableActions()', () => {
         afterEach(() => {
-            thread.removeAllListeners('annotationevent');
+            thread.removeAllListeners('threadevent');
         });
 
         it('should trigger an annotationevent with the number of available undo and redo actions', (done) => {
@@ -275,10 +276,11 @@ describe('lib/annotations/drawing/DrawingThread', () => {
                 redoCount: 2
             };
             sandbox.stub(thread.pathContainer, 'getNumberOfItems').returns(numItems);
-            thread.addListener('annotationevent', (data) => {
-                expect(data.type).to.equal('availableactions');
-                expect(data.undo).to.equal(numItems.undoCount);
-                expect(data.redo).to.equal(numItems.redoCount);
+            thread.addListener('threadevent', (data) => {
+                const { eventData } = data;
+                expect(data.event).to.equal('availableactions');
+                expect(eventData.undo).to.equal(numItems.undoCount);
+                expect(eventData.redo).to.equal(numItems.redoCount);
                 done();
             });
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -50,7 +50,8 @@ const ANNOTATOR_EVENT = {
     modeEnter: 'annotationmodeenter',
     modeExit: 'annotationmodeexit',
     fetch: 'annotationsfetched',
-    error: 'annotationerror'
+    error: 'annotationerror',
+    scale: 'scaleannotations'
 };
 
 @autobind
@@ -711,7 +712,7 @@ class BaseViewer extends EventEmitter {
 
         // Add a custom listener for events related to scaling/orientation changes
         this.addListener('scale', (data) => {
-            this.annotator.emit('scaleannotations', data);
+            this.annotator.emit(ANNOTATOR_EVENT.scale, data);
         });
 
         this.addListener('scrolltoannotation', (data) => {


### PR DESCRIPTION
Emits annotator and annotation thread specific events to the Viewer and Preview

Annotator Events: 
- annotationmodeenter: Enter an annotation mode
- annotationmodeexit: Exit an annotation mode
- annotationsfetched: Annotations have been fetched from the API
- annotationerror: Annotation error occurred

Annotation Thread Events:
- annotationpending: Thread was created but not saved
- annotationthreadsaved: Annotation thread saved on the server
- annotationthreaddeleted: Annotation thread deleted on the server
- annotationsaved: Annotation saved on an existing thread on the server
- annotationdeleted: Annotation deleted from an existing thread on the server
- annotationdeleteerror: Error while deleting an annotation on either an existing/new thread
- annotationcanceled: Annotation cancelled from posting on either an existing/new thread
- annotationcreateerror: Error while creating an annotation on either an existing/new thread