### PR TITLE
New: Enhanced pinch to zoom

### DIFF
--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -3,7 +3,13 @@ import 'whatwg-fetch';
 import fetchMock from 'fetch-mock';
 import * as util from '../util';
 
+const sandbox = sinon.sandbox.create();
+
 describe('lib/util', () => {
+    afterEach(() => {
+        sandbox.verifyAndRestore();
+    });
+
     describe('get()', () => {
         const url = 'foo?bar=bum';
 
@@ -661,6 +667,69 @@ describe('lib/util', () => {
 
             const result = util.pageNumberFromScroll(currentPageNum, previousScrollTop, currentPageEl, wrapperEl);
             expect(result).to.equal(2);
+        });
+    });
+
+    describe('getMidpoint()', () => {
+        it('should correctly calculate the midpoint', () => {
+            const result = util.getMidpoint(10, 10, 0, 0);
+            expect(result).to.deep.equal([5, 5]);
+        });
+    });
+
+    describe('getDistance()', () => {
+        it('should correctly calculate the distance', () => {
+            const result = util.getDistance(0, 0, 6, 8);
+            expect(result).to.equal(10);
+        });
+    });
+
+    describe('getClosestPageToPinch()', () => {
+        it('should find the closest page', () => {
+            const page1 = {
+                id: 1,
+                offsetLeft: 0,
+                offsetTop: 0,
+                scrollWidth: 0,
+                scrollHeight: 0
+            };
+            const page2 = {
+                id: 2,
+                offsetLeft: 100,
+                offsetTop: 0,
+                scrollWidth: 100,
+                scrollHeight: 0
+            };
+            const visiblePages = {
+                first: {
+                    id: 1
+                },
+                last: {
+                    id: 2
+                }
+            }
+
+            const midpointStub = sandbox.stub(document, 'querySelector');
+            midpointStub.onCall(0).returns(page1);
+            midpointStub.onCall(1).returns(page2);
+
+            sandbox.stub(util, 'getMidpoint').returns([0, 0]);
+            const distanceStub = sandbox.stub(util, 'getDistance').returns(100)
+
+            const result = util.getClosestPageToPinch(0, 0, visiblePages);
+            expect(result.id).to.equal(page1.id)
+        });
+
+        it('should return null if there are no pages', () => {
+            let result = util.getClosestPageToPinch(0, 0, null);
+            expect(result).to.equal(null);
+
+            result = util.getClosestPageToPinch(0, 0, {
+                first: null,
+                last: null
+            });
+
+            expect(result).to.equal(null);
         });
     });
 });

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -760,7 +760,7 @@ export function pageNumberFromScroll(currentPageNum, previousScrollTop, currentP
  * @param {number} y1 - The y value of the first point
  * @param {number} x2 - The x value of the second point
  * @param {number} y2 - The y value of the second point
- * @return {Array} the resulting x,y point
+ * @return {Array} The resulting x,y point
  */
 export function getMidpoint(x1, y1, x2, y2) {
     const x = (x1 + x2) / 2;
@@ -776,8 +776,42 @@ export function getMidpoint(x1, y1, x2, y2) {
  * @param {number} y1 - The y value of the first point
  * @param {number} x2 - The x value of the second point
  * @param {number} y2 - The y value of the second point
- * @return {number} the resulting distance
+ * @return {number} The resulting distance
  */
 export function getDistance(x1, y1, x2, y2) {
     return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+}
+
+/**
+ * Returns the closest visible page to a pinch event
+ *
+ * @public
+ * @param {number} x - The x value of pinch
+ * @param {number} y - The y value of the pinch
+ * @param {Object} visiblePages - Object of visible pages to consider
+ * @return {HTMLElement} The resulting page
+ */
+export function getClosestPageToPinch(x, y, visiblePages) {
+    if (!visiblePages || !visiblePages.first || !visiblePages.last) {
+        return null;
+    }
+
+    let closestPage = null;
+    for (let i = visiblePages.first.id, closestDistance = null; i <= visiblePages.last.id; i++) {
+        const page = document.querySelector(`#bp-page-${i}`);
+        const pageMidpoint = getMidpoint(
+            page.offsetLeft,
+            page.offsetTop,
+            page.offsetLeft + page.scrollWidth,
+            page.offsetTop + page.scrollHeight
+        );
+
+        const distance = getDistance(pageMidpoint[0], pageMidpoint[1], x, y);
+        if (!closestPage || distance < closestDistance) {
+            closestPage = page;
+            closestDistance = distance;
+        }
+    }
+
+    return closestPage;
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -751,3 +751,33 @@ export function pageNumberFromScroll(currentPageNum, previousScrollTop, currentP
 
     return pageNum;
 }
+
+/**
+ * Calculates the midpoint from two points.
+ *
+ * @public
+ * @param {number} x1 - The x value of the first point
+ * @param {number} y1 - The y value of the first point
+ * @param {number} x2 - The x value of the second point
+ * @param {number} y2 - The y value of the second point
+ * @return {Array} the resulting x,y point
+ */
+export function getMidpoint(x1, y1, x2, y2) {
+    const x = (x1 + x2) / 2;
+    const y = (y1 + y2) / 2;
+    return [x, y];
+}
+
+/**
+ * Calculates the distance between two points.
+ *
+ * @public
+ * @param {number} x1 - The x value of the first point
+ * @param {number} y1 - The y value of the first point
+ * @param {number} x2 - The x value of the second point
+ * @param {number} y2 - The y value of the second point
+ * @return {number} the resulting distance
+ */
+export function getDistance(x1, y1, x2, y2) {
+    return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+}

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -3,7 +3,6 @@ import DocBaseViewer from './DocBaseViewer';
 import PresentationPreloader from './PresentationPreloader';
 import { CLASS_INVISIBLE } from '../../constants';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT, ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../icons/icons';
-import { getDistance } from '../../util';
 import './Presentation.scss';
 
 const WHEEL_THROTTLE = 200;
@@ -153,14 +152,14 @@ class PresentationViewer extends DocBaseViewer {
      * @protected
      */
     bindDOMListeners() {
+        super.bindDOMListeners();
+
         this.docEl.addEventListener('wheel', this.throttledWheelHandler);
         if (this.hasTouch) {
             this.docEl.addEventListener('touchstart', this.mobileScrollHandler);
             this.docEl.addEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.addEventListener('touchend', this.mobileScrollHandler);
         }
-
-        super.bindDOMListeners();
     }
 
     /**
@@ -171,14 +170,14 @@ class PresentationViewer extends DocBaseViewer {
      * @protected
      */
     unbindDOMListeners() {
+        super.unbindDOMListeners();
+
         this.docEl.removeEventListener('wheel', this.throttledWheelHandler);
         if (this.hasTouch) {
             this.docEl.removeEventListener('touchstart', this.mobileScrollHandler);
             this.docEl.removeEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.removeEventListener('touchend', this.mobileScrollHandler);
         }
-
-        super.unbindDOMListeners();
     }
 
     /**
@@ -291,61 +290,6 @@ class PresentationViewer extends DocBaseViewer {
                 this.previousPage();
             }
         }, WHEEL_THROTTLE);
-    }
-
-    /**
-     * Setups pinch to zoom behavior by wrapping zoomed divs and determining the original pinch distance.
-     *
-     * @protected
-     * @param {Event} event - object
-     * @return {void}
-     */
-    pinchToZoomStartHandler(event) {
-        if (this.isPinching || event.touches.length < 2) {
-            return;
-        }
-
-        this.isPinching = true;
-        event.preventDefault();
-        event.stopPropagation();
-
-        const firstVisiblePage = document.querySelector(`#bp-page-${this.pdfViewer.currentPageNumber}`);
-        this.zoomWrapper = firstVisiblePage;
-
-        this.originalDistance = getDistance(
-            event.touches[0].pageX,
-            event.touches[0].pageY,
-            event.touches[1].pageX,
-            event.touches[1].pageY
-        );
-    }
-
-    /**
-     * Updates the CSS transform zoom based on the distance of the pinch gesture.
-     *
-     * @protected
-     * @param {Event} event - object
-     * @return {void}
-     */
-    pinchToZoomEndHandler() {
-        if (this.zoomWrapper && this.isPinching) {
-            const firstVisiblePage = document.querySelector(`#bp-page-${this.pdfViewer.currentPageNumber}`);
-
-            this.pdfViewer.currentScaleValue = this.pdfViewer.currentScale * this.pinchScale;
-            this.zoomWrapper.style.transform = 'scale(1, 1)';
-
-            const x = firstVisiblePage.offsetLeft + firstVisiblePage.clientWidth / 2 - this.docEl.clientWidth / 2;
-            const y = firstVisiblePage.offsetTop + firstVisiblePage.clientHeight / 2 - this.docEl.clientHeight / 2;
-
-            // Prevents scrolling to another page when zooming out
-            if (this.checkOverflow()) {
-                this.docEl.scroll(x, y);
-            }
-
-            this.pinchScale = 1;
-            this.isPinching = false;
-            this.originalDistance = 0;
-        }
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -3,6 +3,7 @@ import DocBaseViewer from './DocBaseViewer';
 import PresentationPreloader from './PresentationPreloader';
 import { CLASS_INVISIBLE } from '../../constants';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT, ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../icons/icons';
+import { getDistance } from '../../util';
 import './Presentation.scss';
 
 const WHEEL_THROTTLE = 200;
@@ -152,14 +153,14 @@ class PresentationViewer extends DocBaseViewer {
      * @protected
      */
     bindDOMListeners() {
-        super.bindDOMListeners();
-
         this.docEl.addEventListener('wheel', this.throttledWheelHandler);
         if (this.hasTouch) {
             this.docEl.addEventListener('touchstart', this.mobileScrollHandler);
             this.docEl.addEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.addEventListener('touchend', this.mobileScrollHandler);
         }
+
+        super.bindDOMListeners();
     }
 
     /**
@@ -170,14 +171,14 @@ class PresentationViewer extends DocBaseViewer {
      * @protected
      */
     unbindDOMListeners() {
-        super.unbindDOMListeners();
-
         this.docEl.removeEventListener('wheel', this.throttledWheelHandler);
         if (this.hasTouch) {
             this.docEl.removeEventListener('touchstart', this.mobileScrollHandler);
             this.docEl.removeEventListener('touchmove', this.mobileScrollHandler);
             this.docEl.removeEventListener('touchend', this.mobileScrollHandler);
         }
+
+        super.unbindDOMListeners();
     }
 
     /**
@@ -211,7 +212,7 @@ class PresentationViewer extends DocBaseViewer {
      * @return {void}
      */
     mobileScrollHandler(event) {
-        if (this.checkOverflow()) {
+        if (this.checkOverflow() || this.isPinching || event.touches.length > 1) {
             return;
         }
 
@@ -222,12 +223,18 @@ class PresentationViewer extends DocBaseViewer {
         } else {
             const scrollEnd = event.changedTouches[0].clientY;
 
+            if (!this.scrollStart || !scrollEnd) {
+                return;
+            }
+
             // scroll event offset prevents tapping from triggering a scroll
-            if (this.scrollStart && this.scrollStart > scrollEnd + SCROLL_EVENT_OFFSET) {
+            if (this.scrollStart > scrollEnd + SCROLL_EVENT_OFFSET) {
                 this.nextPage();
-            } else if (this.scrollStart && this.scrollStart < scrollEnd - SCROLL_EVENT_OFFSET) {
+            } else if (this.scrollStart < scrollEnd - SCROLL_EVENT_OFFSET) {
                 this.previousPage();
             }
+
+            this.scrollStart = null;
         }
     }
 
@@ -284,6 +291,61 @@ class PresentationViewer extends DocBaseViewer {
                 this.previousPage();
             }
         }, WHEEL_THROTTLE);
+    }
+
+    /**
+     * Setups pinch to zoom behavior by wrapping zoomed divs and determining the original pinch distance.
+     *
+     * @protected
+     * @param {Event} event - object
+     * @return {void}
+     */
+    pinchToZoomStartHandler(event) {
+        if (this.isPinching || event.touches.length < 2) {
+            return;
+        }
+
+        this.isPinching = true;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const firstVisiblePage = document.querySelector(`#bp-page-${this.pdfViewer.currentPageNumber}`);
+        this.zoomWrapper = firstVisiblePage;
+
+        this.originalDistance = getDistance(
+            event.touches[0].pageX,
+            event.touches[0].pageY,
+            event.touches[1].pageX,
+            event.touches[1].pageY
+        );
+    }
+
+    /**
+     * Updates the CSS transform zoom based on the distance of the pinch gesture.
+     *
+     * @protected
+     * @param {Event} event - object
+     * @return {void}
+     */
+    pinchToZoomEndHandler() {
+        if (this.zoomWrapper && this.isPinching) {
+            const firstVisiblePage = document.querySelector(`#bp-page-${this.pdfViewer.currentPageNumber}`);
+
+            this.pdfViewer.currentScaleValue = this.pdfViewer.currentScale * this.pinchScale;
+            this.zoomWrapper.style.transform = 'scale(1, 1)';
+
+            const x = firstVisiblePage.offsetLeft + firstVisiblePage.clientWidth / 2 - this.docEl.clientWidth / 2;
+            const y = firstVisiblePage.offsetTop + firstVisiblePage.clientHeight / 2 - this.docEl.clientHeight / 2;
+
+            // Prevents scrolling to another page when zooming out
+            if (this.checkOverflow()) {
+                this.docEl.scroll(x, y);
+            }
+
+            this.pinchScale = 1;
+            this.isPinching = false;
+            this.originalDistance = 0;
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1159,37 +1159,29 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
 
         it('should add the correct listeners', () => {
-            docBase.isMobile = false;
+            docBase.hasTouch = false;
             docBase.bindDOMListeners();
             expect(stubs.addEventListener).to.be.calledWith('pagesinit', docBase.pagesinitHandler);
             expect(stubs.addEventListener).to.be.calledWith('pagerendered', docBase.pagerenderedHandler);
             expect(stubs.addEventListener).to.be.calledWith('pagechange', docBase.pagechangeHandler);
             expect(stubs.addEventListener).to.be.calledWith('scroll', docBase.throttledScrollHandler);
 
-            expect(stubs.addEventListener).to.not.be.calledWith('gesturestart', docBase.mobileZoomStartHandler);
-            expect(stubs.addEventListener).to.not.be.calledWith('gestureend', docBase.mobileZoomEndHandler);
+
+            expect(stubs.addEventListener).to.not.be.calledWith('touchstart', docBase.pinchToZoomStartHandler);
+            expect(stubs.addEventListener).to.not.be.calledWith('touchmove', docBase.pinchToZoomChangeHandler);
+            expect(stubs.addEventListener).to.not.be.calledWith('touchend', docBase.pinchToZoomEndHandler);
 
             expect(stubs.addListener).to.be.calledWith('enter', docBase.enterfullscreenHandler);
             expect(stubs.addListener).to.be.calledWith('exit', docBase.exitfullscreenHandler);
         });
 
-        it('should add gesture listeners if the browser is iOS', () => {
-            docBase.isMobile = true;
-            stubs.isIOS.returns(true);
-
+        it('should add the pinch to zoom handler if touch is detected', () => {
+            docBase.hasTouch = true;
             docBase.bindDOMListeners();
-            expect(stubs.addEventListener).to.be.calledWith('gesturestart', docBase.mobileZoomStartHandler);
-            expect(stubs.addEventListener).to.be.calledWith('gestureend', docBase.mobileZoomEndHandler);
-        });
 
-        it('should add the touch event listeners if the browser is not iOS', () => {
-            docBase.isMobile = true;
-            stubs.isIOS.returns(false);
-
-            docBase.bindDOMListeners();
-            expect(stubs.addEventListener).to.be.calledWith('touchstart', docBase.mobileZoomStartHandler);
-            expect(stubs.addEventListener).to.be.calledWith('touchmove', docBase.mobileZoomChangeHandler);
-            expect(stubs.addEventListener).to.be.calledWith('touchend', docBase.mobileZoomEndHandler);
+            expect(stubs.addEventListener).to.be.calledWith('touchstart', docBase.pinchToZoomStartHandler);
+            expect(stubs.addEventListener).to.be.calledWith('touchmove', docBase.pinchToZoomChangeHandler);
+            expect(stubs.addEventListener).to.be.calledWith('touchend', docBase.pinchToZoomEndHandler);
         });
     });
 
@@ -1224,23 +1216,22 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(stubs.removeFullscreenListener).to.be.calledWith('exit', docBase.exitfullscreenHandler);
         });
 
-        it('should remove gesture listeners if the browser is iOS', () => {
-            docBase.isMobile = true;
-            stubs.isIOS.returns(true);
+        it('should remove pinch to zoom listeners if the browser has touch', () => {
+            docBase.hasTouch = true;
 
             docBase.unbindDOMListeners();
-            expect(stubs.removeEventListener).to.be.calledWith('gesturestart', docBase.mobileZoomStartHandler);
-            expect(stubs.removeEventListener).to.be.calledWith('gestureend', docBase.mobileZoomEndHandler);
+            expect(stubs.removeEventListener).to.be.calledWith('touchstart', docBase.pinchToZoomStartHandler);
+            expect(stubs.removeEventListener).to.be.calledWith('touchmove', docBase.pinchToZoomChangeHandler);
+            expect(stubs.removeEventListener).to.be.calledWith('touchend', docBase.pinchToZoomEndHandler);
         });
 
-        it('should remove the touch event listeners if the browser is not iOS', () => {
-            docBase.isMobile = true;
-            stubs.isIOS.returns(false);
+        it('should not remove the pinch to zoom listeners if the browser does not have touch', () => {
+            docBase.hasTouch = false;
 
             docBase.unbindDOMListeners();
-            expect(stubs.removeEventListener).to.be.calledWith('touchstart', docBase.mobileZoomStartHandler);
-            expect(stubs.removeEventListener).to.be.calledWith('touchmove', docBase.mobileZoomChangeHandler);
-            expect(stubs.removeEventListener).to.be.calledWith('touchend', docBase.mobileZoomEndHandler);
+            expect(stubs.removeEventListener).to.not.be.calledWith('touchstart', docBase.pinchToZoomStartHandler);
+            expect(stubs.removeEventListener).to.not.be.calledWith('touchmove', docBase.pinchToZoomChangeHandler);
+            expect(stubs.removeEventListener).to.not.be.calledWith('touchend', docBase.pinchToZoomEndHandler);
         });
     });
 
@@ -1409,5 +1400,237 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             clock.tick(SCROLL_END_TIMEOUT + 1);
             expect(stubs.emit).to.be.calledWith('scrollend');
         });
+    });
+
+    describe('pinchToZoomStartHandler()', () => {
+        let event;
+
+        beforeEach(() => {
+            event = {
+                touches: {
+                    length: 2
+                },
+                stopPropagation: sandbox.stub(),
+                preventDefault: sandbox.stub(),
+                pageX: 0,
+                pageY: 0,
+                touches: [
+                    {
+                        pageX: 0,
+                        pageY: 100
+                    },
+                    {
+                        pageX: 200,
+                        pageY: 200
+                    }
+                ]
+            };
+            docBase.isPinching = false;
+            docBase.pdfViewer = {
+                _getVisiblePages: sandbox.stub()
+            }
+            sandbox.stub(util, 'getClosestPageToPinch').returns(document.createElement('div'));
+            sandbox.stub(util, 'getDistance');
+        });
+
+        it('should do nothing if we are already pinching or if the event does not use two finger', () => {
+            event.touches.length = 1;
+
+            docBase.pinchToZoomStartHandler(event);
+            expect(event.stopPropagation).to.not.be.called;
+
+            event.touches = [
+                {
+                    pageX: 0,
+                    pageY: 100
+                },
+                {
+                    pageX: 200,
+                    pageY: 200
+                }
+            ];
+
+            docBase.pinchToZoomStartHandler(event);
+            expect(event.stopPropagation).to.be.called;
+        });
+
+        it('should prevent default behavior and indicate that we are pinching', () => {
+            docBase.pinchToZoomStartHandler(event);
+
+            expect(docBase.isPinching).to.be.true;
+            expect(event.stopPropagation).to.be.called;
+            expect(event.preventDefault).to.be.called;
+        });
+
+        it('should get the closest page and setup the pinching clases', () => {
+            docBase.docEl = document.createElement('div');
+            const pdfViewer = document.createElement('div');
+            docBase.docEl.appendChild(pdfViewer);
+            docBase.pinchToZoomStartHandler(event);
+
+            expect(docBase.pdfViewer._getVisiblePages).to.be.called;
+            expect(util.getClosestPageToPinch).to.be.called;
+        });
+
+        it('should save the original distance for later scale calculation', () => {
+            docBase.pinchToZoomStartHandler(event);
+            expect(util.getDistance).to.be.calledWith(event.touches[0].pageX, event.touches[0].pageY, event.touches[1].pageX, event.touches[1].pageY)
+        });
+    });
+
+    describe('pinchToZoomChangeHandler()', () => {
+        let eventWithScale;
+        let eventWithoutScale;
+
+        beforeEach(() => {
+            docBase.originalDistance = 1;
+            docBase.pinchPage = document.createElement('div');
+            docBase.isPinching = true;
+            eventWithScale = {
+                scale: 1.5
+            };
+
+            eventWithoutScale = {
+                touches: [
+                    {
+                        pageX: 100,
+                        pageY: 100
+                    },
+                    {
+                        pageX: 300,
+                        pageY: 300
+                    }
+                ]
+            };
+
+            docBase.pdfViewer = {
+                currentScale: 1
+            }
+
+            sandbox.stub(util, 'getDistance');
+        });
+
+        it('should do nothing if we are not pinching', () => {
+            docBase.isPinching = false;
+
+            docBase.pinchToZoomChangeHandler(eventWithoutScale);
+            expect(util.getDistance).to.not.be.called;
+
+            docBase.isPinching = true;
+
+            docBase.pinchToZoomChangeHandler(eventWithoutScale);
+            expect(util.getDistance).to.be.called;
+        });
+
+        describe('ignored chages', () => {
+            it('should do nothing if the scale is 1', () => {
+                eventWithScale.scale = 1;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+
+            it('should do nothing if the scale change is less than 0.01', () => {
+                docBase.pinchScale = 1.5;
+                eventWithScale.scale = 1.501;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+
+            it('should do nothing if the scale change bigger than 3', () => {
+                docBase.pinchScale = 1;
+                eventWithScale.scale = 3.5;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+
+            it('should do nothing if the scale change bigger than .25', () => {
+                docBase.pinchScale = 1;
+                eventWithScale.scale = .1;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+
+            it('should do nothing if the proposed scale is greater than the MAX_SCALE', () => {
+                docBase.pdfViewer = {
+                    currentScale: 7
+                }
+
+                eventWithScale.scale = 2;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+
+            it('should do nothing if the proposed scale is less than the MIN_SCALE', () => {
+                docBase.pdfViewer = {
+                    currentScale: .12
+                }
+
+                eventWithScale.scale = .25;
+                docBase.pinchToZoomChangeHandler(eventWithScale);
+
+                expect(docBase.pinchPage.style.transform).to.equal(undefined);
+            });
+        });
+
+        it('should transform the pinched page based on the new scale value', () => {
+            docBase.pinchToZoomChangeHandler(eventWithScale);
+            expect(docBase.pinchPage.style.transform).to.equal('scale(1.5)');
+            expect(docBase.pinchPage.classList.contains('pinch-page')).to.be.true;
+        });
+
+    });
+
+    describe('pinchToZoomEndHandler()', () => {
+        beforeEach(() => {
+            docBase.pdfViewer = {
+                currentScaleValue: 1,
+                currentScale: 1,
+                update: sandbox.stub()
+            }
+
+            docBase.pinchScale = 1.5;
+
+            docBase.docEl.scroll = sandbox.stub();
+
+            docBase.isPinching = true;
+            docBase.pinchPage = document.createElement('div');
+        });
+
+        it('should do nothing if we are not pinching', () => {
+            docBase.isPinching = false;
+            docBase.pinchToZoomEndHandler()
+            expect(docBase.pdfViewer.currentScaleValue).to.equal(1);
+        });
+
+        it('should do nothing if no pinched page exists', () => {
+            docBase.pinchPage = null;
+            docBase.pinchToZoomEndHandler()
+            expect(docBase.pdfViewer.currentScaleValue).to.equal(1);
+        });
+
+        it('should perform a pdf.js zoom', () => {
+            docBase.pinchToZoomEndHandler()
+            expect(docBase.pdfViewer.currentScaleValue).to.equal(1.5);
+        });
+
+        it('should scroll to offset the zoom', () => {
+            docBase.pinchToZoomEndHandler()
+            expect(docBase.docEl.scroll).to.be.called;
+        });
+
+        it('should reset pinching state variables', () => {
+            docBase.pinchToZoomEndHandler()
+
+            expect(docBase.isPinching).to.be.false;
+            expect(docBase.originalDistance).to.equal(0);
+            expect(docBase.pinchScale).to.equal(1);
+            expect(docBase.pinchPage).to.equal(null);
+        });
+
     });
 });

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -354,6 +354,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
                         clientY: 0
                     }
                 ],
+                touches: [1],
                 preventDefault: sandbox.stub()
             };
             stubs.nextPage = sandbox.stub(presentation, 'nextPage');
@@ -368,6 +369,21 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             expect(stubs.event.preventDefault).to.not.be.called;
         });
 
+        it('should do nothing if we are pinching or touch with more than one finger', () => {
+            presentation.isPinching = true;
+
+            presentation.mobileScrollHandler(stubs.event);
+            expect(presentation.scrollStart).to.equal(undefined);
+            expect(stubs.event.preventDefault).to.not.be.called;
+
+            presentation.isPinching = false;
+            stubs.event.touches = [1, 2];
+
+            presentation.mobileScrollHandler(stubs.event);
+            expect(presentation.scrollStart).to.equal(undefined);
+            expect(stubs.event.preventDefault).to.not.be.called;
+        });
+
         it('should set the scroll start position if the event is a touch start', () => {
             stubs.event.type = 'touchstart';
             stubs.event.changedTouches[0].clientY = 100;
@@ -376,7 +392,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             expect(presentation.scrollStart).to.equal(100);
         });
 
-        it('should prevent default behaviour if the event is touchmove', () => {
+        it('should prevent default behavior if the event is touchmove', () => {
             stubs.event.type = 'touchmove';
             stubs.event.changedTouches[0].clientY = 100;
 

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -57,6 +57,12 @@
         }
     }
 
+    .disable-textLayer {
+        .textLayer {
+            display: none;
+        }
+    }
+
     .textLayer {
         bottom: auto;
         top: 15px; // Match 15px padding top on page

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -22,14 +22,13 @@
         /* stylelint-enable declaration-no-important */
     }
 
-    &.is-safari {
-        // Fixes bug in Safari https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/
-        transform: translate3d(0, 0, 0);
-    }
-
     // Fixes vertical scroll issue - scrollbars should be disabled until after preview is loaded
     &.bp-is-scrollable {
         overflow: auto;
+    }
+
+    .pdfViewer.pinching {
+        visibility: hidden;
     }
 
     //---------- Override CSS from generic PDFJS viewer build ----------//
@@ -57,7 +56,10 @@
         }
     }
 
-    .disable-textLayer {
+    .pdfViewer .page.pinch-page {
+        padding: 0;
+        visibility: visible;
+
         .textLayer {
             display: none;
         }


### PR DESCRIPTION
Still a WIP, but this PR adds a more fluid pinch-to-zoom by:
1. Scaling the visible pages canvases with CSS transform
2. Calculating the overall scale and translate it to a PDF.js zoom
3. Removing the CSS scale and scrolling to where we left off while pinching

Open Issues:
1. Slight jump when transitioning from CSS scaling to PDF.js zoom
2. Pages will occasionally scroll when pinching using the presentation viewer. 

  