### PR TITLE
Update: Link to specific Annotations release tag in commit

### DIFF
--- a/build/upgrade_annotations.sh
+++ b/build/upgrade_annotations.sh
@@ -28,7 +28,7 @@ get_changelog() {
 
 push_to_github() {
     # Add new files
-    git add . && git commit -m "Update: box-annotations to v$UPDATED_VERSION" -m "https://github.com/box/box-annotations/releases" -m "$CHANGELOG"
+    git add . && git commit -m "Update: box-annotations to v$UPDATED_VERSION" -m "https://github.com/box/box-annotations/releases/tag/v$LATEST_VERSION" -m "$CHANGELOG"
 
     # Push commit to GitHub
     if git push origin -f --no-verify; then


### PR DESCRIPTION
Uses a link to the latest release (i.e. https://github.com/box/box-annotations/releases/tag/v0.7.3) instead of https://github.com/box/box-annotations/releases/