### PR TITLE
Update: Support additional query params in requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "file-loader": "^0.10.1",
     "husky": "^0.13.4",
     "i18n-webpack-plugin": "^1.0.0",
+    "jsuri": "^1.3.1",
     "karma": "^1.5.0",
     "karma-chai": "^0.1.0",
     "karma-chai-as-promised": "^0.1.2",

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -235,6 +235,42 @@ describe('lib/util', () => {
         });
     });
 
+    describe('appendQueryParams()', () => {
+        it('should return original url when queryParams is null', () => {
+            const url = 'foo';
+            expect(util.appendQueryParams(url, null)).to.equal(url);
+        });
+
+        it('should return original url when queryParams is empty object', () => {
+            const url = 'foo';
+            expect(util.appendQueryParams(url, {})).to.equal(url);
+        });
+
+        it('should append query params to url', () => {
+            const url = 'foo';
+            expect(util.appendQueryParams(url, {
+                foo: 'bar',
+                baz: 'boo'
+            })).to.equal(`${url}/?foo=bar&baz=boo`);
+        });
+
+        it('should correctly append new query params to url', () => {
+            const url = 'foo?test=hah';
+            expect(util.appendQueryParams(url, {
+                foo: 'bar',
+                baz: 'boo'
+            })).to.equal(`foo/?test=hah&foo=bar&baz=boo`);
+        });
+
+        it('should replace values for existing keys', () => {
+            const url = 'test.com/?foo=hah'
+            expect(util.appendQueryParams(url, {
+                foo: 'bar',
+                baz: 'boo'
+            })).to.equal('test.com/?foo=bar&baz=boo');
+        });
+    });
+
     describe('appendAuthParams()', () => {
         it('should return url when no token or shared link is provided', () => {
             const url = 'foo';
@@ -246,7 +282,7 @@ describe('lib/util', () => {
             const token = 'sometoken';
             const sharedLink = 'someSharedLink';
             expect(util.appendAuthParams(url, token, sharedLink)).to.equal(
-                `${url}?access_token=${token}&shared_link=${sharedLink}&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`
+                `${url}/?access_token=${token}&shared_link=${sharedLink}&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`
             );
         });
 
@@ -256,7 +292,7 @@ describe('lib/util', () => {
             const sharedLink = 'someSharedLink';
             const sharedLinkPassword = 'somePass';
             expect(util.appendAuthParams(url, token, sharedLink, sharedLinkPassword)).to.equal(
-                `foobar?access_token=${token}&shared_link=${sharedLink}&shared_link_password=${sharedLinkPassword}&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`
+                `${url}/?access_token=${token}&shared_link=${sharedLink}&shared_link_password=${sharedLinkPassword}&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`
             );
         });
     });

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -1,3 +1,4 @@
+import { appendQueryParams } from './util';
 import { ORIGINAL_REP_NAME } from './constants';
 
 // List of Box Content API fields that the Preview library requires for every file. Updating this list is most likely
@@ -122,9 +123,10 @@ function addOriginalRepresentation(file) {
     }
 
     // Add an original representation if it doesn't already exist
+    const template = appendQueryParams(file.authenticated_download_url, { preview: 'true' });
     file.representations.entries.push({
         content: {
-            url_template: `${file.authenticated_download_url}?preview=true`
+            url_template: template
         },
         representation: ORIGINAL_REP_NAME,
         status: {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -4,6 +4,7 @@ import debounce from 'lodash.debounce';
 import fullscreen from '../Fullscreen';
 import RepStatus from '../RepStatus';
 import {
+    appendQueryParams,
     appendAuthParams,
     getHeaders,
     createContentUrl,
@@ -297,7 +298,9 @@ class BaseViewer extends EventEmitter {
      * @return {string} content url
      */
     createContentUrl(template, asset) {
-        return createContentUrl(template, asset);
+        // Append optional query params
+        const { queryParams } = this.options;
+        return appendQueryParams(createContentUrl(template, asset), queryParams);
     }
 
     /**
@@ -311,7 +314,11 @@ class BaseViewer extends EventEmitter {
      * @return {string} content url
      */
     createContentUrlWithAuthParams(template, asset) {
-        return this.appendAuthParams(this.createContentUrl(template, asset));
+        const urlWithAuthParams = this.appendAuthParams(createContentUrl(template, asset));
+
+        // Append optional query params
+        const { queryParams } = this.options;
+        return appendQueryParams(urlWithAuthParams, queryParams);
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -218,7 +218,7 @@ describe('lib/viewers/BaseViewer', () => {
 
     describe('createContentUrl()', () => {
         it('should return content url with no asset path', () => {
-            const url = 'url{asset_path}';
+            const url = 'url{+asset_path}';
             sandbox.spy(util, 'createContentUrl');
 
             const result = base.createContentUrl(url, '');
@@ -227,7 +227,7 @@ describe('lib/viewers/BaseViewer', () => {
         });
 
         it('should return content url with asset path from args', () => {
-            const url = 'url{asset_path}';
+            const url = 'url{+asset_path}';
 
             base = new BaseViewer({
                 viewer: { ASSET: 'foo' },
@@ -246,11 +246,11 @@ describe('lib/viewers/BaseViewer', () => {
 
     describe('createContentUrlWithAuthParams()', () => {
         it('should return content url with no asset path', () => {
-            sandbox.stub(base, 'createContentUrl').returns('foo');
+            sandbox.stub(util, 'createContentUrl').returns('foo');
             sandbox.stub(base, 'appendAuthParams').returns('bar');
             const result = base.createContentUrlWithAuthParams('boo', 'hoo');
             expect(result).to.equal('bar');
-            expect(base.createContentUrl).to.be.calledWith('boo', 'hoo');
+            expect(util.createContentUrl).to.be.calledWith('boo', 'hoo');
             expect(base.appendAuthParams).to.be.calledWith('foo');
         });
     });

--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -110,12 +110,15 @@ class Video360Viewer extends DashViewer {
         this.renderer.on(EVENT_SHOW_VR_BUTTON, this.handleShowVrButton);
         this.renderer.staticBaseURI = this.options.location.staticBaseURI;
         this.options.sceneEntities = sceneEntities;
-        this.renderer.initBox3d(this.options).then(this.create360Environment).then(() => {
-            // calling super.loadeddataHandler() will ready video playback
-            super.loadeddataHandler();
-            this.createControls();
-            this.renderer.initVr();
-        });
+        this.renderer
+            .initBox3d(this.options)
+            .then(this.create360Environment)
+            .then(() => {
+                // calling super.loadeddataHandler() will ready video playback
+                super.loadeddataHandler();
+                this.createControls();
+                this.renderer.initVr();
+            });
     }
 
     /**

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -99,7 +99,7 @@ class ImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     rotateLeft() {
-        this.currentRotationAngle = (this.currentRotationAngle - 90) % 3600 % 360;
+        this.currentRotationAngle = ((this.currentRotationAngle - 90) % 3600) % 360;
         this.imageEl.setAttribute('data-rotation-angle', this.currentRotationAngle);
         this.imageEl.style.transform = `rotate(${this.currentRotationAngle}deg)`;
         this.emit('rotate');
@@ -238,7 +238,7 @@ class ImageViewer extends ImageBaseViewer {
         this.scale = width
             ? width / this.imageEl.getAttribute('originalWidth')
             : height / this.imageEl.getAttribute('originalHeight');
-        this.rotationAngle = this.currentRotationAngle % 3600 % 360;
+        this.rotationAngle = (this.currentRotationAngle % 3600) % 360;
         this.emit('scale', {
             scale: this.scale,
             rotationAngle: this.rotationAngle
@@ -397,7 +397,7 @@ class ImageViewer extends ImageBaseViewer {
         this.adjustImageZoomPadding();
 
         this.scale = this.imageEl.clientWidth / this.imageEl.getAttribute('originalWidth');
-        this.rotationAngle = this.currentRotationAngle % 3600 % 360;
+        this.rotationAngle = (this.currentRotationAngle % 3600) % 360;
         this.emit('scale', {
             scale: this.scale,
             rotationAngle: this.rotationAngle

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -169,7 +169,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
                     }
                 }
             };
-            const result2 = multiImage.constructImageUrls('file/100/content/{asset_path}');
+            const result2 = multiImage.constructImageUrls('file/100/content/{+asset_path}');
             expect(result2[0]).to.equal(firstURL);
         });
 

--- a/src/lib/viewers/media/MediaControls.js
+++ b/src/lib/viewers/media/MediaControls.js
@@ -248,8 +248,8 @@ class MediaControls extends EventEmitter {
      */
     formatTime(seconds) {
         const h = Math.floor(seconds / 3600);
-        const m = Math.floor(seconds % 3600 / 60);
-        const s = Math.floor(seconds % 3600 % 60);
+        const m = Math.floor((seconds % 3600) / 60);
+        const s = Math.floor((seconds % 3600) % 60);
         const hour = h > 0 ? `${h.toString()}:` : '';
         const sec = s < 10 ? `0${s.toString()}` : s.toString();
         let min = m.toString();

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -36,7 +36,9 @@ class SWFViewer extends BaseViewer {
     load() {
         this.setup();
         super.load();
-        return this.loadAssets(JS).then(this.postLoad).catch(this.handleAssetError);
+        return this.loadAssets(JS)
+            .then(this.postLoad)
+            .catch(this.handleAssetError);
     }
 
     /**

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -27,7 +27,7 @@ describe('lib/viewers/text/CSVViewer', () => {
             },
             representation: {
                 content: {
-                    url_template: 'csvUrl{asset_path}'
+                    url_template: 'csvUrl{+asset_path}'
                 }
             }
         };
@@ -97,7 +97,7 @@ describe('lib/viewers/text/CSVViewer', () => {
 
             sandbox.stub(util, 'get').returns(Promise.resolve());
 
-            const csvUrlWithAuth = `csvUrl?access_token=token&shared_link=sharedLink&shared_link_password=sharedLinkPassword&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`;
+            const csvUrlWithAuth = `csvUrl/?access_token=token&shared_link=sharedLink&shared_link_password=sharedLinkPassword&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`;
 
             return csv.load().then(() => {
                 expect(window.Papa.parse).to.be.calledWith(csvUrlWithAuth, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3815,6 +3815,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsuri@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsuri/-/jsuri-1.3.1.tgz#cd93fc6a87b255142cb7b0f479f00517ab9395ed"
+
 jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"


### PR DESCRIPTION
- Replace manual URL manipulation with jsuri library
- Add support for new `queryParams` Preview option. When used, each key/value pair will be appended to all API requests as query params