### PR TITLE
Update: box-annotations to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.2.1",
+    "box-annotations": "^0.3.0",
     "chai": "^4.1.2",
     "chai-dom": "^1.5.0",
     "conventional-changelog-cli": "^1.3.4",
@@ -120,14 +120,14 @@
     "patch": "./build/release.sh -p"
   },
   "lint-staged": {
-      "functional-tests/*.js": [
-        "prettier-eslint --print-width 120 --single-quote --tab-width 4 --write",
-        "git add"
-      ],
-      "src/lib/**/*.js": [
-        "prettier-eslint --print-width 120 --single-quote --tab-width 4 --write",
-        "git add"
-      ]
+    "functional-tests/*.js": [
+      "prettier-eslint --print-width 120 --single-quote --tab-width 4 --write",
+      "git add"
+    ],
+    "src/lib/**/*.js": [
+      "prettier-eslint --print-width 120 --single-quote --tab-width 4 --write",
+      "git add"
+    ]
   },
   "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.2.1.tgz#1a88b4b945b375033082326f118afd302a7b1396"
+box-annotations@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.3.0.tgz#73b5b99de48e1069366adbcb8eb266ecd9ebe8df"
   dependencies:
     rangy "^1.3.0"
     rbush "^2.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases

# 0.3.0 (2017-11-14)
* Chore: Add conventional-changelog-releaser (#34) ([624e0bd](https://github.com/box/box-annotations/commit/624e0bd))
* Chore: Do not clear out node_modules on when publishing npm package (#30) ([08c180d](https://github.com/box/box-annotations/commit/08c180d))
* Fix: Do not select drawings when creating a point annotation on top (#28) ([07fc4c1](https://github.com/box/box-annotations/commit/07fc4c1))
* Fix: Drawing CSS (#23) ([0493fcd](https://github.com/box/box-annotations/commit/0493fcd))
* Fix: fix highlight selection and typos (#21) ([ca54d5e](https://github.com/box/box-annotations/commit/ca54d5e)), closes [#21](https://github.com/box/box-annotations/issues/21)
* Fix: Hide createHighlightDialog on page re-render (#31) ([0b74717](https://github.com/box/box-annotations/commit/0b74717))
* Fix: Match width of reply textarea with comments (#33) ([5f0f29b](https://github.com/box/box-annotations/commit/5f0f29b))
* Fix: Only registering thread with controller on save (#22) ([ff75bf1](https://github.com/box/box-annotations/commit/ff75bf1))
* Fix: Only show create dialog when creating new point annotations (#29) ([4822ece](https://github.com/box/box-annotations/commit/4822ece))
* Fix: only show newly created annotation dialog on hover (#25) ([0ba1965](https://github.com/box/box-annotations/commit/0ba1965))
* Fix: Position create dialog properly near page edges (#32) ([968efb3](https://github.com/box/box-annotations/commit/968efb3))
* Fix: release script should use correct remote branch (#20) ([8bd12a5](https://github.com/box/box-annotations/commit/8bd12a5))
* Fix: Scrolling on highlight dialogs in powerpoints (#24) ([b21ed0e](https://github.com/box/box-annotations/commit/b21ed0e))
* Fix: Validation message fails to get displayed when user clicks on 'Post' without entering any comme ([d90e72c](https://github.com/box/box-annotations/commit/d90e72c))
*  Fix: Hide mobile dialog on first outside click (#26) ([01ec48b](https://github.com/box/box-annotations/commit/01ec48b))