### PR TITLE
New: Enable 360 video on desktop Safari

### DIFF
--- a/src/lib/viewers/box3d/video360/Video360Loader.js
+++ b/src/lib/viewers/box3d/video360/Video360Loader.js
@@ -19,7 +19,7 @@ const VIDEO_FORMATS = [
     'qt',
     'wmv'
 ];
-const BROWSERS_SUPPORTED = ['Chrome', 'Edge', 'Firefox', 'Opera'];
+const BROWSERS_SUPPORTED = ['Chrome', 'Edge', 'Firefox', 'Opera', 'Safari'];
 
 const VIEWERS = [
     {

--- a/src/lib/viewers/box3d/video360/__tests__/Video360Loader-test.js
+++ b/src/lib/viewers/box3d/video360/__tests__/Video360Loader-test.js
@@ -24,7 +24,7 @@ describe('lib/viewers/box3d/video360/Video360Loader', () => {
 
         it('should throw an error if browser is not supported', () => {
             sandbox.stub(Browser, 'hasWebGL').returns(true);
-            sandbox.stub(Browser, 'getName').returns('Safari'); // Safari is not supported
+            sandbox.stub(Browser, 'getName').returns('IE11');
             expect(() => Video360Loader.determineViewer(file)).to.throw(Error, /support preview for 360-degree videos/);
         });
 


### PR DESCRIPTION
With Safari 11, the long-standing "DOM Exception" bug with video tags and WebGL has been fixed.