### PR TITLE
Chore: Add more detail to shaka error logging

### DIFF
--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -329,7 +329,7 @@ class DashViewer extends VideoBaseViewer {
     shakaErrorHandler(shakaError) {
         const error = new Error(
             `Shaka error. Code = ${shakaError.detail.code}, Category = ${shakaError.detail
-                .category}, Severity = ${shakaError.detail.severity}`
+                .category}, Severity = ${shakaError.detail.severity}, Data = ${shakaError.detail.data.toString()}`
         );
         error.displayMessage = __('error_refresh');
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -434,7 +434,8 @@ describe('lib/viewers/media/DashViewer', () => {
                 detail: {
                     severity: 2, // critical severity
                     category: 1,
-                    code: 1100
+                    code: 1100,
+                    data: ['foobar']
                 }
             };
 
@@ -448,7 +449,8 @@ describe('lib/viewers/media/DashViewer', () => {
                 detail: {
                     severity: 1, // recoverable severity
                     category: 1,
-                    code: 1100
+                    code: 1100,
+                    data: ['foobar']
                 }
             };
 


### PR DESCRIPTION
There is a "data" property to the shaka error object, which gives more
useful detail on the error, especially for media-element errors. See
https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html for
the various errors.