### PR TITLE
Update: Rename 'pauseRequireJS' option to 'fixDependencies'

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ preview.show(fileId, accessToken, {
 | showAnnotations | false | Whether annotations and annotation controls are shown. This option will be overridden by viewer-specific annotation options if they are set. See [Box Annotations](https://github.com/box/box-annotations) for more details |
 | showDownload | false | Whether download button is shown |
 | useHotkeys | true | Whether hotkeys (keyboard shortcuts) are enabled |
-| pauseRequireJS | false | Temporarily disables AMD module loaders (e.g. RequireJS) to allow Preview's third party dependencies to load |
+| fixDependencies | false | Temporarily patches AMD to properly load Preview's dependencies. You may need to enable this if your project uses RequireJS |
 | disableEventLog | false | Disables client-side `preview` event log. Previewing with this option enabled will not increment access stats (content access is still logged server-side) |
 | fileOptions | {} | Mapping of file ID to file-level options. See the file option table below for details |
 

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -814,9 +814,9 @@ class Preview extends EventEmitter {
         // Optional additional query params to append to requests
         this.options.queryParams = options.queryParams || {};
 
-        // Option to pause requireJS while Preview loads third party dependencies
-        // RequireJS will be re-enabled on the 'assetsloaded' event fired by Preview
-        this.options.pauseRequireJS = !!options.pauseRequireJS;
+        // Option to patch AMD module definitions while Preview loads the third party dependencies it expects in the
+        // browser global scope. Definitions will be re-enabled on the 'assetsloaded' event
+        this.options.fixDependencies = !!options.fixDependencies || !!options.pauseRequireJS;
 
         // Option to disable 'preview' event log. Use this if you are using Preview in a way that does not constitute
         // a full preview, e.g. a content feed. Enabling this option skips the client-side log to the Events API

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -970,7 +970,7 @@ describe('lib/Preview', () => {
                 logoUrl: stubs.logoUrl,
                 showDownload: true,
                 showAnnotations: true,
-                pauseRequireJS: true,
+                fixDependencies: true,
                 collection: stubs.collection,
                 loaders: stubs.loaders
             };
@@ -1056,9 +1056,9 @@ describe('lib/Preview', () => {
             expect(preview.options.skipServerUpdate).to.be.true;
         });
 
-        it('should set whether to pause requireJS when loading dependencies', () => {
+        it('should set whether to fix dependencies', () => {
             preview.parseOptions(preview.previewOptions, stubs.tokens);
-            expect(preview.options.pauseRequireJS).to.be.true;
+            expect(preview.options.fixDependencies).to.be.true;
         });
 
         it('should add user created loaders before standard loaders', () => {
@@ -2125,7 +2125,7 @@ describe('lib/Preview', () => {
             expect(Timer.reset).to.be.called;
             expect(preview.emit).to.not.be.called;
         });
-        
+
         it('should reset the timer and escape early if the first load milestone is not hit', () => {
             Timer.reset();// Clear out all entries in the Timer
             sandbox.stub(Timer, 'reset');
@@ -2134,14 +2134,14 @@ describe('lib/Preview', () => {
             expect(Timer.reset).to.be.called;
             expect(preview.emit).to.not.be.called;
         });
-        
+
         it('should emit a preview_metric event', (done) => {
             preview.on(PREVIEW_METRIC, () => {
                 done();
             });
             preview.emitLoadMetrics();
         });
-        
+
         it('should emit a preview_metric event with event_name "preview_load"', () => {
             const tag = Timer.createTag(preview.file.id, LOAD_METRIC.fullDocumentLoadTime);
             Timer.start(tag);
@@ -2164,7 +2164,7 @@ describe('lib/Preview', () => {
             });
             preview.emitLoadMetrics();
         });
-        
+
         it('should emit a preview_metric event with an object, with all of the proper load properties', () => {
             preview.on(PREVIEW_METRIC, (metric) => {
                 expect(metric[LOAD_METRIC.fileInfoTime]).to.exist;
@@ -2174,7 +2174,7 @@ describe('lib/Preview', () => {
             });
             preview.emitLoadMetrics();
         });
-        
+
         it('should reset the Timer', () => {
             sandbox.stub(Timer, 'reset');
             sandbox.stub(preview, 'emit');
@@ -2183,7 +2183,7 @@ describe('lib/Preview', () => {
             expect(preview.emit).to.be.called;
 
         });
-        
+
         it('should default all un-hit milestones, after the first, to 0, and cast float values to ints', () => {
             Timer.get(fileInfoTag).elapsed = 1.00001236712394687;
             preview.on(PREVIEW_METRIC, (metric) => {

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -397,20 +397,17 @@ describe('lib/util', () => {
                 assert.ok(head.querySelector('script[src="bar"]') instanceof HTMLScriptElement);
             });
 
-            it('should clear requireJS until scripts are loaded or fail to load', () => {
-                window.define = true;
-                window.require = true;
-                window.requrejs = true;
+            it('should disable AMD until scripts are loaded or fail to load', () => {
+                const func = () => {};
+                func.amd = ['jquery'];
+                window.define = func;
 
-                return util.loadScripts(['foo', 'bar'], true).catch(() => {
-                    expect(window.define).to.equal(true);
-                    expect(window.require).to.equal(true);
-                    expect(window.requirejs).to.equal(true);
+                const promise = util.loadScripts(['foo', 'bar'], true);
+                expect(define).to.equal(undefined);
+
+                return promise.then(() => {
+                    expect(define).to.equal(func);
                 });
-
-                expect(window.define).to.equal(undefined);
-                expect(window.require).to.equal(undefined);
-                expect(window.requirejs).to.equal(undefined);
             });
         });
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -599,13 +599,12 @@ class BaseViewer extends EventEmitter {
      * Loads assets needed for a viewer
      *
      * @protected
-     * @param {Array} [js] - js assets
-     * @param {Array} [css] - css assets
-     * @param {boolean} [isViewerAsset] is the asset to load third party
+     * @param {Array} [js] - JS assets
+     * @param {Array} [css] - CSS assets
+     * @param {boolean} [isViewerAsset] - Whether we are loading a third party viewer asset
      * @return {Promise} Promise to load scripts
      */
     loadAssets(js, css, isViewerAsset = true) {
-        const disableRequireJS = isViewerAsset && !!this.options.pauseRequireJS;
         // Create an asset path creator function
         const { location } = this.options;
         const assetUrlCreator = createAssetUrlCreator(location);
@@ -614,7 +613,8 @@ class BaseViewer extends EventEmitter {
         loadStylesheets((css || []).map(assetUrlCreator));
 
         // Then load the scripts needed for this preview
-        return loadScripts((js || []).map(assetUrlCreator), disableRequireJS).then(() => {
+        const disableAMD = isViewerAsset && this.options.fixDependencies;
+        return loadScripts((js || []).map(assetUrlCreator), disableAMD).then(() => {
             if (isViewerAsset) {
                 this.emit('assetsloaded');
             }

--- a/src/lib/viewers/doc/docAssets.js
+++ b/src/lib/viewers/doc/docAssets.js
@@ -1,6 +1,6 @@
 import { DOC_STATIC_ASSETS_VERSION } from '../../constants';
 
 const STATIC_URI = `third-party/doc/${DOC_STATIC_ASSETS_VERSION}/`;
-export const JS = [`${STATIC_URI}pdf.min.js`, `${STATIC_URI}pdf_viewer.min.js`, `${STATIC_URI}exif.min.js`];
+export const JS = [`${STATIC_URI}pdf.js`, `${STATIC_URI}pdf_viewer.min.js`, `${STATIC_URI}exif.min.js`];
 export const PRELOAD_JS = [`${STATIC_URI}pdf.worker.min.js`];
 export const CSS = [`${STATIC_URI}pdf_viewer.min.css`];

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -235,6 +235,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
 
         it('should invoke startLoadTimer()', () => {
             sandbox.stub(text, 'startLoadTimer');
+            sandbox.stub(util, 'get').returns(Promise.resolve(''));
 
             text.postLoad();
 
@@ -308,21 +309,24 @@ describe('lib/viewers/text/PlainTextViewer', () => {
         });
 
         it('should setup the print iframe', () => {
+            const appendStub = sandbox.stub();
+
             sandbox.stub(util, 'createAssetUrlCreator').returns(sandbox.stub());
             sandbox.stub(util, 'openContentInsideIframe').returns({
                 contentDocument: {
                     head: {
-                        appendChild: sandbox.stub()
+                        appendChild: appendStub
                     }
                 }
             });
             text.options.location = 'en-US';
+            sandbox.stub(window, 'setTimeout');
 
             text.preparePrint(['blah']);
 
             expect(util.createAssetUrlCreator).to.be.calledWith(text.options.location);
             expect(util.openContentInsideIframe).to.be.calledWith(text.textEl.outerHTML);
-            expect(text.printframe.contentDocument.head.appendChild).to.be.called.once;
+            expect(appendStub).to.be.called;
         });
 
         it('should enable printing via print popup after a delay', () => {


### PR DESCRIPTION
Rename `pauseRequireJS` option since it's not immediately clear what you'd use it for. We retain support for the older name for backwards compatibility. Also remove unnecessary patching of `require` and `requireJS`.