### PR TITLE
Event names into separate file

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -44,7 +44,7 @@ import {
     X_REP_HINT_VIDEO_DASH,
     X_REP_HINT_VIDEO_MP4
 } from './constants';
-import { VIEWER_EVENTS } from './events';
+import { VIEWER_EVENT } from './events';
 import './Preview.scss';
 
 const DEFAULT_DISABLED_VIEWERS = ['Office']; // viewers disabled by default
@@ -947,7 +947,7 @@ class Preview extends EventEmitter {
     attachViewerListeners() {
         // Node requires listener attached to 'error'
         this.viewer.addListener('error', this.triggerError);
-        this.viewer.addListener(VIEWER_EVENTS.generic, this.handleViewerEvents);
+        this.viewer.addListener(VIEWER_EVENT.default, this.handleViewerEvents);
     }
 
     /**
@@ -960,34 +960,34 @@ class Preview extends EventEmitter {
     handleViewerEvents(data) {
         /* istanbul ignore next */
         switch (data.event) {
-            case VIEWER_EVENTS.download:
+            case VIEWER_EVENT.download:
                 this.download();
                 break;
-            case VIEWER_EVENTS.reload:
+            case VIEWER_EVENT.reload:
                 this.reload(); // Reload preview and fetch updated file info depending on `skipServerUpdate` option
                 break;
-            case VIEWER_EVENTS.load:
+            case VIEWER_EVENT.load:
                 this.finishLoading(data.data);
                 break;
-            case VIEWER_EVENTS.progressStart:
+            case VIEWER_EVENT.progressStart:
                 this.ui.startProgressBar();
                 break;
-            case VIEWER_EVENTS.progressEnd:
+            case VIEWER_EVENT.progressEnd:
                 this.ui.finishProgressBar();
                 break;
-            case VIEWER_EVENTS.notificationShow:
+            case VIEWER_EVENT.notificationShow:
                 this.ui.showNotification(data.data);
                 break;
-            case VIEWER_EVENTS.notificationHide:
+            case VIEWER_EVENT.notificationHide:
                 this.ui.hideNotification();
                 break;
-            case VIEWER_EVENTS.mediaEndAutoplay:
+            case VIEWER_EVENT.mediaEndAutoplay:
                 this.navigateRight();
                 break;
             default:
                 // This includes 'notification', 'preload' and others
                 this.emit(data.event, data.data);
-                this.emit(VIEWER_EVENTS.generic, data);
+                this.emit(VIEWER_EVENT.default, data);
         }
     }
 
@@ -1034,7 +1034,7 @@ class Preview extends EventEmitter {
             this.count.error += 1;
 
             // 'load' with { error } signifies a preview error
-            this.emit(VIEWER_EVENTS.load, {
+            this.emit(VIEWER_EVENT.load, {
                 error,
                 metrics: this.logger.done(this.count),
                 file: this.file
@@ -1049,7 +1049,7 @@ class Preview extends EventEmitter {
             this.count.success += 1;
 
             // Finally emit the viewer instance back with a load event
-            this.emit(VIEWER_EVENTS.load, {
+            this.emit(VIEWER_EVENT.load, {
                 viewer: this.viewer,
                 metrics: this.logger.done(this.count),
                 file: this.file

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -44,6 +44,7 @@ import {
     X_REP_HINT_VIDEO_DASH,
     X_REP_HINT_VIDEO_MP4
 } from './constants';
+import { VIEWER_EVENTS } from './events';
 import './Preview.scss';
 
 const DEFAULT_DISABLED_VIEWERS = ['Office']; // viewers disabled by default
@@ -946,7 +947,7 @@ class Preview extends EventEmitter {
     attachViewerListeners() {
         // Node requires listener attached to 'error'
         this.viewer.addListener('error', this.triggerError);
-        this.viewer.addListener('viewerevent', this.handleViewerEvents);
+        this.viewer.addListener(VIEWER_EVENTS.generic, this.handleViewerEvents);
     }
 
     /**
@@ -959,34 +960,34 @@ class Preview extends EventEmitter {
     handleViewerEvents(data) {
         /* istanbul ignore next */
         switch (data.event) {
-            case 'download':
+            case VIEWER_EVENTS.download:
                 this.download();
                 break;
-            case 'reload':
+            case VIEWER_EVENTS.reload:
                 this.reload(); // Reload preview and fetch updated file info depending on `skipServerUpdate` option
                 break;
-            case 'load':
+            case VIEWER_EVENTS.load:
                 this.finishLoading(data.data);
                 break;
-            case 'progressstart':
+            case VIEWER_EVENTS.progressStart:
                 this.ui.startProgressBar();
                 break;
-            case 'progressend':
+            case VIEWER_EVENTS.progressEnd:
                 this.ui.finishProgressBar();
                 break;
-            case 'notificationshow':
+            case VIEWER_EVENTS.notificationShow:
                 this.ui.showNotification(data.data);
                 break;
-            case 'notificationhide':
+            case VIEWER_EVENTS.notificationHide:
                 this.ui.hideNotification();
                 break;
-            case 'mediaendautoplay':
+            case VIEWER_EVENTS.mediaEndAutoplay:
                 this.navigateRight();
                 break;
             default:
                 // This includes 'notification', 'preload' and others
                 this.emit(data.event, data.data);
-                this.emit('viewerevent', data);
+                this.emit(VIEWER_EVENTS.generic, data);
         }
     }
 
@@ -1033,7 +1034,7 @@ class Preview extends EventEmitter {
             this.count.error += 1;
 
             // 'load' with { error } signifies a preview error
-            this.emit('load', {
+            this.emit(VIEWER_EVENTS.load, {
                 error,
                 metrics: this.logger.done(this.count),
                 file: this.file
@@ -1048,7 +1049,7 @@ class Preview extends EventEmitter {
             this.count.success += 1;
 
             // Finally emit the viewer instance back with a load event
-            this.emit('load', {
+            this.emit(VIEWER_EVENTS.load, {
                 viewer: this.viewer,
                 metrics: this.logger.done(this.count),
                 file: this.file

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -8,7 +8,7 @@ import Browser from '../Browser';
 import * as file from '../file';
 import * as util from '../util';
 import { API_HOST, CLASS_NAVIGATION_VISIBILITY } from '../constants';
-import { VIEWER_EVENTS } from '../events';
+import { VIEWER_EVENT } from '../events';
 
 const tokens = require('../tokens');
 
@@ -1436,38 +1436,38 @@ describe('lib/Preview', () => {
 
             preview.attachViewerListeners();
             expect(preview.viewer.addListener).to.be.calledWith('error', sinon.match.func);
-            expect(preview.viewer.addListener).to.be.calledWith(VIEWER_EVENTS.generic, sinon.match.func);
+            expect(preview.viewer.addListener).to.be.calledWith(VIEWER_EVENT.default, sinon.match.func);
         });
     });
 
     describe('handleViewerEvents()', () => {
         it('should call download on download event', () => {
             sandbox.stub(preview, 'download');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.download });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.download });
             expect(preview.download).to.be.called;
         });
 
         it('should reload preview on reload event', () => {
             sandbox.stub(preview, 'reload');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.reload });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.reload });
             expect(preview.reload).to.be.called;
         });
 
         it('should finish loading preview on load event', () => {
             sandbox.stub(preview, 'finishLoading');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.load });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.load });
             expect(preview.finishLoading).to.be.called;
         });
 
         it('should start progress bar on progressstart event', () => {
             sandbox.stub(preview.ui, 'startProgressBar');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.progressStart });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.progressStart });
             expect(preview.ui.startProgressBar).to.be.called;
         });
 
         it('should finish progress bar on progressend event', () => {
             sandbox.stub(preview.ui, 'finishProgressBar');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.progressEnd });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.progressEnd });
             expect(preview.ui.finishProgressBar).to.be.called;
         });
 
