### PR TITLE
Fix: No longer account for header above notification wrapper

### DIFF
--- a/src/lib/_common.scss
+++ b/src/lib/_common.scss
@@ -165,10 +165,6 @@ $header-height: 48px;
     position: absolute; // Override _boxui.scss because Preview cannot assume taking up the full viewport
 }
 
-.bp-has-header .bp-notifications-wrapper {
-    top: 48px;
-}
-
 .bp-toggle-overlay {
     > button {
         margin-bottom: 0;


### PR DESCRIPTION
The extra padding which accounts for the header is no longer needed since the notification wrapper is positioned absolutely.