### PR TITLE
Revert "Chore: Add download reachability checks to Document and Image viewers (#611)"

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -176,8 +176,6 @@ notification_button_default_text=Okay
 notification_annotation_point_mode=Click anywhere to add a comment to the document
 # Notification message shown when user enters drawing annotation mode
 notification_annotation_draw_mode=Press down and drag the pointer to draw on the document
-# Notification message shown when the user has a degraded preview experience due to blocked download hosts
-notification_degraded_preview=It looks like your connection to {1} is being blocked. We think we can make file previews in Box faster for you but we will need your firewall settings to be updated. To do that, please request your Box Admin to configure firewall settings for Box.
 
 # File Types
 # 360 degree video file type

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -730,9 +730,6 @@ class Preview extends EventEmitter {
             this.throttledMousemoveHandler
         );
 
-        // Set up the notification
-        this.ui.setupNotification();
-
         // Update navigation
         this.ui.showNavigation(this.file.id, this.collection);
 
@@ -1130,6 +1127,9 @@ class Preview extends EventEmitter {
 
         // Hide the loading indicator
         this.ui.hideLoadingIndicator();
+
+        // Set up the notification
+        this.ui.setupNotification();
 
         // Prefetch next few files
         this.prefetchNextFiles();

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -935,7 +935,6 @@ describe('lib/Preview', () => {
             previewUIMock.expects('showLoadingIndicator');
             previewUIMock.expects('startProgressBar');
             previewUIMock.expects('showNavigation');
-            previewUIMock.expects('setupNotification');
 
             preview.setupUI();
         })
@@ -1721,6 +1720,11 @@ describe('lib/Preview', () => {
         it('should hide the loading indicator', () => {
             preview.finishLoading();
             expect(stubs.hideLoadingIndicator).to.be.called;
+        });
+
+        it('should set up the notification', () => {
+            preview.finishLoading();
+            expect(stubs.setupNotification).to.be.called;
         });
 
         it('should prefetch next files', () => {

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -10,64 +10,8 @@ describe('lib/util', () => {
         sandbox.verifyAndRestore();
     });
 
-    describe('isCustomDownloadHost()', () => {
-        it('should be true if the url does not start with the default host prefix and is a dl host', () => {
-            let url = 'https://dl3.boxcloud.com/foo';
-            let result = util.isCustomDownloadHost(url)
-            expect(result).to.be.true;
-
-            url = 'https://dl.boxcloud.com/foo';
-            expect(util.isCustomDownloadHost(url)).to.be.false;
-
-            url = 'https://www.google.com';
-            expect(util.isCustomDownloadHost(url)).to.be.false;
-        });
-    });
-
-    describe('replaceDownloadHostWithDefault()', () => {
-        it('should return a download URL with the default host', () => {
-            let url = 'https://dl3.boxcloud.com/foo';
-            const result = util.replaceDownloadHostWithDefault(url);
-
-            expect(result).to.equal('https://dl.boxcloud.com/foo');
-        });
-    });
-
-    describe('setDownloadHostFallback()', () => {
-        it('should set the value in sessionStorage', () => {
-            util.setDownloadHostFallback();
-
-            expect(sessionStorage.getItem('download_host_fallback')).to.equal('true');
-        });
-    });
-
-    describe('shouldShowDegradedDownloadNotification()', () => {
-        beforeEach(() => {
-            sessionStorage.setItem('download_host_fallback', 'false');
-        });
-
-        it('should return true if we do not have an entry for the given host and our session indicates we are falling back to the default host', () => {
-            let result = util.shouldShowDegradedDownloadNotification();
-            expect(result).to.be.false;
-
-            sessionStorage.setItem('download_host_fallback', 'true');
-            result = util.shouldShowDegradedDownloadNotification();
-            expect(result).to.be.true;
-        
-            const shownHostsArr = ['dl5.boxcloud.com'];
-            localStorage.setItem('download_host_notification_shown', JSON.stringify(shownHostsArr));
-            result = util.shouldShowDegradedDownloadNotification(shownHostsArr[0]);
-            expect(result).to.be.false;
-
-        });
-    });
-
-
     describe('get()', () => {
-        let url;
-        beforeEach(() => {
-            url = 'foo?bar=bum';
-        });
+        const url = 'foo?bar=bum';
 
         afterEach(() => {
             fetchMock.restore();
@@ -150,23 +94,6 @@ describe('lib/util', () => {
                 expect(fetchMock.called(url)).to.be.true;
                 expect(response).to.be.an.object;
             });
-        });
-
-        it('set the download host fallback and try again if we\'re fetching from a non default host', () => {
-            url = 'dl7.boxcloud.com'
-            fetchMock.get(url, {
-                status: 500
-            });
-
-            return util.get(url, 'any')
-            .then(() => {
-                expect(response.status).to.equal(200);
-            })
-            .catch(() => {
-                fetchMock.get(url, {
-                    status: 200
-                });
-            })
         });
     });
 
@@ -388,11 +315,6 @@ describe('lib/util', () => {
 
         it('should return correct content url when no asset_path', () => {
             expect(util.createContentUrl('foo', 'bar')).to.equal('foo');
-        });
-
-        it('should replace the download host with the default if we are falling back', () => {
-            sessionStorage.setItem('download_host_fallback', 'true');
-            expect(util.createContentUrl('https://dl6.boxcloud.com', 'bar')).to.equal('https://dl.boxcloud.com');
         });
     });
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -5,11 +5,6 @@ const HEADER_CLIENT_NAME = 'X-Box-Client-Name';
 const HEADER_CLIENT_VERSION = 'X-Box-Client-Version';
 const CLIENT_NAME_KEY = 'box_client_name';
 const CLIENT_VERSION_KEY = 'box_client_version';
-
-const DEFAULT_DOWNLOAD_HOST_PREFIX = 'https://dl.';
-const DOWNLOAD_NOTIFICATION_SHOWN_KEY = 'download_host_notification_shown';
-const DOWNLOAD_HOST_FALLBACK_KEY = 'download_host_fallback';
-
 /* eslint-disable no-undef */
 const CLIENT_NAME = __NAME__;
 const CLIENT_VERSION = __VERSION__;
@@ -117,63 +112,6 @@ function createDownloadIframe() {
 }
 
 /**
- * Checks if the url is a download host, but not the default download host.
- *
- * @public
- * @param {string} url - The URL to check
- * @return {boolean} - HTTP response
- */
-export function isCustomDownloadHost(url) {
-    return !url.startsWith(DEFAULT_DOWNLOAD_HOST_PREFIX) && !!url.match(/^https:\/\/dl\d+\./);
-}
-
-/**
- * Replaces the hostname of a download URL with the default hostname, https://dl.
- *
- * @private
- * @param {string} url - The URL to modify
- * @return {string} - The updated download URL
- */
-export function replaceDownloadHostWithDefault(url) {
-    return url.replace(/^https:\/\/dl\d+\./, DEFAULT_DOWNLOAD_HOST_PREFIX);
-}
-
-/**
- * Sets session storage to use the default download host
- *
- * @public
- * @return {void}
- */
-export function setDownloadHostFallback() {
-    sessionStorage.setItem(DOWNLOAD_HOST_FALLBACK_KEY, 'true');
-}
-
-/**
- * Stores the host in an array via localstorage so that we don't show a notification for it again
- *
- * @public
- * @param {string} downloadHost - Download URL host
- * @return {void}
- */
-export function setDownloadHostNotificationShown(downloadHost) {
-    const shownHostsArr = JSON.parse(localStorage.getItem(DOWNLOAD_NOTIFICATION_SHOWN_KEY)) || [];
-    shownHostsArr.push(downloadHost);
-    localStorage.setItem(DOWNLOAD_NOTIFICATION_SHOWN_KEY, JSON.stringify(shownHostsArr));
-}
-
-/**
- * Determines if the degraded download notification should be shown.
- *
- * @public
- * @param {string} downloadHost - Download URL host
- * @return {boolean} Should the notification be shown
- */
-export function shouldShowDegradedDownloadNotification(downloadHost) {
-    const shownHostsArr = JSON.parse(localStorage.getItem(DOWNLOAD_NOTIFICATION_SHOWN_KEY)) || [];
-    return sessionStorage.getItem(DOWNLOAD_HOST_FALLBACK_KEY) === 'true' && !shownHostsArr.includes(downloadHost);
-}
-
-/**
  * HTTP GETs a URL
  * Usage:
  *     get(url, headers, type)
@@ -220,20 +158,7 @@ export function get(url, ...rest) {
 
     return fetch(url, { headers })
         .then(checkStatus)
-        .then(parser)
-        .catch((e) => {
-            // Make sure we are making a dl call
-            if (isCustomDownloadHost(url)) {
-                // Retry download with default host.
-                setDownloadHostFallback();
-                return get(url, ...rest);
-            }
-
-            /* eslint-disable no-console */
-            console.error(e);
-            /* eslint-enable no-console */
-            return Promise.reject(e);
-        });
+        .then(parser);
 }
 
 /**
@@ -472,12 +397,6 @@ export function appendAuthParams(url, token = '', sharedLink = '', password = ''
  * @return {string} Content url
  */
 export function createContentUrl(template, asset) {
-    if (sessionStorage.getItem(DOWNLOAD_HOST_FALLBACK_KEY) === 'true') {
-        /* eslint-disable no-param-reassign */
-        template = replaceDownloadHostWithDefault(template);
-        /* eslint-enable no-param-reassign */
-    }
-
     return template.replace('{+asset_path}', asset || '');
 }
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -7,17 +7,12 @@ import {
     getProp,
     appendQueryParams,
     appendAuthParams,
-    createContentUrl,
     getHeaders,
-    isCustomDownloadHost,
+    createContentUrl,
     loadStylesheets,
     loadScripts,
     prefetchAssets,
-    setDownloadHostFallback,
-    setDownloadHostNotificationShown,
-    shouldShowDegradedDownloadNotification,
-    createAssetUrlCreator,
-    replacePlaceholders
+    createAssetUrlCreator
 } from '../util';
 import Browser from '../Browser';
 import {
@@ -277,27 +272,6 @@ class BaseViewer extends EventEmitter {
     }
 
     /**
-     * Handles a download error when using a non default host.
-     *
-     * @param {Error} err - Load error
-     * @param {string} downloadURL - download URL
-     * @return {void}
-     */
-    handleDownloadError(err, downloadURL) {
-        if (isCustomDownloadHost(downloadURL)) {
-            setDownloadHostFallback();
-            this.load();
-            return;
-        }
-
-        /* eslint-disable no-console */
-        console.error(err);
-        /* eslint-enable no-console */
-
-        this.triggerError(err);
-    }
-
-    /**
      * Emits error event with refresh message.
      *
      * @protected
@@ -410,27 +384,13 @@ class BaseViewer extends EventEmitter {
     }
 
     /**
-     * Handles the viewer load to finish viewer setup after loading.
+     * Handles the viewer load to potentially set up Box Annotations.
      *
      * @private
      * @param {Object} event - load event data
      * @return {void}
      */
     viewerLoadHandler(event) {
-        const contentHost = document.createElement('a');
-        const contentTemplate = getProp(this.options, 'representation.content.url_template', null);
-        contentHost.href = contentTemplate;
-        const contentHostname = contentHost.hostname;
-        if (contentTemplate && shouldShowDegradedDownloadNotification(contentHostname)) {
-            this.previewUI.notification.show(
-                replacePlaceholders(__('notification_degraded_preview'), [contentHostname]),
-                __('notification_button_default_text'),
-                true
-            );
-
-            setDownloadHostNotificationShown(contentHostname);
-        }
-
         if (event && event.scale) {
             this.scale = event.scale;
         }

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -183,28 +183,6 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
-    describe('handleDownloadError()', () => {
-        beforeEach(() => {
-            sandbox.stub(base, 'triggerError');
-        });
-
-        it('should return false if using the default download host', () => {
-            sandbox.stub(util, 'isCustomDownloadHost').returns(false);
-            base.handleDownloadError('error', 'https://dl.boxcloud.com');
-            expect(base.triggerError).to.be.called;
-        });
-
-        it('should set the download host fallback, rereload, and return true if we are using a non default host', () => {
-            sandbox.stub(util, 'isCustomDownloadHost').returns(true);
-            sandbox.stub(util, 'setDownloadHostFallback')
-            sandbox.stub(base, 'load');
-
-            const result = base.handleDownloadError('error', 'https://dl7.boxcloud.com');
-            expect(base.load).to.be.called;
-            expect(util.setDownloadHostFallback).to.be.called;
-        });
-    });
-
     describe('triggerError()', () => {
         it('should emit error event', () => {
             sandbox.stub(base, 'emit');
@@ -357,13 +335,6 @@ describe('lib/viewers/BaseViewer', () => {
         beforeEach(() => {
             base.annotationsLoadPromise = Promise.resolve();
             stubs.annotationsLoadHandler = sandbox.stub(base, 'annotationsLoadHandler');
-            base.options.representation = {
-                content: {
-                    url_template: 'dl.boxcloud.com'
-                }
-            };
-            stubs.shouldShowDegradedDownloadNotification = sandbox.stub(util, 'shouldShowDegradedDownloadNotification').returns(false);
-
         });
 
         it('should set the scale if it exists', () => {
@@ -392,23 +363,6 @@ describe('lib/viewers/BaseViewer', () => {
                     expect(error).equals(sinon.match.error);
                     expect(error.message).equals('message');
                 });
-        });
-
-        it('should show the notification if downloads are degraded and we have not shown the notification yet', () => {
-            stubs.shouldShowDegradedDownloadNotification.returns(true);
-            base.previewUI =
-            {
-                notification: {
-                    show: sandbox.stub()
-
-                }
-            }
-
-            sandbox.stub(util, 'setDownloadHostNotificationShown');
-            
-            base.viewerLoadHandler({ scale: 1.5 });
-            expect(base.previewUI.notification.show).to.be.called;
-            expect(util.setDownloadHostNotificationShown).to.be.called;
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -539,13 +539,17 @@ class DocBaseViewer extends BaseViewer {
                 }
             })
             .catch((err) => {
+                /* eslint-disable no-console */
+                console.error(err);
+                /* eslint-enable no-console */
+
                 // Display a generic error message but log the real one
                 const error = err;
-                if (err instanceof Error) {
+                if (error instanceof Error) {
                     error.displayMessage = __('error_document');
                 }
 
-                this.handleDownloadError(err, pdfUrl);
+                this.triggerError(error);
             });
     }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -855,23 +855,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.pdfViewer.linkService.setDocument).to.be.called;
             });
         });
-
-        it('should handle any download error', () => {
-            stubs.handleDownloadError = sandbox.stub(docBase, 'handleDownloadError');
-            const doc = {
-                url: 'url'
-            };
-    
-            docBase.options.location = {
-                locale: 'en-US'
-            };
-    
-            const getDocumentStub = sandbox.stub(PDFJS, 'getDocument').returns(Promise.reject(doc));
-
-            return docBase.initViewer('url').catch(() => {
-                expect(stubs.handleDownloadError).to.be.called;
-            });
-        });
     });
 
     describe('resize()', () => {

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -26,6 +26,7 @@ class ImageBaseViewer extends BaseViewer {
         this.handleMouseUp = this.handleMouseUp.bind(this);
         this.cancelDragEvent = this.cancelDragEvent.bind(this);
         this.finishLoading = this.finishLoading.bind(this);
+        this.errorHandler = this.errorHandler.bind(this);
 
         if (this.isMobile) {
             if (Browser.isIOS()) {
@@ -310,20 +311,23 @@ class ImageBaseViewer extends BaseViewer {
     }
 
     /**
-     * Handles a content download error
+     * Handles image element loading errors.
      *
-     * @param {Error} err - Load error
-     * @param {string} imgUrl - URL we are using as the image src
+     * @private
+     * @param {Error} err - Error to handle
      * @return {void}
      */
-    handleDownloadError(err, imgUrl) {
+    errorHandler(err) {
+        /* eslint-disable no-console */
+        console.error(err);
+        /* eslint-enable no-console */
+
         // Display a generic error message but log the real one
         const error = err;
         if (err instanceof Error) {
             error.displayMessage = __('error_refresh');
         }
-
-        super.handleDownloadError(err, imgUrl);
+        this.emit('error', error);
     }
 
     /**

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -16,7 +16,6 @@ class ImageViewer extends ImageBaseViewer {
 
         this.rotateLeft = this.rotateLeft.bind(this);
         this.updatePannability = this.updatePannability.bind(this);
-        this.handleImageDownloadError = this.handleImageDownloadError.bind(this);
 
         if (this.isMobile) {
             this.handleOrientationChange = this.handleOrientationChange.bind(this);
@@ -53,13 +52,12 @@ class ImageViewer extends ImageBaseViewer {
 
         const { representation, viewer } = this.options;
         const template = representation.content.url_template;
-        const downloadURL = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
         return this.getRepStatus()
             .getPromise()
             .then(() => {
-                this.imageEl.src = downloadURL;
+                this.imageEl.src = this.createContentUrlWithAuthParams(template, viewer.ASSET);
             })
             .catch(this.handleAssetError);
     }
@@ -353,16 +351,6 @@ class ImageViewer extends ImageBaseViewer {
     //--------------------------------------------------------------------------
 
     /**
-     * Passes the error and download URL to the download error handler.
-     *
-     * @param {Error} err - Download error
-     * @return {void}
-     */
-    handleImageDownloadError(err) {
-        this.handleDownloadError(err, this.imageEl.src);
-    }
-
-    /**
      * Binds DOM listeners for image viewer.
      *
      * @protected
@@ -372,7 +360,7 @@ class ImageViewer extends ImageBaseViewer {
         super.bindDOMListeners();
 
         this.imageEl.addEventListener('load', this.finishLoading);
-        this.imageEl.addEventListener('error', this.handleImageDownloadError);
+        this.imageEl.addEventListener('error', this.errorHandler);
 
         if (this.isMobile) {
             this.imageEl.addEventListener('orientationchange', this.handleOrientationChange);
@@ -390,7 +378,7 @@ class ImageViewer extends ImageBaseViewer {
 
         if (this.imageEl) {
             this.imageEl.removeEventListener('load', this.finishLoading);
-            this.imageEl.removeEventListener('error', this.handleImageDownloadError);
+            this.imageEl.removeEventListener('error', this.errorHandler);
         }
 
         if (this.isMobile) {

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -21,7 +21,6 @@ class MultiImageViewer extends ImageBaseViewer {
         this.setPage = this.setPage.bind(this);
         this.scrollHandler = this.scrollHandler.bind(this);
         this.handlePageChangeFromScroll = this.handlePageChangeFromScroll.bind(this);
-        this.handleMultiImageDownloadError = this.handleMultiImageDownloadError.bind(this);
     }
 
     /**
@@ -244,25 +243,6 @@ class MultiImageViewer extends ImageBaseViewer {
     }
 
     /**
-     * Passes the error and download URL to the download error handler.
-     *
-     * @param {Error} err - Download error
-     * @return {void}
-     */
-    handleMultiImageDownloadError(err) {
-        this.singleImageEls.forEach((el, index) => {
-            this.unbindImageListeners(index);
-        });
-
-        // Since we're using the src to get the hostname, we can always use the src of the first page
-        const { src } = this.singleImageEls[0];
-        // Clear any images we may have started to load.
-        this.singleImageEls = [];
-
-        this.handleDownloadError(err, src);
-    }
-
-    /**
      * Binds error and load event listeners for an image element.
      *
      * @param {number} index - Index of image to bind listeners to
@@ -273,7 +253,7 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].addEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].addEventListener('error', this.handleMultiImageDownloadError);
+        this.singleImageEls[index].addEventListener('error', this.errorHandler);
     }
 
     /**
@@ -287,7 +267,7 @@ class MultiImageViewer extends ImageBaseViewer {
             this.singleImageEls[index].removeEventListener('load', this.finishLoading);
         }
 
-        this.singleImageEls[index].removeEventListener('error', this.handleMultiImageDownloadError);
+        this.singleImageEls[index].removeEventListener('error', this.errorHandler);
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -77,6 +77,7 @@ describe('lib/viewers/image/ImageViewer', () => {
             sandbox.stub(image, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             stubs.event = sandbox.stub(image.imageEl, 'addEventListener');
             stubs.load = sandbox.stub(image, 'finishLoading');
+            stubs.error = sandbox.stub(image, 'errorHandler');
             stubs.bind = sandbox.stub(image, 'bindDOMListeners');
 
             // load the image
@@ -444,12 +445,6 @@ describe('lib/viewers/image/ImageViewer', () => {
             stubs.listeners = image.imageEl.addEventListener;
         });
 
-        it('should bind error and load listeners', () => {
-            image.bindDOMListeners();
-            expect(stubs.listeners).to.have.been.calledWith('load', image.finishLoading);
-            expect(stubs.listeners).to.have.been.calledWith('error', image.handleImageDownloadError);
-        });
-
         it('should bind all mobile listeners', () => {
             sandbox.stub(Browser, 'isIOS').returns(true);
             image.bindDOMListeners();
@@ -468,7 +463,7 @@ describe('lib/viewers/image/ImageViewer', () => {
         it('should unbind all default image listeners', () => {
             image.unbindDOMListeners();
             expect(stubs.listeners).to.have.been.calledWith('load', image.finishLoading);
-            expect(stubs.listeners).to.have.been.calledWith('error', image.handleImageDownloadError);
+            expect(stubs.listeners).to.have.been.calledWith('error', image.errorHandler);
         });
 
         it('should unbind all mobile listeners', () => {

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -18,6 +18,7 @@ let clock;
 let containerEl;
 
 describe('lib/viewers/image/MultiImageViewer', () => {
+    stubs.errorHandler = MultiImageViewer.prototype.errorHandler;
     const setupFunc = BaseViewer.prototype.setup;
     const sizeFunc = ImageBaseViewer.prototype.setOriginalImageSize;
 
@@ -343,7 +344,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         });
     });
 
-    describe('bindPageControlListeners()', () => {
+    describe('bindPageControlListeners', () => {
         beforeEach(() => {
             multiImage.currentPageNumber = 1;
             multiImage.pagesCount = 10;
@@ -373,34 +374,8 @@ describe('lib/viewers/image/MultiImageViewer', () => {
 
     });
 
-    describe('handleMultiImageDownloadError()', () => {
-        beforeEach(() => {
-            multiImage.singleImageEls = [
-                {
-                    src: 'foo'
-                },
-                {
-                    src: 'baz'
-                }
-            ];
 
-            sandbox.stub(multiImage, 'handleDownloadError');
-            sandbox.stub(multiImage, 'unbindImageListeners')
-        });
-
-        it('unbind the image listeners, clear the image Els array, and handle the download error', () => {
-            const src = multiImage.singleImageEls[0].src;
-            
-            multiImage.handleMultiImageDownloadError('err');
-            
-            expect(multiImage.singleImageEls).to.deep.equal([]);
-            expect(multiImage.handleDownloadError).to.be.calledWith('err', src);
-            expect(multiImage.unbindImageListeners).to.be.calledTwice;
-
-        });
-    });
-
-    describe('bindImageListeners()', () => {
+    describe('bindImageListeners', () => {
         beforeEach(() => {
             multiImage.singleImageEls = [
                 {
@@ -423,7 +398,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         });
     });
 
-    describe('unbindImageListeners()', () => {
+    describe('unbindImageListeners', () => {
         beforeEach(() => {
             multiImage.singleImageEls = [
                 {


### PR DESCRIPTION
Issue with this commit:
We don't have a way of determining the status code of the request, thus we cannot know if Preview failed due to a blocked host vs. any regular error (404, 500, etc). This means I was indiscriminately falling back on any error that preview saw to the default host. This is not intended/desired behavior. 