### PR TITLE
Fix: define check

### DIFF
--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -93,7 +93,7 @@ describe('lib/util', () => {
 
             return util.get(url, 'any').then((response) => {
                 expect(fetchMock.called(url)).to.be.true;
-                expect(response).to.be.an.object;
+                expect(typeof response === 'object').to.be.true;
             });
         });
     });
@@ -398,15 +398,15 @@ describe('lib/util', () => {
             });
 
             it('should disable AMD until scripts are loaded or fail to load', () => {
-                const func = () => {};
-                func.amd = ['jquery'];
-                window.define = func;
+                const defineFunc = () => {};
+                defineFunc.amd = { jquery: '' };
+                window.define = defineFunc;
 
                 const promise = util.loadScripts(['foo', 'bar'], true);
                 expect(define).to.equal(undefined);
 
                 return promise.then(() => {
-                    expect(define).to.equal(func);
+                    expect(define).to.equal(defineFunc);
                 });
             });
         });

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -489,8 +489,10 @@ export function loadScripts(urls, disableAMD = false) {
     // scripts are loaded.
 
     /* eslint-disable no-undef */
-    const defineRef = typeof define === 'function' ? define : undefined;
-    if (disableAMD && typeof define === 'function' && define.amd) {
+    const amdPresent = !!window.define && typeof define === 'function' && !!define.amd;
+    const defineRef = amdPresent ? define : undefined;
+
+    if (disableAMD && amdPresent) {
         define = undefined;
     }
 
@@ -509,10 +511,14 @@ export function loadScripts(urls, disableAMD = false) {
 
     return Promise.all(promises)
         .then(() => {
-            define = defineRef || define;
+            if (disableAMD && amdPresent) {
+                define = defineRef;
+            }
         })
         .catch(() => {
-            define = defineRef || define;
+            if (disableAMD && amdPresent) {
+                define = defineRef;
+            }
         });
 }
 

--- a/src/lib/viewers/doc/docAssets.js
+++ b/src/lib/viewers/doc/docAssets.js
@@ -1,6 +1,6 @@
 import { DOC_STATIC_ASSETS_VERSION } from '../../constants';
 
 const STATIC_URI = `third-party/doc/${DOC_STATIC_ASSETS_VERSION}/`;
-export const JS = [`${STATIC_URI}pdf.js`, `${STATIC_URI}pdf_viewer.min.js`, `${STATIC_URI}exif.min.js`];
+export const JS = [`${STATIC_URI}pdf.min.js`, `${STATIC_URI}pdf_viewer.min.js`, `${STATIC_URI}exif.min.js`];
 export const PRELOAD_JS = [`${STATIC_URI}pdf.worker.min.js`];
 export const CSS = [`${STATIC_URI}pdf_viewer.min.css`];


### PR DESCRIPTION
Global define check was causing errors, adding a window.define check and also fixing document viewer to correctly rely on minified pdf.js.