### PR TITLE
Fix: Fix inheritance chains in DashViewer

### DIFF
--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -78,6 +78,14 @@ class VideoBaseViewer extends MediaBaseViewer {
     }
 
     /**
+     * @inheritdoc
+     */
+    showLoadingIcon() {
+        // Fixes inheritance chain from DashViewer
+        super.showLoadingIcon();
+    }
+
+    /**
      * Handler for a pointer event on the media element.
      *
      * @param  {Event} event pointer event, either touch or mouse
@@ -208,6 +216,14 @@ class VideoBaseViewer extends MediaBaseViewer {
         if (this.containerEl) {
             this.containerEl.classList.add(CLASS_DARK);
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    onKeydown(key) {
+        // Fixes inheritance chain from DashViewer
+        return super.onKeydown(key);
     }
 }
 

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -144,6 +144,7 @@ class TextBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     resize() {
+        // Fixes inheritance chain from CSVViewer
         super.resize();
     }
 }


### PR DESCRIPTION
There's a problem with our babel config that causes inheritance to fail in the following situation.

Class A -> Class B -> Class C
1. Class A has method foo()
2. Class B does not override the method
3. Class C overrides foo and calls super()

This may be related to `modules: false` in our .babelrc for the es2015 preset