### PR TITLE
New: Added enabledTypes property. Backwards compat for disabledTypes

### DIFF
--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -9,7 +9,7 @@ import { canLoadAnnotations } from './annotatorUtil';
  * CONSTRUCTOR: Constructor for the annotator.
  * VIEWER: The kinds of viewers that can be annotated by this.
  * TYPE: The types of annotations that can be used by this annotator.
- * DEFAULT_ENABLED: The default annotation types enabled if none provided.
+ * DEFAULT_TYPES: The default annotation types enabled if none provided.
  */
 const ANNOTATORS = [
     {
@@ -17,14 +17,14 @@ const ANNOTATORS = [
         CONSTRUCTOR: DocAnnotator,
         VIEWER: ['Document', 'Presentation'],
         TYPE: [TYPES.point, TYPES.highlight, TYPES.highlight_comment, TYPES.draw],
-        DEFAULT_ENABLED: [TYPES.point, TYPES.highlight, TYPES.highlight_comment]
+        DEFAULT_TYPES: [TYPES.point, TYPES.highlight, TYPES.highlight_comment]
     },
     {
         NAME: 'Image',
         CONSTRUCTOR: ImageAnnotator,
         VIEWER: ['Image', 'MultiImage'],
         TYPE: [TYPES.point],
-        DEFAULT_ENABLED: [TYPES.point]
+        DEFAULT_TYPES: [TYPES.point]
     }
 ];
 
@@ -112,7 +112,7 @@ class BoxAnnotations {
 
         modifiedAnnotator = Object.assign({}, annotator);
 
-        const enabledTypes = viewerConfig.enabledTypes || [...modifiedAnnotator.DEFAULT_ENABLED];
+        const enabledTypes = viewerConfig.enabledTypes || [...modifiedAnnotator.DEFAULT_TYPES];
 
         // Keeping disabledTypes for backwards compatibility
         const disabledTypes = viewerConfig.disabledTypes || [];

--- a/src/lib/annotations/BoxAnnotations.js
+++ b/src/lib/annotations/BoxAnnotations.js
@@ -4,18 +4,27 @@ import DrawingModeController from './drawing/DrawingModeController';
 import { TYPES } from './annotationConstants';
 import { canLoadAnnotations } from './annotatorUtil';
 
+/**
+ * NAME: The name of the annotator.
+ * CONSTRUCTOR: Constructor for the annotator.
+ * VIEWER: The kinds of viewers that can be annotated by this.
+ * TYPE: The types of annotations that can be used by this annotator.
+ * DEFAULT_ENABLED: The default annotation types enabled if none provided.
+ */
 const ANNOTATORS = [
     {
         NAME: 'Document',
         CONSTRUCTOR: DocAnnotator,
         VIEWER: ['Document', 'Presentation'],
-        TYPE: [TYPES.point, TYPES.highlight, TYPES.highlight_comment]
+        TYPE: [TYPES.point, TYPES.highlight, TYPES.highlight_comment, TYPES.draw],
+        DEFAULT_ENABLED: [TYPES.point, TYPES.highlight, TYPES.highlight_comment]
     },
     {
         NAME: 'Image',
         CONSTRUCTOR: ImageAnnotator,
         VIEWER: ['Image', 'MultiImage'],
-        TYPE: [TYPES.point]
+        TYPE: [TYPES.point],
+        DEFAULT_ENABLED: [TYPES.point]
     }
 ];
 
@@ -104,12 +113,19 @@ class BoxAnnotations {
 
         modifiedAnnotator = Object.assign({}, annotator);
 
-        // Filter out disabled annotation types
-        if (Array.isArray(viewerConfig.disabledTypes)) {
-            modifiedAnnotator.TYPE = modifiedAnnotator.TYPE.filter((type) => {
-                return !viewerConfig.disabledTypes.includes(type);
-            });
-        }
+        const enabledTypes = viewerConfig.enabledTypes || [...modifiedAnnotator.DEFAULT_ENABLED];
+
+        // Keeping disabledTypes for backwards compatibility
+        const disabledTypes = viewerConfig.disabledTypes || [];
+
+        const annotatorTypes = enabledTypes.filter((type) => {
+            return (
+                !disabledTypes.some((disabled) => disabled === type) &&
+                modifiedAnnotator.TYPE.some((allowed) => allowed === type)
+            );
+        });
+
+        modifiedAnnotator.TYPE = annotatorTypes;
 
         return modifiedAnnotator;
     }

--- a/src/lib/annotations/README.md
+++ b/src/lib/annotations/README.md
@@ -140,7 +140,6 @@ preview.show(..., {
             annotations: {
                 enabled: Boolean, // Enables/disables if set. Respects "showAnnotations" if empty
                 enabledTypes: String[] | null // List of annotation types to enable for this viewer. If empty, will respect default types for that annotator.
-                disabledTypes: String[] | null // DEPRECATED. List of annotation types to disable.
             }
         }
     }

--- a/src/lib/annotations/README.md
+++ b/src/lib/annotations/README.md
@@ -139,7 +139,8 @@ preview.show(..., {
         VIEWER_NAME: {
             annotations: {
                 enabled: Boolean, // Enables/disables if set. Respects "showAnnotations" if empty
-                disabledTypes: String[] // List of annotation types to disable
+                enabledTypes: String[] | null // List of annotation types to enable for this viewer. If empty, will respect default types for that annotator.
+                disabledTypes: String[] | null // DEPRECATED. List of annotation types to disable.
             }
         }
     }
@@ -147,7 +148,7 @@ preview.show(..., {
 ```
 
 ### Example
-Enable all annotations, turn off for Image Viewers, and disable point annotations on Document viewer:
+Enable all annotations, turn off for Image Viewers, and enable only point annotations on Document viewer:
 ```
 preview.show(fileId, token, {
     showAnnotations: true,
@@ -160,7 +161,7 @@ preview.show(fileId, token, {
         Document: {
             annotations: {
                 enabled: true,
-                disabledTypes: ['point']
+                enabledTypes: ['point']
             }
         }
     }

--- a/src/lib/annotations/__tests__/BoxAnnotations-test.js
+++ b/src/lib/annotations/__tests__/BoxAnnotations-test.js
@@ -69,7 +69,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['point'],
-                DEFAULT_ENABLED: ['point']
+                DEFAULT_TYPES: ['point']
             };
 
             stubs.options = {
@@ -109,7 +109,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: viewer,
                 VIEWER: ['Document'],
                 TYPE: ['point', 'highlight'],
-                DEFAULT_ENABLED: ['point']
+                DEFAULT_TYPES: ['point']
             };
 
             sandbox.stub(loader, 'getAnnotatorsForViewer').returns(docAnnotator);
@@ -138,7 +138,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['point', 'highlight'],
-                DEFAULT_ENABLED: ['point', 'highlight']
+                DEFAULT_TYPES: ['point', 'highlight']
             };
             sandbox.stub(loader, 'getAnnotatorsForViewer').returns(docAnnotator);
             const annotator = loader.determineAnnotator(stubs.options, config);
@@ -149,7 +149,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['highlight'],
-                DEFAULT_ENABLED: ['point', 'highlight']
+                DEFAULT_TYPES: ['point', 'highlight']
             });
             expect(loader.getAnnotatorsForViewer).to.be.called;
         });
@@ -164,7 +164,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['point', 'highlight', 'highlight-comment', 'draw'],
-                DEFAULT_ENABLED: ['point', 'highlight']
+                DEFAULT_TYPES: ['point', 'highlight']
             };
             
             sandbox.stub(loader, 'getAnnotatorsForViewer').returns(docAnnotator);
@@ -175,7 +175,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['point'],
-                DEFAULT_ENABLED: ['point', 'highlight']
+                DEFAULT_TYPES: ['point', 'highlight']
             });
         });
 
