### PR TITLE
Fix: Bind close method in DocFindBar

### DIFF
--- a/src/lib/viewers/doc/DocFindBar.js
+++ b/src/lib/viewers/doc/DocFindBar.js
@@ -40,6 +40,7 @@ class DocFindBar extends EventEmitter {
         this.barKeyDownHandler = this.barKeyDownHandler.bind(this);
         this.findNextHandler = this.findNextHandler.bind(this);
         this.findPreviousHandler = this.findPreviousHandler.bind(this);
+        this.close = this.close.bind(this);
 
         // overriding some find controller methods to update match count
         this.findController.updateUIState = this.updateUIState.bind(this);


### PR DESCRIPTION
Open doesn't need to be bound as it's not used as a handler callback. 