### PR TITLE
Fix: BaseViewer debounced resize handler binding

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -108,7 +108,7 @@ class BaseViewer extends EventEmitter {
         // Bind context for callbacks
         this.resetLoadTimeout = this.resetLoadTimeout.bind(this);
         this.preventDefault = this.preventDefault.bind(this);
-        this.debouncedResizeHandler = this.debouncedResizeHandler.bind(this);
+        this.debouncedResizeHandler = this.getResizeHandler().bind(this);
         this.handleAssetError = this.handleAssetError.bind(this);
         this.toggleFullscreen = this.toggleFullscreen.bind(this);
         this.onFullscreenToggled = this.onFullscreenToggled.bind(this);
@@ -209,7 +209,7 @@ class BaseViewer extends EventEmitter {
      * @private
      * @return {Function} debounced resize handler
      */
-    debouncedResizeHandler() {
+    getResizeHandler() {
         return debounce(() => {
             this.resize();
         }, RESIZE_WAIT_TIME_IN_MILLIS);

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -125,9 +125,9 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
-    describe('debouncedResizeHandler()', () => {
+    describe('getResizeHandler()', () => {
         it('should return a resize handler', () => {
-            expect(base.debouncedResizeHandler()).to.be.a.function;
+            expect(base.getResizeHandler()).to.be.a.function;
         });
     });
 
@@ -288,15 +288,14 @@ describe('lib/viewers/BaseViewer', () => {
             stubs.baseAddListener = sandbox.spy(base, 'addListener');
             stubs.documentAddEventListener = sandbox.stub(document.defaultView, 'addEventListener');
             sandbox.stub(base, 'initAnnotations');
-
-
         });
+
         it('should append common event listeners', () => {
             base.addCommonListeners();
 
             expect(stubs.fullscreenAddListener).to.be.calledWith('enter', sinon.match.func);
             expect(stubs.fullscreenAddListener).to.be.calledWith('exit', sinon.match.func);
-            expect(stubs.documentAddEventListener).to.be.calledWith('resize', base.debouncedResizeHandler);
+            expect(stubs.documentAddEventListener).to.be.calledWith('resize', sinon.match.func);
             expect(stubs.baseAddListener).to.be.calledWith('load', sinon.match.func);
         });
 


### PR DESCRIPTION
Context was bound to the fetch resize handler function instead of the actual handler