### PR TITLE
Fix: Set watermark-cache params for dash segments

### DIFF
--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -215,9 +215,46 @@ describe('lib/viewers/media/DashViewer', () => {
         it('should append representation URLs with tokens', () => {
             stubs.createUrl = sandbox.stub(dash, 'createContentUrlWithAuthParams').returns('auth_url');
             stubs.req = { uris: ['uri'] };
+            dash.options = {
+                file: {
+                    watermark_info: {
+                        is_watermarked: false
+                    },
+                    representations: {
+                        entries: [
+                            { representation: 'dash' },
+                        ]
+                    }
+                }
+            }
+
             dash.requestFilter('', stubs.req);
+
             expect(stubs.createUrl).to.be.calledOnce;
             expect(stubs.req.uris).to.deep.equal(['auth_url']);
+        });
+
+        it('should append watermark cache-busting query params if file is watermarked', () => {
+            stubs.createUrl = sandbox.stub(dash, 'createContentUrlWithAuthParams').returns('www.authed.com/?foo=bar');
+            stubs.req = { uris: ['uri'] };
+            dash.watermarkCacheBust = '123'
+            dash.options = {
+                file: {
+                    watermark_info: {
+                        is_watermarked: true
+                    },
+                    representations: {
+                        entries: [
+                            { representation: 'dash' },
+                        ]
+                    }
+                }
+            }
+
+            dash.requestFilter('', stubs.req);
+
+            expect(stubs.createUrl).to.be.calledOnce;
+            expect(stubs.req.uris).to.deep.equal(['www.authed.com/?foo=bar&watermark-cache=123']);
         });
     });
 


### PR DESCRIPTION
In theory, if a content-url-template is given with watermark-cache
(cache-busting) params from the server, all dash requests should carry
those cache-busting params. They did not however, because the
content-url-template is only used to construct the URL of the manifest -
the segment URLs are constructed by shaka-player itself, based on the
manifest url, but ignores all query-params on the manifest. This is why
we have a requestFilter function, but watermark-cache busting parameters
weren't taken into account. This commit adds a watermark cache-busting
parameter to every segment request, if the file is watermarked.