### PR TITLE
Fix: Never cache watermarked files, add reload() method

### DIFF
--- a/src/lib/PreviewUI.js
+++ b/src/lib/PreviewUI.js
@@ -258,10 +258,10 @@ class PreviewUI {
     hideLoadingIndicator() {
         if (this.contentContainer) {
             this.contentContainer.classList.add(CLASS_PREVIEW_LOADED);
+
+            // Re-show the cralwer for the next preview since it is hidden in finishLoadingSetup() in BaseViewer.js
             const crawler = this.contentContainer.querySelector(SELECTOR_BOX_PREVIEW_CRAWLER_WRAPPER);
             if (crawler) {
-                // We need to remove this since it was hidden specially as a
-                // part of finishLoadingSetup in BaseViewer.js
                 crawler.classList.remove(CLASS_HIDDEN);
             }
 

--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -119,6 +119,21 @@ describe('lib/file', () => {
     });
 
     describe('cacheFile', () => {
+        it('should not cache file if it is watermarked', () => {
+            const cache = {
+                set: sandbox.stub()
+            };
+            const file = {
+                watermark_info: {
+                    is_watermarked: true
+                }
+            };
+
+            cacheFile(cache, file);
+
+            expect(cache.set).to.not.be.called;
+        });
+
         it('should not add original representation if file object doesnt have any to start with', () => {
             const cache = {
                 set: sandbox.stub()

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -143,8 +143,7 @@ function addOriginalRepresentation(file) {
 }
 
 /**
- * Wrapper for caching a file object. Adds the faked 'ORIGINAL' representation
- * when appropraite before caching.
+ * Wrapper for caching a file object.
  *
  * @public
  * @param {Cache} cache - Cache instance
@@ -152,6 +151,12 @@ function addOriginalRepresentation(file) {
  * @return {void}
  */
 export function cacheFile(cache, file) {
+    // Don't cache watermarked files
+    if (isWatermarked(file)) {
+        return;
+    }
+
+    // Some viewers require the original file for preview, so this adds a faked 'ORIGINAL' representation
     if (file.representations) {
         addOriginalRepresentation(file);
     }

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -54,6 +54,8 @@ const ANNOTATOR_EVENT = {
     scale: 'scaleannotations'
 };
 
+const DEFAULT_FILE_ICON_NAME = 'FILE_DEFAULT';
+
 class BaseViewer extends EventEmitter {
     /** @property {Controls} - UI used to interact with the document in the viewer */
     controls;
@@ -175,7 +177,9 @@ class BaseViewer extends EventEmitter {
         }
 
         const iconWrapperEl = container.querySelector(SELECTOR_BOX_PREVIEW_ICON);
-        iconWrapperEl.innerHTML = this.fileLoadingIcon || getIconFromName('FILE_DEFAULT');
+        if (iconWrapperEl) {
+            iconWrapperEl.innerHTML = this.fileLoadingIcon || getIconFromName(DEFAULT_FILE_ICON_NAME);
+        }
     }
 
     /**


### PR DESCRIPTION
- Never cache watermarked files
- Separate loading and re-loading (when cache is stale or file is newly watermarked) when loading from server
- Remove superfluous caching before loading from cache
- Add new public method to reload current preview and replace legacy methods of reloading preview with new method