### PR TITLE
Fix: Avoid use of Number.isFinite()

### DIFF
--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -540,7 +540,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {boolean} - true if time is valid
      */
     isValidTime(time) {
-        return typeof time === 'number' && Number.isFinite(time) && time >= 0 && time <= this.mediaEl.duration;
+        return typeof time === 'number' && time >= 0 && time <= this.mediaEl.duration;
     }
 
     /**


### PR DESCRIPTION
Number.isFinite() is not supported in IE, and all it does is check that the input is a number and call the global isFinite, which is supported everywhere. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite