### PR TITLE
Fix: Respect view permissions when viewer.initAnnotations() is called

### DIFF
--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -555,7 +555,7 @@ class Annotator extends EventEmitter {
 
         // Do not load any pre-existing annotations if the user does not have
         // the correct permissions
-        if (!this.permissions.canViewAllAnnotations || !this.permissions.canViewOwnAnnotations) {
+        if (!this.permissions.canViewAllAnnotations && !this.permissions.canViewOwnAnnotations) {
             return Promise.resolve(this.threads);
         }
 

--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -88,12 +88,12 @@ class BoxAnnotations {
      * Chooses a annotator based on viewer.
      *
      * @param {Object} viewerName - Current preview viewer name
+     * @param {Object} permissions - File permissions
      * @param {Object} [viewerConfig] - Annotation configuration for a specific viewer
-     * @param {Object} [Object] - File permissions
      * @param {Array} [disabledAnnotators] - List of disabled annotators
      * @return {Object|null} A copy of the annotator to use, if available
      */
-    determineAnnotator(viewerName, viewerConfig = {}, permissions, disabledAnnotators = []) {
+    determineAnnotator(viewerName, permissions, viewerConfig = {}, disabledAnnotators = []) {
         let modifiedAnnotator = null;
 
         const hasAnnotationPermissions = canLoadAnnotations(permissions);

--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -2,6 +2,7 @@ import DocAnnotator from './doc/DocAnnotator';
 import ImageAnnotator from './image/ImageAnnotator';
 import DrawingModeController from './drawing/DrawingModeController';
 import { TYPES } from './annotationConstants';
+import { canLoadAnnotations } from './annotatorUtil';
 
 const ANNOTATORS = [
     {
@@ -88,14 +89,16 @@ class BoxAnnotations {
      *
      * @param {Object} viewerName - Current preview viewer name
      * @param {Object} [viewerConfig] - Annotation configuration for a specific viewer
+     * @param {Object} [Object] - File permissions
      * @param {Array} [disabledAnnotators] - List of disabled annotators
      * @return {Object|null} A copy of the annotator to use, if available
      */
-    determineAnnotator(viewerName, viewerConfig = {}, disabledAnnotators = []) {
-        const annotator = this.getAnnotatorsForViewer(viewerName, disabledAnnotators);
+    determineAnnotator(viewerName, viewerConfig = {}, permissions, disabledAnnotators = []) {
         let modifiedAnnotator = null;
 
-        if (!annotator || viewerConfig.enabled === false) {
+        const hasAnnotationPermissions = canLoadAnnotations(permissions);
+        const annotator = this.getAnnotatorsForViewer(viewerName, disabledAnnotators);
+        if (!hasAnnotationPermissions || !annotator || viewerConfig.enabled === false) {
             return modifiedAnnotator;
         }
 

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -477,23 +477,29 @@ describe('lib/annotations/Annotator', () => {
                 stubs.serviceMock.expects('getThreadMap').never();
                 annotator.permissions = {
                     canViewAllAnnotations: false,
+                    canViewOwnAnnotations: false
+                };
+                const result = annotator.fetchAnnotations();
+                expect(result instanceof Promise).to.be.truthy;
+            });
+
+            it('should fetch existing annotations if the user can view all annotations', () => {
+                stubs.serviceMock.expects('getThreadMap').returns(Promise.resolve());
+                annotator.permissions = {
+                    canViewAllAnnotations: false,
                     canViewOwnAnnotations: true
                 };
-                let result = annotator.fetchAnnotations();
+                const result = annotator.fetchAnnotations();
                 expect(result instanceof Promise).to.be.truthy;
+            });
 
+            it('should fetch existing annotations if the user can view all annotations', () => {
+                stubs.serviceMock.expects('getThreadMap').returns(Promise.resolve());
                 annotator.permissions = {
                     canViewAllAnnotations: true,
                     canViewOwnAnnotations: false
                 };
-                result = annotator.fetchAnnotations();
-                expect(result instanceof Promise).to.be.truthy;
-
-                annotator.permissions = {
-                    canViewAllAnnotations: false,
-                    canViewOwnAnnotations: false
-                };
-                result = annotator.fetchAnnotations();
+                const result = annotator.fetchAnnotations();
                 expect(result instanceof Promise).to.be.truthy;
             });
 

--- a/src/lib/annotations/__tests__/annotatorUtil-test.js
+++ b/src/lib/annotations/__tests__/annotatorUtil-test.js
@@ -26,7 +26,8 @@ import {
     replacePlaceholders,
     createLocation,
     round,
-    prevDefAndStopProp
+    prevDefAndStopProp,
+    canLoadAnnotations
 } from '../annotatorUtil';
 import {
     STATES,
@@ -38,6 +39,7 @@ import {
 const DIALOG_WIDTH = 81;
 
 const sandbox = sinon.sandbox.create();
+let stubs = {};
 
 describe('lib/annotations/annotatorUtil', () => {
     let childEl;
@@ -631,6 +633,35 @@ describe('lib/annotations/annotatorUtil', () => {
 
         it('should replace with the same value if the placeholder is repeated', () => {
             expect(replacePlaceholders('{2} highlighted {2}', ['Bob', 'Suzy'])).to.equal('Suzy highlighted Suzy');
+        });
+    });
+
+    describe('canLoadAnnotations()', () => {
+        beforeEach(() => {
+            stubs.permissions = {
+                can_annotate: false,
+                can_view_annotations_all: false,
+                can_view_annotations_self: false
+            };
+        });
+
+        it('should return false if permissions do not exist', () => {
+            expect(canLoadAnnotations()).to.be.false;
+        });
+
+        it('should return true if user has at least can_annotate permissions', () => {
+            stubs.permissions.can_annotate = true;
+            expect(canLoadAnnotations(stubs.permissions)).to.be.true;
+        });
+
+        it('should return true if user has at least can_view_annotations_all permissions', () => {
+            stubs.permissions.can_view_annotations_all = true;
+            expect(canLoadAnnotations(stubs.permissions)).to.be.true;
+        });
+
+        it('should return true if user has at least can_view_annotations_self permissions', () => {
+            stubs.permissions.can_view_annotations_self = true;
+            expect(canLoadAnnotations(stubs.permissions)).to.be.true;
         });
     });
 });

--- a/src/lib/annotations/annotationConstants.js
+++ b/src/lib/annotations/annotationConstants.js
@@ -78,6 +78,10 @@ export const SELECTOR_DIALOG_CLOSE = `.${CLASS_DIALOG_CLOSE}`;
 export const SELECTOR_HIGHLIGHT_BTNS = `.${CLASS_HIGHLIGHT_BTNS}`;
 export const SELECTOR_ADD_HIGHLIGHT_BTN = `.${CLASS_ADD_HIGHLIGHT_BTN}`;
 
+export const PERMISSION_ANNOTATE = 'can_annotate';
+export const PERMISSION_CAN_VIEW_ANNOTATIONS_ALL = 'can_view_annotations_all';
+export const PERMISSION_CAN_VIEW_ANNOTATIONS_SELF = 'can_view_annotations_self';
+
 export const DRAW_STATES = {
     idle: 'idle',
     drawing: 'drawing',

--- a/src/lib/annotations/annotatorUtil.js
+++ b/src/lib/annotations/annotatorUtil.js
@@ -1,5 +1,8 @@
 import 'whatwg-fetch';
 import {
+    PERMISSION_ANNOTATE,
+    PERMISSION_CAN_VIEW_ANNOTATIONS_ALL,
+    PERMISSION_CAN_VIEW_ANNOTATIONS_SELF,
     TYPES,
     SELECTOR_ANNOTATION_CARET,
     PENDING_STATES,
@@ -279,7 +282,10 @@ export function getAvatarHtml(avatarUrl, userId, userName) {
     let initials = '';
     if (userId !== '0') {
         // http://stackoverflow.com/questions/8133630/spliting-the-first-character-of-the-words
-        initials = userName.replace(/\W*(\w)\w*/g, '$1').toUpperCase().substring(0, 3);
+        initials = userName
+            .replace(/\W*(\w)\w*/g, '$1')
+            .toUpperCase()
+            .substring(0, 3);
     }
 
     const index = parseInt(userId, 10) || 0;
@@ -641,4 +647,24 @@ export function replacePlaceholders(string, placeholderValues) {
         return placeholderValues[placeholderIndex] ? placeholderValues[placeholderIndex] : match;
         /* eslint-enable no-plusplus */
     });
+}
+
+/**
+ * Determines whether the user has file permissions to annotate, view (either
+ * their own or everyone's) annotations which would allow annotations to at
+ * least be fetched for the current file
+ *
+ * @param {Object} permissions - File permissions
+ * @return {boolean} Whether or not the user has either view OR annotate permissions
+ */
+export function canLoadAnnotations(permissions) {
+    if (!permissions) {
+        return false;
+    }
+
+    const canAnnotate = permissions[PERMISSION_ANNOTATE];
+    const canViewAllAnnotations = permissions[PERMISSION_CAN_VIEW_ANNOTATIONS_ALL];
+    const canViewOwnAnnotations = permissions[PERMISSION_CAN_VIEW_ANNOTATIONS_SELF];
+
+    return !!canAnnotate || !!canViewAllAnnotations || !!canViewOwnAnnotations;
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -62,6 +62,8 @@ export const SELECTOR_BOX_PREVIEW_PROGRESS_BAR = `.${CLASS_BOX_PREVIEW_PROGRESS_
 
 export const PERMISSION_DOWNLOAD = 'can_download';
 export const PERMISSION_ANNOTATE = 'can_annotate';
+export const PERMISSION_CAN_VIEW_ANNOTATIONS_ALL = 'can_view_annotations_all';
+export const PERMISSION_CAN_VIEW_ANNOTATIONS_SELF = 'can_view_annotations_self';
 export const PERMISSION_PREVIEW = 'can_preview';
 
 export const API_HOST = 'https://api.box.com';

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -61,9 +61,6 @@ export const SELECTOR_BOX_PREVIEW_LOGO_DEFAULT = `.${CLASS_BOX_PREVIEW_LOGO_DEFA
 export const SELECTOR_BOX_PREVIEW_PROGRESS_BAR = `.${CLASS_BOX_PREVIEW_PROGRESS_BAR}`;
 
 export const PERMISSION_DOWNLOAD = 'can_download';
-export const PERMISSION_ANNOTATE = 'can_annotate';
-export const PERMISSION_CAN_VIEW_ANNOTATIONS_ALL = 'can_view_annotations_all';
-export const PERMISSION_CAN_VIEW_ANNOTATIONS_SELF = 'can_view_annotations_self';
 export const PERMISSION_PREVIEW = 'can_preview';
 
 export const API_HOST = 'https://api.box.com';

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -12,12 +12,8 @@ import {
     prefetchAssets,
     createAssetUrlCreator
 } from '../util';
-import { checkPermission } from '../file';
 import Browser from '../Browser';
 import {
-    PERMISSION_ANNOTATE,
-    PERMISSION_CAN_VIEW_ANNOTATIONS_ALL,
-    PERMISSION_CAN_VIEW_ANNOTATIONS_SELF,
     CLASS_FULLSCREEN,
     CLASS_FULLSCREEN_UNSUPPORTED,
     CLASS_HIDDEN,
@@ -661,19 +657,15 @@ class BaseViewer extends EventEmitter {
         const viewerName = this.options.viewer.NAME;
         const annotationsConfig = this.getViewerAnnotationsConfig();
 
-        this.annotatorConf = boxAnnotations.determineAnnotator(viewerName, annotationsConfig);
+        const { file } = this.options;
+        this.annotatorConf = boxAnnotations.determineAnnotator(viewerName, annotationsConfig, file.permissions);
+
+        // No annotatorConf will be returned if the user does not have the correct permissions
         if (!this.annotatorConf) {
             return;
         }
 
-        const { file } = this.options;
-        this.canAnnotate = checkPermission(file, PERMISSION_ANNOTATE);
-        this.canViewAllAnnotations = checkPermission(file, PERMISSION_CAN_VIEW_ANNOTATIONS_ALL);
-        this.canViewOwnAnnotations = checkPermission(file, PERMISSION_CAN_VIEW_ANNOTATIONS_SELF);
-
-        if (this.canAnnotate || this.canViewAllAnnotations || this.canViewOwnAnnotations) {
-            this.initAnnotations();
-        }
+        this.initAnnotations();
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -16,6 +16,8 @@ import { checkPermission } from '../file';
 import Browser from '../Browser';
 import {
     PERMISSION_ANNOTATE,
+    PERMISSION_CAN_VIEW_ANNOTATIONS_ALL,
+    PERMISSION_CAN_VIEW_ANNOTATIONS_SELF,
     CLASS_FULLSCREEN,
     CLASS_FULLSCREEN_UNSUPPORTED,
     CLASS_HIDDEN,
@@ -666,8 +668,10 @@ class BaseViewer extends EventEmitter {
 
         const { file } = this.options;
         this.canAnnotate = checkPermission(file, PERMISSION_ANNOTATE);
+        this.canViewAllAnnotations = checkPermission(file, PERMISSION_CAN_VIEW_ANNOTATIONS_ALL);
+        this.canViewOwnAnnotations = checkPermission(file, PERMISSION_CAN_VIEW_ANNOTATIONS_SELF);
 
-        if (this.canAnnotate) {
+        if (this.canAnnotate || this.canViewAllAnnotations || this.canViewOwnAnnotations) {
             this.initAnnotations();
         }
     }

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -658,7 +658,7 @@ class BaseViewer extends EventEmitter {
         const annotationsConfig = this.getViewerAnnotationsConfig();
 
         const { file } = this.options;
-        this.annotatorConf = boxAnnotations.determineAnnotator(viewerName, annotationsConfig, file.permissions);
+        this.annotatorConf = boxAnnotations.determineAnnotator(viewerName, file.permissions, annotationsConfig);
 
         // No annotatorConf will be returned if the user does not have the correct permissions
         if (!this.annotatorConf) {

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -766,9 +766,9 @@ describe('lib/viewers/BaseViewer', () => {
                 },
                 file: {
                     permissions: {
-                        can_annotate: false,
-                        can_view_annotations_all: false,
-                        can_view_annotations_self: false
+                        can_annotate: true,
+                        can_view_annotations_all: true,
+                        can_view_annotations_self: true
                     }
                 }
             };
@@ -818,43 +818,6 @@ describe('lib/viewers/BaseViewer', () => {
             stubs.areAnnotationsEnabled.returns(false);
             base.loadAnnotator();
             expect(base.initAnnotations).to.not.be.called;
-        });
-
-        it('should load an annotator if the user at least one of the correct permissions', () => {
-            class BoxAnnotations {
-                determineAnnotator() {
-                    return stubs.annotatorConf;
-                }
-            }
-            window.BoxAnnotations = BoxAnnotations;
-            stubs.areAnnotationsEnabled.returns(true);
-
-            base.loadAnnotator();
-            expect(base.initAnnotations).to.not.be.called;
-        });
-
-        it('should load an annotator if the user at least one of the correct permissions', () => {
-            class BoxAnnotations {
-                determineAnnotator() {
-                    return stubs.annotatorConf;
-                }
-            }
-            window.BoxAnnotations = BoxAnnotations;
-            stubs.areAnnotationsEnabled.returns(true);
-
-            base.options.file.permissions.can_annotate = true;
-            base.loadAnnotator();
-            expect(base.initAnnotations).to.be.called;
-
-            base.options.file.permissions.can_annotate = false;
-            base.options.file.permissions.can_view_annotations_all = true;
-            base.loadAnnotator();
-            expect(base.initAnnotations).to.be.called;
-
-            base.options.file.permissions.can_view_annotations_all = false;
-            base.options.file.permissions.can_view_annotations_self = true;
-            base.loadAnnotator();
-            expect(base.initAnnotations).to.be.called;
         });
     });
 


### PR DESCRIPTION
Annotations should be rendered in view-only if at LEAST one of the correct annotation permissions are true. This fully completes the separation of create + view permissions from #358. 