### PR TITLE
Chore: Optimize annotations fetch by separating permissions

### DIFF
--- a/src/lib/annotations/annotationConstants.js
+++ b/src/lib/annotations/annotationConstants.js
@@ -25,6 +25,7 @@ export const CLASS_TEXTAREA = 'bp-textarea';
 export const CLASS_HIGHLIGHT_BTNS = 'bp-annotation-highlight-btns';
 export const CLASS_ADD_HIGHLIGHT_BTN = 'bp-add-highlight-btn';
 export const CLASS_ADD_HIGHLIGHT_COMMENT_BTN = 'bp-highlight-comment-btn';
+export const CLASS_DELETE_COMMENT_BTN = 'delete-comment-btn';
 export const CLASS_ANNOTATION_LAYER_HIGHLIGHT = 'bp-annotation-layer-highlight';
 export const CLASS_ANNOTATION_LAYER_DRAW = 'bp-annotation-layer-draw';
 export const CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS = 'bp-annotation-layer-draw-in-progress';
@@ -77,6 +78,7 @@ export const SELECTOR_MOBILE_DIALOG_HEADER = `.${CLASS_MOBILE_DIALOG_HEADER}`;
 export const SELECTOR_DIALOG_CLOSE = `.${CLASS_DIALOG_CLOSE}`;
 export const SELECTOR_HIGHLIGHT_BTNS = `.${CLASS_HIGHLIGHT_BTNS}`;
 export const SELECTOR_ADD_HIGHLIGHT_BTN = `.${CLASS_ADD_HIGHLIGHT_BTN}`;
+export const SELECTOR_DELETE_COMMENT_BTN = `.${CLASS_DELETE_COMMENT_BTN}`;
 
 export const PERMISSION_ANNOTATE = 'can_annotate';
 export const PERMISSION_CAN_VIEW_ANNOTATIONS_ALL = 'can_view_annotations_all';

