### PR TITLE
Fix: controller.handleAnnotationEvent() not bound correctly

### DIFF
--- a/src/lib/annotations/AnnotationModeController.js
+++ b/src/lib/annotations/AnnotationModeController.js
@@ -9,17 +9,6 @@ class AnnotationModeController extends EventEmitter {
     handlers = [];
 
     /**
-     * [constructor]
-     *
-     * @return {AnnotationModeController} Annotation controller instance
-     */
-    constructor() {
-        super();
-
-        this.handleAnnotationEvent = this.handleAnnotationEvent.bind(this);
-    }
-
-    /**
      * Register the annotator and any information associated with the annotator
      *
      * @public

--- a/src/lib/annotations/Annotator.js
+++ b/src/lib/annotations/Annotator.js
@@ -472,6 +472,7 @@ class Annotator extends EventEmitter {
      * needs to bind event listeners to the DOM in the normal state (ie not
      * in any annotation mode).
      *
+     * @protected
      * @return {void}
      */
     bindDOMListeners() {}
@@ -719,7 +720,6 @@ class Annotator extends EventEmitter {
      * @param {number} [rotationAngle] - current angle image is rotated
      * @param {number} [pageNum] - Page number
      * @return {void}
-     * @private
      */
     rotateAnnotations(rotationAngle = 0, pageNum = 0) {
         // Only render a specific page's annotations unless no page number
@@ -767,6 +767,7 @@ class Annotator extends EventEmitter {
     /**
      * Returns click handler for toggling annotation mode.
      *
+     * @private
      * @param {string} mode - Target annotation mode
      * @return {Function|null} Click handler
      */
@@ -783,7 +784,7 @@ class Annotator extends EventEmitter {
     /**
      * Orient annotations to the correct scale and orientation of the annotated document.
      *
-     * @protected
+     * @private
      * @param {Object} data - Scale and orientation values needed to orient annotations.
      * @return {void}
      */

--- a/src/lib/annotations/__tests__/AnnotationModeController-test.js
+++ b/src/lib/annotations/__tests__/AnnotationModeController-test.js
@@ -1,4 +1,5 @@
 import AnnotationModeController from '../AnnotationModeController';
+import DocDrawingThread from '../doc/DocDrawingThread';
 import * as util from '../annotatorUtil';
 
 let annotationModeController;
@@ -108,6 +109,25 @@ describe('lib/annotations/AnnotationModeController', () => {
             annotationModeController.bindCustomListenersOnThread(thread);
             expect(annotationModeController.annotator.bindCustomListenersOnThread).to.be.called;
             expect(thread.addListener).to.be.called;
+        });
+
+        // Catches edge case where sometimes the first click upon entering
+        // Draw annotation mode, the annotator is not registered properly
+        // with the controller
+        it('should maintain annotator context when a "threadevent" is fired', () => {
+            Object.defineProperty(DocDrawingThread.prototype, 'setup', { value: sandbox.stub() });
+            Object.defineProperty(DocDrawingThread.prototype, 'getThreadEventData', { value: sandbox.stub() });
+            const thread = new DocDrawingThread({ threadID: 123 });
+
+            annotationModeController.handleAnnotationEvent = () => {
+                expect(annotationModeController.annotator).to.not.be.undefined;
+            };
+            annotationModeController.annotator = {
+                bindCustomListenersOnThread: sandbox.stub()
+            };
+
+            annotationModeController.bindCustomListenersOnThread(thread);
+            thread.emit('threadevent', {});
         });
     });
 


### PR DESCRIPTION
Temporary fix until mode specific logic is moved into annotation controllers