### PR TITLE
Chore: Only getBrowserInfo() once per preview instance

### DIFF
--- a/src/lib/Browser.js
+++ b/src/lib/Browser.js
@@ -340,6 +340,30 @@ class Browser {
             (Browser.isIOS() && /(?:OS\s)10_3/i.test(userAgent)) || (Browser.isMac() && Browser.getName() === 'Safari')
         );
     }
+
+    /**
+     * Gets browser capability information.
+     *
+     * @private
+     * @return {Object} Browser capability information
+     */
+    static getBrowserInfo() {
+        return {
+            name: Browser.getName(),
+            swf: Browser.hasFlash(),
+            svg: Browser.hasSVG(),
+            mse: Browser.hasMSE(),
+            webgl: Browser.hasWebGL(),
+            mp3: Browser.canPlayMP3(),
+            dash: Browser.canPlayDash(),
+            box3d: Browser.supportsModel3D(),
+            h264: {
+                baseline: Browser.canPlayH264Baseline(),
+                main: Browser.canPlayH264Main(),
+                high: Browser.canPlayH264High()
+            }
+        };
+    }
 }
 
 export default Browser;

--- a/src/lib/Logger.js
+++ b/src/lib/Logger.js
@@ -1,5 +1,3 @@
-import Browser from './Browser';
-
 /* eslint-disable no-undef */
 const CLIENT_NAME = __NAME__;
 const CLIENT_VERSION = __VERSION__;
@@ -10,14 +8,15 @@ class Logger {
      * [constructor]
      *
      * @param {string} locale - Locale
+     * @param {Object} browser - Browser information
      * @return {Logger} Logger instance
      */
-    constructor(locale) {
+    constructor(locale, browser) {
         this.start = Date.now();
         this.log = {
             locale,
             event: 'preview',
-            browser: this.getBrowserInfo(),
+            browser,
             client: {
                 name: CLIENT_NAME,
                 version: CLIENT_VERSION
@@ -31,30 +30,6 @@ class Logger {
                 conversion: 0,
                 rendering: 0,
                 total: 0
-            }
-        };
-    }
-
-    /**
-     * Gets browser capability information.
-     *
-     * @private
-     * @return {Object} Browser capability information
-     */
-    getBrowserInfo() {
-        return {
-            name: Browser.getName(),
-            swf: Browser.hasFlash(),
-            svg: Browser.hasSVG(),
-            mse: Browser.hasMSE(),
-            webgl: Browser.hasWebGL(),
-            mp3: Browser.canPlayMP3(),
-            dash: Browser.canPlayDash(),
-            box3d: Browser.supportsModel3D(),
-            h264: {
-                baseline: Browser.canPlayH264Baseline(),
-                main: Browser.canPlayH264Main(),
-                high: Browser.canPlayH264High()
             }
         };
     }

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -129,6 +129,7 @@ class Preview extends EventEmitter {
 
         this.cache = new Cache();
         this.ui = new PreviewUI();
+        this.browserInfo = Browser.getBrowserInfo();
     }
 
     /**
@@ -536,7 +537,7 @@ class Preview extends EventEmitter {
         this.open = true;
 
         // Init performance logging
-        this.logger = new Logger(this.location.locale);
+        this.logger = new Logger(this.location.locale, this.browserInfo);
 
         // Clear any existing retry timeouts
         clearTimeout(this.retryTimeout);

--- a/src/lib/__tests__/Logger-test.js
+++ b/src/lib/__tests__/Logger-test.js
@@ -6,7 +6,7 @@ const sandbox = sinon.sandbox.create();
 
 describe('lib/Logger', () => {
     beforeEach(() => {
-        logger = new Logger('FOO');
+        logger = new Logger('FOO', {});
     });
 
     afterEach(() => {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -716,9 +716,11 @@ describe('lib/Preview', () => {
         });
 
         it('should set the preview to open, and initialize the performance logger', () => {
+            sandbox.stub(Browser, 'getBrowserInfo');
             preview.load('0');
             expect(preview.open).to.be.true;
             expect(preview.logger instanceof Logger);
+            expect(Browser.getBrowserInfo).to.not.be.called; // cached from preview constructor
         });
 
         it('should clear the retry timeout', () => {


### PR DESCRIPTION
This information should only be fetched once rather than each time a Logger is instantiated for every Viewer