### PR TITLE
Fix: startAt should disable document preload

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -228,9 +228,13 @@ class DocBaseViewer extends BaseViewer {
         const { file } = this.options;
         const isWatermarked = file && file.watermark_info && file.watermark_info.is_watermarked;
 
-        // Don't show preload if there's a cached page since preloads are only for the 1st page
+        // Don't show preload if there's a cached page or startAt is set and > 1 since preloads are only for the 1st page
         // Also don't show preloads for watermarked files
-        if (!this.preloader || isWatermarked || this.getCachedPage() !== 1) {
+        if (
+            !this.preloader ||
+            isWatermarked ||
+            ((this.startPageNum && this.startPageNum !== 1) || this.getCachedPage() !== 1)
+        ) {
             return;
         }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -244,6 +244,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.showPreload();
         });
 
+        it('should not do anything if startAt is not page 1', () => {
+            sandbox.stub(docBase, 'getCachedPage').returns(2);
+            docBase.startPageNum = 3;
+            sandbox.mock(docBase.preloader).expects('showPreload').never();
+
+            docBase.showPreload();
+        });
+
         it('should not do anything if file is watermarked', () => {
             docBase.options.file = {
                 watermark_info: {
@@ -870,17 +878,17 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(docBase.startLoadTimer).to.be.called;
 
         });
-        
+
         it('should handle any download error', () => {
             stubs.handleDownloadError = sandbox.stub(docBase, 'handleDownloadError');
             const doc = {
                 url: 'url'
             };
-    
+
             docBase.options.location = {
                 locale: 'en-US'
             };
-    
+
             const getDocumentStub = sandbox.stub(PDFJS, 'getDocument').returns(Promise.reject(doc));
 
             return docBase.initViewer('url').catch(() => {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -245,7 +245,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
 
         it('should not do anything if startAt is not page 1', () => {
-            sandbox.stub(docBase, 'getCachedPage').returns(2);
+            sandbox.stub(docBase, 'getCachedPage').returns(1);
             docBase.startPageNum = 3;
             sandbox.mock(docBase.preloader).expects('showPreload').never();
 


### PR DESCRIPTION
Fixes an issue where document preload was being shown when startAt was set