### PR TITLE
Chore: Passing localized strings into annotations

### DIFF
--- a/src/lib/annotations/AnnotationDialog.js
+++ b/src/lib/annotations/AnnotationDialog.js
@@ -478,13 +478,13 @@ class AnnotationDialog extends EventEmitter {
         // Temporary until annotation user API is available
         let userName;
         if (userId === '0') {
-            userName = __('annotation_posting_message');
+            userName = this.localized.posting;
         } else {
-            userName = annotatorUtil.htmlEscape(annotation.user.name) || __('annotation_anonymous_user_name');
+            userName = annotatorUtil.htmlEscape(annotation.user.name) || this.localized.anonymousUserName;
         }
 
         const avatarUrl = annotatorUtil.htmlEscape(annotation.user.avatarUrl || '');
-        const avatarHtml = annotatorUtil.getAvatarHtml(avatarUrl, userId, userName);
+        const avatarHtml = annotatorUtil.getAvatarHtml(avatarUrl, userId, userName, this.localized.profileAlt);
         const created = new Date(annotation.created).toLocaleString(this.locale, {
             month: '2-digit',
             day: '2-digit',
@@ -506,19 +506,19 @@ class AnnotationDialog extends EventEmitter {
             <div class="comment-text">${text}</div>
             <button class="bp-btn-plain ${CLASS_BUTTON_DELETE_COMMENT} ${annotation.permissions.can_delete
     ? ''
-    : constants.CLASS_HIDDEN}" data-type="${constants.DATA_TYPE_DELETE}" title="${__('annotation_delete')}">
+    : constants.CLASS_HIDDEN}" data-type="${constants.DATA_TYPE_DELETE}" title="${this.localized.deleteButton}">
                 ${ICON_DELETE}
             </button>
             <div class="${CLASS_DELETE_CONFIRMATION} ${constants.CLASS_HIDDEN}">
                 <div class="delete-confirmation-message">
-                    ${__('annotation_delete_confirmation_message')}
+                    ${this.localized.deleteConfirmation}
                 </div>
                 <div class="${constants.CLASS_BUTTON_CONTAINER}">
                     <button class="bp-btn ${CLASS_CANCEL_DELETE}" data-type="${constants.DATA_TYPE_CANCEL_DELETE}">
-                        ${__('annotation_cancel')}
+                        ${this.localized.cancelButton}
                     </button>
                     <button class="bp-btn bp-btn-primary ${CLASS_BUTTON_DELETE_CONFIRM}" data-type="${constants.DATA_TYPE_CONFIRM_DELETE}">
-                        ${__('annotation_delete')}
+                        ${this.localized.delete}
                     </button>
                 </div>
             </div>`.trim();
@@ -670,13 +670,13 @@ class AnnotationDialog extends EventEmitter {
         dialogEl.innerHTML = `
             <section class="${numAnnotations ? constants.CLASS_HIDDEN : ''}" data-section="create">
                 <textarea class="${constants.CLASS_TEXTAREA} ${constants.CLASS_ANNOTATION_TEXTAREA}"
-                    placeholder="${__('annotation_add_comment_placeholder')}"></textarea>
+                    placeholder="${this.localized.addCommentPlaceholder}"></textarea>
                 <div class="${constants.CLASS_BUTTON_CONTAINER}">
                     <button class="bp-btn ${constants.CLASS_ANNOTATION_BUTTON_CANCEL}" data-type="${constants.DATA_TYPE_CANCEL}">
-                        ${__('annotation_cancel')}
+                        ${this.localized.cancelButton}
                     </button>
                     <button class="bp-btn bp-btn-primary ${constants.CLASS_ANNOTATION_BUTTON_POST}" data-type="${constants.DATA_TYPE_POST}">
-                        ${__('annotation_post')}
+                        ${this.localized.postButton}
                     </button>
                 </div>
             </section>
@@ -684,15 +684,14 @@ class AnnotationDialog extends EventEmitter {
                 <div class="${CLASS_COMMENTS_CONTAINER}"></div>
                 <div class="${CLASS_REPLY_CONTAINER}">
                     <textarea class="${constants.CLASS_TEXTAREA} ${CLASS_REPLY_TEXTAREA}"
-                        placeholder="${__(
-        'annotation_reply_placeholder'
-    )}" data-type="${constants.DATA_TYPE_REPLY_TEXTAREA}"></textarea>
+                        placeholder="${this.localized
+        .replyPlaceholder}" data-type="${constants.DATA_TYPE_REPLY_TEXTAREA}"></textarea>
                     <div class="${constants.CLASS_BUTTON_CONTAINER} ${constants.CLASS_HIDDEN}">
                         <button class="bp-btn ${constants.CLASS_ANNOTATION_BUTTON_CANCEL}" data-type="${constants.DATA_TYPE_CANCEL_REPLY}">
-                            ${__('annotation_cancel')}
+                            ${this.localized.cancelButton}
                         </button>
                         <button class="bp-btn bp-btn-primary ${constants.CLASS_ANNOTATION_BUTTON_POST}" data-type="${constants.DATA_TYPE_POST_REPLY}">
-                            ${__('annotation_post')}
+                            ${this.localized.postButton}
                         </button>
                     </div>
                 </div>

--- a/src/lib/annotations/AnnotationService.js
+++ b/src/lib/annotations/AnnotationService.js
@@ -4,11 +4,6 @@ import autobind from 'autobind-decorator';
 import Annotation from './Annotation';
 import { getHeaders } from './annotatorUtil';
 
