### PR TITLE
Fix: Downgrade pdf.js

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const webpackConfig = require('./webpack.karma.config');
 
-const DOC_STATIC_ASSETS_VERSION = '1.9.0';
+const DOC_STATIC_ASSETS_VERSION = '1.7.0';
 const MEDIA_STATIC_ASSETS_VERSION = '1.8.0';
 const MODEL3D_STATIC_ASSETS_VERSION = '1.9.1';
 const SWF_STATIC_ASSETS_VERSION = '0.112.0';

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -82,7 +82,7 @@ export const X_REP_HINT_VIDEO_MP4 = '[mp4]';
 
 // These should be updated to match the Preview version in package.json
 // whenever a file in that third party directory is updated
-export const DOC_STATIC_ASSETS_VERSION = '1.9.0';
+export const DOC_STATIC_ASSETS_VERSION = '1.7.0';
 export const MEDIA_STATIC_ASSETS_VERSION = '1.8.0';
 export const MODEL3D_STATIC_ASSETS_VERSION = '1.9.1';
 export const SWF_STATIC_ASSETS_VERSION = '0.112.0';


### PR DESCRIPTION
New version of pdf.js is showing a lot more console errors and is causing problems with Catchpoint.