### PR TITLE
Fix: Cachebust original representation URL

### DIFF
--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -167,6 +167,25 @@ describe('lib/file', () => {
             cacheFile(cache, file);
             expect(file.representations.entries.length).to.equal(1);
         });
+
+        it('should append file version to original rep content URL', () => {
+            const cache = {
+                set: sandbox.stub()
+            };
+
+            const file = {
+                id: '0',
+                file_version: {
+                    id: '123'
+                },
+                representations: {
+                    entries: []
+                }
+            };
+
+            cacheFile(cache, file);
+            expect(file.representations.entries[0].content.url_template).to.have.string('version=123');
+        });
     });
 
     describe('uncacheFile', () => {

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -122,8 +122,15 @@ function addOriginalRepresentation(file) {
         return;
     }
 
-    // Add an original representation if it doesn't already exist
-    const template = appendQueryParams(file.authenticated_download_url, { preview: 'true' });
+    const queryParams = {
+        preview: 'true'
+    };
+
+    if (file.file_version) {
+        queryParams.version = file.file_version.id;
+    }
+
+    const template = appendQueryParams(file.authenticated_download_url, queryParams);
     file.representations.entries.push({
         content: {
             url_template: template


### PR DESCRIPTION
Append file version to streaming download endpoint so a preview of a different file version doesn't render a cached file.