### PR TITLE
Fix: add extra padding to settings menu to prevent scrollbar when zoomed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^0.11.0",
+    "box-annotations": "^0.11.1",
     "chai": "^4.1.2",
     "chai-dom": "^1.5.0",
     "conventional-changelog-cli": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,9 +1164,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.11.0.tgz#776304de58d0cab6661373d028e6ad35e4c0f298"
+box-annotations@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-0.11.1.tgz#14c11890f26d5f55aa9705e7bd158c0dfd3a4cf3"
   dependencies:
     box-react-ui "^21.0.3"
     rangy "^1.3.0"


### PR DESCRIPTION
Adds 1px extra to the height of the settings menu, to prevent scrollbar from appearing in devices which have zoomed in