-const ANONYMOUS_USER = {
-    id: '0',
-    name: __('annotation_anonymous_user_name')
-};
-
 @autobind
 class AnnotationService extends EventEmitter {
     //--------------------------------------------------------------------------
@@ -60,7 +55,10 @@ class AnnotationService extends EventEmitter {
         this.fileId = data.fileId;
         this.headers = getHeaders({}, data.token);
         this.canAnnotate = data.canAnnotate;
-        this.user = ANONYMOUS_USER;
+        this.user = {
+            id: '0',
+            name: this.anonymousUserName
+        };
     }
 
     /**

--- a/src/lib/annotations/AnnotationThread.js
+++ b/src/lib/annotations/AnnotationThread.js
@@ -58,6 +58,7 @@ class AnnotationThread extends EventEmitter {
         this.isMobile = data.isMobile;
         this.hasTouch = data.hasTouch;
         this.permissions = data.permissions;
+        this.localized = data.localized;
 
         this.setup();
     }
@@ -312,6 +313,7 @@ class AnnotationThread extends EventEmitter {
 
         if (this.dialog) {
             this.dialog.isMobile = this.isMobile;
+            this.dialog.localized = this.localized;
         }
 
         this.setupElement();

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -55,6 +55,7 @@ class Annotator extends EventEmitter {
         this.isMobile = options.isMobile || false;
         this.hasTouch = options.hasTouch || false;
         this.annotationModeHandlers = [];
+        this.localized = options.localizedStrings;
 
         const { file } = this.options;
         this.fileVersionId = file.file_version.id;
@@ -117,7 +118,8 @@ class Annotator extends EventEmitter {
             apiHost,
             fileId: file.id,
             token,
-            canAnnotate: this.permissions.canAnnotate
+            canAnnotate: this.permissions.canAnnotate,
+            anonymousUserName: this.localized.anonymousUserName
         });
 
         // Set up mobile annotations dialog
@@ -901,7 +903,7 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        this.emit(ANNOTATOR_EVENT.error, __('annotations_load_error'));
+        this.emit(ANNOTATOR_EVENT.error, this.localized.loadError);
         /* eslint-disable no-console */
         console.error('Annotation could not be created due to invalid params');
         /* eslint-enable no-console */
@@ -921,18 +923,18 @@ class Annotator extends EventEmitter {
         let errorMessage = '';
         switch (data.reason) {
             case 'read':
-                errorMessage = __('annotations_load_error');
+                errorMessage = this.localized.loadError;
                 break;
             case 'create':
-                errorMessage = __('annotations_create_error');
+                errorMessage = this.localized.createError;
                 this.showAnnotations();
                 break;
             case 'delete':
-                errorMessage = __('annotations_delete_error');
+                errorMessage = this.localized.deleteError;
                 this.showAnnotations();
                 break;
             case 'authorization':
-                errorMessage = __('annotations_authorization_error');
+                errorMessage = this.localized.authError;
                 break;
             default:
         }
@@ -980,11 +982,11 @@ class Annotator extends EventEmitter {
                 this.emit(data.event, data.data);
                 break;
             case THREAD_EVENT.deleteError:
-                this.emit(ANNOTATOR_EVENT.error, __('annotations_delete_error'));
+                this.emit(ANNOTATOR_EVENT.error, this.localized.deleteError);
                 this.emit(data.event, data.data);
                 break;
             case THREAD_EVENT.createError:
-                this.emit(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+                this.emit(ANNOTATOR_EVENT.error, this.localized.createError);
                 this.emit(data.event, data.data);
                 break;
             default:

--- a/src/lib/annotations/CommentBox.js
+++ b/src/lib/annotations/CommentBox.js
@@ -2,32 +2,27 @@ import EventEmitter from 'events';
 import * as constants from './annotationConstants';
 import { hideElement, showElement } from './annotatorUtil';
 
-// Display Text
-const TEXT_ANNOTATION_CANCEL = __('annotation_cancel');
-const TEXT_ANNOTATION_POST = __('annotation_post');
-const TEXT_ADD_COMMENT_PLACEHOLDER = __('annotation_add_comment_placeholder');
-
 class CommentBox extends EventEmitter {
     /**
      * Text displayed in the Cancel button element.
      *
      * @property {string}
      */
-    cancelText = TEXT_ANNOTATION_CANCEL;
+    cancelText;
 
     /**
      * Text displayed in the Post button element.
      *
      * @property {string}
      */
-    postText = TEXT_ANNOTATION_POST;
+    postText;
 
     /**
      * Placeholder text displayed in the text area element.
      *
      * @property {string}
      */
-    placeholderText = TEXT_ADD_COMMENT_PLACEHOLDER;
+    placeholderText;
 
     /**
      * Reference to the comment box element. Contains buttons and text area.
@@ -78,19 +73,17 @@ class CommentBox extends EventEmitter {
      *
      * @param {HTMLElement} parentEl - Parent element
      * @param {Object} [config] - Object containing text values to be displayed to the user.
-     * @param {string} config.cancel - Text displayed in the "Cancel" button
-     * @param {string} config.post - Text displayed in the "Post" button
-     * @param {string} config.placeholder - Placeholder text displayed in the text area
+     * @param {Object} config.localized - Translated strings for UI
      */
     constructor(parentEl, config = {}) {
         super();
 
         this.parentEl = parentEl;
 
-        this.cancelText = config.cancel || this.cancelText;
-        this.postText = config.post || this.postText;
-        this.placeholderText = config.placeholder || this.placeholderText;
         this.hasTouch = config.hasTouch;
+        this.cancelText = config.localized.cancelButton;
+        this.postText = config.localized.postButton;
+        this.placeholderText = config.localized.addCommentPlaceholder;
 
         // Explicit scope binding for event listeners
         this.onCancel = this.onCancel.bind(this);

--- a/src/lib/annotations/__tests__/AnnotationDialog-test.js
+++ b/src/lib/annotations/__tests__/AnnotationDialog-test.js
@@ -31,6 +31,10 @@ describe('lib/annotations/AnnotationDialog', () => {
             annotations: [],
             canAnnotate: true
         });
+        dialog.localized = {
+            addCommentPlaceholder: 'add comment placeholder',
+            posting: 'posting'
+        };
         dialog.setup([]);
         document.querySelector('.annotated-element').appendChild(dialog.element);
 
@@ -606,7 +610,7 @@ describe('lib/annotations/AnnotationDialog', () => {
                 })
             );
             const username = document.querySelector('.user-name');
-            expect(username).to.contain.html(sinon.match.string);
+            expect(username).to.contain.html(dialog.localized.posting);
         });
 
         it('should display user name if the user id is not 0', () => {

--- a/src/lib/annotations/__tests__/AnnotationDialog-test.js
+++ b/src/lib/annotations/__tests__/AnnotationDialog-test.js
@@ -606,7 +606,7 @@ describe('lib/annotations/AnnotationDialog', () => {
                 })
             );
             const username = document.querySelector('.user-name');
-            expect(username).to.contain.html(__('annotation_posting_message'));
+            expect(username).to.contain.html(sinon.match.string);
         });
 
         it('should display user name if the user id is not 0', () => {

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -46,7 +46,14 @@ describe('lib/annotations/Annotator', () => {
             isMobile: false,
             options,
             modeButtons: {},
-            location: {}
+            location: {},
+            localizedStrings: {
+                anonymousUserName: 'anonymous',
+                loadError: 'load error',
+                createError: 'create error',
+                deleteError: 'delete error',
+                authError: 'auth error',
+            }
         });
         annotator.threads = {};
         annotator.modeControllers = {};

--- a/src/lib/annotations/__tests__/Annotator-test.js
+++ b/src/lib/annotations/__tests__/Annotator-test.js
@@ -1048,7 +1048,7 @@ describe('lib/annotations/Annotator', () => {
                 };
                 annotator.handleAnnotationThreadEvents(data);
                 expect(stubs.emit).to.be.calledWith(data.event, data.data);
-                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, __('annotations_delete_error'));
+                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, sinon.match.string);
                 expect(stubs.unbind).to.not.be.called;
                 expect(stubs.remove).to.not.be.called;
             });
@@ -1061,7 +1061,7 @@ describe('lib/annotations/Annotator', () => {
                 };
                 annotator.handleAnnotationThreadEvents(data);
                 expect(stubs.emit).to.be.calledWith(data.event, data.data);
-                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+                expect(stubs.emit).to.be.calledWith(ANNOTATOR_EVENT.error, sinon.match.string);
                 expect(stubs.unbind).to.not.be.called;
                 expect(stubs.remove).to.not.be.called;
             });

