### PR TITLE
Fix: Reset retry count after successful preview

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -860,6 +860,10 @@ class Preview extends EventEmitter {
         // Once the viewer instance has been created, emit it so that clients can attach their events.
         // Viewer object will still be sent along the load event also.
         this.emit('viewer', this.viewer);
+
+        // Reset retry count after successful load so we don't go into the retry short circuit when the same file
+        // previewed again
+        this.retryCount = 0;
     }
 
     /**

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1349,6 +1349,11 @@ describe('lib/Preview', () => {
             preview.loadViewer();
             expect(stubs.emit).to.be.calledWith('viewer', stubs.viewer);
         });
+
+        it('should reset retry count', () => {
+            preview.loadViewer();
+            expect(preview.retryCount).to.equal(0);
+        });
     });
 
     describe('attachViewerListeners()', () => {


### PR DESCRIPTION
Solves:

```
There is one issue in preview right now...if you call preview.show(...,...,options)...and then after call preview.show() again with different options, the 2nd time the options are not parsed and ignored
cuz of https://github.com/box/box-content-preview/blob/master/src/lib/Preview.js#L599
returns after loadFromServer()
probably the retryCount should be reset to 0 when stuff has loaded successfully
```