### PR TITLE
Chore: support for numeric file id

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Initialization
 var preview = new Box.Preview();
 preview.show(fileId, accessToken, { options });
 ```
-Where `fileId` is a string or number `Box_File` id and `accessToken` is a Box API access token.
+Where `fileId` is a string `Box_File` id and `accessToken` is a Box API access token.
 
 
 Parameters & Options

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Initialization
 var preview = new Box.Preview();
 preview.show(fileId, accessToken, { options });
 ```
-Where `fileId` is a string `Box_File` id and `accessToken` is a Box API access token.
+Where `fileId` is a string or number `Box_File` id and `accessToken` is a Box API access token.
 
 
 Parameters & Options

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -23,7 +23,8 @@ import {
     findScriptLocation,
     appendQueryParams,
     replacePlaceholders,
-    stripAuthFromString
+    stripAuthFromString,
+    isValidFileId
 } from './util';
 import {
     getURL,
@@ -287,13 +288,16 @@ class Preview extends EventEmitter {
         const fileIds = [];
 
         fileOrIds.forEach((fileOrId) => {
-            if (fileOrId && typeof fileOrId === 'string') {
+            if (fileOrId && isValidFileId(fileOrId)) {
                 // String id found in the collection
-                fileIds.push(fileOrId);
-            } else if (fileOrId && typeof fileOrId === 'object' && typeof fileOrId.id === 'string') {
+                fileIds.push(fileOrId.toString());
+            } else if (fileOrId && typeof fileOrId === 'object' && isValidFileId(fileOrId.id)) {
                 // Possible well-formed file object found in the collection
-                fileIds.push(fileOrId.id);
-                files.push(fileOrId);
+                const wellFormedFileObj = Object.assign({}, fileOrId, {
+                    id: fileOrId.id.toString()
+                });
+                fileIds.push(wellFormedFileObj.id);
+                files.push(wellFormedFileObj);
             } else {
                 throw new Error('Bad collection provided!');
             }
@@ -640,8 +644,8 @@ class Preview extends EventEmitter {
         const fileVersionId = this.getFileOption(fileIdOrFile, FILE_OPTION_FILE_VERSION_ID) || '';
 
         // Check what was passed to preview.show()—string file ID or some file object
-        if (typeof fileIdOrFile === 'string') {
-            const fileId = fileIdOrFile;
+        if (typeof fileIdOrFile === 'string' || typeof fileIdOrFile === 'number') {
+            const fileId = fileIdOrFile.toString();
 
             // If we want to load by file version ID, use that as key for cache
             const cacheKey = fileVersionId ? { fileVersionId } : { fileId };

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -298,7 +298,7 @@ describe('lib/Preview', () => {
         });
 
         it('should set the preview collection to an array of file ids when files passed in', () => {
-            let files = ['1', { id: '2' }, '3', { id: '4' }, { id: '5' }];
+            let files = ['1', { id: '2' }, 3, { id: '4' }, { id: 5 }];
 
             preview.updateCollection(files);
             expect(stubs.updateFileCache).to.be.calledWith([{ id: '2' }, { id: '4' }, { id: '5' }]);
@@ -809,6 +809,12 @@ describe('lib/Preview', () => {
             const fileId = '123';
             preview.load(fileId);
             expect(file.getCachedFile).to.be.calledWith(preview.cache, { fileId });
+        });
+
+        it('should fetch file from cache and convert file id to string when file id passed as a number', () => {
+            const fileId = 123;
+            preview.load(fileId);
+            expect(file.getCachedFile).to.be.calledWith(preview.cache, { fileId : fileId.toString() });
         });
 
         it('should fetch file from cache using file version ID as key if file version ID is in options', () => {

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -812,4 +812,26 @@ describe('lib/util', () => {
             expect(util.getProp(a, 'foo.bar', 'default')).to.equal('default');
         });
     });
+
+    describe('isValidFileId()', () => {
+        it('should be valid if fileId is a numeric string', () => {
+            expect(util.isValidFileId('1')).to.be.true;
+        });
+
+        it('should be valid if fileId is a number', () => {
+            expect(util.isValidFileId(1)).to.be.true;
+        });
+
+        it('should be invalid if fileId is undefined', () => {
+            expect(util.isValidFileId()).to.be.false;
+        });
+
+        it('should be invalid if fileId is NaN', () => {
+            expect(util.isValidFileId(NaN)).to.be.false;
+        });
+
+        it('should be invalid if fileId is a mixed string', () => {
+            expect(util.isValidFileId('1234foo')).to.be.false;
+        });
+    });
 });

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -887,3 +887,15 @@ export function getProp(object, propPath, defaultValue) {
 
     return value !== undefined ? value : defaultValue;
 }
+
+/**
+ * Checks that a fileId is of the expected type.
+ * A fileId can be a number, or a string represenation of a number
+ *
+ * @param {number} fileId - The file id
+ * @return {boolean} True if it is valid
+ */
+export function isValidFileId(fileId) {
+    // Tests that the string or number contains all numbers
+    return /^\d+$/.test(fileId);
+}


### PR DESCRIPTION
Adds support for passing fileId's as a number. It currently breaks if a number is passed instead of a string