### PR TITLE
Fix: Correctly revoke objectURL for print blob in office viewer

### DIFF
--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -50,6 +50,11 @@ class OfficeViewer extends BaseViewer {
         if (this.printPopup) {
             this.printPopup.destroy();
         }
+
+        if (this.printURL) {
+            URL.revokeObjectURL(this.printURL);
+        }
+
         super.destroy();
     }
 
@@ -331,8 +336,11 @@ class OfficeViewer extends BaseViewer {
 
             // For other browsers, open and print in a new tab
         } else {
-            const printURL = URL.createObjectURL(this.printBlob);
-            const printResult = window.open(printURL);
+            if (!this.printURL) {
+                this.printURL = URL.createObjectURL(this.printBlob);
+            }
+
+            const printResult = window.open(this.printURL);
 
             // Open print popup if possible
             if (printResult && typeof printResult.print === 'function') {
@@ -360,8 +368,6 @@ class OfficeViewer extends BaseViewer {
             } else {
                 this.emit('printsuccess');
             }
-
-            URL.revokeObjectURL(printURL);
         }
     }
 }

--- a/src/lib/viewers/office/__tests__/OfficeViewer-test.js
+++ b/src/lib/viewers/office/__tests__/OfficeViewer-test.js
@@ -92,6 +92,13 @@ describe('lib/viewers/office/OfficeViewer', () => {
             office.destroy();
             expect(office.printBlob).to.equal(null);
         });
+
+        it('should revoke the printURL object', () => {
+            sandbox.stub(URL, 'revokeObjectURL');
+            office.printURL = 'someblob';
+            office.destroy();
+            expect(URL.revokeObjectURL).to.be.calledWith(office.printURL);
+        });
     });
 
     describe('load()', () => {
@@ -382,7 +389,6 @@ describe('lib/viewers/office/OfficeViewer', () => {
             stubs.createObject = sandbox.stub(URL, 'createObjectURL');
             stubs.open = sandbox.stub(window, 'open').returns(false);
             stubs.browser = sandbox.stub(Browser, 'getName').returns('Chrome');
-            stubs.revokeObjectURL = sandbox.stub(URL, 'revokeObjectURL');
             stubs.printResult = {
                 print: sandbox.stub(),
                 addEventListener: sandbox.stub()
@@ -429,7 +435,6 @@ describe('lib/viewers/office/OfficeViewer', () => {
             expect(stubs.open).to.be.called.with;
             expect(stubs.browser).to.be.called;
             expect(stubs.emit).to.be.called;
-            expect(stubs.revokeObjectURL).to.be.called;
         });
 
         it('should use a timeout in safari', () => {


### PR DESCRIPTION
Original fix here: https://github.com/box/box-content-preview/pull/444
feeling the pain of repeated code