@@ -1475,7 +1475,7 @@ describe('lib/Preview', () => {
             const message = 'notification_message';
             sandbox.stub(preview.ui, 'showNotification');
             preview.handleViewerEvents({
-                event: VIEWER_EVENTS.notificationShow,
+                event: VIEWER_EVENT.notificationShow,
                 data: message
             });
             expect(preview.ui.showNotification).to.be.calledWith(message);
@@ -1483,13 +1483,13 @@ describe('lib/Preview', () => {
 
         it('should hide notification on notificationhide event', () => {
             sandbox.stub(preview.ui, 'hideNotification');
-            preview.handleViewerEvents({ event: VIEWER_EVENTS.notificationHide });
+            preview.handleViewerEvents({ event: VIEWER_EVENT.notificationHide });
             expect(preview.ui.hideNotification).to.be.called;
         });
 
         it('should navigate right on mediaendautoplay event', () => {
             sandbox.stub(preview, 'navigateRight');
-            const data = { event: VIEWER_EVENTS.mediaEndAutoplay };
+            const data = { event: VIEWER_EVENT.mediaEndAutoplay };
 
             preview.handleViewerEvents(data);
             expect(preview.navigateRight).to.be.called;
@@ -1503,7 +1503,7 @@ describe('lib/Preview', () => {
             };
             preview.handleViewerEvents(data);
             expect(preview.emit).to.be.calledWith(data.event, data.data);
-            expect(preview.emit).to.be.calledWith(VIEWER_EVENTS.generic, data);
+            expect(preview.emit).to.be.calledWith(VIEWER_EVENT.default, data);
         });
     });
 

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -8,6 +8,7 @@ import Browser from '../Browser';
 import * as file from '../file';
 import * as util from '../util';
 import { API_HOST, CLASS_NAVIGATION_VISIBILITY } from '../constants';
+import { VIEWER_EVENTS } from '../events';
 
 const tokens = require('../tokens');
 
@@ -1435,38 +1436,38 @@ describe('lib/Preview', () => {
 
             preview.attachViewerListeners();
             expect(preview.viewer.addListener).to.be.calledWith('error', sinon.match.func);
-            expect(preview.viewer.addListener).to.be.calledWith('viewerevent', sinon.match.func);
+            expect(preview.viewer.addListener).to.be.calledWith(VIEWER_EVENTS.generic, sinon.match.func);
         });
     });
 
     describe('handleViewerEvents()', () => {
         it('should call download on download event', () => {
             sandbox.stub(preview, 'download');
-            preview.handleViewerEvents({ event: 'download' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.download });
             expect(preview.download).to.be.called;
         });
 
         it('should reload preview on reload event', () => {
             sandbox.stub(preview, 'reload');
-            preview.handleViewerEvents({ event: 'reload' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.reload });
             expect(preview.reload).to.be.called;
         });
 
         it('should finish loading preview on load event', () => {
             sandbox.stub(preview, 'finishLoading');
-            preview.handleViewerEvents({ event: 'load' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.load });
             expect(preview.finishLoading).to.be.called;
         });
 
         it('should start progress bar on progressstart event', () => {
             sandbox.stub(preview.ui, 'startProgressBar');
-            preview.handleViewerEvents({ event: 'progressstart' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.progressStart });
             expect(preview.ui.startProgressBar).to.be.called;
         });
 
         it('should finish progress bar on progressend event', () => {
             sandbox.stub(preview.ui, 'finishProgressBar');
-            preview.handleViewerEvents({ event: 'progressend' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.progressEnd });
             expect(preview.ui.finishProgressBar).to.be.called;
         });
 
@@ -1474,7 +1475,7 @@ describe('lib/Preview', () => {
             const message = 'notification_message';
             sandbox.stub(preview.ui, 'showNotification');
             preview.handleViewerEvents({
-                event: 'notificationshow',
+                event: VIEWER_EVENTS.notificationShow,
                 data: message
             });
             expect(preview.ui.showNotification).to.be.calledWith(message);
@@ -1482,13 +1483,13 @@ describe('lib/Preview', () => {
 
         it('should hide notification on notificationhide event', () => {
             sandbox.stub(preview.ui, 'hideNotification');
-            preview.handleViewerEvents({ event: 'notificationhide' });
+            preview.handleViewerEvents({ event: VIEWER_EVENTS.notificationHide });
             expect(preview.ui.hideNotification).to.be.called;
         });
 
         it('should navigate right on mediaendautoplay event', () => {
             sandbox.stub(preview, 'navigateRight');
-            const data = { event: 'mediaendautoplay' };
+            const data = { event: VIEWER_EVENTS.mediaEndAutoplay };
 
             preview.handleViewerEvents(data);
             expect(preview.navigateRight).to.be.called;
@@ -1502,7 +1503,7 @@ describe('lib/Preview', () => {
             };
             preview.handleViewerEvents(data);
             expect(preview.emit).to.be.calledWith(data.event, data.data);
-            expect(preview.emit).to.be.calledWith('viewerevent', data);
+            expect(preview.emit).to.be.calledWith(VIEWER_EVENTS.generic, data);
         });
     });
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,6 +1,6 @@
 // Events emitted by Viewers
 // eslint-disable-next-line import/prefer-default-export
-export const VIEWER_EVENTS = {
+export const VIEWER_EVENT = {
     download: 'download', // Begin downloading the file.
     reload: 'reload', // Reload preview.
     load: 'load', // Preview is finished loading.
@@ -9,5 +9,5 @@ export const VIEWER_EVENTS = {
     notificationShow: 'notificationshow', // Show notification modal.
     notificationHide: 'notificationhide', // Hide notification modal.
     mediaEndAutoplay: 'mediaendautoplay', // Media playback has completed, with autoplay enabled.
-    generic: 'viewerevent' // The generic default viewer event
+    default: 'viewerevent' // The default viewer event
 };

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,13 +1,13 @@
 // Events emitted by Viewers
 // eslint-disable-next-line import/prefer-default-export
 export const VIEWER_EVENTS = {
-    download: 'download',
-    reload: 'reload',
-    load: 'load',
-    progressStart: 'progressstart',
-    progressEnd: 'progressend',
-    notificationShow: 'notificationshow',
-    notificationHide: 'notificationhide',
-    mediaEndAutoplay: 'mediaendautoplay',
-    generic: 'viewerevent'
+    download: 'download', // Begin downloading the file.
+    reload: 'reload', // Reload preview.
+    load: 'load', // Preview is finished loading.
+    progressStart: 'progressstart', // Begin using loading indicator.
+    progressEnd: 'progressend', // Stop using loading indicator.
+    notificationShow: 'notificationshow', // Show notification modal.
+    notificationHide: 'notificationhide', // Hide notification modal.
+    mediaEndAutoplay: 'mediaendautoplay', // Media playback has completed, with autoplay enabled.
+    generic: 'viewerevent' // The generic default viewer event
 };

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,0 +1,13 @@
+// Events emitted by Viewers
+// eslint-disable-next-line import/prefer-default-export
+export const VIEWER_EVENTS = {
+    download: 'download',
+    reload: 'reload',
+    load: 'load',
+    progressStart: 'progressstart',
+    progressEnd: 'progressend',
+    notificationShow: 'notificationshow',
+    notificationHide: 'notificationhide',
+    mediaEndAutoplay: 'mediaendautoplay',
+    generic: 'viewerevent'
+};

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -28,7 +28,7 @@ import {
     STATUS_VIEWABLE
 } from '../constants';
 import { getIconFromExtension, getIconFromName } from '../icons/icons';
-import { VIEWER_EVENTS } from '../events';
+import { VIEWER_EVENT } from '../events';
 
 const ANNOTATIONS_JS = 'annotations.js';
 const ANNOTATIONS_CSS = 'annotations.css';
@@ -379,7 +379,7 @@ class BaseViewer extends EventEmitter {
             this.containerEl.addEventListener('contextmenu', this.preventDefault);
         }
 
-        this.addListener(VIEWER_EVENTS.load, this.viewerLoadHandler);
+        this.addListener(VIEWER_EVENT.load, this.viewerLoadHandler);
     }
 
     /**
@@ -475,7 +475,7 @@ class BaseViewer extends EventEmitter {
         const { file, viewer } = this.options;
 
         super.emit(event, data);
-        super.emit(VIEWER_EVENTS.generic, {
+        super.emit(VIEWER_EVENT.defaultÍS, {
             event,
             data,
             viewerName: viewer ? viewer.NAME : '',
@@ -828,22 +828,22 @@ class BaseViewer extends EventEmitter {
                 this.disableViewerControls();
 
                 if (data.data.mode === ANNOTATION_TYPE_POINT) {
-                    this.emit(VIEWER_EVENTS.notificationShow, __('notification_annotation_point_mode'));
+                    this.emit(VIEWER_EVENT.notificationShow, __('notification_annotation_point_mode'));
                 } else if (data.data.mode === ANNOTATION_TYPE_DRAW) {
-                    this.emit(VIEWER_EVENTS.notificationShow, __('notification_annotation_draw_mode'));
+                    this.emit(VIEWER_EVENT.notificationShow, __('notification_annotation_draw_mode'));
                     this.previewUI.replaceHeader(data.data.headerSelector);
                 }
                 break;
             case ANNOTATOR_EVENT.modeExit:
                 this.enableViewerControls();
-                this.emit(VIEWER_EVENTS.notificationHide);
+                this.emit(VIEWER_EVENT.notificationHide);
 
                 if (data.data.mode === ANNOTATION_TYPE_DRAW) {
                     this.previewUI.replaceHeader(data.data.headerSelector);
                 }
                 break;
             case ANNOTATOR_EVENT.error:
-                this.emit(VIEWER_EVENTS.notificationShow, data.data);
+                this.emit(VIEWER_EVENT.notificationShow, data.data);
                 break;
             case ANNOTATOR_EVENT.fetch:
                 this.emit('scale', {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -28,6 +28,7 @@ import {
     STATUS_VIEWABLE
 } from '../constants';
 import { getIconFromExtension, getIconFromName } from '../icons/icons';
+import { VIEWER_EVENTS } from '../events';
 
 const ANNOTATIONS_JS = 'annotations.js';
 const ANNOTATIONS_CSS = 'annotations.css';
@@ -378,7 +379,7 @@ class BaseViewer extends EventEmitter {
             this.containerEl.addEventListener('contextmenu', this.preventDefault);
         }
 
-        this.addListener('load', this.viewerLoadHandler);
+        this.addListener(VIEWER_EVENTS.load, this.viewerLoadHandler);
     }
 
     /**
@@ -474,7 +475,7 @@ class BaseViewer extends EventEmitter {
         const { file, viewer } = this.options;
 
         super.emit(event, data);
-        super.emit('viewerevent', {
+        super.emit(VIEWER_EVENTS.generic, {
             event,
             data,
             viewerName: viewer ? viewer.NAME : '',
@@ -823,22 +824,22 @@ class BaseViewer extends EventEmitter {
                 this.disableViewerControls();
 
                 if (data.data.mode === ANNOTATION_TYPE_POINT) {
-                    this.emit('notificationshow', __('notification_annotation_point_mode'));
+                    this.emit(VIEWER_EVENTS.notificationShow, __('notification_annotation_point_mode'));
                 } else if (data.data.mode === ANNOTATION_TYPE_DRAW) {
-                    this.emit('notificationshow', __('notification_annotation_draw_mode'));
+                    this.emit(VIEWER_EVENTS.notificationShow, __('notification_annotation_draw_mode'));
                     this.previewUI.replaceHeader(data.data.headerSelector);
                 }
                 break;
             case ANNOTATOR_EVENT.modeExit:
                 this.enableViewerControls();
-                this.emit('notificationhide');
+                this.emit(VIEWER_EVENTS.notificationHide);
 
                 if (data.data.mode === ANNOTATION_TYPE_DRAW) {
                     this.previewUI.replaceHeader(data.data.headerSelector);
                 }
                 break;
             case ANNOTATOR_EVENT.error:
-                this.emit('notificationshow', data.data);
+                this.emit(VIEWER_EVENTS.notificationShow, data.data);
                 break;
             case ANNOTATOR_EVENT.fetch:
                 this.emit('scale', {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -475,7 +475,7 @@ class BaseViewer extends EventEmitter {
         const { file, viewer } = this.options;
 
         super.emit(event, data);
-        super.emit(VIEWER_EVENT.defaultÍS, {
+        super.emit(VIEWER_EVENT.default, {
             event,
             data,
             viewerName: viewer ? viewer.NAME : '',

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -8,7 +8,7 @@ import * as util from '../../util';
 import * as file from '../../file';
 import * as icons from '../../icons/icons';
 import * as constants from '../../constants';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 let base;
 let containerEl;
@@ -300,7 +300,7 @@ describe('lib/viewers/BaseViewer', () => {
             expect(stubs.fullscreenAddListener).to.be.calledWith('enter', sinon.match.func);
             expect(stubs.fullscreenAddListener).to.be.calledWith('exit', sinon.match.func);
             expect(stubs.documentAddEventListener).to.be.calledWith('resize', sinon.match.func);
-            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENTS.load, sinon.match.func);
+            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENT.load, sinon.match.func);
         });
 
         it('should prevent the context menu if preview only permissions', () => {
@@ -320,7 +320,7 @@ describe('lib/viewers/BaseViewer', () => {
 
         it('should handle annotations load', () => {
             base.addCommonListeners();
-            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENTS.load, sinon.match.func);
+            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENT.load, sinon.match.func);
         });
     });
 
@@ -497,7 +497,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.emit(event, data);
 
             expect(emitStub).to.be.calledWith(event, data);
-            expect(emitStub).to.be.calledWithMatch(VIEWER_EVENTS.generic, {
+            expect(emitStub).to.be.calledWithMatch(VIEWER_EVENT.default, {
                 event,
                 data,
                 viewerName,
@@ -1010,7 +1010,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, sinon.match.string);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENT.notificationShow, sinon.match.string);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1025,7 +1025,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, sinon.match.string);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENT.notificationShow, sinon.match.string);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1039,7 +1039,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.enableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationHide);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENT.notificationHide);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1053,7 +1053,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.enableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationHide);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENT.notificationHide);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1064,7 +1064,7 @@ describe('lib/viewers/BaseViewer', () => {
                 data: 'message'
             };
             base.handleAnnotatorEvents(data);
-            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, data.data);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENT.notificationShow, data.data);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1092,7 +1092,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.not.be.called;
             expect(base.enableViewerControls).to.not.be.called;
-            expect(base.emit).to.not.be.calledWith(VIEWER_EVENTS.notificationShow, data.data);
+            expect(base.emit).to.not.be.calledWith(VIEWER_EVENT.notificationShow, data.data);
             expect(base.emit).to.not.be.calledWith('scale', {
                 scale: base.scale,
                 rotationAngle: base.rotationAngle

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -8,6 +8,7 @@ import * as util from '../../util';
 import * as file from '../../file';
 import * as icons from '../../icons/icons';
 import * as constants from '../../constants';
+import { VIEWER_EVENTS } from '../../events';
 
 let base;
 let containerEl;
@@ -299,7 +300,7 @@ describe('lib/viewers/BaseViewer', () => {
             expect(stubs.fullscreenAddListener).to.be.calledWith('enter', sinon.match.func);
             expect(stubs.fullscreenAddListener).to.be.calledWith('exit', sinon.match.func);
             expect(stubs.documentAddEventListener).to.be.calledWith('resize', sinon.match.func);
-            expect(stubs.baseAddListener).to.be.calledWith('load', sinon.match.func);
+            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENTS.load, sinon.match.func);
         });
 
         it('should prevent the context menu if preview only permissions', () => {
@@ -319,7 +320,7 @@ describe('lib/viewers/BaseViewer', () => {
 
         it('should handle annotations load', () => {
             base.addCommonListeners();
-            expect(stubs.baseAddListener).to.be.calledWith('load', sinon.match.func);
+            expect(stubs.baseAddListener).to.be.calledWith(VIEWER_EVENTS.load, sinon.match.func);
         });
     });
 
@@ -496,7 +497,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.emit(event, data);
 
             expect(emitStub).to.be.calledWith(event, data);
-            expect(emitStub).to.be.calledWithMatch('viewerevent', {
+            expect(emitStub).to.be.calledWithMatch(VIEWER_EVENTS.generic, {
                 event,
                 data,
                 viewerName,
@@ -1007,7 +1008,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith('notificationshow', sinon.match.string);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, sinon.match.string);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1022,7 +1023,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith('notificationshow', sinon.match.string);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, sinon.match.string);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1036,7 +1037,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.enableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith('notificationhide');
+            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationHide);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1050,7 +1051,7 @@ describe('lib/viewers/BaseViewer', () => {
             };
             base.handleAnnotatorEvents(data);
             expect(base.enableViewerControls).to.be.called;
-            expect(base.emit).to.be.calledWith('notificationhide');
+            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationHide);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1061,7 +1062,7 @@ describe('lib/viewers/BaseViewer', () => {
                 data: 'message'
             };
             base.handleAnnotatorEvents(data);
-            expect(base.emit).to.be.calledWith('notificationshow', data.data);
+            expect(base.emit).to.be.calledWith(VIEWER_EVENTS.notificationShow, data.data);
             expect(base.emit).to.be.calledWith(data.event, data.data);
             expect(base.emit).to.be.calledWith('annotatorevent', data);
         });
@@ -1089,7 +1090,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.handleAnnotatorEvents(data);
             expect(base.disableViewerControls).to.not.be.called;
             expect(base.enableViewerControls).to.not.be.called;
-            expect(base.emit).to.not.be.calledWith('notificationshow', data.data);
+            expect(base.emit).to.not.be.calledWith(VIEWER_EVENTS.notificationShow, data.data);
             expect(base.emit).to.not.be.calledWith('scale', {
                 scale: base.scale,
                 rotationAngle: base.rotationAngle

--- a/src/lib/viewers/box3d/Box3DViewer.js
+++ b/src/lib/viewers/box3d/Box3DViewer.js
@@ -19,6 +19,7 @@ import {
 } from './box3DConstants';
 import JS from './box3DAssets';
 import './Box3D.scss';
+import { VIEWER_EVENTS } from '../../events';
 
 // Milliseconds to wait for model to load before cancelling Preview
 const LOAD_TIMEOUT = 50000;
@@ -249,7 +250,7 @@ class Box3DViewer extends BaseViewer {
     handleContextRestored() {
         this.detachEventHandlers();
         this.contextNotification.show('WebGL Context Restored');
-        this.emit('progressstart');
+        this.emit(VIEWER_EVENTS.progressStart);
         this.previewUI.showLoadingIndicator();
         this.postLoad();
     }

--- a/src/lib/viewers/box3d/Box3DViewer.js
+++ b/src/lib/viewers/box3d/Box3DViewer.js
@@ -19,7 +19,7 @@ import {
 } from './box3DConstants';
 import JS from './box3DAssets';
 import './Box3D.scss';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 // Milliseconds to wait for model to load before cancelling Preview
 const LOAD_TIMEOUT = 50000;
@@ -250,7 +250,7 @@ class Box3DViewer extends BaseViewer {
     handleContextRestored() {
         this.detachEventHandlers();
         this.contextNotification.show('WebGL Context Restored');
-        this.emit(VIEWER_EVENTS.progressStart);
+        this.emit(VIEWER_EVENT.progressStart);
         this.previewUI.showLoadingIndicator();
         this.postLoad();
     }

--- a/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
+++ b/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
@@ -16,7 +16,7 @@ import {
     EVENT_TOGGLE_VR,
     EVENT_WEBGL_CONTEXT_RESTORED
 } from '../box3DConstants';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 const sandbox = sinon.sandbox.create();
 
@@ -548,7 +548,7 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
     describe('handleContextRestored()', () => {
         it('should call emit() with params ["progressstart"]', () => {
             const emitStub = sandbox.stub(box3d, 'emit').callsFake((eventName) => {
-                expect(eventName).to.equal(VIEWER_EVENTS.progressStart);
+                expect(eventName).to.equal(VIEWER_EVENT.progressStart);
             });
 
             box3d.handleContextRestored();

--- a/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
+++ b/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
@@ -16,6 +16,7 @@ import {
     EVENT_TOGGLE_VR,
     EVENT_WEBGL_CONTEXT_RESTORED
 } from '../box3DConstants';
+import { VIEWER_EVENTS } from '../../../events';
 
 const sandbox = sinon.sandbox.create();
 
@@ -547,7 +548,7 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
     describe('handleContextRestored()', () => {
         it('should call emit() with params ["progressstart"]', () => {
             const emitStub = sandbox.stub(box3d, 'emit').callsFake((eventName) => {
-                expect(eventName).to.equal('progressstart');
+                expect(eventName).to.equal(VIEWER_EVENTS.progressStart);
             });
 
             box3d.handleContextRestored();

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -22,6 +22,7 @@ import { checkPermission, getRepresentation } from '../../file';
 import { get, createAssetUrlCreator, getMidpoint, getDistance, getClosestPageToPinch } from '../../util';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { JS, CSS } from './docAssets';
+import { VIEWER_EVENTS } from '../../events';
 
 const CURRENT_PAGE_MAP_KEY = 'doc-current-page-map';
 const DEFAULT_SCALE_DELTA = 1.1;
@@ -857,7 +858,7 @@ class DocBaseViewer extends BaseViewer {
         // Broadcast that preview has 'loaded' when page structure is available
         if (!this.loaded) {
             this.loaded = true;
-            this.emit('load', {
+            this.emit(VIEWER_EVENTS.load, {
                 numPages: this.pdfViewer.pagesCount,
                 endProgress: false, // Indicate that viewer will end progress later
                 scale: this.pdfViewer.currentScale
@@ -891,7 +892,7 @@ class DocBaseViewer extends BaseViewer {
             // Fire progressend event to hide progress bar and cleanup preload after a page is rendered
             if (!this.somePageRendered) {
                 this.hidePreload();
-                this.emit('progressend');
+                this.emit(VIEWER_EVENTS.progressEnd);
                 this.somePageRendered = true;
             }
         }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -22,7 +22,7 @@ import { checkPermission, getRepresentation } from '../../file';
 import { get, createAssetUrlCreator, getMidpoint, getDistance, getClosestPageToPinch } from '../../util';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { JS, CSS } from './docAssets';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const CURRENT_PAGE_MAP_KEY = 'doc-current-page-map';
 const DEFAULT_SCALE_DELTA = 1.1;
@@ -858,7 +858,7 @@ class DocBaseViewer extends BaseViewer {
         // Broadcast that preview has 'loaded' when page structure is available
         if (!this.loaded) {
             this.loaded = true;
-            this.emit(VIEWER_EVENTS.load, {
+            this.emit(VIEWER_EVENT.load, {
                 numPages: this.pdfViewer.pagesCount,
                 endProgress: false, // Indicate that viewer will end progress later
                 scale: this.pdfViewer.currentScale
@@ -892,7 +892,7 @@ class DocBaseViewer extends BaseViewer {
             // Fire progressend event to hide progress bar and cleanup preload after a page is rendered
             if (!this.somePageRendered) {
                 this.hidePreload();
-                this.emit(VIEWER_EVENTS.progressEnd);
+                this.emit(VIEWER_EVENT.progressEnd);
                 this.somePageRendered = true;
             }
         }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -19,6 +19,7 @@ import {
 } from '../../../constants';
 
 import { ICON_PRINT_CHECKMARK } from '../../../icons/icons';
+import { VIEWER_EVENTS } from '../../../events';
 
 const LOAD_TIMEOUT_MS = 180000; // 3 min timeout
 const PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
@@ -1264,7 +1265,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.pdfViewer.pagesCount = 5;
 
             docBase.pagesinitHandler();
-            expect(stubs.emit).to.be.calledWith('load', {
+            expect(stubs.emit).to.be.calledWith(VIEWER_EVENTS.load, {
                 endProgress: false,
                 numPages: 5,
                 scale: sinon.match.any
@@ -1295,7 +1296,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
         it('should emit handleAssetAndRepLoad event if not already emitted', () => {
             docBase.pagerenderedHandler(docBase.event);
-            expect(stubs.emit).to.be.calledWith('progressend');
+            expect(stubs.emit).to.be.calledWith(VIEWER_EVENTS.progressEnd);
         });
     });
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -19,7 +19,7 @@ import {
 } from '../../../constants';
 
 import { ICON_PRINT_CHECKMARK } from '../../../icons/icons';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 const LOAD_TIMEOUT_MS = 180000; // 3 min timeout
 const PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
@@ -1265,7 +1265,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.pdfViewer.pagesCount = 5;
 
             docBase.pagesinitHandler();
-            expect(stubs.emit).to.be.calledWith(VIEWER_EVENTS.load, {
+            expect(stubs.emit).to.be.calledWith(VIEWER_EVENT.load, {
                 endProgress: false,
                 numPages: 5,
                 scale: sinon.match.any
@@ -1296,7 +1296,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
         it('should emit handleAssetAndRepLoad event if not already emitted', () => {
             docBase.pagerenderedHandler(docBase.event);
-            expect(stubs.emit).to.be.calledWith(VIEWER_EVENTS.progressEnd);
+            expect(stubs.emit).to.be.calledWith(VIEWER_EVENT.progressEnd);
         });
     });
 

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -4,7 +4,7 @@ import Browser from '../../Browser';
 import { PERMISSION_DOWNLOAD } from '../../constants';
 import { getIconFromExtension, getIconFromName } from '../../icons/icons';
 import './PreviewError.scss';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 class PreviewErrorViewer extends BaseViewer {
     /**
@@ -104,7 +104,7 @@ class PreviewErrorViewer extends BaseViewer {
         // Filter out any access tokens
         const filteredMsg = errorMsg.replace(/access_token=([^&]*)/, 'access_token=[FILTERED]');
 
-        this.emit(VIEWER_EVENTS.load, {
+        this.emit(VIEWER_EVENT.load, {
             error: filteredMsg
         });
     }
@@ -132,7 +132,7 @@ class PreviewErrorViewer extends BaseViewer {
      * @return {void}
      */
     download() {
-        this.emit(VIEWER_EVENTS.download);
+        this.emit(VIEWER_EVENT.download);
     }
 }
 

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -4,6 +4,7 @@ import Browser from '../../Browser';
 import { PERMISSION_DOWNLOAD } from '../../constants';
 import { getIconFromExtension, getIconFromName } from '../../icons/icons';
 import './PreviewError.scss';
+import { VIEWER_EVENTS } from '../../events';
 
 class PreviewErrorViewer extends BaseViewer {
     /**
@@ -103,7 +104,7 @@ class PreviewErrorViewer extends BaseViewer {
         // Filter out any access tokens
         const filteredMsg = errorMsg.replace(/access_token=([^&]*)/, 'access_token=[FILTERED]');
 
-        this.emit('load', {
+        this.emit(VIEWER_EVENTS.load, {
             error: filteredMsg
         });
     }
@@ -131,7 +132,7 @@ class PreviewErrorViewer extends BaseViewer {
      * @return {void}
      */
     download() {
-        this.emit('download');
+        this.emit(VIEWER_EVENTS.download);
     }
 }
 

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -5,7 +5,7 @@ import Browser from '../../../Browser';
 import * as file from '../../../file';
 import { PERMISSION_DOWNLOAD } from '../../../constants';
 import * as icons from '../../../icons/icons';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 const sandbox = sinon.sandbox.create();
 let error;
@@ -140,7 +140,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.load(err);
 
             expect(error.emit).to.be.calledWith(
-                VIEWER_EVENTS.load, {
+                VIEWER_EVENT.load, {
                     error: 'this is bad'
                 }
             );
@@ -157,7 +157,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
 
             expect(error.emit).to.be.calledWith(
-                VIEWER_EVENTS.load, {
+                VIEWER_EVENT.load, {
                     error: 'reason'
                 }
             );
@@ -172,7 +172,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.load(err);
 
             expect(error.emit).to.be.calledWith(
-                VIEWER_EVENTS.load, {
+                VIEWER_EVENT.load, {
                     error: 'Unexpected server response (0) while retrieving PDF "www.box.com?access_token=[FILTERED]&test=okay"'
                 }
             );
@@ -203,7 +203,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.setup();
             sandbox.stub(error, 'emit');
             error.download();
-            expect(error.emit).to.be.calledWith(VIEWER_EVENTS.download);
+            expect(error.emit).to.be.calledWith(VIEWER_EVENT.download);
         });
     });
 

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -5,6 +5,7 @@ import Browser from '../../../Browser';
 import * as file from '../../../file';
 import { PERMISSION_DOWNLOAD } from '../../../constants';
 import * as icons from '../../../icons/icons';
+import { VIEWER_EVENTS } from '../../../events';
 
 const sandbox = sinon.sandbox.create();
 let error;
@@ -139,7 +140,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.load(err);
 
             expect(error.emit).to.be.calledWith(
-                'load', {
+                VIEWER_EVENTS.load, {
                     error: 'this is bad'
                 }
             );
@@ -156,7 +157,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
 
             expect(error.emit).to.be.calledWith(
-                'load', {
+                VIEWER_EVENTS.load, {
                     error: 'reason'
                 }
             );
@@ -171,7 +172,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.load(err);
 
             expect(error.emit).to.be.calledWith(
-                'load', {
+                VIEWER_EVENTS.load, {
                     error: 'Unexpected server response (0) while retrieving PDF "www.box.com?access_token=[FILTERED]&test=okay"'
                 }
             );
@@ -202,7 +203,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             error.setup();
             sandbox.stub(error, 'emit');
             error.download();
-            expect(error.emit).to.be.calledWith('download');
+            expect(error.emit).to.be.calledWith(VIEWER_EVENTS.download);
         });
     });
 

--- a/src/lib/viewers/iframe/IFrameViewer.js
+++ b/src/lib/viewers/iframe/IFrameViewer.js
@@ -1,4 +1,5 @@
 import BaseViewer from '../BaseViewer';
+import { VIEWER_EVENTS } from '../../events';
 
 class IFrameViewer extends BaseViewer {
     /**
@@ -43,7 +44,7 @@ class IFrameViewer extends BaseViewer {
 
         this.iframeEl.src = src;
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
         super.load();
     }
 }

--- a/src/lib/viewers/iframe/IFrameViewer.js
+++ b/src/lib/viewers/iframe/IFrameViewer.js
@@ -1,5 +1,5 @@
 import BaseViewer from '../BaseViewer';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 class IFrameViewer extends BaseViewer {
     /**
@@ -44,7 +44,7 @@ class IFrameViewer extends BaseViewer {
 
         this.iframeEl.src = src;
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
         super.load();
     }
 }

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -5,6 +5,7 @@ import { ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../icons/icons';
 import { get } from '../../util';
 
 import { CLASS_INVISIBLE } from '../../constants';
+import { VIEWER_EVENTS } from '../../events';
 
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
@@ -78,7 +79,7 @@ class ImageBaseViewer extends BaseViewer {
 
                 this.imageEl.classList.remove(CLASS_INVISIBLE);
                 this.loaded = true;
-                this.emit('load');
+                this.emit(VIEWER_EVENTS.load);
             })
             .catch(this.errorHandler);
     }

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -5,7 +5,7 @@ import { ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../icons/icons';
 import { get } from '../../util';
 
 import { CLASS_INVISIBLE } from '../../constants';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
@@ -79,7 +79,7 @@ class ImageBaseViewer extends BaseViewer {
 
                 this.imageEl.classList.remove(CLASS_INVISIBLE);
                 this.loaded = true;
-                this.emit(VIEWER_EVENTS.load);
+                this.emit(VIEWER_EVENT.load);
             })
             .catch(this.errorHandler);
     }

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -5,6 +5,7 @@ import Browser from '../../../Browser';
 import fullscreen from '../../../Fullscreen';
 import * as util from '../../../util';
 import { ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../../icons/icons';
+import { VIEWER_EVENTS } from '../../../events';
 
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
@@ -568,7 +569,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         });
 
         it('should load UI if not destroyed', (done) => {
-            imageBase.on('load', () => {
+            imageBase.on(VIEWER_EVENTS.load, () => {
                 expect(stubs.errorHandler).to.not.have.been.called;
                 expect(imageBase.loaded).to.be.true;
                 expect(stubs.zoom).to.have.been.called;

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -5,7 +5,7 @@ import Browser from '../../../Browser';
 import fullscreen from '../../../Fullscreen';
 import * as util from '../../../util';
 import { ICON_ZOOM_IN, ICON_ZOOM_OUT } from '../../../icons/icons';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
@@ -569,7 +569,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         });
 
         it('should load UI if not destroyed', (done) => {
-            imageBase.on(VIEWER_EVENTS.load, () => {
+            imageBase.on(VIEWER_EVENT.load, () => {
                 expect(stubs.errorHandler).to.not.have.been.called;
                 expect(imageBase.loaded).to.be.true;
                 expect(stubs.zoom).to.have.been.called;

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -5,6 +5,7 @@ import { getRepresentation } from '../../file';
 import { MEDIA_STATIC_ASSETS_VERSION } from '../../constants';
 import './Dash.scss';
 import getLanguageName from '../../lang';
+import { VIEWER_EVENTS } from '../../events';
 
 const CSS_CLASS_DASH = 'bp-media-dash';
 const CSS_CLASS_HD = 'bp-media-controls-is-hd';
@@ -444,7 +445,7 @@ class DashViewer extends VideoBaseViewer {
         this.showPlayButton();
 
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
 
         // Make media element visible after resize
         this.showMedia();

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -5,7 +5,7 @@ import { getRepresentation } from '../../file';
 import { MEDIA_STATIC_ASSETS_VERSION } from '../../constants';
 import './Dash.scss';
 import getLanguageName from '../../lang';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const CSS_CLASS_DASH = 'bp-media-dash';
 const CSS_CLASS_HD = 'bp-media-controls-is-hd';
@@ -445,7 +445,7 @@ class DashViewer extends VideoBaseViewer {
         this.showPlayButton();
 
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
 
         // Make media element visible after resize
         this.showMedia();

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -3,7 +3,7 @@ import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
 import MediaControls from './MediaControls';
 import { CLASS_ELEM_KEYBOARD_FOCUS, CLASS_HIDDEN, CLASS_IS_BUFFERING, CLASS_IS_VISIBLE } from '../../constants';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const CSS_CLASS_MEDIA = 'bp-media';
 const CSS_CLASS_MEDIA_CONTAINER = 'bp-media-container';
@@ -160,7 +160,7 @@ class MediaBaseViewer extends BaseViewer {
         }
         this.handleVolume();
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
 
         this.loadUI();
         this.resize();
@@ -441,7 +441,7 @@ class MediaBaseViewer extends BaseViewer {
      */
     mediaendHandler() {
         if (this.isAutoplayEnabled()) {
-            this.emit(VIEWER_EVENTS.mediaEndAutoplay);
+            this.emit(VIEWER_EVENT.mediaEndAutoplay);
         }
     }
 

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -3,6 +3,7 @@ import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
 import MediaControls from './MediaControls';
 import { CLASS_ELEM_KEYBOARD_FOCUS, CLASS_HIDDEN, CLASS_IS_BUFFERING, CLASS_IS_VISIBLE } from '../../constants';
+import { VIEWER_EVENTS } from '../../events';
 
 const CSS_CLASS_MEDIA = 'bp-media';
 const CSS_CLASS_MEDIA_CONTAINER = 'bp-media-container';
@@ -159,7 +160,7 @@ class MediaBaseViewer extends BaseViewer {
         }
         this.handleVolume();
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
 
         this.loadUI();
         this.resize();
@@ -440,7 +441,7 @@ class MediaBaseViewer extends BaseViewer {
      */
     mediaendHandler() {
         if (this.isAutoplayEnabled()) {
-            this.emit('mediaendautoplay');
+            this.emit(VIEWER_EVENTS.mediaEndAutoplay);
         }
     }
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -5,7 +5,7 @@ import BaseViewer from '../../BaseViewer';
 import fullscreen from '../../../Fullscreen';
 import * as util from '../../../util';
 import { MEDIA_STATIC_ASSETS_VERSION } from '../../../constants';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 let dash;
 let stubs = {};
@@ -530,7 +530,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(dash.showPlayButton).to.be.called;
             expect(dash.loadSubtitles).to.be.called;
             expect(dash.loadAlternateAudio).to.be.called;
-            expect(dash.emit).to.be.calledWith(VIEWER_EVENTS.load);
+            expect(dash.emit).to.be.calledWith(VIEWER_EVENT.load);
             expect(dash.loaded).to.be.true;
             expect(document.activeElement).to.equal(dash.mediaContainerEl);
             expect(dash.mediaControls.show).to.be.called;

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -5,6 +5,7 @@ import BaseViewer from '../../BaseViewer';
 import fullscreen from '../../../Fullscreen';
 import * as util from '../../../util';
 import { MEDIA_STATIC_ASSETS_VERSION } from '../../../constants';
+import { VIEWER_EVENTS } from '../../../events';
 
 let dash;
 let stubs = {};
@@ -529,7 +530,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(dash.showPlayButton).to.be.called;
             expect(dash.loadSubtitles).to.be.called;
             expect(dash.loadAlternateAudio).to.be.called;
-            expect(dash.emit).to.be.calledWith('load');
+            expect(dash.emit).to.be.calledWith(VIEWER_EVENTS.load);
             expect(dash.loaded).to.be.true;
             expect(document.activeElement).to.equal(dash.mediaContainerEl);
             expect(dash.mediaControls.show).to.be.called;

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -4,6 +4,7 @@ import MediaBaseViewer from '../MediaBaseViewer';
 import BaseViewer from '../../BaseViewer';
 import Cache from '../../../Cache';
 import { CLASS_ELEM_KEYBOARD_FOCUS } from '../../../constants';
+import { VIEWER_EVENTS } from '../../../events';
 
 let media;
 let stubs;
@@ -161,7 +162,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
             expect(media.handleVolume).to.be.called;
             expect(media.loaded).to.be.true;
-            expect(media.emit).to.be.calledWith('load');
+            expect(media.emit).to.be.calledWith(VIEWER_EVENTS.load);
             expect(media.loadUI).to.be.called;
             expect(media.resize).to.be.called;
             expect(media.showMedia).to.be.called;
@@ -408,7 +409,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             media.isAutoplayEnabled.returns(true);
 
             media.mediaendHandler();
-            expect(media.emit).to.be.calledWith('mediaendautoplay');
+            expect(media.emit).to.be.calledWith(VIEWER_EVENTS.mediaEndAutoplay);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -4,7 +4,7 @@ import MediaBaseViewer from '../MediaBaseViewer';
 import BaseViewer from '../../BaseViewer';
 import Cache from '../../../Cache';
 import { CLASS_ELEM_KEYBOARD_FOCUS } from '../../../constants';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 let media;
 let stubs;
@@ -162,7 +162,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
             expect(media.handleVolume).to.be.called;
             expect(media.loaded).to.be.true;
-            expect(media.emit).to.be.calledWith(VIEWER_EVENTS.load);
+            expect(media.emit).to.be.calledWith(VIEWER_EVENT.load);
             expect(media.loadUI).to.be.called;
             expect(media.resize).to.be.called;
             expect(media.showMedia).to.be.called;
@@ -409,7 +409,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             media.isAutoplayEnabled.returns(true);
 
             media.mediaendHandler();
-            expect(media.emit).to.be.calledWith(VIEWER_EVENTS.mediaEndAutoplay);
+            expect(media.emit).to.be.calledWith(VIEWER_EVENT.mediaEndAutoplay);
         });
     });
 

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -5,7 +5,7 @@ import { CLASS_HIDDEN } from '../../constants';
 import { getRepresentation } from '../../file';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { get } from '../../util';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const LOAD_TIMEOUT_MS = 120000;
 const SAFARI_PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
@@ -74,7 +74,7 @@ class OfficeViewer extends BaseViewer {
         this.setup();
         super.load();
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
     }
 
     /**

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -5,6 +5,7 @@ import { CLASS_HIDDEN } from '../../constants';
 import { getRepresentation } from '../../file';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { get } from '../../util';
+import { VIEWER_EVENTS } from '../../events';
 
 const LOAD_TIMEOUT_MS = 120000;
 const SAFARI_PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
@@ -73,7 +74,7 @@ class OfficeViewer extends BaseViewer {
         this.setup();
         super.load();
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
     }
 
     /**

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -1,6 +1,6 @@
 import BaseViewer from '../BaseViewer';
 import { SWF_STATIC_ASSETS_VERSION } from '../../constants';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const SWF_PARAMS = {
     allowfullscreen: 'true',
@@ -64,7 +64,7 @@ class SWFViewer extends BaseViewer {
                     return;
                 }
                 this.loaded = true;
-                this.emit(VIEWER_EVENTS.load);
+                this.emit(VIEWER_EVENT.load);
             }
         );
     };

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -1,5 +1,6 @@
 import BaseViewer from '../BaseViewer';
 import { SWF_STATIC_ASSETS_VERSION } from '../../constants';
+import { VIEWER_EVENTS } from '../../events';
 
 const SWF_PARAMS = {
     allowfullscreen: 'true',
@@ -63,7 +64,7 @@ class SWFViewer extends BaseViewer {
                     return;
                 }
                 this.loaded = true;
-                this.emit('load');
+                this.emit(VIEWER_EVENTS.load);
             }
         );
     };

--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -2,6 +2,7 @@ import TextBaseViewer from './TextBaseViewer';
 import { createAssetUrlCreator, get } from '../../util';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import './CSV.scss';
+import { VIEWER_EVENTS } from '../../events';
 
 const JS = [`third-party/text/${TEXT_STATIC_ASSETS_VERSION}/papaparse.min.js`, 'csv.js'];
 
@@ -116,7 +117,7 @@ class CSVViewer extends TextBaseViewer {
 
         this.loadUI();
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
     }
 }
 

--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -2,7 +2,7 @@ import TextBaseViewer from './TextBaseViewer';
 import { createAssetUrlCreator, get } from '../../util';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import './CSV.scss';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const JS = [`third-party/text/${TEXT_STATIC_ASSETS_VERSION}/papaparse.min.js`, 'csv.js'];
 
@@ -117,7 +117,7 @@ class CSVViewer extends TextBaseViewer {
 
         this.loadUI();
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
     }
 }
 

--- a/src/lib/viewers/text/MarkdownViewer.js
+++ b/src/lib/viewers/text/MarkdownViewer.js
@@ -3,6 +3,7 @@ import PlainTextViewer from './PlainTextViewer';
 import { CLASS_HIDDEN, TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT } from '../../icons/icons';
 import './Markdown.scss';
+import { VIEWER_EVENTS } from '../../events';
 
 const STATIC_URI = `third-party/text/${TEXT_STATIC_ASSETS_VERSION}/`;
 
@@ -77,7 +78,7 @@ class MarkdownViewer extends PlainTextViewer {
         this.loadUI();
         this.textEl.classList.remove(CLASS_HIDDEN);
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
 
         // Show message that text was truncated along with a download button
         if (this.truncated) {

--- a/src/lib/viewers/text/MarkdownViewer.js
+++ b/src/lib/viewers/text/MarkdownViewer.js
@@ -3,7 +3,7 @@ import PlainTextViewer from './PlainTextViewer';
 import { CLASS_HIDDEN, TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT } from '../../icons/icons';
 import './Markdown.scss';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 const STATIC_URI = `third-party/text/${TEXT_STATIC_ASSETS_VERSION}/`;
 
@@ -78,7 +78,7 @@ class MarkdownViewer extends PlainTextViewer {
         this.loadUI();
         this.textEl.classList.remove(CLASS_HIDDEN);
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
 
         // Show message that text was truncated along with a download button
         if (this.truncated) {

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -6,6 +6,7 @@ import { CLASS_HIDDEN, TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { HIGHLIGHTTABLE_EXTENSIONS } from '../../extensions';
 import { get, openContentInsideIframe, createAssetUrlCreator, createStylesheet } from '../../util';
+import { VIEWER_EVENTS } from '../../events';
 
 // Inline web worker JS
 const HIGHLIGHT_WORKER_JS =
@@ -160,7 +161,7 @@ class PlainTextViewer extends TextBaseViewer {
         this.textEl.classList.remove(CLASS_HIDDEN);
 
         this.loaded = true;
-        this.emit('load');
+        this.emit(VIEWER_EVENTS.load);
 
         // Show message that text was truncated along with a download button
         if (this.truncated) {
@@ -342,7 +343,7 @@ class PlainTextViewer extends TextBaseViewer {
      * @return {void}
      */
     download() {
-        this.emit('download');
+        this.emit(VIEWER_EVENTS.download);
     }
 }
 

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -6,7 +6,7 @@ import { CLASS_HIDDEN, TEXT_STATIC_ASSETS_VERSION } from '../../constants';
 import { ICON_PRINT_CHECKMARK } from '../../icons/icons';
 import { HIGHLIGHTTABLE_EXTENSIONS } from '../../extensions';
 import { get, openContentInsideIframe, createAssetUrlCreator, createStylesheet } from '../../util';
-import { VIEWER_EVENTS } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 
 // Inline web worker JS
 const HIGHLIGHT_WORKER_JS =
@@ -161,7 +161,7 @@ class PlainTextViewer extends TextBaseViewer {
         this.textEl.classList.remove(CLASS_HIDDEN);
 
         this.loaded = true;
-        this.emit(VIEWER_EVENTS.load);
+        this.emit(VIEWER_EVENT.load);
 
         // Show message that text was truncated along with a download button
         if (this.truncated) {
@@ -343,7 +343,7 @@ class PlainTextViewer extends TextBaseViewer {
      * @return {void}
      */
     download() {
-        this.emit(VIEWER_EVENTS.download);
+        this.emit(VIEWER_EVENT.download);
     }
 }
 

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -5,6 +5,7 @@ import CSVViewer from '../CSVViewer';
 import TextBaseViewer from '../TextBaseViewer';
 import BaseViewer from '../../BaseViewer';
 import * as util from '../../../util';
+import { VIEWER_EVENTS } from '../../../events';
 
 let containerEl;
 let options;
@@ -168,7 +169,7 @@ describe('lib/viewers/text/CSVViewer', () => {
 
             expect(csv.loadUI).to.be.called;
             expect(csv.loaded).to.be.true;
-            expect(csv.emit).to.be.calledWith('load');
+            expect(csv.emit).to.be.calledWith(VIEWER_EVENTS.load);
         });
     });
 });

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -5,7 +5,7 @@ import CSVViewer from '../CSVViewer';
 import TextBaseViewer from '../TextBaseViewer';
 import BaseViewer from '../../BaseViewer';
 import * as util from '../../../util';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 let containerEl;
 let options;
