### PR TITLE
New: Allow BoxAnnotations to be passed in as a Preview option

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -690,6 +690,9 @@ class Preview extends EventEmitter {
         // Custom Box3D application definition
         this.options.box3dApplication = options.box3dApplication;
 
+        // Custom BoxAnnotations definition
+        this.options.boxAnnotations = options.boxAnnotations;
+
         // Save the reference to any additional custom options for viewers
         this.options.viewers = options.viewers || {};
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -695,9 +695,10 @@ class BaseViewer extends EventEmitter {
         }
 
         // Auto-resolves promise if BoxAnnotations is passed in as a Preview option
-        this.annotationsLoadPromise = this.options.boxAnnotations
-            ? Promise.resolve()
-            : this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS]);
+        this.annotationsLoadPromise =
+            this.options.boxAnnotations instanceof BoxAnnotations
+                ? Promise.resolve()
+                : this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS]);
     }
 
     /**
@@ -772,7 +773,8 @@ class BaseViewer extends EventEmitter {
 
         // Ignore viewer config if BoxAnnotations was pass into Preview as an option
         // Otherwise, use global preview annotation option
-        return this.options.boxAnnotations || !!this.options.showAnnotations;
+        /* global BoxAnnotations */
+        return this.options.boxAnnotations instanceof BoxAnnotations || !!this.options.showAnnotations;
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -694,18 +694,26 @@ class BaseViewer extends EventEmitter {
             return;
         }
 
