### PR TITLE
Update: Uppercase unsupported file types

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1042,7 +1042,7 @@ class Preview extends EventEmitter {
             const code = isFileTypeSupported ? ERROR_CODE.ACCOUNT : ERROR_CODE.UNSUPPORTED_FILE_TYPE;
             const message = isFileTypeSupported
                 ? __('error_account')
-                : replacePlaceholders(__('error_unsupported'), [`.${this.file.extension}`]);
+                : replacePlaceholders(__('error_unsupported'), [(this.file.extension || '').toUpperCase()]);
 
             throw new PreviewError(code, message);
         }

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1507,7 +1507,7 @@ describe('lib/Preview', () => {
                 preview.loadViewer();
             } catch (e) {
                 expect(e.message).to.equal(
-                    util.replacePlaceholders(__('error_unsupported'), [`.${preview.file.extension}`])
+                    util.replacePlaceholders(__('error_unsupported'), ['ZIP'])
                 );
             }
         });


### PR DESCRIPTION
Uppercase the extensions for unsupported file types to prevent the dual period `...didn't load. .zip files...` --> `...didn't load. ZIP files...`