### PR TITLE
Use correct property for handle viewer event

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1196,7 +1196,7 @@ class Preview extends EventEmitter {
 
             // Explicit preview failure
             this.handleViewerMetrics({
-                event_name: 'failure'
+                event: 'failure'
             });
 
             // Hookup for phantom JS health check
@@ -1216,7 +1216,7 @@ class Preview extends EventEmitter {
 
             // Explicit preview success
             this.handleViewerMetrics({
-                event_name: 'success'
+                event: 'success'
             });
 
             // If there wasn't an error and event logging is not disabled, use Events API to log a preview

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1745,7 +1745,7 @@ describe('lib/Preview', () => {
 
             preview.finishLoading();
 
-            expect(handleViewerMetrics).to.be.calledWith({ event_name });
+            expect(handleViewerMetrics).to.be.calledWith({ event: event_name });
         });
 
         it('should emit a metrics message for failed preview', () => {
@@ -1756,7 +1756,7 @@ describe('lib/Preview', () => {
 
             preview.finishLoading({ error: {} });
 
-            expect(handleViewerMetrics).to.be.calledWith({ event_name });
+            expect(handleViewerMetrics).to.be.calledWith({ event: event_name });
         });
 
         it('should emit the load event', () => {


### PR DESCRIPTION
My misreading lead to a null event_name being used for the metric. This fixes it to use the correct one.