### PR TITLE
Chore: Add download reachability checks to Document and Image viewers

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -176,6 +176,8 @@ notification_button_default_text=Okay
 notification_annotation_point_mode=Click anywhere to add a comment to the document
 # Notification message shown when user enters drawing annotation mode
 notification_annotation_draw_mode=Press down and drag the pointer to draw on the document
+# Notification message shown when the user has a degraded preview experience due to blocked download hosts
+notification_degraded_preview=Your preview experience is degraded!
 
 # File Types
 # 360 degree video file type

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -177,7 +177,7 @@ notification_annotation_point_mode=Click anywhere to add a comment to the docume
 # Notification message shown when user enters drawing annotation mode
 notification_annotation_draw_mode=Press down and drag the pointer to draw on the document
 # Notification message shown when the user has a degraded preview experience due to blocked download hosts
-notification_degraded_preview=Your preview experience is degraded!
+notification_degraded_preview=It looks like your connection to {1} is being blocked. We think we can make file previews in Box faster for you but we will need your firewall settings to be updated. To do that, please request your Box Admin to configure firewall settings for Box.
 
 # File Types
 # 360 degree video file type

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -730,6 +730,9 @@ class Preview extends EventEmitter {
             this.throttledMousemoveHandler
         );
 
+        // Set up the notification
+        this.ui.setupNotification();
+
         // Update navigation
         this.ui.showNavigation(this.file.id, this.collection);
 
