### PR TITLE
Chore: Change webpack source maps to 'inline-cheap-source-map'

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -91,7 +91,7 @@ function updateConfig(conf, language, index) {
         }
 
         // Add inline source map
-        config.devtool = 'inline-source-map';
+        config.devtool = 'inline-cheap-source-map';
     }
 
     if (isRelease) {


### PR DESCRIPTION
Options can be found here: https://webpack.js.org/configuration/devtool/