### PR TITLE
Fix: Fixing document zoom on mobile

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -32,14 +32,11 @@
 
     //---------- Override CSS from generic PDFJS viewer build ----------//
     .pdfViewer .page {
-        align-items: center;
         border: 0;
         border-image: none;
         /* stylelint-disable declaration-no-important */
         box-sizing: content-box !important;
         /* stylelint-enable declaration-no-important */
-        display: flex;
-        justify-content: center;
         margin: 0 auto;
         // We use padding instead of margin to push down since we want to
         // include this padding when PDF.js jumps to pages


### PR DESCRIPTION
This change was originally included to enforce that the loading icon would be centered on a page when rendering. It may not be necessary and it causes problems when zooming on mobile devices.