### PR TITLE
New: Option to disable `preview` event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ preview.show(fileId, accessToken, {
 | sharedLink |  | Shared link URL |
 | sharedLinkPassword |  | Shared link password |
 | collection |  | List of file IDs to iterate over for previewing |
-| header | 'light' | String value of 'none' or 'dark' or 'light' that controls header visibility and theme |
+| header | 'light' | String value of `none` or `dark` or `light` that controls header visibility and theme |
 | logoUrl |  | URL of logo to show in header |
 | showAnnotations | false | Whether annotations and annotation controls are shown. This option will be overridden by viewer-specific annotation options if they are set. See [Box Annotations](https://github.com/box/box-annotations) for more details |
 | showDownload | false | Whether download button is shown |
 | useHotkeys | true | Whether hotkeys (keyboard shortcuts) are enabled |
-| pauseRequireJS | false | Temporarily disables requireJS to allow Preview's third party dependencies to load |
-| fileOptions | {} | Mapping of file ID to file-level option. See below for details |
+| pauseRequireJS | false | Temporarily disables AMD module loaders (e.g. RequireJS) to allow Preview's third party dependencies to load |
+| disableEventLog | false | Disables client-side `preview` event log. Previewing with this option enabled will not increment access stats (content access is still logged server-side) |
+| fileOptions | {} | Mapping of file ID to file-level options. See the file option table below for details |
 
 | File Option | Description |
 | --- | --- |

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -804,6 +804,11 @@ class Preview extends EventEmitter {
         // RequireJS will be re-enabled on the 'assetsloaded' event fired by Preview
         this.options.pauseRequireJS = !!options.pauseRequireJS;
 
+        // Option to disable 'preview' event log. Use this if you are using Preview in a way that does not constitute
+        // a full preview, e.g. a content feed. Enabling this option skips the client-side log to the Events API
+        // (access stats will not be incremented), but content access is still logged server-side for audit purposes
+        this.options.disableEventLog = !!options.disableEventLog;
+
         // Prefix any user created loaders before our default ones
         this.loaders = (options.loaders || []).concat(loaderList);
 
@@ -1117,8 +1122,10 @@ class Preview extends EventEmitter {
                 file: this.file
             });
 
-            // If there wasn't an error, use Events API to log a preview
-            this.logPreviewEvent(this.file.id, this.options);
+            // If there wasn't an error and event logging is not disabled, use Events API to log a preview
+            if (!this.options.disableEventLog) {
+                this.logPreviewEvent(this.file.id, this.options);
+            }
 
             // Hookup for phantom JS health check
             if (typeof window.callPhantom === 'function') {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -852,8 +852,8 @@ export function getProp(object, propPath, defaultValue) {
     const path = propPath.split('.');
 
     for (let i = 0; i < path.length; i++) {
+        // Checks against null or undefined
         if (value == null) {
-            // Checks against null or undefined
             return defaultValue;
         }
 


### PR DESCRIPTION
Add new Preview option `disableEventLog` to disable the client-side `preview` log to the Events API. Previews with this option enabled will not increment access stats, but all content access is still logged server-side for audit purposes.

Resolves #471.