### PR TITLE
Fix: Rename "watermark-cache" query param to "watermark_content"

### DIFF
--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -183,7 +183,7 @@ class DashViewer extends VideoBaseViewer {
         request.uris = request.uris.map((uri) => {
             let newUri = this.createContentUrlWithAuthParams(uri, asset);
             if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
-                newUri = appendQueryParams(newUri, { 'watermark-cache': this.watermarkCacheBust });
+                newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
             }
             return newUri;
         });

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -258,7 +258,7 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.requestFilter('', stubs.req);
 
             expect(stubs.createUrl).to.be.calledOnce;
-            expect(stubs.req.uris).to.deep.equal(['www.authed.com/?foo=bar&watermark-cache=123']);
+            expect(stubs.req.uris).to.deep.equal(['www.authed.com/?foo=bar&watermark_content=123']);
         });
     });
 


### PR DESCRIPTION
This fixes a bug caused by a backwards incompatible change on
the server to look for "watermark_content" query param instead of
watermark-cache.