@@ -169,7 +169,7 @@ describe('lib/viewers/text/CSVViewer', () => {
 
             expect(csv.loadUI).to.be.called;
             expect(csv.loaded).to.be.true;
-            expect(csv.emit).to.be.calledWith(VIEWER_EVENTS.load);
+            expect(csv.emit).to.be.calledWith(VIEWER_EVENT.load);
         });
     });
 });

--- a/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
+++ b/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
@@ -3,7 +3,7 @@ import MarkdownViewer from '../MarkdownViewer';
 import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 let containerEl;
 let markdown;
@@ -128,7 +128,7 @@ describe('lib/viewers/text/MarkdownViewer', () => {
             expect(markdown.initRemarkable).to.be.called;
             expect(md.render).to.be.called;
             expect(markdown.loadUI).to.be.called;
-            expect(markdown.emit).to.be.calledWith(VIEWER_EVENTS.load);
+            expect(markdown.emit).to.be.calledWith(VIEWER_EVENT.load);
             expect(markdown.loaded).to.be.true;
             expect(markdown.textEl.classList.contains('bp-is-hidden')).to.be.false;
         });

--- a/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
+++ b/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
@@ -3,6 +3,7 @@ import MarkdownViewer from '../MarkdownViewer';
 import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
+import { VIEWER_EVENTS } from '../../../events';
 
 let containerEl;
 let markdown;
