### PR TITLE
Fix: Instant Preview when thumbnail is pending

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -73,6 +73,7 @@ export const PRELOAD_REP_NAME = 'jpg';
 export const STATUS_ERROR = 'error';
 export const STATUS_SUCCESS = 'success';
 export const STATUS_VIEWABLE = 'viewable';
+export const STATUS_PENDING = 'pending';
 
 // X-Rep-Hints for Representations API
 export const X_REP_HINT_BASE = '[3d][pdf][text][mp3]';

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -17,7 +17,7 @@ import {
     DOC_STATIC_ASSETS_VERSION,
     PERMISSION_DOWNLOAD,
     PRELOAD_REP_NAME,
-    STATUS_ERROR
+    STATUS_SUCCESS
 } from '../../constants';
 import { checkPermission, getRepresentation } from '../../file';
 import { get, createAssetUrlCreator } from '../../util';
@@ -201,10 +201,9 @@ class DocBaseViewer extends BaseViewer {
             return;
         }
 
-        // Don't show preload if there is no preload rep, the 'preload' viewer option isn't set,
-        // or the rep has an error
+        // Don't show preload if there is no preload rep, the 'preload' viewer option isn't set, or the rep isn't ready
         const preloadRep = getRepresentation(file, PRELOAD_REP_NAME);
-        if (!preloadRep || !this.getViewerOption('preload') || RepStatus.getStatus(preloadRep) === STATUS_ERROR) {
+        if (!preloadRep || !this.getViewerOption('preload') || RepStatus.getStatus(preloadRep) !== STATUS_SUCCESS) {
             return;
         }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -14,6 +14,7 @@ import {
     CLASS_HIDDEN,
     PERMISSION_DOWNLOAD,
     STATUS_ERROR,
+    STATUS_PENDING,
     STATUS_SUCCESS,
 } from '../../../constants';
 
@@ -284,6 +285,19 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             sandbox.stub(file, 'getRepresentation').returns({
                 status: {
                     state: STATUS_ERROR
+                }
+            });
+            sandbox.mock(docBase.preloader).expects('showPreload').never();
+
+            docBase.showPreload();
+        });
+
+        it('should not do anything if preload rep is pending', () => {
+            sandbox.stub(docBase, 'getCachedPage').returns(1);
+            sandbox.stub(docBase, 'getViewerOption').withArgs('preload').returns(true);
+            sandbox.stub(file, 'getRepresentation').returns({
+                status: {
+                    state: STATUS_PENDING
                 }
             });
             sandbox.mock(docBase.preloader).expects('showPreload').never();


### PR DESCRIPTION
Explicitly check for success status instead of checking against error since we also can't show a pending image rep