--- a/src/lib/annotations/__tests__/CommentBox-test.js
+++ b/src/lib/annotations/__tests__/CommentBox-test.js
@@ -13,7 +13,11 @@ describe('lib/annotations/CommentBox', () => {
 
     beforeEach(() => {
         parentEl = document.createElement('span');
-        commentBox = new CommentBox(parentEl);
+        commentBox = new CommentBox(parentEl, {
+            localized: {
+                cancelButton: 'cancel'
+            }
+        });
     });
 
     afterEach(() => {
@@ -24,14 +28,14 @@ describe('lib/annotations/CommentBox', () => {
 
     describe('constructor()', () => {
         let tempCommentBox;
-        const config = {
-            placeholder: 'some placeholder',
-            cancel: 'some cancel',
-            post: 'some postage'
+        const localized = {
+            cancelButton: 'cancel',
+            postButton: 'post',
+            addCommentPlaceholder: 'placeholder'
         };
 
         beforeEach(() => {
-            tempCommentBox = new CommentBox(parentEl, config);
+            tempCommentBox = new CommentBox(parentEl, { localized });
         });
 
         afterEach(() => {
@@ -44,15 +48,15 @@ describe('lib/annotations/CommentBox', () => {
         });
 
         it('should assign cancelText to the string passed in the config', () => {
-            expect(tempCommentBox.cancelText).to.equal(config.cancel);
+            expect(tempCommentBox.cancelText).to.equal(localized.cancelButton);
         });
 
         it('should assign postText to the string passed in the config', () => {
-            expect(tempCommentBox.postText).to.equal(config.post);
+            expect(tempCommentBox.postText).to.equal(localized.postButton);
         });
 
         it('should assign placeholderText to the string passed in the config', () => {
-            expect(tempCommentBox.placeholderText).to.equal(config.placeholder);
+            expect(tempCommentBox.placeholderText).to.equal(localized.addCommentPlaceholder);
         });
     });
 

--- a/src/lib/annotations/__tests__/annotatorUtil-test.js
+++ b/src/lib/annotations/__tests__/annotatorUtil-test.js
@@ -28,7 +28,8 @@ import {
     round,
     prevDefAndStopProp,
     canLoadAnnotations,
-    insertTemplate
+    insertTemplate,
+    generateBtn
 } from '../annotatorUtil';
 import {
     STATES,
@@ -223,7 +224,6 @@ describe('lib/annotations/annotatorUtil', () => {
         });
     });
 
-
     describe('insertTemplate()', () => {
         it('should insert template into node', () => {
             const node = document.createElement('div');
@@ -231,6 +231,17 @@ describe('lib/annotations/annotatorUtil', () => {
 
             insertTemplate(node, '<div class="foo"></div>');
             assert.equal(node.firstElementChild.className, 'foo');
+        });
+    });
+
+    describe('generateBtn()', () => {
+        it('should return button node from specified details', () => {
+            const btn = generateBtn('class', 'title', 'content', 'type');
+            expect(btn).to.have.class('bp-btn-plain');
+            expect(btn).to.have.class('class');
+            expect(btn).to.have.attribute('data-type', 'type');
+            expect(btn).to.have.attribute('title', 'title');
+            expect(btn).to.have.text('content');
         });
     });
 
@@ -250,7 +261,7 @@ describe('lib/annotations/annotatorUtil', () => {
     describe('getAvatarHtml()', () => {
         it('should return avatar HTML with img if avatarUrl is provided', () => {
             const expectedHtml = '<img src="https://example.com" alt="Avatar">';
-            assert.equal(getAvatarHtml('https://example.com', '1', 'Some Name'), expectedHtml);
+            assert.equal(getAvatarHtml('https://example.com', '1', 'Some Name', 'Avatar'), expectedHtml);
         });
 
         it('should return avatar HTML initials if no avatarUrl is provided', () => {

--- a/src/lib/annotations/annotationConstants.js
+++ b/src/lib/annotations/annotationConstants.js
@@ -4,6 +4,7 @@ export const CLASS_ACTIVE = 'bp-is-active';
 export const CLASS_HIDDEN = 'bp-is-hidden';
 export const CLASS_INVISIBLE = 'bp-is-invisible';
 export const CLASS_DISABLED = 'is-disabled';
+export const CLASS_BUTTON = 'bp-btn-plain';
 
 export const CLASS_ANNOTATION_BUTTON_CANCEL = 'cancel-annotation-btn';
 export const CLASS_ANNOTATION_BUTTON_POST = 'post-annotation-btn';

--- a/src/lib/annotations/annotatorUtil.js
+++ b/src/lib/annotations/annotatorUtil.js
@@ -9,7 +9,8 @@ import {
     CLASS_ACTIVE,
     CLASS_HIDDEN,
     CLASS_INVISIBLE,
-    CLASS_DISABLED
+    CLASS_DISABLED,
+    CLASS_BUTTON
 } from './annotationConstants';
 
 const HEADER_CLIENT_NAME = 'X-Box-Client-Name';
@@ -37,8 +38,8 @@ const THREAD_PARAMS = [
 /**
  * Finds the closest ancestor DOM element with the specified class.
  *
- * @param {HTMLElement} element - Element to search ancestors of
- * @param {string} className - Class name to query
+ * @param {HTMLElement} element Element to search ancestors of
+ * @param {string} className Class name to query
  * @return {HTMLElement|null} Closest ancestor with given class or null
  */
 export function findClosestElWithClass(element, className) {
@@ -54,7 +55,7 @@ export function findClosestElWithClass(element, className) {
 /**
  * Returns the page element and page number that the element is on.
  *
- * @param {HTMLElement} element - Element to find page and page number for
+ * @param {HTMLElement} element Element to find page and page number for
  * @return {Object} Page element/page number if found or null/-1 if not
  */
 export function getPageInfo(element) {
@@ -73,8 +74,8 @@ export function getPageInfo(element) {
  * an attributeName is provided, search for that data atttribute instead of
  * data type.
  *
- * @param {HTMLElement} element - Element to find closest data type for
- * @param {string} [attributeName] - Optional different data attribute to search
+ * @param {HTMLElement} element Element to find closest data type for
+ * @param {string} [attributeName] Optional different data attribute to search
  * for
  * @return {string} Closest data type or empty string
  */
@@ -93,7 +94,7 @@ export function findClosestDataType(element, attributeName) {
 /**
  * Shows the specified element or element with specified selector.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function showElement(elementOrSelector) {
@@ -110,7 +111,7 @@ export function showElement(elementOrSelector) {
 /**
  * Hides the specified element or element with specified selector.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function hideElement(elementOrSelector) {
@@ -127,7 +128,7 @@ export function hideElement(elementOrSelector) {
 /**
  * Disables the specified element or element with specified selector.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function disableElement(elementOrSelector) {
@@ -144,7 +145,7 @@ export function disableElement(elementOrSelector) {
 /**
  * Enables the specified element or element with specified selector.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function enableElement(elementOrSelector) {
@@ -161,7 +162,7 @@ export function enableElement(elementOrSelector) {
 /**
  * Shows the specified element or element with specified selector.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function showInvisibleElement(elementOrSelector) {
@@ -179,7 +180,7 @@ export function showInvisibleElement(elementOrSelector) {
  * Hides the specified element or element with specified selector. The element
  * will still take up DOM space but not be visible in the UI.
  *
- * @param {HTMLElement|string} elementOrSelector - Element or CSS selector
+ * @param {HTMLElement|string} elementOrSelector Element or CSS selector
  * @return {void}
  */
 export function hideElementVisibility(elementOrSelector) {
@@ -197,8 +198,8 @@ export function hideElementVisibility(elementOrSelector) {
  * Reset textarea element - clears value, resets styles, and remove active
  * state.
  *
- * @param {HTMLElement} element - Textarea to reset
- * @param {boolean} clearText - Whether or not text in text area should be cleared
+ * @param {HTMLElement} element Textarea to reset
+ * @param {boolean} clearText Whether or not text in text area should be cleared
  * @return {void}
  */
 export function resetTextarea(element, clearText) {
@@ -216,8 +217,8 @@ export function resetTextarea(element, clearText) {
  * Checks whether mouse is inside the dialog represented by this thread.
  *
  * @private
- * @param {Event} event - Mouse event
- * @param {HTMLElement} dialogEl - Dialog element
+ * @param {Event} event Mouse event
+ * @param {HTMLElement} dialogEl Dialog element
  * @return {boolean} Whether or not mouse is inside dialog
  */
 export function isInDialog(event, dialogEl) {
@@ -247,8 +248,8 @@ export function isInDialog(event, dialogEl) {
  * Creates contextual fragment
  *
  * @public
- * @param {Element} node - DOM node
- * @param {string} template - HTML template
+ * @param {Element} node DOM node
+ * @param {string} template HTML template
  * @return {DocumentFragment} Document fragment
  */
 export function createFragment(node, template) {
@@ -261,13 +262,33 @@ export function createFragment(node, template) {
  * Inserts template string into DOM node, before beforeNode. If beforeNode is null, inserts at end of child nodes
  *
  * @public
- * @param {Element} node - DOM node
+ * @param {Element} node DOM node
  * @param {string} template  html template
- * @param {Element|void} beforeNode - DOM node
+ * @param {Element|void} beforeNode DOM node
  * @return {void}
  */
 export function insertTemplate(node, template, beforeNode = null) {
     node.insertBefore(createFragment(node, template), beforeNode);
+}
+
+/**
+ * Returns a button HTMLElement with specified information
+ *
+ * @public
+ * @param {string} className Button CSS class
+ * @param {string} title Accessibilty title
+ * @param {string} content Button HTML content
+ * @param {string} [dataType] Optional data type
+ * @return {HTMLElement} Button
+ */
+export function generateBtn(className, title, content, dataType = '') {
+    const buttonEl = document.createElement('button');
+    buttonEl.classList.add(CLASS_BUTTON);
+    buttonEl.classList.add(className);
+    buttonEl.title = title;
+    buttonEl.textContent = content;
+    buttonEl.setAttribute('data-type', dataType);
+    return buttonEl;
 }
 
 //------------------------------------------------------------------------------
@@ -277,7 +298,7 @@ export function insertTemplate(node, template, beforeNode = null) {
 /**
  * Checks whether element is fully in viewport.
  *
- * @param {HTMLElement} element - The element to check and see if it lies in the viewport
+ * @param {HTMLElement} element The element to check and see if it lies in the viewport
  * @return {boolean} Whether the element is fully in viewport
  */
 export function isElementInViewport(element) {
@@ -296,20 +317,24 @@ export function isElementInViewport(element) {
  * image with the supplied avatar URL as a source if there is a URL passed in
  * or one generated using the initials of the annotator.
  *
- * @param {string} avatarUrl - URL of avatar photo
- * @param {string} userId - User ID of annotator
- * @param {string} userName - Username of annotator
+ * @param {string} avatarUrl URL of avatar photo
+ * @param {string} userId User ID of annotator
+ * @param {string} userName Username of annotator
+ * @param {string} altText Alternate text if profile picture is not available
  * @return {string} HTML for profile image
  */
-export function getAvatarHtml(avatarUrl, userId, userName) {
+export function getAvatarHtml(avatarUrl, userId, userName, altText) {
     if (avatarUrl !== '') {
-        return `<img src="${avatarUrl}" alt="${__('annotation_profile_alt')}">`.trim();
+        return `<img src="${avatarUrl}" alt="${altText}">`.trim();
     }
 
     let initials = '';
     if (userId !== '0') {
         // http://stackoverflow.com/questions/8133630/spliting-the-first-character-of-the-words
-        initials = userName.replace(/\W*(\w)\w*/g, '$1').toUpperCase().substring(0, 3);
+        initials = userName
+            .replace(/\W*(\w)\w*/g, '$1')
+            .toUpperCase()
+            .substring(0, 3);
     }
 
     const index = parseInt(userId, 10) || 0;
@@ -319,7 +344,7 @@ export function getAvatarHtml(avatarUrl, userId, userName) {
 /**
  * Returns zoom scale of annotated element.
  *
- * @param {HTMLElement} annotatedElement - HTML element being annotated on
+ * @param {HTMLElement} annotatedElement HTML element being annotated on
  * @return {number} Zoom scale
  */
 export function getScale(annotatedElement) {
@@ -333,7 +358,7 @@ export function getScale(annotatedElement) {
 /**
  * Whether or not a highlight annotation has comments or is a plain highlight
  *
- * @param {Annotation[]} annotations - Annotations in highlight thread
+ * @param {Annotation[]} annotations Annotations in highlight thread
  * @return {boolean} Whether annotation is a plain highlight annotation
  */
 export function isPlainHighlight(annotations) {
@@ -344,7 +369,7 @@ export function isPlainHighlight(annotations) {
  * Returns whether or not the annotation type is 'highlight' or
  * 'highlight-comment'
  *
- * @param {string} type - Annotatation type
+ * @param {string} type Annotatation type
  * @return {boolean} Whether or not annotation is a highlight
  */
 export function isHighlightAnnotation(type) {
@@ -360,10 +385,10 @@ export function isHighlightAnnotation(type) {
  * the current annotated element dimensions scaled to 100% with annotated
  * element dimensions when annotations were created.
  *
- * @param {Object} dimensions - Dimensions saved in annotation
- * @param {Object} fileDimensions - Current annotated element dimensions
- * @param {number} zoomScale - Zoom scale
- * @param {number} heightPadding - Top & bottom padding for annotated element
+ * @param {Object} dimensions Dimensions saved in annotation
+ * @param {Object} fileDimensions Current annotated element dimensions
+ * @param {number} zoomScale Zoom scale
+ * @param {number} heightPadding Top & bottom padding for annotated element
  * @return {Object|null} {x, y} dimension scale if needed, null otherwise
  */
 export function getDimensionScale(dimensions, fileDimensions, zoomScale, heightPadding) {
@@ -389,7 +414,7 @@ export function getDimensionScale(dimensions, fileDimensions, zoomScale, heightP
 /**
  * Escapes HTML.
  *
- * @param {string} str - Input string
+ * @param {string} str Input string
  * @return {string} HTML escaped string
  */
 export function htmlEscape(str) {
@@ -447,7 +472,7 @@ export function repositionCaret(dialogEl, dialogX, highlightDialogWidth, browser
 /**
  * Checks thread is in a pending or pending-active state
  *
- * @param {string} threadState - State of thread
+ * @param {string} threadState State of thread
  * @return {boolean} Whether annotation thread is in a pending state
  */
 export function isPending(threadState) {
@@ -458,7 +483,7 @@ export function isPending(threadState) {
  * Checks whether annotation thread is valid by checking whether each property
  * in THREAD_PARAMS on the specified file object is defined.
  *
- * @param {Object} thread - Annotation thread params to check
+ * @param {Object} thread Annotation thread params to check
  * @return {boolean} Whether or not annotation thread has all the required params
  */
 export function validateThreadParams(thread) {
@@ -471,8 +496,8 @@ export function validateThreadParams(thread) {
 /**
  * Returns a function that passes a callback a location when given an event on the document text layer
  *
- * @param {Function} locationFunction - The function to get a location from an event
- * @param {Function} callback - Callback to be called upon receiving an event
+ * @param {Function} locationFunction The function to get a location from an event
+ * @param {Function} callback Callback to be called upon receiving an event
  * @return {Function} Event listener to convert to document location
  */
 export function eventToLocationHandler(locationFunction, callback) {
@@ -495,7 +520,7 @@ export function eventToLocationHandler(locationFunction, callback) {
 /**
  * Call preventDefault and stopPropagation on an event
  *
- * @param {event} event - Event object to stop event bubbling
+ * @param {event} event Event object to stop event bubbling
  * @return {void}
  */
 export function prevDefAndStopProp(event) {
@@ -510,10 +535,10 @@ export function prevDefAndStopProp(event) {
 /**
  * Create a JSON object containing x/y coordinates and optionally dimensional information
  *
- * @param {number} x - The x position of the location object
- * @param {number} y - The y position of the location object
- * @param {Object} [dimensions] - The dimensional information of the location object
- * @return {Object} - A location object with x/y position information as well as provided dimensional information
+ * @param {number} x The x position of the location object
+ * @param {number} y The y position of the location object
+ * @param {Object} [dimensions] The dimensional information of the location object
+ * @return {Object} A location object with x/y position information as well as provided dimensional information
  */
 export function createLocation(x, y, dimensions) {
     const loc = { x, y };
@@ -531,7 +556,7 @@ export function createLocation(x, y, dimensions) {
 /**
  * Function to decode key down events into keys
  *
- * @param {Event} event - Keydown event
+ * @param {Event} event Keydown event
  * @return {string} Decoded keydown key
  */
 export function decodeKeydown(event) {
@@ -600,10 +625,10 @@ export function decodeKeydown(event) {
 /**
  * Builds a list of required XHR headers.
  *
- * @param {Object} [headers] - Optional headers
- * @param {string} [token] - Optional auth token
- * @param {string} [sharedLink] - Optional shared link
- * @param {string} [password] - Optional shared link password
+ * @param {Object} [headers] Optional headers
+ * @param {string} [token] Optional auth token
+ * @param {string} [sharedLink] Optional shared link
+ * @param {string} [password] Optional shared link password
  * @return {Object} Headers
  */
 export function getHeaders(headers = {}, token = '', sharedLink = '', password = '') {
@@ -635,8 +660,8 @@ export function getHeaders(headers = {}, token = '', sharedLink = '', password =
 /**
  * Round a number to a certain decimal place by concatenating an exponential factor. Credits to lodash library.
  *
- * @param {number} number - The number to be rounded
- * @param {number} precision - The amount of decimal places to keep
+ * @param {number} number The number to be rounded
+ * @param {number} precision The amount of decimal places to keep
  * @return {number} The rounded number
  */
 export function round(number, precision) {
@@ -652,8 +677,8 @@ export function round(number, precision) {
  * Replaces variable place holders specified between {} in the string with
  * specified custom value. Localizes strings that include variables.
  *
- * @param {string} string - String to be interpolated
- * @param {string[]} placeholderValues - Custom values to replace into string
+ * @param {string} string String to be interpolated
+ * @param {string[]} placeholderValues Custom values to replace into string
  * @return {string} Properly translated string with replaced custom variable
  */
 export function replacePlaceholders(string, placeholderValues) {
@@ -678,7 +703,7 @@ export function replacePlaceholders(string, placeholderValues) {
  * their own or everyone's) annotations which would allow annotations to at
  * least be fetched for the current file
  *
- * @param {Object} permissions - File permissions
+ * @param {Object} permissions File permissions
  * @return {boolean} Whether or not the user has either view OR annotate permissions
  */
 export function canLoadAnnotations(permissions) {

--- a/src/lib/annotations/doc/CreateHighlightDialog.js
+++ b/src/lib/annotations/doc/CreateHighlightDialog.js
@@ -8,8 +8,6 @@ const CLASS_CREATE_DIALOG = 'bp-create-annotation-dialog';
 const DATA_TYPE_HIGHLIGHT = 'add-highlight-btn';
 const DATA_TYPE_ADD_HIGHLIGHT_COMMENT = 'add-highlight-comment-btn';
 
-const CARAT_TEMPLATE = `<div class="${constants.CLASS_ANNOTATION_CARET}" style="left: 50%;"></div>`;
-
 /**
  * Events emitted by this component.
  * TODO(@spramod): Evaluate if these events need to be propogated to viewer
@@ -321,8 +319,15 @@ class CreateHighlightDialog extends EventEmitter {
      * @return {HTMLElement} The element containing Highlight creation UI
      */
     createElement() {
-        const dialogEl = document.createElement('div');
-        dialogEl.classList.add(constants.CLASS_ANNOTATION_HIGHLIGHT_DIALOG);
+        const highlightDialogEl = document.createElement('div');
+        highlightDialogEl.classList.add(CLASS_CREATE_DIALOG);
+
+        if (!this.isMobile) {
+            const caretTemplate = document.createElement('div');
+            caretTemplate.classList.add(constants.CLASS_ANNOTATION_CARET);
+            caretTemplate.left = '50%';
+            highlightDialogEl.appendChild(caretTemplate);
+        }
 
         const buttonsEl = document.createElement('span');
         buttonsEl.classList.add(constants.CLASS_HIGHLIGHT_BTNS);
@@ -347,11 +352,9 @@ class CreateHighlightDialog extends EventEmitter {
             buttonsEl.appendChild(commentEl);
         }
 
-        const highlightDialogEl = document.createElement('div');
-        highlightDialogEl.classList.add(CLASS_CREATE_DIALOG);
-
-        const caretTemplate = this.isMobile ? '' : CARAT_TEMPLATE;
-        highlightDialogEl.appendChild(caretTemplate);
+        const dialogEl = document.createElement('div');
+        dialogEl.classList.add(constants.CLASS_ANNOTATION_HIGHLIGHT_DIALOG);
+        dialogEl.appendChild(buttonsEl);
         highlightDialogEl.appendChild(dialogEl);
 
         // Get rid of the caret

--- a/src/lib/annotations/doc/DocAnnotator.js
+++ b/src/lib/annotations/doc/DocAnnotator.js
@@ -119,7 +119,8 @@ class DocAnnotator extends Annotator {
             isMobile: this.isMobile,
             hasTouch: this.hasTouch,
             allowComment: this.commentHighlightEnabled,
-            allowHighlight: this.plainHighlightEnabled
+            allowHighlight: this.plainHighlightEnabled,
+            localized: this.localized
         });
 
         if (this.commentHighlightEnabled) {
@@ -246,7 +247,7 @@ class DocAnnotator extends Annotator {
 
             // Do not create annotation if event doesn't have coordinates
             if (isNaN(x) || isNaN(y)) {
-                this.emit(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+                this.emit(ANNOTATOR_EVENT.error, this.localized.createError);
                 return location;
             }
 
@@ -332,7 +333,8 @@ class DocAnnotator extends Annotator {
             locale: this.locale,
             location,
             type,
-            permissions: this.permissions
+            permissions: this.permissions,
+            localized: this.localized
         };
 
         // Set existing thread ID if created with annotations
@@ -355,7 +357,7 @@ class DocAnnotator extends Annotator {
         }
 
         if (!thread && this.notification) {
-            this.emit(ANNOTATOR_EVENT.error, __('annotations_create_error'));
+            this.emit(ANNOTATOR_EVENT.error, this.localized.createError);
         } else if (thread && (type !== TYPES.draw || location.page)) {
             this.addThreadToMap(thread);
         }

--- a/src/lib/annotations/doc/DocDrawingDialog.js
+++ b/src/lib/annotations/doc/DocDrawingDialog.js
@@ -3,8 +3,6 @@ import * as annotatorUtil from '../annotatorUtil';
 import * as constants from '../annotationConstants';
 import { ICON_DRAW_SAVE, ICON_DRAW_DELETE } from '../../icons/icons';
 
-const LABEL_TEMPLATE = `<span class="${constants.CLASS_ANNOTATION_DRAWING_LABEL} ${constants.CLASS_HIDDEN}"></span>`;
-
 class DocDrawingDialog extends AnnotationDialog {
     /** @property {boolean} Whether or not the dialog is visible */
     visible = false;
@@ -199,19 +197,22 @@ class DocDrawingDialog extends AnnotationDialog {
         const canCommit = annotations.length === 0;
         const canDelete = canCommit || (annotations[0].permissions && annotations[0].permissions.can_delete);
 
-        const drawingDialogEl = document.createElement('div');
-        drawingDialogEl.classList.add(constants.CLASS_ANNOTATION_DRAWING_DIALOG);
-
         const drawingButtonsEl = document.createElement('span');
         drawingButtonsEl.classList.add(constants.CLASS_ANNOTATION_DRAWING_BTNS);
-        drawingButtonsEl.textContent = LABEL_TEMPLATE;
 
-        const commitButton = annotatorUtil.generateBtn(
-            constants.CLASS_ADD_DRAWING_BTN,
-            this.localized.drawSave,
-            `${ICON_DRAW_SAVE}${this.localized.saveButton}`.trim()
-        );
-        drawingButtonsEl.appendChild(commitButton);
+        const labelTemplate = document.createElement('span');
+        labelTemplate.classList.add(constants.CLASS_ANNOTATION_DRAWING_LABEL);
+        labelTemplate.classList.add(constants.CLASS_HIDDEN);
+        drawingButtonsEl.appendChild(labelTemplate);
+
+        if (canCommit) {
+            const commitButton = annotatorUtil.generateBtn(
+                constants.CLASS_ADD_DRAWING_BTN,
+                this.localized.drawSave,
+                `${ICON_DRAW_SAVE}${this.localized.saveButton}`.trim()
+            );
+            drawingButtonsEl.appendChild(commitButton);
+        }
 
         if (canDelete) {
             const deleteButton = annotatorUtil.generateBtn(
@@ -221,6 +222,11 @@ class DocDrawingDialog extends AnnotationDialog {
             );
             drawingButtonsEl.appendChild(deleteButton);
         }
+
+        const drawingDialogEl = document.createElement('div');
+        drawingDialogEl.classList.add(constants.CLASS_ANNOTATION_DRAWING_DIALOG);
+        drawingDialogEl.appendChild(drawingButtonsEl);
+
         return drawingDialogEl;
     }
 

--- a/src/lib/annotations/doc/DocDrawingDialog.js
+++ b/src/lib/annotations/doc/DocDrawingDialog.js
@@ -4,18 +4,6 @@ import * as constants from '../annotationConstants';
 import { ICON_DRAW_SAVE, ICON_DRAW_DELETE } from '../../icons/icons';
 
 const LABEL_TEMPLATE = `<span class="${constants.CLASS_ANNOTATION_DRAWING_LABEL} ${constants.CLASS_HIDDEN}"></span>`;
-const COMMIT_TEMPLATE = `
-    <button class="bp-btn-plain ${constants.CLASS_ADD_DRAWING_BTN}"
-        title="${__('annotation_draw_save')}">
-        ${ICON_DRAW_SAVE}
-        ${__('annotation_save')}
-    </button>`.trim();
-const DELETE_TEMPLATE = `
-    <button class="bp-btn-plain ${constants.CLASS_DELETE_DRAWING_BTN}"
-        title="${__('annotation_draw_delete')}">
-        ${ICON_DRAW_DELETE}
-        ${__('annotation_delete')}
-    </button>`.trim();
 
 class DocDrawingDialog extends AnnotationDialog {
     /** @property {boolean} Whether or not the dialog is visible */
@@ -212,18 +200,27 @@ class DocDrawingDialog extends AnnotationDialog {
         const canDelete = canCommit || (annotations[0].permissions && annotations[0].permissions.can_delete);
 
         const drawingDialogEl = document.createElement('div');
-
-        let includedButtonsHTML = canCommit ? COMMIT_TEMPLATE : '';
-        if (canDelete) {
-            includedButtonsHTML += DELETE_TEMPLATE;
-        }
-
         drawingDialogEl.classList.add(constants.CLASS_ANNOTATION_DRAWING_DIALOG);
-        drawingDialogEl.innerHTML = `
-            <span class="${constants.CLASS_ANNOTATION_DRAWING_BTNS}">
-                ${LABEL_TEMPLATE}
-                ${includedButtonsHTML}
-            </span>`.trim();
+
+        const drawingButtonsEl = document.createElement('span');
+        drawingButtonsEl.classList.add(constants.CLASS_ANNOTATION_DRAWING_BTNS);
+        drawingButtonsEl.textContent = LABEL_TEMPLATE;
+
+        const commitButton = annotatorUtil.generateBtn(
+            constants.CLASS_ADD_DRAWING_BTN,
+            this.localized.drawSave,
+            `${ICON_DRAW_SAVE}${this.localized.saveButton}`.trim()
+        );
+        drawingButtonsEl.appendChild(commitButton);
+
+        if (canDelete) {
+            const deleteButton = annotatorUtil.generateBtn(
+                constants.CLASS_DELETE_DRAWING_BTN,
+                this.localized.drawDelete,
+                `${ICON_DRAW_DELETE}${this.localized.deleteButton}`.trim()
+            );
+            drawingButtonsEl.appendChild(deleteButton);
+        }
         return drawingDialogEl;
     }
 
@@ -242,7 +239,7 @@ class DocDrawingDialog extends AnnotationDialog {
 
         const drawingLabelEl = this.drawingDialogEl.querySelector(`.${constants.CLASS_ANNOTATION_DRAWING_LABEL}`);
         const username = savedAnnotation.user ? savedAnnotation.user.name : constants.USER_ANONYMOUS;
-        drawingLabelEl.textContent = annotatorUtil.replacePlaceholders(__('annotation_who_drew'), [username]);
+        drawingLabelEl.textContent = annotatorUtil.replacePlaceholders(this.localized.whoDrew, [username]);
 
         annotatorUtil.showElement(drawingLabelEl);
     }

--- a/src/lib/annotations/doc/DocDrawingThread.js
+++ b/src/lib/annotations/doc/DocDrawingThread.js
@@ -222,6 +222,7 @@ class DocDrawingThread extends DrawingThread {
             isMobile: this.isMobile,
             hasTouch: this.hasTouch
         });
+        this.dialog.localized = this.localized;
 
         this.bindCustomListenersOnDialog();
     }

--- a/src/lib/annotations/doc/DocHighlightDialog.js
+++ b/src/lib/annotations/doc/DocHighlightDialog.js
@@ -33,7 +33,7 @@ class DocHighlightDialog extends AnnotationDialog {
         // Will be displayed as '{name} highlighted'
         if (annotation.text === '' && annotation.user.id !== '0') {
             const highlightLabelEl = this.highlightDialogEl.querySelector(`.${CLASS_HIGHLIGHT_LABEL}`);
-            highlightLabelEl.textContent = annotatorUtil.replacePlaceholders(__('annotation_who_highlighted'), [
+            highlightLabelEl.textContent = annotatorUtil.replacePlaceholders(this.localized.whoHighlighted, [
                 annotation.user.name
             ]);
             annotatorUtil.showElement(highlightLabelEl);
@@ -315,7 +315,7 @@ class DocHighlightDialog extends AnnotationDialog {
         // be 'Some User'
         if (annotatorUtil.isPlainHighlight(annotations) && annotations[0].user.id !== '0') {
             const highlightLabelEl = this.highlightDialogEl.querySelector(`.${CLASS_HIGHLIGHT_LABEL}`);
-            highlightLabelEl.textContent = annotatorUtil.replacePlaceholders(__('annotation_who_highlighted'), [
+            highlightLabelEl.textContent = annotatorUtil.replacePlaceholders(this.localized.whoHighlighted, [
                 annotations[0].user.name
             ]);
             annotatorUtil.showElement(highlightLabelEl);
@@ -571,12 +571,12 @@ class DocHighlightDialog extends AnnotationDialog {
             <span class="${constants.CLASS_HIGHLIGHT_BTNS}">
                 <button class="bp-btn-plain ${constants.CLASS_ADD_HIGHLIGHT_BTN}"
                     data-type="${constants.DATA_TYPE_HIGHLIGHT}"
-                    title="${__('annotation_highlight_toggle')}">
+                    title="${this.localized.highlightToggle}">
                     ${ICON_HIGHLIGHT}
                 </button>
                 <button class="bp-btn-plain ${constants.CLASS_ADD_HIGHLIGHT_COMMENT_BTN}"
                     data-type="${constants.DATA_TYPE_ADD_HIGHLIGHT_COMMENT}"
-                    title="${__('annotation_highlight_comment')}">
+                    title="${this.localized.highlightComment}">
                     ${ICON_HIGHLIGHT_COMMENT}
                 </button>
             </span>`.trim();

--- a/src/lib/annotations/doc/__tests__/CreateHighlightDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/CreateHighlightDialog-test.js
@@ -15,10 +15,14 @@ describe('lib/annotations/doc/CreateHighlightDialog', () => {
     const sandbox = sinon.sandbox.create();
     let dialog;
     let parentEl;
+    const localized = {
+        highlightToggle: 'highlight toggle',
+        highlightComment: 'highlight comment'
+    };
 
     beforeEach(() => {
         parentEl = document.createElement('div');
-        dialog = new CreateHighlightDialog(parentEl);
+        dialog = new CreateHighlightDialog(parentEl, { localized });
     });
 
     afterEach(() => {
@@ -37,7 +41,8 @@ describe('lib/annotations/doc/CreateHighlightDialog', () => {
         it('should take config falsey value to disable highlights and comments, when passed in', () => {
             const config = {
                 allowHighlight: 'this will falsey to true',
-                allowComment: false
+                allowComment: false,
+                localized
             };
             const instance = new CreateHighlightDialog(document.createElement('div'), config);
             expect(instance.allowHighlight).to.be.true;
@@ -83,7 +88,7 @@ describe('lib/annotations/doc/CreateHighlightDialog', () => {
 
         it('should set the parentEl to a new reference, via setParentEl(), if a new one is supplied', () => {
             const set = sandbox.stub(dialog, 'setParentEl');
-            const newParent = { name: 'NewParent' };
+            const newParent = document.createElement('span');
             dialog.show(newParent);
             expect(set).to.be.calledWith(newParent);
         });
@@ -380,7 +385,6 @@ describe('lib/annotations/doc/CreateHighlightDialog', () => {
     });
 
     describe('createElement()', () => {
-
         it('should create a div with the proper create highlight class', () => {
             let containerEl = dialog.createElement();
             expect(containerEl.nodeName).to.equal('DIV');

--- a/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
+++ b/src/lib/annotations/doc/__tests__/DocAnnotator-test.js
@@ -50,6 +50,9 @@ describe('lib/annotations/doc/DocAnnotator', () => {
             modeButtons: {},
             location: {
                 locale: 'en-US'
+            },
+            localizedStrings: {
+                anonymousUserName: 'anonymous'
             }
         });
         annotator.annotatedElement = document.querySelector('.annotated-element');

--- a/src/lib/annotations/doc/__tests__/DocDrawingDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/DocDrawingDialog-test.js
@@ -1,7 +1,8 @@
 import * as annotatorUtil from '../../annotatorUtil';
+import * as constants from '../../annotationConstants';
 import DocDrawingDialog from '../DocDrawingDialog';
 
-let docDrawingDialog;
+let dialog;
 let stubs;
 const sandbox = sinon.sandbox.create();
 
@@ -12,30 +13,34 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
 
     beforeEach(() => {
         fixture.load('annotations/doc/__tests__/DocDrawingDialog-test.html');
-        docDrawingDialog = new DocDrawingDialog({
+        dialog = new DocDrawingDialog({
             annotatedElement: document.querySelector('.annotated-element'),
             location: {},
             annotations: [],
             canAnnotate: true
         });
+        dialog.localized = {
+            drawSave: 'save',
+            whoDrew: 'someone drew'
+        };
         stubs = {};
     });
 
     afterEach(() => {
         sandbox.verifyAndRestore();
-        docDrawingDialog = null;
+        dialog = null;
         stubs = null;
     });
 
     describe('isVisible()', () => {
         it('should return true if the dialog is visible', () => {
-            docDrawingDialog.visible = true;
-            expect(docDrawingDialog.isVisible()).to.be.truthy;
+            dialog.visible = true;
+            expect(dialog.isVisible()).to.be.truthy;
         });
 
         it('should return false if the dialog is not visible', () => {
-            docDrawingDialog.visible = false;
-            expect(docDrawingDialog.isVisible()).to.be.falsy;
+            dialog.visible = false;
+            expect(dialog.isVisible()).to.be.falsy;
         });
     });
 
@@ -45,10 +50,10 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
                 stopPropagation: sandbox.stub(),
                 preventDefault: sandbox.stub()
             }
-            sandbox.stub(docDrawingDialog, 'emit');
+            sandbox.stub(dialog, 'emit');
 
-            docDrawingDialog.postDrawing(event);
-            expect(docDrawingDialog.emit).to.be.calledWith('annotationcreate');
+            dialog.postDrawing(event);
+            expect(dialog.emit).to.be.calledWith('annotationcreate');
             expect(event.stopPropagation).to.be.called;
             expect(event.preventDefault).to.be.called;
         });
@@ -56,72 +61,72 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
 
     describe('bindDOMListeners()', () => {
         it('should bind listeners to a commit button element', () => {
-            docDrawingDialog.hasTouch = true;
-            docDrawingDialog.commitButtonEl = {
+            dialog.hasTouch = true;
+            dialog.commitButtonEl = {
                 addEventListener: sandbox.stub()
             };
 
-            docDrawingDialog.bindDOMListeners();
-            expect(docDrawingDialog.commitButtonEl.addEventListener).to.be.calledWith(
+            dialog.bindDOMListeners();
+            expect(dialog.commitButtonEl.addEventListener).to.be.calledWith(
                 'click',
-                docDrawingDialog.postDrawing
+                dialog.postDrawing
             );
-            expect(docDrawingDialog.commitButtonEl.addEventListener).to.be.calledWith(
+            expect(dialog.commitButtonEl.addEventListener).to.be.calledWith(
                 'touchend',
-                docDrawingDialog.postDrawing
+                dialog.postDrawing
             );
         });
 
         it('should bind listeners to a delete button element', () => {
-            docDrawingDialog.hasTouch = true;
-            docDrawingDialog.deleteButtonEl = {
+            dialog.hasTouch = true;
+            dialog.deleteButtonEl = {
                 addEventListener: sandbox.stub()
             };
 
-            docDrawingDialog.bindDOMListeners();
-            expect(docDrawingDialog.deleteButtonEl.addEventListener).to.be.calledWith(
+            dialog.bindDOMListeners();
+            expect(dialog.deleteButtonEl.addEventListener).to.be.calledWith(
                 'click',
-                docDrawingDialog.deleteAnnotation
+                dialog.deleteAnnotation
             );
-            expect(docDrawingDialog.deleteButtonEl.addEventListener).to.be.calledWith(
+            expect(dialog.deleteButtonEl.addEventListener).to.be.calledWith(
                 'touchend',
-                docDrawingDialog.deleteAnnotation
+                dialog.deleteAnnotation
             );
         })
     });
 
     describe('unbindDOMListeners()', () => {
         it('should unbind listeners on a commit button element', () => {
-            docDrawingDialog.hasTouch = true;
-            docDrawingDialog.commitButtonEl = {
+            dialog.hasTouch = true;
+            dialog.commitButtonEl = {
                 removeEventListener: sandbox.stub()
             };
 
-            docDrawingDialog.unbindDOMListeners();
-            expect(docDrawingDialog.commitButtonEl.removeEventListener).to.be.calledWith(
+            dialog.unbindDOMListeners();
+            expect(dialog.commitButtonEl.removeEventListener).to.be.calledWith(
                 'click',
-                docDrawingDialog.postDrawing
+                dialog.postDrawing
             );
-            expect(docDrawingDialog.commitButtonEl.removeEventListener).to.be.calledWith(
+            expect(dialog.commitButtonEl.removeEventListener).to.be.calledWith(
                 'touchend',
-                docDrawingDialog.postDrawing
+                dialog.postDrawing
             );
         });
 
         it('should unbind listeners on a delete button element', () => {
-            docDrawingDialog.hasTouch = true;
-            docDrawingDialog.deleteButtonEl = {
+            dialog.hasTouch = true;
+            dialog.deleteButtonEl = {
                 removeEventListener: sandbox.stub()
             };
 
-            docDrawingDialog.unbindDOMListeners();
-            expect(docDrawingDialog.deleteButtonEl.removeEventListener).to.be.calledWith(
+            dialog.unbindDOMListeners();
+            expect(dialog.deleteButtonEl.removeEventListener).to.be.calledWith(
                 'click',
-                docDrawingDialog.deleteAnnotation
+                dialog.deleteAnnotation
             );
-            expect(docDrawingDialog.deleteButtonEl.removeEventListener).to.be.calledWith(
+            expect(dialog.deleteButtonEl.removeEventListener).to.be.calledWith(
                 'touchend',
-                docDrawingDialog.deleteAnnotation
+                dialog.deleteAnnotation
             );
         })
     });
@@ -132,9 +137,9 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
         beforeEach(() => {
             drawingDialogEl = document.querySelector('.bp-annotation-drawing-dialog');
 
-            sandbox.stub(docDrawingDialog, 'generateDialogEl').returns(drawingDialogEl);
-            sandbox.stub(docDrawingDialog, 'bindDOMListeners');
-            sandbox.stub(docDrawingDialog, 'assignDrawingLabel');
+            sandbox.stub(dialog, 'generateDialogEl').returns(drawingDialogEl);
+            sandbox.stub(dialog, 'bindDOMListeners');
+            sandbox.stub(dialog, 'assignDrawingLabel');
         });
 
         it('should setup the dialog element without a commit button when given an annotation', () => {
@@ -144,23 +149,23 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
                 }
             };
 
-            expect(docDrawingDialog.element).to.be.undefined;
-            docDrawingDialog.setup([annotation]);
-            expect(docDrawingDialog.generateDialogEl).to.be.called;
-            expect(docDrawingDialog.bindDOMListeners).to.be.called;
-            expect(docDrawingDialog.assignDrawingLabel).to.be.called;
-            expect(docDrawingDialog.element.contains(docDrawingDialog.drawingDialogEl));
-            expect(docDrawingDialog.commitButtonEl).to.be.null;
+            expect(dialog.element).to.be.undefined;
+            dialog.setup([annotation]);
+            expect(dialog.generateDialogEl).to.be.called;
+            expect(dialog.bindDOMListeners).to.be.called;
+            expect(dialog.assignDrawingLabel).to.be.called;
+            expect(dialog.element.contains(dialog.drawingDialogEl));
+            expect(dialog.commitButtonEl).to.be.null;
         });
 
         it('should setup the dialog element with a commit button when not given an annotation', () => {
-            docDrawingDialog.setup([]);
-            expect(docDrawingDialog.generateDialogEl).to.be.called;
-            expect(docDrawingDialog.bindDOMListeners).to.be.called;
-            expect(docDrawingDialog.assignDrawingLabel).to.not.be.called;
-            expect(docDrawingDialog.element.contains(docDrawingDialog.drawingDialogEl));
-            expect(docDrawingDialog.commitButtonEl).to.not.be.undefined;
-            expect(docDrawingDialog.element.contains(docDrawingDialog.commitButtonEl));
+            dialog.setup([]);
+            expect(dialog.generateDialogEl).to.be.called;
+            expect(dialog.bindDOMListeners).to.be.called;
+            expect(dialog.assignDrawingLabel).to.not.be.called;
+            expect(dialog.element.contains(dialog.drawingDialogEl));
+            expect(dialog.commitButtonEl).to.not.be.undefined;
+            expect(dialog.element.contains(dialog.commitButtonEl));
         });
     });
 
@@ -174,13 +179,13 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
                 appendChild: sandbox.stub()
             };
 
-            docDrawingDialog.location = {
+            dialog.location = {
                 page: 1
             };
-            docDrawingDialog.annotatedElement = {
+            dialog.annotatedElement = {
                 querySelector: sandbox.stub().returns(pageEl)
             };
-            docDrawingDialog.element = {
+            dialog.element = {
                 style: {
                     left: 0,
                     top: 0
@@ -188,12 +193,12 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
                 getBoundingClientRect: sandbox.stub().returns(rect)
             }
 
-            docDrawingDialog.position(5, 10);
-            expect(docDrawingDialog.element.getBoundingClientRect).to.be.called;
+            dialog.position(5, 10);
+            expect(dialog.element.getBoundingClientRect).to.be.called;
             expect(pageEl.contains).to.be.called;
-            expect(pageEl.appendChild).to.be.calledWith(docDrawingDialog.element);
-            expect(docDrawingDialog.annotatedElement.querySelector).to.be.called;
-            expect(docDrawingDialog.element.style.left).to.equal(`4px`, `10px`);
+            expect(pageEl.appendChild).to.be.calledWith(dialog.element);
+            expect(dialog.annotatedElement.querySelector).to.be.called;
+            expect(dialog.element.style.left).to.equal(`4px`, `10px`);
         });
     });
 
@@ -202,12 +207,12 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
             const element = 'e';
 
             sandbox.stub(annotatorUtil, 'hideElement');
-            docDrawingDialog.element = element;
-            expect(docDrawingDialog.visible).to.be.truthy;
+            dialog.element = element;
+            expect(dialog.visible).to.be.truthy;
 
-            docDrawingDialog.hide();
+            dialog.hide();
             expect(annotatorUtil.hideElement).to.be.calledWith(element);
-            expect(docDrawingDialog.visible).to.be.falsy;
+            expect(dialog.visible).to.be.falsy;
         });
     });
 
@@ -216,12 +221,12 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
             const element = 'e';
 
             sandbox.stub(annotatorUtil, 'showElement');
-            docDrawingDialog.element = element;
-            expect(docDrawingDialog.visible).to.be.falsy;
+            dialog.element = element;
+            expect(dialog.visible).to.be.falsy;
 
-            docDrawingDialog.show();
+            dialog.show();
             expect(annotatorUtil.showElement).to.be.calledWith(element);
-            expect(docDrawingDialog.visible).to.be.truthy;
+            expect(dialog.visible).to.be.truthy;
         });
     });
 
@@ -242,27 +247,27 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
         it('should generate the correctly formatted label dialog element', () => {
             annotation.permissions.can_delete = false;
 
-            const returnValue = docDrawingDialog.generateDialogEl([annotation]);
-            expect(returnValue.classList.contains('bp-annotation-drawing-dialog')).to.be.truthy;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-delete')).to.be.null;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-add')).to.be.null;
-            expect(returnValue.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
+            const dialogEl = dialog.generateDialogEl([annotation]);
+            expect(dialogEl.classList.contains(constants.CLASS_ANNOTATION_DRAWING_DIALOG)).to.be.truthy;
+            expect(dialogEl.querySelector(`.${constants.CLASS_DELETE_DRAWING_BTN}`)).to.be.null;
+            expect(dialogEl.querySelector(`.${constants.CLASS_ADD_DRAWING_BTN}`)).to.be.null;
+            expect(dialogEl.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
         });
 
         it('should generate without a save button', () => {
-            const returnValue = docDrawingDialog.generateDialogEl([annotation]);
-            expect(returnValue.classList.contains('bp-annotation-drawing-dialog')).to.be.truthy;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-delete')).to.not.be.null;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-add')).to.be.null;
-            expect(returnValue.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
+            const dialogEl = dialog.generateDialogEl([annotation]);
+            expect(dialogEl.classList.contains(constants.CLASS_ANNOTATION_DRAWING_DIALOG)).to.be.truthy;
+            expect(dialogEl.querySelector(`.${constants.CLASS_DELETE_DRAWING_BTN}`)).to.not.be.null;
+            expect(dialogEl.querySelector(`.${constants.CLASS_ADD_DRAWING_BTN}`)).to.be.null;
+            expect(dialogEl.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
         });
 
         it('should generate a save and delete button', () => {
-            const returnValue = docDrawingDialog.generateDialogEl([]);
-            expect(returnValue.classList.contains('bp-annotation-drawing-dialog')).to.be.truthy;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-delete')).to.not.be.null;
-            expect(returnValue.querySelector('.bp-btn-annotate-draw-add')).to.not.be.null;
-            expect(returnValue.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
+            const dialogEl = dialog.generateDialogEl([]);
+            expect(dialogEl.classList.contains(constants.CLASS_ANNOTATION_DRAWING_DIALOG)).to.be.truthy;
+            expect(dialogEl.querySelector(`.${constants.CLASS_DELETE_DRAWING_BTN}`)).to.not.be.null;
+            expect(dialogEl.querySelector(`.${constants.CLASS_ADD_DRAWING_BTN}`)).to.not.be.null;
+            expect(dialogEl.querySelector('.bp-annotation-drawing-label')).to.not.be.null;
         });
     });
 
@@ -270,25 +275,25 @@ describe('lib/annotations/doc/DocDrawingDialog', () => {
         it('should assign a name to a drawing label', () => {
             const drawingLabelEl = {};
             const notYaoMing = 'not yao ming';
-            docDrawingDialog.drawingDialogEl = {
+            dialog.drawingDialogEl = {
                 querySelector: sandbox.stub().returns(drawingLabelEl)
             };
             sandbox.stub(annotatorUtil, 'replacePlaceholders').returns(notYaoMing);
             sandbox.stub(annotatorUtil, 'showElement');
 
-            docDrawingDialog.assignDrawingLabel('non empty');
+            dialog.assignDrawingLabel('non empty');
             expect(drawingLabelEl.textContent).to.equal(notYaoMing);
-            expect(docDrawingDialog.drawingDialogEl.querySelector).to.be.called;
+            expect(dialog.drawingDialogEl.querySelector).to.be.called;
             expect(annotatorUtil.replacePlaceholders).to.be.called;
             expect(annotatorUtil.showElement).to.be.called;
         });
 
         it('should do nothing when given an invalid annotation or does not have a dialog', () => {
-            expect(docDrawingDialog.assignDrawingLabel, 'not empty').to.not.throw();
+            expect(dialog.assignDrawingLabel, 'not empty').to.not.throw();
 
-            docDrawingDialog.drawingDialogEl = 'not empty';
-            expect(docDrawingDialog.assignDrawingLabel, undefined).to.not.throw();
-            expect(docDrawingDialog.assignDrawingLabel, null).to.not.throw();
+            dialog.drawingDialogEl = 'not empty';
+            expect(dialog.assignDrawingLabel, undefined).to.not.throw();
+            expect(dialog.assignDrawingLabel, null).to.not.throw();
         });
     });
 });

--- a/src/lib/annotations/doc/__tests__/DocHighlightDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/DocHighlightDialog-test.js
@@ -34,6 +34,10 @@ describe('lib/annotations/doc/DocHighlightDialog', () => {
             annotations: [],
             canAnnotate: true
         });
+        dialog.localized = {
+            highlightToggle: 'highlight toggle',
+            whoHighlighted: '{1} highlighted'
+        };
         dialog.setup([]);
         document.querySelector('.annotated-element').appendChild(dialog.element);
 

--- a/src/lib/annotations/doc/__tests__/DocHighlightThread-test.html
+++ b/src/lib/annotations/doc/__tests__/DocHighlightThread-test.html
@@ -1,4 +1,6 @@
 <div class="annotated-element">
-  <button class="bp-highlight-comment-btn"></button>
-  <textarea class="annotation-textarea"></textarea>
+  <div class="bp-annotation-dialog bp-annotation-highlight-dialog">
+    <button class="bp-highlight-comment-btn"></button>
+    <textarea class="annotation-textarea"></textarea>
+  </div>
 </div>

--- a/src/lib/annotations/doc/__tests__/DocPointDialog-test.js
+++ b/src/lib/annotations/doc/__tests__/DocPointDialog-test.js
@@ -20,6 +20,7 @@ describe('lib/annotations/doc/DocPointDialog', () => {
             annotations: [],
             canAnnotate: true
         });
+        dialog.localized = { addCommentPlaceholder: 'placeholder' };
         dialog.setup([]);
         dialog.threadEl = {
             offsetLeft: 1,

--- a/src/lib/annotations/drawing/DrawingThread.js
+++ b/src/lib/annotations/drawing/DrawingThread.js
@@ -246,7 +246,6 @@ class DrawingThread extends AnnotationThread {
             // Saved thread, load boundary dialog
             this.state = STATES.inactive;
             this.createDialog();
-            this.dialog.localized = this.localized;
         }
     }
 

--- a/src/lib/annotations/drawing/DrawingThread.js
+++ b/src/lib/annotations/drawing/DrawingThread.js
@@ -246,6 +246,7 @@ class DrawingThread extends AnnotationThread {
             // Saved thread, load boundary dialog
             this.state = STATES.inactive;
             this.createDialog();
+            this.dialog.localized = this.localized;
         }
     }
 

--- a/src/lib/annotations/image/ImageAnnotator.js
+++ b/src/lib/annotations/image/ImageAnnotator.js
@@ -3,7 +3,11 @@ import Annotator from '../Annotator';
 import ImagePointThread from './ImagePointThread';
 import * as annotatorUtil from '../annotatorUtil';
 import * as imageAnnotatorUtil from './imageAnnotatorUtil';
-import { CLASS_ANNOTATION_POINT_MARKER, SELECTOR_ANNOTATION_BUTTON_POINT } from '../annotationConstants';
+import {
+    CLASS_ANNOTATION_POINT_MARKER,
+    SELECTOR_ANNOTATION_BUTTON_POINT,
+    ANNOTATOR_EVENT
+} from '../annotationConstants';
 
 const IMAGE_NODE_NAME = 'img';
 // Selector for image container OR multi-image container
@@ -61,7 +65,7 @@ class ImageAnnotator extends Annotator {
 
         // Do not create annotation if event doesn't have coordinates
         if (isNaN(x) || isNaN(y)) {
-            this.emit('annotationerror', __('annotations_create_error'));
+            this.emit(ANNOTATOR_EVENT.error, this.localized.createError);
             return location;
         }
 
@@ -117,7 +121,8 @@ class ImageAnnotator extends Annotator {
             locale: this.locale,
             location: fixedLocation,
             type,
-            permissions: this.permissions
+            permissions: this.permissions,
+            localized: this.localized
         };
 
         if (!annotatorUtil.validateThreadParams(threadParams)) {

--- a/src/lib/annotations/image/__tests__/ImageAnnotator-test.js
+++ b/src/lib/annotations/image/__tests__/ImageAnnotator-test.js
@@ -34,6 +34,9 @@ describe('lib/annotations/image/ImageAnnotator', () => {
             modeButtons: {},
             location: {
                 locale: 'en-US'
+            },
+            localizedStrings: {
+                anonymousUserName: 'anonymous'
             }
         });
         annotator.annotatedElement = annotator.getAnnotatedEl(document);

--- a/src/lib/annotations/image/__tests__/ImagePointDialog-test.js
+++ b/src/lib/annotations/image/__tests__/ImagePointDialog-test.js
@@ -22,6 +22,7 @@ describe('lib/annotations/image/ImagePointDialog', () => {
             annotations: [],
             canAnnotate: true
         });
+        dialog.localized = { addCommentPlaceholder: 'placeholder' };
         dialog.setup([]);
         dialog.element.style.width = '282px';
         dialog.threadEl = {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -803,11 +803,39 @@ class BaseViewer extends EventEmitter {
      * @return {Object} combined options
      */
     createAnnotatorOptions(moreOptions) {
+        // Temporary solution for localizing strings in the BoxAnnotations npm package
+        // TODO(@spramod): Remove once BoxAnnotations has it's own localization strategy
+        const localizedStrings = {
+            loadError: __('annotations_load_error'),
+            createError: __('annotations_create_error'),
+            deleteError: __('annotations_delete_error'),
+            authError: __('annotations_authorization_error'),
+            cancelButton: __('annotation_cancel'),
+            saveButton: __('annotation_save'),
+            postButton: __('annotation_post'),
+            deleteButton: __('annotation_delete'),
+            addCommentPlaceholder: __('annotation_add_comment_placeholder'),
+            replyPlaceholder: __('annotation_reply_placeholder'),
+            deleteConfirmation: __('annotation_delete_confirmation_message'),
+            posting: __('annotation_posting_message'),
+            profileAlt: __('annotation_profile_alt'),
+            anonymousUserName: __('annotation_anonymous_user_name'),
+            pointToggle: __('annotation_point_toggle'),
+            highlightToggle: __('annotation_highlight_toggle'),
+            highlightComment: __('annotation_highlight_comment'),
+            whoHighlighted: __('annotation_who_highlighted'),
+            drawToggle: __('annotation_draw_toggle'),
+            drawSave: __('annotation_draw_save'),
+            drawDelete: __('annotation_draw_delete'),
+            whoDrew: __('annotation_who_drew')
+        };
+
         return cloneDeep(
             Object.assign({}, this.options, moreOptions, {
                 isMobile: this.isMobile,
                 hasTouch: this.hasTouch,
-                locale: this.options.location.locale
+                locale: this.options.location.locale,
+                localizedStrings
             })
         );
     }

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1040,14 +1040,13 @@ describe('lib/viewers/BaseViewer', () => {
             base.hasTouch = false;
 
             const combinedOptions = base.createAnnotatorOptions({ randomOption: 'derp' });
-            expect(combinedOptions).to.deep.equal({
-                file: { id: 1 },
-                isMobile: true,
-                hasTouch: false,
-                locale: 'en-US',
-                location: { locale: 'en-US' },
-                randomOption: 'derp'
-            });
+            expect(combinedOptions.file).to.deep.equal({ id: 1 });
+            expect(combinedOptions.isMobile).to.be.true;
+            expect(combinedOptions.hasTouch).to.be.false;
+            expect(combinedOptions.locale).to.equal('en-US');
+            expect(combinedOptions.location).to.deep.equal({ locale: 'en-US' });
+            expect(combinedOptions.randomOption).to.equal('derp');
+            expect(combinedOptions.localizedStrings).to.not.be.undefined;
         });
     });
 });


### PR DESCRIPTION
Since BoxAnnotations will be included as an npm package, it will not be able to use the mojito generated versions of the code based on the locale. Until BoxAnnotations can be written in React with it's own localization strategy, a temporary solution will be to pass in the localized strings as an option from Preview into BoxAnnotations on initialization. 

- Tests + documentation coming soon