### PR TITLE
Chore: only use source maps when running unit tests in debug mode

### DIFF
--- a/build/webpack.karma.config.js
+++ b/build/webpack.karma.config.js
@@ -1,18 +1,27 @@
 require('babel-polyfill');
 
+const { argv } = process;
+const isDebug = argv.find((arg) => {
+    return arg === '--auto-watch' || arg === '--no-single-run';
+});
+
 const { IgnorePlugin } = require('webpack');
 const commonConfig = require('./webpack.common.config');
 
 const baseConfig = commonConfig('en-US');
 
 const config = Object.assign(baseConfig, {
-    devtool: 'inline-source-map',
     resolve: {
         alias: {
             sinon: 'sinon/pkg/sinon'
         }
     }
 });
+
+if (isDebug) {
+    config.devtool = 'inline-source-map';
+}
+
 
 config.plugins.push(
     new IgnorePlugin(/react\/addons/),


### PR DESCRIPTION
Source maps don't work in phantom, so we should turn them off unless running our tests in debug mode in a browser. This should shave off between 30-45 seconds every place we run our tests; locally, jenkins, and travis. 