### PR TITLE
Update: box-annotations to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.3.1",
+    "box-annotations": "^0.4.0",
     "chai": "^4.1.2",
     "chai-dom": "^1.5.0",
     "conventional-changelog-cli": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.3.1.tgz#ee0526f0d276eac1af0ea32223f66af4232ede3e"
+box-annotations@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.4.0.tgz#01f9d190e8472755b5a7efbd70ce9c4399837c6e"
   dependencies:
     rangy "^1.3.0"
     rbush "^2.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases

# 0.4.0 (2017-11-21)
* Chore: Cleanup annotations permissions (#40) ([a52ed54](https://github.com/box/box-annotations/commit/a52ed54))
* Fix: Activate annotation dialog on post (#42) ([bc001be](https://github.com/box/box-annotations/commit/bc001be))
* Fix: Disable highlight creation when the mobile shared dialog is visible (#35) ([de7f392](https://github.com/box/box-annotations/commit/de7f392))
* Fix: Don't clear reply textarea when annotation is added to dialog (#36) ([1f88d55](https://github.com/box/box-annotations/commit/1f88d55))
* Fix: Ensure commentbox event listeners are bound properly (#37) ([fcce638](https://github.com/box/box-annotations/commit/fcce638))
* Fix: Prevent creation of highlights when a point annotation is pending (#41) ([42e29ce](https://github.com/box/box-annotations/commit/42e29ce))
* Fix: Validate pendingThreadID when calling onSelectionChange() (#39) ([10c1c98](https://github.com/box/box-annotations/commit/10c1c98))
* Update: packages (#43) ([97a91c3](https://github.com/box/box-annotations/commit/97a91c3))
*  Fix: Ensure newly created threads are set as inactive while saving (#38) ([8072fa8](https://github.com/box/box-annotations/commit/8072fa8))