### PR TITLE
Update: box-annotations to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.3.0",
+    "box-annotations": "^0.3.1",
     "chai": "^4.1.2",
     "chai-dom": "^1.5.0",
     "conventional-changelog-cli": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.3.0.tgz#73b5b99de48e1069366adbcb8eb266ecd9ebe8df"
+box-annotations@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.3.1.tgz#ee0526f0d276eac1af0ea32223f66af4232ede3e"
   dependencies:
     rangy "^1.3.0"
     rbush "^2.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases

# 0.3.1 (2017-11-15)
* Release: 0.3.1 ([6af2062](https://github.com/box/box-annotations/commit/6af2062))
* Fix: Disable highlight creation when the mobile shared dialog is visible (#35) ([de7f392](https://github.com/box/box-annotations/commit/de7f392))
* Fix: Ensure commentbox event listeners are bound properly (#37) ([fcce638](https://github.com/box/box-annotations/commit/fcce638))
*  Fix: Ensure newly created threads are set as inactive while saving (#38) ([8072fa8](https://github.com/box/box-annotations/commit/8072fa8))