### PR TITLE
Fix: Add bindings for more audio-track and subtitles controls

### DIFF
--- a/src/lib/viewers/media/MediaControls.js
+++ b/src/lib/viewers/media/MediaControls.js
@@ -82,6 +82,8 @@ class MediaControls extends EventEmitter {
         this.handleRate = this.handleRate.bind(this);
         this.handleQuality = this.handleQuality.bind(this);
         this.handleAutoplay = this.handleAutoplay.bind(this);
+        this.handleSubtitle = this.handleSubtitle.bind(this);
+        this.handleAudioTrack = this.handleAudioTrack.bind(this);
 
         this.setDuration(this.mediaEl.duration);
         this.setupSettings();


### PR DESCRIPTION
Audio-track and subtitle selection is not working, since autobind
removal