### PR TITLE
Update: Modify file info retry logic

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -57,7 +57,7 @@ import { getClientLogDetails, createPreviewError, getISOTime } from './logUtils'
 const DEFAULT_DISABLED_VIEWERS = ['Office']; // viewers disabled by default
 const PREFETCH_COUNT = 4; // number of files to prefetch
 const MOUSEMOVE_THROTTLE_MS = 1500; // for showing or hiding the navigation icons
-const RETRY_COUNT = 5; // number of times to retry network request for a file
+const RETRY_COUNT = 3; // number of times to retry network request for a file
 const KEYDOWN_EXCEPTIONS = ['INPUT', 'SELECT', 'TEXTAREA']; // Ignore keydown events on these elements
 const LOG_RETRY_TIMEOUT_MS = 500; // retry interval for logging preview event
 const LOG_RETRY_COUNT = 3; // number of times to retry logging preview event
@@ -1253,8 +1253,8 @@ class Preview extends EventEmitter {
 
         clearTimeout(this.retryTimeout);
 
-        // Respect 'Retry-After' header if present, otherwise retry using exponential backoff
-        let timeoutMs = 2 ** this.retryCount * MS_IN_S;
+        // Respect 'Retry-After' header if present, otherwise retry full jitter
+        let timeoutMs = Math.random() * (2 ** this.retryCount * MS_IN_S);
         if (err.headers) {
             const retryAfterS = parseInt(err.headers.get('Retry-After'), 10);
             if (!Number.isNaN(retryAfterS)) {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1883,7 +1883,7 @@ describe('lib/Preview', () => {
             expect(stubs.load).to.be.calledWith(1);
         });
 
-        it('should retry using exponential backoff', () => {
+        it('should retry using full jitter', () => {
             preview.file = {
                 id: '0'
             };
@@ -1892,9 +1892,6 @@ describe('lib/Preview', () => {
             preview.retryCount = 3;
 
             preview.handleFetchError(stubs.error);
-
-            clock.tick(7000);
-            expect(stubs.load).to.not.be.called;
 
             clock.tick(8001);
             expect(stubs.load).to.be.called;


### PR DESCRIPTION
Retry a maximum of 3 times and use full jitter instead of exponential backoff.