### PR TITLE
Fix: Allow annotation text to be selectable

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -79,6 +79,13 @@
         }
     }
 
+    // Allow other text to be selectable
+    input,
+    p,
+    span {
+        user-select: text;
+    }
+
     // This is so hover and click targets for links inside the document show
     // up correctly. We add 15px top margin since PDF.js sets the top for these
     // manually assuming there is no vertical padding on the page


### PR DESCRIPTION
Old CSS was prevent user selection of anything that wasn't a text layer div to prevent weird selection edge cases. This patch relaxes that to allow selection of `<span>`, `<p>` & `<input>` so annotation dialog text can be selected (they use `<p>`).