### PR TITLE
Fix: Use local storage to cache media settings

### DIFF
--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -293,7 +293,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     setVolume(volume) {
-        this.cache.set(MEDIA_VOLUME_CACHE_KEY, volume);
+        this.cache.set(MEDIA_VOLUME_CACHE_KEY, volume, true);
         this.handleVolume();
     }
 
@@ -488,9 +488,9 @@ class MediaBaseViewer extends BaseViewer {
     toggleMute() {
         if (this.mediaEl.volume) {
             this.oldVolume = this.mediaEl.volume;
-            this.cache.set(MEDIA_VOLUME_CACHE_KEY, 0);
+            this.cache.set(MEDIA_VOLUME_CACHE_KEY, 0, true);
         } else {
-            this.cache.set(MEDIA_VOLUME_CACHE_KEY, this.oldVolume);
+            this.cache.set(MEDIA_VOLUME_CACHE_KEY, this.oldVolume, true);
         }
         this.handleVolume();
     }

--- a/src/lib/viewers/media/Settings.js
+++ b/src/lib/viewers/media/Settings.js
@@ -420,7 +420,7 @@ class Settings extends EventEmitter {
      */
     chooseOption(type, value) {
         // Save the value
-        this.cache.set(`media-${type}`, value);
+        this.cache.set(`media-${type}`, value, true);
 
         // Emit to the listener what was chosen
         this.emit(type);


### PR DESCRIPTION
@bhh1988 was caching of media settings working previously? I observed it being broken on live since the cache object is getting cleared on each navigate/hide.