### PR TITLE
Update: box-annotations to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.4.0",
+    "box-annotations": "^0.5.0",
     "chai": "^4.1.2",
     "chai-dom": "^1.5.0",
     "conventional-changelog-cli": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.4.0.tgz#01f9d190e8472755b5a7efbd70ce9c4399837c6e"
+box-annotations@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.5.0.tgz#84c42e13532f51be5074d8a24ab1ad400adad796"
   dependencies:
     rangy "^1.3.0"
     rbush "^2.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases

* Chore: Disable dialog actions until annotation is saved on the server (#48) ([6dbcda2](https://github.com/box/box-annotations/commit/6dbcda2))
* Chore: Remove autobind from base classes (#44) ([639f8d2](https://github.com/box/box-annotations/commit/639f8d2))
* Chore: Remove autobind from doc classes (#46) ([d7ded88](https://github.com/box/box-annotations/commit/d7ded88))
* Chore: Remove autobind from Image classes (#45) ([1dda3a4](https://github.com/box/box-annotations/commit/1dda3a4))
* Chore: Remove NPM install from release/publish scripts (#50) ([48822c4](https://github.com/box/box-annotations/commit/48822c4))
* Update: Remaining packages (#49) ([4dab273](https://github.com/box/box-annotations/commit/4dab273))
*  Update: Sinon to v4.1.2 & remove autobind-decorator (#47) ([eea7dcf](https://github.com/box/box-annotations/commit/eea7dcf))