@@ -1127,9 +1130,6 @@ class Preview extends EventEmitter {
 
         // Hide the loading indicator
         this.ui.hideLoadingIndicator();
-
-        // Set up the notification
-        this.ui.setupNotification();
 
         // Prefetch next few files
         this.prefetchNextFiles();

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -935,6 +935,7 @@ describe('lib/Preview', () => {
             previewUIMock.expects('showLoadingIndicator');
             previewUIMock.expects('startProgressBar');
             previewUIMock.expects('showNavigation');
+            previewUIMock.expects('setupNotification');
 
             preview.setupUI();
         })
@@ -1720,11 +1721,6 @@ describe('lib/Preview', () => {
         it('should hide the loading indicator', () => {
             preview.finishLoading();
             expect(stubs.hideLoadingIndicator).to.be.called;
-        });
-
-        it('should set up the notification', () => {
-            preview.finishLoading();
-            expect(stubs.setupNotification).to.be.called;
         });
 
         it('should prefetch next files', () => {

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -10,17 +10,17 @@ describe('lib/util', () => {
         sandbox.verifyAndRestore();
     });
 
-    describe('isNonDefaultDownloadHost()', () => {
+    describe('isCustomDownloadHost()', () => {
         it('should be true if the url does not start with the default host prefix and is a dl host', () => {
             let url = 'https://dl3.boxcloud.com/foo';
-            let result = util.isNonDefaultDownloadHost(url)
+            let result = util.isCustomDownloadHost(url)
             expect(result).to.be.true;
 
             url = 'https://dl.boxcloud.com/foo';
-            expect(util.isNonDefaultDownloadHost(url)).to.be.false;
+            expect(util.isCustomDownloadHost(url)).to.be.false;
 
             url = 'https://www.google.com';
-            expect(util.isNonDefaultDownloadHost(url)).to.be.false;
+            expect(util.isCustomDownloadHost(url)).to.be.false;
         });
     });
 

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -10,6 +10,56 @@ describe('lib/util', () => {
         sandbox.verifyAndRestore();
     });
 
+    describe('isNonDefaultDownloadHost()', () => {
+        it('should be true if the url does not start with the default host prefix and is a dl host', () => {
+            let url = 'https://dl3.boxcloud.com/foo';
+            let result = util.isNonDefaultDownloadHost(url)
+            expect(result).to.be.true;
+
+            url = 'https://dl.boxcloud.com/foo';
+            expect(util.isNonDefaultDownloadHost(url)).to.be.false;
+
+            url = 'https://www.google.com';
+            expect(util.isNonDefaultDownloadHost(url)).to.be.false;
+        });
+    });
+
+    describe('replaceDownloadHostWithDefault()', () => {
+        it('should return a download URL with the default host', () => {
+            let url = 'https://dl3.boxcloud.com/foo';
+            const result = util.replaceDownloadHostWithDefault(url);
+
+            expect(result).to.equal('https://dl.boxcloud.com/foo');
+        });
+    });
+
+    describe('shouldShowDegradedDownloadNotification()', () => {
+
+        after(() => {
+            sessionStorage.setItem('download_host_fallback', 'false');
+
+            let date = new Date();
+            date.setDate(date.getDate() - 1);
+
+            document.cookie = `show_degraded_download_notification=true;expires=${date.toUTCString()};secure`
+        });
+
+        it('should return true if we do not have a notification cookie and our session indicates we are falling back to the default host', () => {
+            let result = util.shouldShowDegradedDownloadNotification();
+            expect(result).to.be.false;
+
+            sessionStorage.setItem('download_host_fallback', 'true');
+            result = util.shouldShowDegradedDownloadNotification();
+            expect(result).to.be.true;
+        
+            document.cookie = 'show_degraded_download_notification=true'
+            result = util.shouldShowDegradedDownloadNotification();
+            expect(result).to.be.false;
+
+        });
+    });
+
+
     describe('get()', () => {
         const url = 'foo?bar=bum';
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -70,6 +70,7 @@ export const PERMISSION_PREVIEW = 'can_preview';
 
 export const API_HOST = 'https://api.box.com';
 export const APP_HOST = 'https://app.box.com';
+export const DEFAULT_DOWNLOAD_HOST_PREFIX = 'https://dl.';
 
 export const ORIGINAL_REP_NAME = 'ORIGINAL';
 export const PRELOAD_REP_NAME = 'jpg';

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -70,7 +70,6 @@ export const PERMISSION_PREVIEW = 'can_preview';
 
 export const API_HOST = 'https://api.box.com';
 export const APP_HOST = 'https://app.box.com';
-export const DEFAULT_DOWNLOAD_HOST_PREFIX = 'https://dl.';
 
 export const ORIGINAL_REP_NAME = 'ORIGINAL';
 export const PRELOAD_REP_NAME = 'jpg';

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -231,7 +231,7 @@ export function get(url, ...rest) {
             /* eslint-disable no-console */
             console.error(e);
             /* eslint-enable no-console */
-            return Promise.reject();
+            return Promise.reject(e);
         });
 }
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -123,14 +123,14 @@ function createDownloadIframe() {
  * @param {string} url - The URL to check
  * @return {boolean} - HTTP response
  */
-export function isNonDefaultDownloadHost(url) {
+export function isCustomDownloadHost(url) {
     return !url.startsWith(DEFAULT_DOWNLOAD_HOST_PREFIX) && !!url.match(/^https:\/\/dl\d+\./);
 }
 
 /**
  * Replaces the hostname of a download URL with the default hostname, https://dl.
  *
- * @public
+ * @private
  * @param {string} url - The URL to modify
  * @return {string} - The updated download URL
  */
@@ -223,7 +223,7 @@ export function get(url, ...rest) {
         .then(parser)
         .catch((e) => {
             // Make sure we are making a dl call
-            if (isNonDefaultDownloadHost(url)) {
+            if (isCustomDownloadHost(url)) {
                 // Retry download with default host.
                 setDownloadHostFallback();
                 return get(url, ...rest);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -121,7 +121,7 @@ function createDownloadIframe() {
  * @return {boolean} - HTTP response
  */
 export function isNonDefaultDownloadHost(url) {
-    return !url.startsWith(DEFAULT_DOWNLOAD_HOST_PREFIX) && url.match(/^https:\/\/dl\d+\./);
+    return !url.startsWith(DEFAULT_DOWNLOAD_HOST_PREFIX) && !!url.match(/^https:\/\/dl\d+\./);
 }
 
 /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -413,17 +413,18 @@ class BaseViewer extends EventEmitter {
      * @return {void}
      */
     viewerLoadHandler(event) {
-        const contentTemplate = document.createElement('a');
-        contentTemplate.href = this.options.representation.content.url_template;
-        const contentHost = contentTemplate.hostname;
-        if (shouldShowDegradedDownloadNotification(contentHost)) {
+        const contentHost = document.createElement('a');
+        const contentTemplate = getProp(this.options, 'representation.content.url_template', null);
+        contentHost.href = contentTemplate;
+        const contentHostname = contentHost.hostname;
+        if (contentTemplate && shouldShowDegradedDownloadNotification(contentHostname)) {
             this.previewUI.notification.show(
-                replacePlaceholders(__('notification_degraded_preview'), [contentHost]),
+                replacePlaceholders(__('notification_degraded_preview'), [contentHostname]),
                 __('notification_button_default_text'),
                 true
             );
 
-            setDownloadHostNotificationShown(contentHost);
+            setDownloadHostNotificationShown(contentHostname);
         }
 
         if (event && event.scale) {

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -127,6 +127,11 @@ class BaseViewer extends EventEmitter {
         this.handleAnnotatorEvents = this.handleAnnotatorEvents.bind(this);
         this.annotationsLoadHandler = this.annotationsLoadHandler.bind(this);
         this.viewerLoadHandler = this.viewerLoadHandler.bind(this);
+
+        this.options.representation.content.url_template = this.options.representation.content.url_template.replace(
+            'https://dl.',
+            'https://dl88.'
+        );
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -9,7 +9,7 @@ import {
     appendAuthParams,
     createContentUrl,
     getHeaders,
-    isNonDefaultDownloadHost,
+    isCustomDownloadHost,
     loadStylesheets,
     loadScripts,
     prefetchAssets,
@@ -281,16 +281,20 @@ class BaseViewer extends EventEmitter {
      *
      * @param {Error} err - Load error
      * @param {string} downloadURL - download URL
-     * @return {boolean} If the error was handled
+     * @return {void}
      */
     handleDownloadError(err, downloadURL) {
-        if (isNonDefaultDownloadHost(downloadURL)) {
+        if (isCustomDownloadHost(downloadURL)) {
             setDownloadHostFallback();
             this.load();
-            return true;
+            return;
         }
 
-        return false;
+        /* eslint-disable no-console */
+        console.error(err);
+        /* eslint-enable no-console */
+
+        this.triggerError(err);
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -14,9 +14,10 @@ import {
     loadScripts,
     prefetchAssets,
     setDownloadHostFallback,
-    setDownloadNotificationCookie,
+    setDownloadHostNotificationShown,
     shouldShowDegradedDownloadNotification,
-    createAssetUrlCreator
+    createAssetUrlCreator,
+    replacePlaceholders
 } from '../util';
 import Browser from '../Browser';
 import {
@@ -127,11 +128,6 @@ class BaseViewer extends EventEmitter {
         this.handleAnnotatorEvents = this.handleAnnotatorEvents.bind(this);
         this.annotationsLoadHandler = this.annotationsLoadHandler.bind(this);
         this.viewerLoadHandler = this.viewerLoadHandler.bind(this);
-
-        this.options.representation.content.url_template = this.options.representation.content.url_template.replace(
-            'https://dl.',
-            'https://dl88.'
-        );
     }
 
     /**
@@ -417,13 +413,17 @@ class BaseViewer extends EventEmitter {
      * @return {void}
      */
     viewerLoadHandler(event) {
-        if (shouldShowDegradedDownloadNotification()) {
+        const contentTemplate = document.createElement('a');
+        contentTemplate.href = this.options.representation.content.url_template;
+        const contentHost = contentTemplate.hostname;
+        if (shouldShowDegradedDownloadNotification(contentHost)) {
             this.previewUI.notification.show(
-                __('notification_degraded_preview'),
+                replacePlaceholders(__('notification_degraded_preview'), [contentHost]),
                 __('notification_button_default_text'),
                 true
             );
-            setDownloadNotificationCookie();
+
+            setDownloadHostNotificationShown(contentHost);
         }
 
         if (event && event.scale) {

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -183,6 +183,25 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
+    describe('handleDownloadError()', () => {
+        it('should return false if using the default download host', () => {
+            sandbox.stub(util, 'isNonDefaultDownloadHost').returns(false);
+            const result = base.handleDownloadError('error', 'https://dl.boxcloud.com');
+            expect(result).to.be.false;
+        });
+
+        it('should set the download host fallback, rereload, and return true if we are using a non default host', () => {
+            sandbox.stub(util, 'isNonDefaultDownloadHost').returns(true);
+            sandbox.stub(util, 'setDownloadHostFallback')
+            sandbox.stub(base, 'load');
+
+            const result = base.handleDownloadError('error', 'https://dl7.boxcloud.com');
+            expect(base.load).to.be.called;
+            expect(util.setDownloadHostFallback).to.be.called;
+            expect(result).to.be.true;
+        });
+    });
+
     describe('triggerError()', () => {
         it('should emit error event', () => {
             sandbox.stub(base, 'emit');
@@ -335,6 +354,13 @@ describe('lib/viewers/BaseViewer', () => {
         beforeEach(() => {
             base.annotationsLoadPromise = Promise.resolve();
             stubs.annotationsLoadHandler = sandbox.stub(base, 'annotationsLoadHandler');
+            base.options.representation = {
+                content: {
+                    url_template: 'dl.boxcloud.com'
+                }
+            };
+            stubs.shouldShowDegradedDownloadNotification = sandbox.stub(util, 'shouldShowDegradedDownloadNotification').returns(false);
+
         });
 
         it('should set the scale if it exists', () => {
@@ -363,6 +389,23 @@ describe('lib/viewers/BaseViewer', () => {
                     expect(error).equals(sinon.match.error);
                     expect(error.message).equals('message');
                 });
+        });
+
+        it('should show the notification if downloads are degraded and we have not shown the notification yet', () => {
+            stubs.shouldShowDegradedDownloadNotification.returns(true);
+            base.previewUI =
+            {
+                notification: {
+                    show: sandbox.stub()
+
+                }
+            }
+
+            sandbox.stub(util, 'setDownloadHostNotificationShown');
+            
+            base.viewerLoadHandler({ scale: 1.5 });
+            expect(base.previewUI.notification.show).to.be.called;
+            expect(util.setDownloadHostNotificationShown).to.be.called;
         });
     });
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -184,21 +184,24 @@ describe('lib/viewers/BaseViewer', () => {
     });
 
     describe('handleDownloadError()', () => {
+        beforeEach(() => {
+            sandbox.stub(base, 'triggerError');
+        });
+
         it('should return false if using the default download host', () => {
-            sandbox.stub(util, 'isNonDefaultDownloadHost').returns(false);
-            const result = base.handleDownloadError('error', 'https://dl.boxcloud.com');
-            expect(result).to.be.false;
+            sandbox.stub(util, 'isCustomDownloadHost').returns(false);
+            base.handleDownloadError('error', 'https://dl.boxcloud.com');
+            expect(base.triggerError).to.be.called;
         });
 
         it('should set the download host fallback, rereload, and return true if we are using a non default host', () => {
-            sandbox.stub(util, 'isNonDefaultDownloadHost').returns(true);
+            sandbox.stub(util, 'isCustomDownloadHost').returns(true);
             sandbox.stub(util, 'setDownloadHostFallback')
             sandbox.stub(base, 'load');
 
             const result = base.handleDownloadError('error', 'https://dl7.boxcloud.com');
             expect(base.load).to.be.called;
             expect(util.setDownloadHostFallback).to.be.called;
-            expect(result).to.be.true;
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -538,19 +538,31 @@ class DocBaseViewer extends BaseViewer {
                     linkService.setViewer(this.pdfViewer);
                 }
             })
-            .catch((err) => {
-                /* eslint-disable no-console */
-                console.error(err);
-                /* eslint-enable no-console */
+            .catch((err) => this.handleDownloadError(err, pdfUrl));
+    }
 
-                // Display a generic error message but log the real one
-                const error = err;
-                if (error instanceof Error) {
-                    error.displayMessage = __('error_document');
-                }
+    /**
+     * Handles a content download error
+     *
+     * @param {Error} err - Load error
+     * @param {string} pdfUrl - URL we are using to download the PDF
+     * @return {void}
+     */
+    handleDownloadError(err, pdfUrl) {
+        const errorHandled = super.handleDownloadError(err, pdfUrl);
+        if (!errorHandled) {
+            /* eslint-disable no-console */
+            console.error(err);
+            /* eslint-enable no-console */
 
-                this.triggerError(error);
-            });
+            // Display a generic error message but log the real one
+            const error = err;
+            if (err instanceof Error) {
+                error.displayMessage = __('error_document');
+            }
+
+            this.triggerError(error);
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -538,33 +538,15 @@ class DocBaseViewer extends BaseViewer {
                     linkService.setViewer(this.pdfViewer);
                 }
             })
-            .catch((err) => this.handleDownloadError(err, pdfUrl));
-    }
+            .catch((err) => {
+                // Display a generic error message but log the real one
+                const error = err;
+                if (err instanceof Error) {
+                    error.displayMessage = __('error_document');
+                }
 
-    /**
-     * Handles a content download error
-     *
-     * @param {Error} err - Load error
-     * @param {string} pdfUrl - URL we are using to download the PDF
-     * @return {void}
-     */
-    handleDownloadError(err, pdfUrl) {
-        const errorHandled = super.handleDownloadError(err, pdfUrl);
-        if (errorHandled) {
-            return;
-        }
-
-        /* eslint-disable no-console */
-        console.error(err);
-        /* eslint-enable no-console */
-
-        // Display a generic error message but log the real one
-        const error = err;
-        if (err instanceof Error) {
-            error.displayMessage = __('error_document');
-        }
-
-        this.triggerError(error);
+                this.handleDownloadError(err, pdfUrl);
+            });
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -550,19 +550,21 @@ class DocBaseViewer extends BaseViewer {
      */
     handleDownloadError(err, pdfUrl) {
         const errorHandled = super.handleDownloadError(err, pdfUrl);
-        if (!errorHandled) {
-            /* eslint-disable no-console */
-            console.error(err);
-            /* eslint-enable no-console */
-
-            // Display a generic error message but log the real one
-            const error = err;
-            if (err instanceof Error) {
-                error.displayMessage = __('error_document');
-            }
-
-            this.triggerError(error);
+        if (errorHandled) {
+            return;
         }
+
+        /* eslint-disable no-console */
+        console.error(err);
+        /* eslint-enable no-console */
+
+        // Display a generic error message but log the real one
+        const error = err;
+        if (err instanceof Error) {
+            error.displayMessage = __('error_document');
+        }
+
+        this.triggerError(error);
     }
 
     /**

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -855,6 +855,49 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.pdfViewer.linkService.setDocument).to.be.called;
             });
         });
+
+        it('should handle any download error', () => {
+            stubs.handleDownloadError = sandbox.stub(docBase, 'handleDownloadError');
+            const doc = {
+                url: 'url'
+            };
+    
+            docBase.options.location = {
+                locale: 'en-US'
+            };
+    
+            const getDocumentStub = sandbox.stub(PDFJS, 'getDocument').returns(Promise.reject(doc));
+
+            return docBase.initViewer('url').catch(() => {
+                expect(stubs.handleDownloadError).to.be.called;
+            });
+        });
+    });
+
+    describe('handleDownloadError()', () => {
+        beforeEach(() => {
+            sandbox.stub(docBase, 'triggerError');
+        });
+
+        it('should do nothing if the error is handled', () => {
+            Object.defineProperty(Object.getPrototypeOf(DocBaseViewer.prototype), 'handleDownloadError', {
+                value: sandbox.stub().returns(true)
+            });
+
+            docBase.handleDownloadError('error', 'url');
+
+            expect(docBase.triggerError).to.not.be.called;
+        });
+
+        it('should trigger an error if the error is not handled', () => {
+            Object.defineProperty(Object.getPrototypeOf(DocBaseViewer.prototype), 'handleDownloadError', {
+                value: sandbox.stub().returns(false)
+            });
+
+            docBase.handleDownloadError('error', 'url');
+
+            expect(docBase.triggerError).to.be.called;
+        });
     });
 
     describe('resize()', () => {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -874,32 +874,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
     });
 
-    describe('handleDownloadError()', () => {
-        beforeEach(() => {
-            sandbox.stub(docBase, 'triggerError');
-        });
-
-        it('should do nothing if the error is handled', () => {
-            Object.defineProperty(Object.getPrototypeOf(DocBaseViewer.prototype), 'handleDownloadError', {
-                value: sandbox.stub().returns(true)
-            });
-
-            docBase.handleDownloadError('error', 'url');
-
-            expect(docBase.triggerError).to.not.be.called;
-        });
-
-        it('should trigger an error if the error is not handled', () => {
-            Object.defineProperty(Object.getPrototypeOf(DocBaseViewer.prototype), 'handleDownloadError', {
-                value: sandbox.stub().returns(false)
-            });
-
-            docBase.handleDownloadError('error', 'url');
-
-            expect(docBase.triggerError).to.be.called;
-        });
-    });
-
     describe('resize()', () => {
         const resizeFunc = BaseViewer.prototype.resize;
 

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -317,20 +317,13 @@ class ImageBaseViewer extends BaseViewer {
      * @return {void}
      */
     handleDownloadError(err, imgUrl) {
-        const errorHandled = super.handleDownloadError(err, imgUrl);
-        if (!errorHandled) {
-            /* eslint-disable no-console */
-            console.error(err);
-            /* eslint-enable no-console */
-
-            // Display a generic error message but log the real one
-            const error = err;
-            if (err instanceof Error) {
-                error.displayMessage = __('error_document');
-            }
-
-            this.triggerError(error);
+        // Display a generic error message but log the real one
+        const error = err;
+        if (err instanceof Error) {
+            error.displayMessage = __('error_refresh');
         }
+
+        super.handleDownloadError(err, imgUrl);
     }
 
     /**

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -26,7 +26,6 @@ class ImageBaseViewer extends BaseViewer {
         this.handleMouseUp = this.handleMouseUp.bind(this);
         this.cancelDragEvent = this.cancelDragEvent.bind(this);
         this.finishLoading = this.finishLoading.bind(this);
-        this.errorHandler = this.errorHandler.bind(this);
 
         if (this.isMobile) {
             if (Browser.isIOS()) {
@@ -311,23 +310,27 @@ class ImageBaseViewer extends BaseViewer {
     }
 
     /**
-     * Handles image element loading errors.
+     * Handles a content download error
      *
-     * @private
-     * @param {Error} err - Error to handle
+     * @param {Error} err - Load error
+     * @param {string} imgUrl - URL we are using as the image src
      * @return {void}
      */
-    errorHandler(err) {
-        /* eslint-disable no-console */
-        console.error(err);
-        /* eslint-enable no-console */
+    handleDownloadError(err, imgUrl) {
+        const errorHandled = super.handleDownloadError(err, imgUrl);
+        if (!errorHandled) {
+            /* eslint-disable no-console */
+            console.error(err);
+            /* eslint-enable no-console */
 
-        // Display a generic error message but log the real one
-        const error = err;
-        if (err instanceof Error) {
-            error.displayMessage = __('error_refresh');
+            // Display a generic error message but log the real one
+            const error = err;
+            if (err instanceof Error) {
+                error.displayMessage = __('error_document');
+            }
+
+            this.triggerError(error);
         }
-        this.emit('error', error);
     }
 
     /**

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -16,6 +16,7 @@ class ImageViewer extends ImageBaseViewer {
 
         this.rotateLeft = this.rotateLeft.bind(this);
         this.updatePannability = this.updatePannability.bind(this);
+        this.handleImageDownloadError = this.handleImageDownloadError.bind(this);
 
         if (this.isMobile) {
             this.handleOrientationChange = this.handleOrientationChange.bind(this);
@@ -352,6 +353,16 @@ class ImageViewer extends ImageBaseViewer {
     //--------------------------------------------------------------------------
 
     /**
+     * Passes the error and download URL to the download error handler.
+     *
+     * @param {Error} err - Download error
+     * @return {void}
+     */
+    handleImageDownloadError(err) {
+        this.handleDownloadError(err, this.imageEl.src);
+    }
+
+    /**
      * Binds DOM listeners for image viewer.
      *
      * @protected
@@ -361,7 +372,7 @@ class ImageViewer extends ImageBaseViewer {
         super.bindDOMListeners();
 
         this.imageEl.addEventListener('load', this.finishLoading);
-        this.imageEl.addEventListener('error', (err) => this.handleDownloadError(err, this.imageEl.src));
+        this.imageEl.addEventListener('error', this.handleImageDownloadError);
 
         if (this.isMobile) {
             this.imageEl.addEventListener('orientationchange', this.handleOrientationChange);
@@ -379,7 +390,7 @@ class ImageViewer extends ImageBaseViewer {
 
         if (this.imageEl) {
             this.imageEl.removeEventListener('load', this.finishLoading);
-            this.imageEl.removeEventListener('error', this.errorHandler);
+            this.imageEl.removeEventListener('error', this.handleImageDownloadError);
         }
 
         if (this.isMobile) {

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -52,12 +52,13 @@ class ImageViewer extends ImageBaseViewer {
 
         const { representation, viewer } = this.options;
         const template = representation.content.url_template;
+        const downloadURL = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
         return this.getRepStatus()
             .getPromise()
             .then(() => {
-                this.imageEl.src = this.createContentUrlWithAuthParams(template, viewer.ASSET);
+                this.imageEl.src = downloadURL;
             })
             .catch(this.handleAssetError);
     }
@@ -360,7 +361,7 @@ class ImageViewer extends ImageBaseViewer {
         super.bindDOMListeners();
 
         this.imageEl.addEventListener('load', this.finishLoading);
-        this.imageEl.addEventListener('error', this.errorHandler);
+        this.imageEl.addEventListener('error', (err) => this.handleDownloadError(err, this.imageEl.src));
 
         if (this.isMobile) {
             this.imageEl.addEventListener('orientationchange', this.handleOrientationChange);

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -269,7 +269,9 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].removeEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].removeEventListener('error', this.errorHandler);
+        this.singleImageEls[index].removeEventListener('error', (err) => {
+            this.handleDownloadError(err, this.singleImageEls[0].src);
+        });
     }
 
     /**

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -21,6 +21,7 @@ class MultiImageViewer extends ImageBaseViewer {
         this.setPage = this.setPage.bind(this);
         this.scrollHandler = this.scrollHandler.bind(this);
         this.handlePageChangeFromScroll = this.handlePageChangeFromScroll.bind(this);
+        this.handleMultiImageDownloadError = this.handleMultiImageDownloadError.bind(this);
     }
 
     /**
@@ -243,6 +244,17 @@ class MultiImageViewer extends ImageBaseViewer {
     }
 
     /**
+     * Passes the error and download URL to the download error handler.
+     *
+     * @param {Error} err - Download error
+     * @return {void}
+     */
+    handleMultiImageDownloadError(err) {
+        // Since we're using the src to get the hostname, we can always use the src of the first page
+        this.handleMultiImageDownloadError(err, this.singleImageEls[0]);
+    }
+
+    /**
      * Binds error and load event listeners for an image element.
      *
      * @param {number} index - Index of image to bind listeners to
@@ -253,9 +265,7 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].addEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].addEventListener('error', (err) =>
-            this.handleDownloadError(err, this.singleImageEls[0])
-        );
+        this.singleImageEls[index].addEventListener('error', this.handleMultiImageDownloadError);
     }
 
     /**
@@ -269,9 +279,7 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].removeEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].removeEventListener('error', (err) => {
-            this.handleDownloadError(err, this.singleImageEls[0].src);
-        });
+        this.singleImageEls[index].removeEventListener('error', this.handleMultiImageDownloadError);
     }
 
     /**

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -253,7 +253,9 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].addEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].addEventListener('error', this.errorHandler);
+        this.singleImageEls[index].addEventListener('error', (err) =>
+            this.handleDownloadError(err, this.singleImageEls[0])
+        );
     }
 
     /**

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -250,8 +250,16 @@ class MultiImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     handleMultiImageDownloadError(err) {
+        this.singleImageEls.forEach((el, index) => {
+            this.unbindImageListeners(index);
+        });
+
         // Since we're using the src to get the hostname, we can always use the src of the first page
-        this.handleMultiImageDownloadError(err, this.singleImageEls[0]);
+        const { src } = this.singleImageEls[0];
+        // Clear any images we may have started to load.
+        this.singleImageEls = [];
+
+        this.handleDownloadError(err, src);
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -531,28 +531,30 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
     });
 
     describe('handleDownloadError()', () => {
+        const handleDownloadErrorFunc = BaseViewer.prototype.handleDownloadError;
+
         beforeEach(() => {
-            sandbox.stub(imageBase, 'triggerError');
+            Object.defineProperty(Object.getPrototypeOf(ImageBaseViewer.prototype), 'handleDownloadError', {
+                value: sandbox.stub()
+            });        
         });
 
-        it('should do nothing if the error is handled', () => {
+        afterEach(() => {
             Object.defineProperty(Object.getPrototypeOf(ImageBaseViewer.prototype), 'handleDownloadError', {
-                value: sandbox.stub().returns(true)
+                value: handleDownloadErrorFunc
             });
-
-            imageBase.handleDownloadError('error', 'url');
-
-            expect(imageBase.triggerError).to.not.be.called;
         });
 
-        it('should trigger an error if the error is not handled', () => {
-            Object.defineProperty(Object.getPrototypeOf(ImageBaseViewer.prototype), 'handleDownloadError', {
-                value: sandbox.stub().returns(false)
-            });
+        it('should call the parent method with an error display message and the image URL', () => {
+            const err = new Error('downloadError')
 
-            imageBase.handleDownloadError('error', 'url');
+            try {
+                imageBase.handleDownloadError(err, 'foo');
+            } catch (e) {
+                // no-op
+            }
 
-            expect(imageBase.triggerError).to.be.called;
+            expect(BaseViewer.prototype.handleDownloadError).to.be.calledWith(err, 'foo')
         });
     });
 
@@ -562,6 +564,14 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             stubs.zoom = sandbox.stub(imageBase, 'zoom');
             stubs.loadUI = sandbox.stub(imageBase, 'loadUI');
             stubs.setOriginalImageSize = sandbox.stub(imageBase, 'setOriginalImageSize');
+            imageBase.options = {
+                file: {
+                    id: 1
+                },
+                viewer: {
+                    viewerName: "Image"
+                }
+            }
         });
 
         it('should do nothing if already destroyed', () => {

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -530,6 +530,32 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         });
     });
 
+    describe('handleDownloadError()', () => {
+        beforeEach(() => {
+            sandbox.stub(imageBase, 'triggerError');
+        });
+
+        it('should do nothing if the error is handled', () => {
+            Object.defineProperty(Object.getPrototypeOf(ImageBaseViewer.prototype), 'handleDownloadError', {
+                value: sandbox.stub().returns(true)
+            });
+
+            imageBase.handleDownloadError('error', 'url');
+
+            expect(imageBase.triggerError).to.not.be.called;
+        });
+
+        it('should trigger an error if the error is not handled', () => {
+            Object.defineProperty(Object.getPrototypeOf(ImageBaseViewer.prototype), 'handleDownloadError', {
+                value: sandbox.stub().returns(false)
+            });
+
+            imageBase.handleDownloadError('error', 'url');
+
+            expect(imageBase.triggerError).to.be.called;
+        });
+    });
+
     describe('finishLoading()', () => {
         beforeEach(() => {
             imageBase.loaded = false;

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -530,29 +530,12 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         });
     });
 
-    describe('errorHandler()', () => {
-        beforeEach(() => {
-            stubs.emit = sandbox.stub(imageBase, 'emit');
-        });
-
-        it('should console log error and emit with generic display error message', () => {
-            const err = new Error('blah');
-            sandbox.mock(window.console).expects('error').withArgs(err);
-
-            imageBase.errorHandler(err);
-
-            err.displayMessage = 'We\'re sorry, the preview didn\'t load. Please refresh the page.';
-            expect(stubs.emit).to.have.been.calledWith('error', err);
-        });
-    });
-
     describe('finishLoading()', () => {
         beforeEach(() => {
             imageBase.loaded = false;
             stubs.zoom = sandbox.stub(imageBase, 'zoom');
             stubs.loadUI = sandbox.stub(imageBase, 'loadUI');
             stubs.setOriginalImageSize = sandbox.stub(imageBase, 'setOriginalImageSize');
-            stubs.errorHandler = sandbox.stub(imageBase, 'errorHandler');
         });
 
         it('should do nothing if already destroyed', () => {
@@ -565,12 +548,10 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.zoom).to.not.have.been.called;
             expect(stubs.setOriginalImageSize).to.not.have.been.called;
             expect(stubs.loadUI).to.not.have.been.called;
-            expect(stubs.errorHandler).to.not.have.been.called;
         });
 
         it('should load UI if not destroyed', (done) => {
             imageBase.on(VIEWER_EVENT.load, () => {
-                expect(stubs.errorHandler).to.not.have.been.called;
                 expect(imageBase.loaded).to.be.true;
                 expect(stubs.zoom).to.have.been.called;
                 expect(stubs.loadUI).to.have.been.called;

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -444,6 +444,12 @@ describe('lib/viewers/image/ImageViewer', () => {
             stubs.listeners = image.imageEl.addEventListener;
         });
 
+        it('should bind error and load listeners', () => {
+            image.bindDOMListeners();
+            expect(stubs.listeners).to.have.been.calledWith('load', image.finishLoading);
+            expect(stubs.listeners).to.have.been.calledWith('error', image.handleImageDownloadError);
+        });
+
         it('should bind all mobile listeners', () => {
             sandbox.stub(Browser, 'isIOS').returns(true);
             image.bindDOMListeners();
@@ -462,6 +468,7 @@ describe('lib/viewers/image/ImageViewer', () => {
         it('should unbind all default image listeners', () => {
             image.unbindDOMListeners();
             expect(stubs.listeners).to.have.been.calledWith('load', image.finishLoading);
+            expect(stubs.listeners).to.have.been.calledWith('error', image.handleImageDownloadError);
         });
 
         it('should unbind all mobile listeners', () => {

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -77,7 +77,6 @@ describe('lib/viewers/image/ImageViewer', () => {
             sandbox.stub(image, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             stubs.event = sandbox.stub(image.imageEl, 'addEventListener');
             stubs.load = sandbox.stub(image, 'finishLoading');
-            stubs.error = sandbox.stub(image, 'errorHandler');
             stubs.bind = sandbox.stub(image, 'bindDOMListeners');
 
             // load the image
@@ -463,7 +462,6 @@ describe('lib/viewers/image/ImageViewer', () => {
         it('should unbind all default image listeners', () => {
             image.unbindDOMListeners();
             expect(stubs.listeners).to.have.been.calledWith('load', image.finishLoading);
-            expect(stubs.listeners).to.have.been.calledWith('error', image.errorHandler);
         });
 
         it('should unbind all mobile listeners', () => {

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -373,6 +373,33 @@ describe('lib/viewers/image/MultiImageViewer', () => {
 
     });
 
+    describe('handleMultiImageDownloadError()', () => {
+        beforeEach(() => {
+            multiImage.singleImageEls = [
+                {
+                    src: 'foo'
+                },
+                {
+                    src: 'baz'
+                }
+            ];
+
+            sandbox.stub(multiImage, 'handleDownloadError');
+            sandbox.stub(multiImage, 'unbindImageListeners')
+        });
+
+        it('unbind the image listeners, clear the image Els array, and handle the download error', () => {
+            const src = multiImage.singleImageEls[0].src;
+            
+            multiImage.handleMultiImageDownloadError('err');
+            
+            expect(multiImage.singleImageEls).to.deep.equal([]);
+            expect(multiImage.handleDownloadError).to.be.calledWith('err', src);
+            expect(multiImage.unbindImageListeners).to.be.calledTwice;
+
+        });
+    });
+
     describe('bindImageListeners()', () => {
         beforeEach(() => {
             multiImage.singleImageEls = [

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -18,7 +18,6 @@ let clock;
 let containerEl;
 
 describe('lib/viewers/image/MultiImageViewer', () => {
-    stubs.errorHandler = MultiImageViewer.prototype.errorHandler;
     const setupFunc = BaseViewer.prototype.setup;
     const sizeFunc = ImageBaseViewer.prototype.setOriginalImageSize;
 

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -343,7 +343,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         });
     });
 
-    describe('bindPageControlListeners', () => {
+    describe('bindPageControlListeners()', () => {
         beforeEach(() => {
             multiImage.currentPageNumber = 1;
             multiImage.pagesCount = 10;
@@ -373,8 +373,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
 
     });
 
-
-    describe('bindImageListeners', () => {
+    describe('bindImageListeners()', () => {
         beforeEach(() => {
             multiImage.singleImageEls = [
                 {
@@ -397,7 +396,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         });
     });
 
-    describe('unbindImageListeners', () => {
+    describe('unbindImageListeners()', () => {
         beforeEach(() => {
             multiImage.singleImageEls = [
                 {


### PR DESCRIPTION
This also will add the check to any generic download request, such as prefetching or preloading. 

Tests on the way, other viewers will be in a separate PR. 