### PR TITLE
Fix: Show point annotation above dialog only on hover

### DIFF
--- a/src/lib/annotations/Annotator.scss
+++ b/src/lib/annotations/Annotator.scss
@@ -264,7 +264,10 @@ $avatar-color-9: #f22c44;
     padding: 0;
     position: absolute;
     width: 24px;
-    z-index: 10000; // Ensure activated point annotation icon is above dialog
+
+    &:hover {
+        z-index: 10000; // Ensure activated point annotation icon is above dialog
+    }
 
     svg {
         fill: fade-out($box-blue, .35);


### PR DESCRIPTION
Fixes this issue
<img width="462" alt="screen shot 2017-09-12 at 10 16 57 am" src="https://user-images.githubusercontent.com/3299001/30339335-8b0b8a92-97a3-11e7-8a3b-bace36d10e00.png">
