### PR TITLE
COXP-4005: Preview JS error in console - 'unable to get property handleEvent' of undefined or null reference

### DIFF
--- a/src/lib/viewers/box3d/model3d/Model3DControls.js
+++ b/src/lib/viewers/box3d/model3d/Model3DControls.js
@@ -326,10 +326,6 @@ class Model3DControls extends Box3DControls {
 
     /** @inheritdoc */
     destroy() {
-        if (this.controls) {
-            this.controls.controlsEl.removeEventListener('click', this.handleControlsClick);
-        }
-
         this.animationClipsPullup.removeListener(EVENT_SELECT_ANIMATION_CLIP, this.handleSelectAnimationClip);
         this.animationClipsPullup.destroy();
         this.animationClipsPullup = null;


### PR DESCRIPTION
Looks like we missed removing the unbinding of an event listener to a function that no longer exists