### PR TITLE
Fix: Polyfill Reflect.construct and Array.from for IE11

### DIFF
--- a/src/lib/polyfill.js
+++ b/src/lib/polyfill.js
@@ -217,4 +217,171 @@ Number.isNaN =
     function(value) {
         return value !== value;
     };
+
+// Reflect.construct polyfill for IE11, adapted from
+// https://github.com/zloirock/core-js/blob/master/modules/es6.reflect.construct.js
+(function() {
+    function aFunction(it) {
+        if (typeof it != 'function') throw TypeError(it + ' is not a function!');
+        return it;
+    }
+    function isObject(it) {
+        return typeof it === 'object' ? it !== null : typeof it === 'function';
+    }
+    function anObject(it) {
+        if (!isObject(it)) throw TypeError(it + ' is not an object!');
+        return it;
+    }
+    function fails(exec) {
+        try {
+            return !!exec();
+        } catch (e) {
+            return true;
+        }
+    }
+    var rConstruct = (typeof Reflect !== 'undefined' ? Reflect : {}).construct;
+
+    // MS Edge supports only 2 arguments and argumentsList argument is optional
+    // FF Nightly sets third argument as `new.target`, but does not create `this` from it
+    var NEW_TARGET_BUG = fails(function() {
+        function F() {
+            /* empty */
+        }
+        return !(
+            rConstruct(
+                function() {
+                    /* empty */
+                },
+                [],
+                F
+            ) instanceof F
+        );
+    });
+    var ARGS_BUG = !fails(function() {
+        rConstruct(function() {
+            /* empty */
+        });
+    });
+    function construct(Target, args /* , newTarget */) {
+        aFunction(Target);
+        anObject(args);
+        var newTarget = arguments.length < 3 ? Target : aFunction(arguments[2]);
+        if (ARGS_BUG && !NEW_TARGET_BUG) return rConstruct(Target, args, newTarget);
+        if (Target == newTarget) {
+            // w/o altered newTarget, optimization for 0-4 arguments
+            switch (args.length) {
+                case 0:
+                    return new Target();
+                case 1:
+                    return new Target(args[0]);
+                case 2:
+                    return new Target(args[0], args[1]);
+                case 3:
+                    return new Target(args[0], args[1], args[2]);
+                case 4:
+                    return new Target(args[0], args[1], args[2], args[3]);
+            }
+            // w/o altered newTarget, lot of arguments case
+            var $args = [null];
+            $args.push.apply($args, args);
+            return new (Function.bind.apply(Target, $args))();
+        }
+        // with altered newTarget, not support built-in constructors
+        var proto = newTarget.prototype;
+        var instance = Object.create(isObject(proto) ? proto : Object.prototype);
+        var result = Function.apply.call(Target, instance, args);
+        return isObject(result) ? result : instance;
+    }
+
+    if (typeof Reflect !== 'undefined') {
+        Reflect.construct = construct;
+    } else {
+        Reflect = {
+            construct
+        };
+    }
+})();
+
+// Production steps of ECMA-262, Edition 6, 22.1.2.1
+if (!Array.from) {
+    Array.from = (function() {
+        var toStr = Object.prototype.toString;
+        var isCallable = function(fn) {
+            return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+        };
+        var toInteger = function(value) {
+            var number = Number(value);
+            if (isNaN(number)) {
+                return 0;
+            }
+            if (number === 0 || !isFinite(number)) {
+                return number;
+            }
+            return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+        };
+        var maxSafeInteger = Math.pow(2, 53) - 1;
+        var toLength = function(value) {
+            var len = toInteger(value);
+            return Math.min(Math.max(len, 0), maxSafeInteger);
+        };
+
+        // The length property of the from method is 1.
+        return function from(arrayLike /*, mapFn, thisArg */) {
+            // 1. Let C be the this value.
+            var C = this;
+
+            // 2. Let items be ToObject(arrayLike).
+            var items = Object(arrayLike);
+
+            // 3. ReturnIfAbrupt(items).
+            if (arrayLike == null) {
+                throw new TypeError('Array.from requires an array-like object - not null or undefined');
+            }
+
+            // 4. If mapfn is undefined, then let mapping be false.
+            var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+            var T;
+            if (typeof mapFn !== 'undefined') {
+                // 5. else
+                // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+                if (!isCallable(mapFn)) {
+                    throw new TypeError('Array.from: when provided, the second argument must be a function');
+                }
+
+                // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                if (arguments.length > 2) {
+                    T = arguments[2];
+                }
+            }
+
+            // 10. Let lenValue be Get(items, "length").
+            // 11. Let len be ToLength(lenValue).
+            var len = toLength(items.length);
+
+            // 13. If IsConstructor(C) is true, then
+            // 13. a. Let A be the result of calling the [[Construct]] internal method
+            // of C with an argument list containing the single item len.
+            // 14. a. Else, Let A be ArrayCreate(len).
+            var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+
+            // 16. Let k be 0.
+            var k = 0;
+            // 17. Repeat, while k < len… (also steps a - h)
+            var kValue;
+            while (k < len) {
+                kValue = items[k];
+                if (mapFn) {
+                    A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+                } else {
+                    A[k] = kValue;
+                }
+                k += 1;
+            }
+            // 18. Let putStatus be Put(A, "length", len, true).
+            A.length = len;
+            // 20. Return A.
+            return A;
+        };
+    })();
+}
 /* eslint-enable */


### PR DESCRIPTION
Extending Error to PreviewError requires `babel-plugin-transform-builtin-extend`, which requires Reflect.construct and Array.from. This patch polyfills Reflect.construct, deriving from the core-js polyfill, and Array.from, using the MDN-suggested polyfill.