@@ -127,7 +128,7 @@ describe('lib/viewers/text/MarkdownViewer', () => {
             expect(markdown.initRemarkable).to.be.called;
             expect(md.render).to.be.called;
             expect(markdown.loadUI).to.be.called;
-            expect(markdown.emit).to.be.calledWith('load');
+            expect(markdown.emit).to.be.calledWith(VIEWER_EVENTS.load);
             expect(markdown.loaded).to.be.true;
             expect(markdown.textEl.classList.contains('bp-is-hidden')).to.be.false;
         });

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -6,6 +6,7 @@ import Popup from '../../../Popup';
 import TextBaseViewer from '../TextBaseViewer';
 import * as util from '../../../util';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
+import { VIEWER_EVENTS } from '../../../events';
 
 let containerEl;
 let text;
@@ -378,7 +379,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             text.finishLoading('', true);
 
             expect(text.loadUI).to.be.called;
-            expect(text.emit).to.be.calledWith('load');
+            expect(text.emit).to.be.calledWith(VIEWER_EVENTS.load);
             expect(text.loaded).to.be.true;
             expect(text.textEl.classList.contains('bp-is-hidden')).to.be.false;
         });
@@ -418,7 +419,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
         it('should emit download', () => {
             sandbox.stub(text, 'emit');
             text.download();
-            expect(text.emit).to.be.calledWith('download');
+            expect(text.emit).to.be.calledWith(VIEWER_EVENTS.download);
         });
     });
 });

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -6,7 +6,7 @@ import Popup from '../../../Popup';
 import TextBaseViewer from '../TextBaseViewer';
 import * as util from '../../../util';
 import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
-import { VIEWER_EVENTS } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 
 let containerEl;
 let text;
@@ -379,7 +379,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             text.finishLoading('', true);
 
             expect(text.loadUI).to.be.called;
-            expect(text.emit).to.be.calledWith(VIEWER_EVENTS.load);
+            expect(text.emit).to.be.calledWith(VIEWER_EVENT.load);
             expect(text.loaded).to.be.true;
             expect(text.textEl.classList.contains('bp-is-hidden')).to.be.false;
         });
@@ -419,7 +419,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
         it('should emit download', () => {
             sandbox.stub(text, 'emit');
             text.download();
-            expect(text.emit).to.be.calledWith(VIEWER_EVENTS.download);
+            expect(text.emit).to.be.calledWith(VIEWER_EVENT.download);
         });
     });
 });


### PR DESCRIPTION
This pull request moves all viewer events into `events.js` to provide documentation for each event and reduce possibility of using the wrong event names.