### PR TITLE
Fix: Ensure only loading wrapper is interactable preview container

### DIFF
--- a/src/lib/_loading.scss
+++ b/src/lib/_loading.scss
@@ -39,8 +39,12 @@
 }
 
 // Only the loading wrapper should be interactable inside the Preview container
-.bp:not(.bp-loaded) > div:not(.bp-loading-wrapper) {
+.bp:not(.bp-loaded) {
     pointer-events: none;
+
+    & .bp-loading-wrapper {
+        pointer-events: all;
+    }
 }
 
 .bp-loading {

--- a/src/lib/_loading.scss
+++ b/src/lib/_loading.scss
@@ -38,8 +38,8 @@
     }
 }
 
-// Preview content should not be interactable during loading
-:not(.bp-loaded) > .bp-loading-wrapper + div {
+// Only the loading wrapper should be interactable inside the Preview container
+.bp:not(.bp-loaded) > div:not(.bp-loading-wrapper) {
     pointer-events: none;
 }
 


### PR DESCRIPTION
- The preview CSS selector only prevented the div directly adjacent to the .bp-loading-wrapper from being interactable.
- This selector prevents all divs within the Preview Container EXCEPT .bp-loading-wrapper from being interactable. This prevents interactions from the Preview content, find bar, controls, etc.