### PR TITLE
Fix: Turn off rendering interactive forms

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -473,8 +473,7 @@ class DocBaseViewer extends BaseViewer {
             container: this.docEl,
             linkService: new PDFJS.PDFLinkService(),
             // Enhanced text selection uses more memory, so disable on mobile
-            enhanceTextSelection: !this.isMobile,
-            renderInteractiveForms: true
+            enhanceTextSelection: !this.isMobile
         });
 
         // Use chunk size set in viewer options if available

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -679,7 +679,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             stubs.emit = sandbox.stub(docBase, 'emit');
         });
 
-        it('should turn on enhanced text selection if not on mobile and turn on rendering of interactive forms', () => {
+        it('should turn on enhanced text selection if not on mobile', () => {
             docBase.options.location = {
                 locale: 'en-US'
             };
@@ -691,8 +691,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(stubs.pdfViewerStub).to.be.calledWith({
                 container: sinon.match.any,
                 linkService: sinon.match.any,
-                enhanceTextSelection: true,
-                renderInteractiveForms: true
+                enhanceTextSelection: true
             });
         });
 
@@ -708,8 +707,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(stubs.pdfViewerStub).to.be.calledWith({
                 container: sinon.match.any,
                 linkService: sinon.match.any,
-                enhanceTextSelection: false,
-                renderInteractiveForms: true
+                enhanceTextSelection: false
             });
         });
 


### PR DESCRIPTION
- Checkbox/radio button styling can be incorrect with interactive forms
- Interactive styling is distinct and some customers don't want it
- Forms are pseudo-interactive - changed data isn't actually saved