@@ -188,7 +188,7 @@ describe('lib/annotators/BoxAnnotations', () => {
                 NAME: 'Document',
                 VIEWER: ['Document'],
                 TYPE: ['point', 'highlight', 'highlight-comment', 'draw'],
-                DEFAULT_ENABLED: ['point', 'draw']
+                DEFAULT_TYPES: ['point', 'draw']
             };
             sandbox.stub(loader, 'getAnnotatorsForViewer').returns(docAnnotator);
             const annotator = loader.determineAnnotator(stubs.options, config);

--- a/src/lib/annotations/__tests__/BoxAnnotations-test.js
+++ b/src/lib/annotations/__tests__/BoxAnnotations-test.js
@@ -93,7 +93,8 @@ describe('lib/annotators/BoxAnnotations', () => {
             const docAnnotator = {
                 NAME: viewer,
                 VIEWER: ['Document'],
-                TYPE: ['point']
+                TYPE: ['point', 'highlight'],
+                DEFAULT_ENABLED: ['point']
             };
             loader.annotators = [docAnnotator];
             const annotator = loader.determineAnnotator(viewer, {});
@@ -118,7 +119,8 @@ describe('lib/annotators/BoxAnnotations', () => {
             const docAnnotator = {
                 NAME: 'Document',
                 VIEWER: ['Document'],
-                TYPE: ['point', 'highlight']
+                TYPE: ['point', 'highlight'],
+                DEFAULT_ENABLED: ['point', 'highlight']
             };
             loader.annotators = [docAnnotator];
             const annotator = loader.determineAnnotator('Document', {}, config);
@@ -127,9 +129,52 @@ describe('lib/annotators/BoxAnnotations', () => {
             expect(annotator).to.deep.equal({
                 NAME: 'Document',
                 VIEWER: ['Document'],
-                TYPE: ['highlight']
+                TYPE: ['highlight'],
+                DEFAULT_ENABLED: ['point', 'highlight']
             });
             expect(stubs.instantiateControllers).to.be.called;
+        });
+        
+        it('should filter and only keep allowed types of annotations', () => {
+            const config = {
+                enabled: true,
+                enabledTypes: ['point', 'timestamp']
+            };
+
+            const docAnnotator = {
+                NAME: 'Document',
+                VIEWER: ['Document'],
+                TYPE: ['point', 'highlight', 'highlight-comment', 'draw'],
+                DEFAULT_ENABLED: ['point', 'highlight']
+            };
+            loader.annotators = [docAnnotator];
+            const annotator = loader.determineAnnotator('Document', {}, config);
+            expect(annotator.TYPE.includes('point')).to.be.true;
+            expect(annotator.TYPE.includes('highlight')).to.be.false;
+            expect(annotator).to.deep.equal({
+                NAME: 'Document',
+                VIEWER: ['Document'],
+                TYPE: ['point'],
+                DEFAULT_ENABLED: ['point', 'highlight']
+            });
+            expect(stubs.instantiateControllers).to.be.called;
+        });
+
+        it('should respect default annotators if none provided', () => {
+            const config = {
+                enabled: true
+            };
+
+            const docAnnotator = {
+                NAME: 'Document',
+                VIEWER: ['Document'],
+                TYPE: ['point', 'highlight', 'highlight-comment', 'draw'],
+                DEFAULT_ENABLED: ['point', 'draw']
+            };
+            loader.annotators = [docAnnotator];
+            const annotator = loader.determineAnnotator('Document', {}, config);
+            
+            expect(annotator.TYPE).to.deep.equal(['point', 'draw']);
         });
     });
 


### PR DESCRIPTION
Adding `enabledTypes` to the annotation configuration, as well as a default enabled annotation types(`DEFAULT_ENABLED`), if none provided, to `ANNOTATORS`. This allows us to specify all of the *allowed* kinds of annotators, and the ones that are enabled by default (if no config provided).

IE)
```
// for document annotator, results in only 'point' annotations, as timestamp are not allowed
enabledTypes: ['point', 'timestamp']
```