### PR TITLE
Update: box-annotations to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.1.0",
+    "box-annotations": "^0.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "5.3.0",
     "chai-dom": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,9 +1095,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.1.0.tgz#2951ec199eb7674c2b8a00825cc36a0b5b13711f"
+box-annotations@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.2.0.tgz#489efba51665b165886837a2ef5edc5e4586e3f9"
   dependencies:
     rangy "^1.3.0"
     rbush "^2.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases

# 0.2.0 (2017-11-08)
* Chore: Cleaning up mobile phone drawing CSS (#17) ([b125b8b](https://github.com/box/box-annotations/commit/b125b8b))
* Chore: Move controllers into a separate folder (#18) ([3efa19f](https://github.com/box/box-annotations/commit/3efa19f))
* Chore: Paging draw threads in the controller's internal thread map (#6) ([fc52e9e](https://github.com/box/box-annotations/commit/fc52e9e))
* Chore: Refactoring annotation mode logic into controllers (#15) ([2be6ba3](https://github.com/box/box-annotations/commit/2be6ba3))
* Chore: Separate fetching and rendering of annotations (#16) ([328681e](https://github.com/box/box-annotations/commit/328681e))
*  Chore: Store threads.annotations as an object by annotationID (#5) ([080c0f3](https://github.com/box/box-annotations/commit/080c0f3))
* Update README.md (#14) ([0b55fe6](https://github.com/box/box-annotations/commit/0b55fe6))