--- a/src/lib/annotations/annotatorUtil.js
+++ b/src/lib/annotations/annotatorUtil.js
@@ -307,13 +307,25 @@ export function getScale(annotatedElement) {
 //------------------------------------------------------------------------------
 
 /**
+ * Return first annotation in thread
+ *
+ * @param {Object} annotations - Annotations in thread
+ * @return {Annotation} First annotation in thread
+ */
+export function getFirstAnnotation(annotations) {
+    const firstAnnotationId = Object.keys(annotations)[0];
+    return annotations[firstAnnotationId];
+}
+
+/**
  * Whether or not a highlight annotation has comments or is a plain highlight
  *
- * @param {Annotation[]} annotations - Annotations in highlight thread
+ * @param {Object} annotations - Annotations in highlight thread
  * @return {boolean} Whether annotation is a plain highlight annotation
  */
 export function isPlainHighlight(annotations) {
-    return annotations.length === 1 && annotations[0].text === '';
+    const firstAnnotation = getFirstAnnotation(annotations);
+    return annotations.length === 1 && firstAnnotation.text === '';
 }
 
 /**

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -321,7 +321,7 @@ class DocAnnotator extends Annotator {
      * Creates the proper type of thread, adds it to in-memory map, and returns it.
      *
      * @override
-     * @param {Annotation[]} annotations - Annotations in thread
+     * @param {Object} annotations - Annotations in thread
      * @param {Object} location - Location object
      * @param {string} [type] - Optional annotation type
      * @return {AnnotationThread} Created annotation thread
@@ -344,8 +344,9 @@ class DocAnnotator extends Annotator {
 
         // Set existing thread ID if created with annotations
         if (annotations.length > 0) {
-            threadParams.threadID = annotations[0].threadID;
-            threadParams.threadNumber = annotations[0].threadNumber;
+            const firstAnnotation = annotatorUtil.getFirstAnnotation(annotations);
+            threadParams.threadID = firstAnnotation.threadID;
+            threadParams.threadNumber = firstAnnotation.threadNumber;
         }
 
         if (!annotatorUtil.validateThreadParams(threadParams)) {
@@ -408,7 +409,7 @@ class DocAnnotator extends Annotator {
             return null;
         }
 
-        const annotations = [];
+        const annotations = {};
         const thread = this.createAnnotationThread(annotations, location, highlightType);
         this.lastHighlightEvent = null;
         this.lastSelection = null;

--- a/src/lib/annotations/doc/DocDrawingDialog.js
+++ b/src/lib/annotations/doc/DocDrawingDialog.js
@@ -127,7 +127,7 @@ class DocDrawingDialog extends AnnotationDialog {
      * Sets up the drawing dialog element.
      *
      * @protected
-     * @param {Annotation[]} annotations - Annotations to show in the dialog
+     * @param {Object} annotations - Annotations to show in the dialog
      * @param {HTMLElement} threadEl - Annotation icon element
      * @return {void}
      */

--- a/src/lib/annotations/doc/DocHighlightDialog.js
+++ b/src/lib/annotations/doc/DocHighlightDialog.js
@@ -273,7 +273,8 @@ class DocHighlightDialog extends AnnotationDialog {
 
         // Determine if highlight buttons or comments dialog will display
         if (annotations.length > 0) {
-            this.hasComments = annotations[0].text !== '' || annotations.length > 1;
+            const firstAnnotation = annotatorUtil.getFirstAnnotation(annotations);
+            this.hasComments = firstAnnotation.text !== '' || annotations.length > 1;
         }
 
         // Generate HTML of highlight dialog
@@ -301,7 +302,8 @@ class DocHighlightDialog extends AnnotationDialog {
 
             // Adding thread number to dialog
             if (annotations.length > 0) {
-                this.element.dataset.threadNumber = annotations[0].threadNumber;
+                const firstAnnotation = annotatorUtil.getFirstAnnotation(annotations);
+                this.element.dataset.threadNumber = firstAnnotation.threadNumber;
             }
         }
 
@@ -313,22 +315,13 @@ class DocHighlightDialog extends AnnotationDialog {
         // Checks if highlight is a plain highlight annotation and if
         // user name has been populated. If userID is 0, user name will
         // be 'Some User'
-        if (annotatorUtil.isPlainHighlight(annotations) && annotations[0].user.id !== '0') {
+        const firstAnnotation = annotatorUtil.getFirstAnnotation(annotations);
+        if (annotatorUtil.isPlainHighlight(annotations) && firstAnnotation.user.id !== '0') {
             const highlightLabelEl = this.highlightDialogEl.querySelector(`.${CLASS_HIGHLIGHT_LABEL}`);
             highlightLabelEl.textContent = annotatorUtil.replacePlaceholders(__('annotation_who_highlighted'), [
-                annotations[0].user.name
+                firstAnnotation.user.name
             ]);
             annotatorUtil.showElement(highlightLabelEl);
-
-            if (!this.canAnnotate) {
-                // Hide all action buttons if user cannot annotate
-                const highlightButtons = this.highlightDialogEl.querySelector(constants.SELECTOR_HIGHLIGHT_BTNS);
-                annotatorUtil.hideElement(highlightButtons);
-            } else if (annotations[0].permissions && !annotations[0].permissions.can_delete) {
-                // Hide delete button on plain highlights if user doesn't have permissions
-                const addHighlightBtn = this.highlightDialogEl.querySelector(constants.SELECTOR_ADD_HIGHLIGHT_BTN);
-                annotatorUtil.hideElement(addHighlightBtn);
-            }
         }
 
         // Add annotation elements

--- a/src/lib/annotations/doc/DocHighlightThread.js
+++ b/src/lib/annotations/doc/DocHighlightThread.js
@@ -6,6 +6,7 @@ import * as docAnnotatorUtil from './docAnnotatorUtil';
 import {
     STATES,
     TYPES,
+    SELECTOR_HIGHLIGHT_BTNS,
     SELECTOR_ADD_HIGHLIGHT_BTN,
     HIGHLIGHT_FILL,
     CLASS_ANNOTATION_LAYER_HIGHLIGHT,
@@ -112,7 +113,8 @@ class DocHighlightThread extends AnnotationThread {
 
         // Hide delete button on plain highlights if user doesn't have
         // permissions
-        if (this.annotations.length && this.annotations[0].permissions && !this.annotations[0].permissions.can_delete) {
+        const firstAnnotation = annotatorUtil.getFirstAnnotation(this.annotations);
+        if (this.annotations.length && firstAnnotation.permissions && !firstAnnotation.permissions.can_delete) {
             const addHighlightBtn = this.dialog.element.querySelector(SELECTOR_ADD_HIGHLIGHT_BTN);
             annotatorUtil.hideElement(addHighlightBtn);
         }
@@ -292,6 +294,23 @@ class DocHighlightThread extends AnnotationThread {
             this.dialog.setup(this.annotations);
         }
 
+        // Show/hide delete button once permissions are updated
+        const firstAnnotation = annotatorUtil.getFirstAnnotation(this.annotations);
+        if (!annotatorUtil.isPlainHighlight(firstAnnotation.type)) {
+            // Hide all action buttons if user cannot annotate
+            if (this.permissions.canAnnotate) {
+                const highlightButtons = this.dialog.element.querySelector(SELECTOR_HIGHLIGHT_BTNS);
+                annotatorUtil.showElement(highlightButtons);
+            }
+
+            if (firstAnnotation.permissions && firstAnnotation.permissions.can_delete) {
+                const addHighlightBtn = this.dialog.element.querySelector(SELECTOR_ADD_HIGHLIGHT_BTN);
+                annotatorUtil.showElement(addHighlightBtn);
+            }
+        } else {
+            this.dialog.showAnnotationDelete(this.annotations);
+        }
+
         this.dialog.show(showPlain, showComment);
     }
 
@@ -313,7 +332,8 @@ class DocHighlightThread extends AnnotationThread {
 
         // Ensures that previously created annotations have the right type
         if (this.annotations.length) {
-            if ((this.annotations[0].text !== '' || this.annotations.length > 1) && this.type === TYPES.highlight) {
+            const firstAnnotation = annotatorUtil.getFirstAnnotation(this.annotations);
+            if ((firstAnnotation.text !== '' || this.annotations.length > 1) && this.type === TYPES.highlight) {
                 this.type = TYPES.highlight_comment;
             }
         }
@@ -376,7 +396,8 @@ class DocHighlightThread extends AnnotationThread {
             if (data) {
                 this.deleteAnnotation(data.annotationID);
             } else {
-                this.deleteAnnotation(this.annotations[0].annotationID);
+                const firstAnnotation = annotatorUtil.getFirstAnnotation(this.annotations);
+                this.deleteAnnotation(firstAnnotation.annotationID);
             }
         });
     }

--- a/src/lib/annotations/image/ImageAnnotator.js
+++ b/src/lib/annotations/image/ImageAnnotator.js
@@ -93,7 +93,7 @@ class ImageAnnotator extends Annotator {
      * it.
      *
      * @override
-     * @param {Annotation[]} annotations - Annotations in thread
+     * @param {Object} annotations - Annotations in thread
      * @param {Object} location - Location object
      * @param {string} [type] - Optional annotation type
      * @return {AnnotationThread} Created annotation thread
@@ -127,8 +127,9 @@ class ImageAnnotator extends Annotator {
 
         // Set existing thread ID if created with annotations
         if (annotations.length > 0) {
-            threadParams.threadID = annotations[0].threadID;
-            threadParams.threadNumber = annotations[0].threadNumber;
+            const firstAnnotation = annotatorUtil.getFirstAnnotation(annotations);
+            threadParams.threadID = firstAnnotation.threadID;
+            threadParams.threadNumber = firstAnnotation.threadNumber;
         }
 
         thread = new ImagePointThread(threadParams);


### PR DESCRIPTION
- Storing thread.annotations as an object by annotationId rather than an
  array of annotations