### PR TITLE
Fix: move startAt from constructor to setup

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -112,9 +112,6 @@ class BaseViewer extends EventEmitter {
         this.options = options;
         this.cache = options.cache;
         this.previewUI = options.ui;
-
-        this.startAt = getProp(options, `fileOptions.${options.file.id}.${FILE_OPTION_START}`, {});
-
         this.repStatuses = [];
         this.isMobile = Browser.isMobile();
         this.hasTouch = Browser.hasTouch();
@@ -143,6 +140,7 @@ class BaseViewer extends EventEmitter {
         if (this.options.file) {
             const fileExt = this.options.file.extension;
             this.fileLoadingIcon = getIconFromExtension(fileExt);
+            this.startAt = getProp(this.options, `fileOptions.${this.options.file.id}.${FILE_OPTION_START}`, {});
         }
 
         this.finishLoadingSetup();

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -57,8 +57,6 @@ class DocBaseViewer extends BaseViewer {
     constructor(options) {
         super(options);
 
-        this.startPageNum = this.getStartPage();
-
         // Bind context for callbacks
         this.handleAssetAndRepLoad = this.handleAssetAndRepLoad.bind(this);
         this.print = this.print.bind(this);
@@ -102,6 +100,8 @@ class DocBaseViewer extends BaseViewer {
         this.viewerEl = this.docEl.appendChild(document.createElement('div'));
         this.viewerEl.classList.add('pdfViewer');
         this.loadTimeout = LOAD_TIMEOUT_MS;
+
+        this.startPageNum = this.getStartPage(this.startAt);
     }
 
     /**
@@ -160,12 +160,13 @@ class DocBaseViewer extends BaseViewer {
     /**
      * Converts a value and unit to page number
      *
+     * @param {Object} startAt - the unit and value that describes where to start the preview
      * @return {number|undefined} a page number > 0
      */
-    getStartPage() {
+    getStartPage(startAt = {}) {
         let convertedValue;
 
-        const { unit, value } = this.startAt;
+        const { unit, value } = startAt;
 
         if (!value || !unit) {
             return convertedValue;

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1662,60 +1662,60 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
     describe('getStartPage()', () => {
         it('should return the start page as a number', () => {
-            docBase.startAt = {
+            const startAt = {
                 value : 3,
                 unit : PAGES_UNIT_NAME
             };
 
-            expect(docBase.getStartPage()).to.equal(3);
+            expect(docBase.getStartPage(startAt)).to.equal(3);
         });
 
         it('should return the floored number if a floating point number is passed', () => {
-            docBase.startAt = {
+            const startAt = {
                 value : 4.1,
                 unit : PAGES_UNIT_NAME
             };
 
-            expect(docBase.getStartPage()).to.equal(4);
+            expect(docBase.getStartPage(startAt)).to.equal(4);
         });
 
         it('should return undefined if a value < 1 is passed', () => {
-            docBase.startAt = {
+            let startAt = {
                 value : 0,
                 unit : PAGES_UNIT_NAME
             };
 
-            expect(docBase.getStartPage()).to.be.undefined;
+            expect(docBase.getStartPage(startAt)).to.be.undefined;
 
-            docBase.startAt = {
+            startAt = {
                 value : -100,
                 unit : PAGES_UNIT_NAME
             };
 
-            expect(docBase.getStartPage()).to.be.undefined;
+            expect(docBase.getStartPage(startAt)).to.be.undefined;
         });
 
         it('should return undefined if an invalid unit is passed', () => {
-            docBase.startAt = {
+            const startAt = {
                 value : 3,
                 unit : 'foo'
             };
 
-            expect(docBase.getStartPage()).to.be.undefined;
+            expect(docBase.getStartPage(startAt)).to.be.undefined;
         });
 
         it('should return undefined if an invalid value is passed', () => {
-            docBase.startAt = {
+            const startAt = {
                 value : 'foo',
                 unit : PAGES_UNIT_NAME
             };
 
-            expect(docBase.getStartPage()).to.be.undefined;
+            expect(docBase.getStartPage(startAt)).to.be.undefined;
         });
 
         it('should return undefined if no unit and value is passed', () => {
-            docBase.startAt = {};
-            expect(docBase.getStartPage()).to.be.undefined;
+            const startAt = {};
+            expect(docBase.getStartPage(startAt)).to.be.undefined;
         });
     });
 });

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -64,21 +64,20 @@ class MediaBaseViewer extends BaseViewer {
         this.oldVolume = DEFAULT_VOLUME;
         this.pauseListener = null;
 
-        this.startTimeInSeconds = this.getStartTimeInSeconds();
+        this.startTimeInSeconds = this.getStartTimeInSeconds(this.startAt);
     }
 
     /**
      * Converts a value and unit to seconds
      *
-     * @param {string|number} value - the value e.g. 1
-     * @param {string} unit - the unit e.g. seconds
+     * @param {Object} startAt - the unit and value that describes where to start the preview
      * @return {number} a time in seconds
      */
-    getStartTimeInSeconds() {
+    getStartTimeInSeconds(startAt = {}) {
         let convertedValue = INITIAL_TIME_IN_SECONDS;
 
-        const value = getProp(this.startAt, 'value');
-        const unit = getProp(this.startAt, 'unit');
+        const value = getProp(startAt, 'value');
+        const unit = getProp(startAt, 'unit');
 
         if (!value || !unit) {
             return INITIAL_TIME_IN_SECONDS;


### PR DESCRIPTION
Changed to setup due to prefetch. Refactored tests and getStart* to avoid changing a bunch of test setup 