-        this.annotationsLoadPromise = this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS]);
+        // Auto-resolves promise if BoxAnnotations is passed in as a Preview option
+        this.annotationsLoadPromise = this.options.boxAnnotations
+            ? Promise.resolve()
+            : this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS]);
     }
 
     /**
-     * Fetches the Box Annotations library
+     * Fetches the Box Annotations library. Creates an instance of BoxAnnotations
+     * if one isn't passed in to the preview options
      *
      * @protected
      * @return {void}
      */
     annotationsLoadHandler() {
+        // Set viewer-specific annotation options
+        const viewerOptions = {};
+        viewerOptions[this.options.viewer.NAME] = this.viewerConfig;
+
         /* global BoxAnnotations */
-        const boxAnnotations = new BoxAnnotations();
+        const boxAnnotations = this.options.boxAnnotations || new BoxAnnotations(viewerOptions);
         this.annotatorConf = boxAnnotations.determineAnnotator(this.options, this.viewerConfig);
 
         if (this.annotatorConf) {
@@ -762,8 +770,9 @@ class BaseViewer extends EventEmitter {
             return this.viewerConfig.enabled;
         }
 
+        // Ignore viewer config if BoxAnnotations was pass into Preview as an option
         // Otherwise, use global preview annotation option
-        return !!this.options.showAnnotations;
+        return this.options.boxAnnotations || !!this.options.showAnnotations;
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -764,8 +764,15 @@ class BaseViewer extends EventEmitter {
      */
     areAnnotationsEnabled() {
         // Respect viewer-specific annotation option if it is set
-        // #TODO(@spramod|@jholdstock): remove this after we have annotation instancing
-        this.viewerConfig = this.getViewerAnnotationsConfig();
+        if (this.options.boxAnnotations instanceof BoxAnnotations) {
+            const { boxAnnotations, viewer } = this.options;
+            const annotatorConfig = boxAnnotations.options[viewer.NAME];
+            this.viewerConfig = {
+                enabled: annotatorConfig.enabled || !!annotatorConfig.enabledTypes
+            };
+        } else {
+            this.viewerConfig = this.getViewerAnnotationsConfig();
+        }
 
         if (this.viewerConfig && this.viewerConfig.enabled !== undefined) {
             return this.viewerConfig.enabled;
@@ -773,8 +780,7 @@ class BaseViewer extends EventEmitter {
 
         // Ignore viewer config if BoxAnnotations was pass into Preview as an option
         // Otherwise, use global preview annotation option
-        /* global BoxAnnotations */
-        return this.options.boxAnnotations instanceof BoxAnnotations || !!this.options.showAnnotations;
+        return !!this.options.showAnnotations;
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -895,13 +895,17 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.areAnnotationsEnabled()).to.equal(false);
         });
 
-        it('should ignore viewer config if an instance of BoxAnnotations is passed into Preview', () => {
+        it('should user BoxAnnotations options if an instance of BoxAnnotations is passed into Preview', () => {
             stubs.getViewerOption.withArgs('annotations').returns(null);
             base.options.showAnnotations = false;
             base.options.boxAnnotations = undefined;
             expect(base.areAnnotationsEnabled()).to.equal(false);
 
+            base.options.viewer = { NAME: 'viewerName' };
             base.options.boxAnnotations = sinon.createStubInstance(window.BoxAnnotations);
+            base.options.boxAnnotations.options = {
+                'viewerName': { enabled: true }
+            }
             expect(base.areAnnotationsEnabled()).to.equal(true);
         });
     });

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import EventEmitter from 'events';
+import BoxAnnotations from 'box-annotations';
 import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
 import RepStatus from '../../RepStatus';
@@ -775,10 +776,19 @@ describe('lib/viewers/BaseViewer', () => {
 
         });
 
+        it('should resolve the promise if a BoxAnnotations instance was passed into Preview', (done) => {
+            base.areAnnotationsEnabled.returns(true);
+            base.options.boxAnnotations = new BoxAnnotations({});
+
+            base.loadAnnotator();
+            expect(base.loadAssets).to.not.be.calledWith(['annotations.js']);
+            base.annotationsLoadPromise.then(() => done());
+        });
+
         it('should load the annotations assets', () => {
             base.areAnnotationsEnabled.returns(true);
             base.loadAnnotator();
-            expect(base.loadAssets).to.be.calledWith(['annotations.js']);
+            expect(base.loadAssets).to.be.calledWith(['annotations.js'], ['annotations.css']);
         });
     });
 
@@ -792,6 +802,7 @@ describe('lib/viewers/BaseViewer', () => {
         };
 
         beforeEach(() => {
+            base.options.viewer = { NAME: 'viewerName' };
             window.BoxAnnotations = function BoxAnnotations() {
                 this.determineAnnotator = sandbox.stub().returns(conf);
             }
@@ -802,6 +813,14 @@ describe('lib/viewers/BaseViewer', () => {
         it('should determine the annotator', () => {
             base.annotationsLoadHandler();
             expect(base.annotatorConf).to.equal(conf);
+        });
+
+        it('should not instantiate an instance of BoxAnnotations if one is already passed in', () => {
+            base.options.boxAnnotations = {
+                determineAnnotator: sandbox.stub()
+            };
+            base.annotationsLoadHandler();
+            expect(base.options.boxAnnotations.determineAnnotator).to.be.called;
         });
 
         it('should init annotations if a conf is present', () => {
@@ -874,6 +893,16 @@ describe('lib/viewers/BaseViewer', () => {
 
             base.options.showAnnotations = false;
             expect(base.areAnnotationsEnabled()).to.equal(false);
+        });
+
+        it('should ignore viewer config if an instance of BoxAnnotations is passed into Preview', () => {
+            stubs.getViewerOption.withArgs('annotations').returns(null);
+            base.options.showAnnotations = false;
+            base.options.boxAnnotations = undefined;
+            expect(base.areAnnotationsEnabled()).to.equal(false);
+
+            base.options.boxAnnotations = sinon.createStubInstance(window.BoxAnnotations);
+            expect(base.areAnnotationsEnabled()).to.equal(true);
         });
     });
 


### PR DESCRIPTION
This change combined with https://github.com/box/box-annotations/pull/68 will allow a developer to instantiate annotations outside of Preview like this: 
```
const options = {
    Image: {
        enabledTypes: ['point']
    },

    // Document/Presentation Annotators are the same so the config is simplified here
    Document: {
        enabledTypes: ['highlight', 'draw']
    }
};


/* global BoxAnnotations */
const boxAnnotations = new BoxAnnotations(options);

var preview = new Box.Preview();
preview.show(FILE_ID, ACCESS_TOKEN, {
    container: '.preview-container',
    showDownload: true,
    boxAnnotations
});
```