### PR TITLE
New: Specific error messages for unsupported/tariff restricted files

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -37,7 +37,11 @@ text_truncated=This file has been truncated due to size limits. Please download 
 
 # Error messages
 # Default preview error message
-error_default=We're sorry, the preview didn't load. This file type may not be supported.
+error_generic=We're sorry, the preview didn't load.
+# Default preview error message
+error_unsupported=We're sorry, the preview didn't load. {1} files are not currently supported.
+# Account doesn't have a sufficient tariff to preview the requested file type
+error_account=We're sorry, your account is unable to preview this file type.
 # No permissions preview error message
 error_permissions=We're sorry, you don't have permission to preview this file.
 # Preview refresh error message suggesting refreshing the page as a possible fix
@@ -48,8 +52,6 @@ error_rate_limit=We're sorry, the preview didn't load because your request was r
 error_reupload=We're sorry, the preview didn't load. Please re-upload the file or contact Box support.
 # Preview error message shown when the user's browser doesn't support previews of this file type
 error_browser_unsupported=We're sorry, your browser doesn't support preview for {1}.
-# Preview error message shown when an iWork file is previewed
-error_iwork=We're sorry, iWork files are not currently supported.
 # Preview error message shown when document loading fails (most likely due to password or watermark)
 error_document=We're sorry, the preview didn't load. This document may be protected.
 # Preview error message shown when the document is password protected

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1325,7 +1325,7 @@ describe('lib/Preview', () => {
             try {
                 preview.loadViewer();
             } catch (e) {
-                expect(spy.threw('Error'));
+                expect(e.message).to.equal(__('error_permissions'));
             }
         });
 
@@ -1366,27 +1366,25 @@ describe('lib/Preview', () => {
             expect(stubs.showLoadingDownloadButton).to.be.called;
         });
 
-        it('should throw a generic error if there is no loader for general file types', () => {
+        it('should throw an unsupported error if there is no loader for general file types', () => {
             preview.file.extension = 'zip';
             stubs.getLoader.returns(undefined);
-            const spy = sandbox.spy(preview, 'loadViewer');
 
             try {
                 preview.loadViewer();
             } catch (e) {
-                expect(spy.threw('Error', __('error_default')));
+                expect(e.message).to.equal(util.replacePlaceholders(__('error_unsupported'), [`.${preview.file.extension}`]));
             }
         });
 
-        it('should throw a specific error if there is no loader for a specific file type', () => {
-            preview.file.extension = 'key';
+        it('should throw an account upgrade error if there is no loader but the file type is supported', () => {
+            preview.file.extension = 'mp4';
             stubs.getLoader.returns(undefined);
-            const spy = sandbox.spy(preview, 'loadViewer');
 
             try {
                 preview.loadViewer();
             } catch (e) {
-                expect(spy.threw('Error', __('error_iwork')));
+                expect(e.message).to.equal(__('error_account'));
             }
         });
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -99,11 +99,4 @@ export const MODEL3D_STATIC_ASSETS_VERSION = '1.12.0';
 export const SWF_STATIC_ASSETS_VERSION = '0.112.0';
 export const TEXT_STATIC_ASSETS_VERSION = '0.114.0';
 
-//  Maps file extension to error message.
-export const FILE_EXT_ERROR_MAP = {
-    numbers: __('error_iwork'),
-    pages: __('error_iwork'),
-    key: __('error_iwork')
-};
-
 export const PREVIEW_SCRIPT_NAME = 'preview.js';

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -633,7 +633,7 @@ export function findScriptLocation(name, script) {
  *
  * @public
  * @param {string} string - String to be interpolated
- * @param {string[]} placeholderValues - Custom values to replace into string
+ * @param {Array} placeholderValues - Ordered array of replacement strings
  * @return {string} Properly translated string with replaced custom variable
  */
 export function replacePlaceholders(string, placeholderValues) {

--- a/src/lib/viewers/box3d/model3d/Model3DRenderer.js
+++ b/src/lib/viewers/box3d/model3d/Model3DRenderer.js
@@ -365,7 +365,7 @@ class Model3DRenderer extends Box3DRenderer {
      * @return {void}
      */
     onUnsupportedRepresentation() {
-        this.emit('error', new Error(__('error_default')));
+        this.emit('error', new Error(__('error_unsupported')));
     }
 
     /**

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -80,12 +80,12 @@ class PreviewErrorViewer extends BaseViewer {
         }
 
         /* eslint-disable no-param-reassign */
-        err = err instanceof Error ? err : new Error(__('error_default'));
+        err = err instanceof Error ? err : new Error(__('error_generic'));
         /* eslint-enable no-param-reassign */
 
         // If there is no display message fallback to the message from above
         let displayMessage = err.displayMessage || err.message;
-        displayMessage = typeof displayMessage === 'string' ? displayMessage : __('error_default');
+        displayMessage = typeof displayMessage === 'string' ? displayMessage : __('error_generic');
 
         this.iconEl.innerHTML = this.icon;
         this.messageEl.textContent = displayMessage;

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -118,7 +118,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
             error.load(err);
 
-            expect(error.messageEl.textContent).to.equal(__('error_default'));
+            expect(error.messageEl.textContent).to.equal(__('error_generic'));
         });
 
         it('should not add download button if the browser cannot download', () => {


### PR DESCRIPTION
New Errors:
1. Generic: Only used when we  have no other message to display
2. Unsupported: We can now be sure that the file mentioned is not supported!
3. Account: In the case that Box supports the file, but your tariff does not allow preview for the given type. 