### PR TITLE
Chore: update readme and changlog to reflect correct versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,3 @@
-<a name="1.31.0"></a>
-# 1.31.0 (2018-02-14)
-
-* Chore: change travis notifications (#661) ([efe8b04](https://github.com/box/box-content-preview/commit/efe8b04))
-* Chore: pass file id to RepStatus for easier timers (#660) ([6bfb193](https://github.com/box/box-content-preview/commit/6bfb193))
-* Fix: markdown ul and ol css overrides (#651) ([822a98c](https://github.com/box/box-content-preview/commit/822a98c))
-* Mojito: Update translations (#656) ([8f823e0](https://github.com/box/box-content-preview/commit/8f823e0))
-* Upgrade: Shaka Player 2.3.2 (#657) ([58f15cf](https://github.com/box/box-content-preview/commit/58f15cf))
-
-
-
 <a name="1.30.0"></a>
 # 1.30.0 (2018-02-13)
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ If you are using Internet Explorer 11, which doesn't natively support promises, 
 
 Current Version
 ---------------
-* Version: v1.31.0
+* Version: v1.30.1
 * Locale: en-US
 
-https://cdn01.boxcdn.net/platform/preview/1.31.0/en-US/preview.js
-https://cdn01.boxcdn.net/platform/preview/1.31.0/en-US/preview.css
+https://cdn01.boxcdn.net/platform/preview/1.30.1/en-US/preview.js
+https://cdn01.boxcdn.net/platform/preview/1.30.1/en-US/preview.css
 
 Supported Locales
 -----------------


### PR DESCRIPTION
I made a minor release instead of a patch release last week. Upon removing the release, I forgot to update documentation. Fixed to reflect actual patch release