### PR TITLE
Fix: Reduce WebGL checks to reduce instances of Rats! error

### DIFF
--- a/src/lib/Browser.js
+++ b/src/lib/Browser.js
@@ -3,7 +3,7 @@ const MIME_H264_MAIN = 'video/mp4; codecs="avc1.4D401E"';
 const MIME_H264_HIGH = 'video/mp4; codecs="avc1.64001E"';
 const EXT_STANDARD_DERIVATIVES = 'OES_standard_derivatives';
 const EXT_LOSE_CONTEXT = 'WEBGL_lose_context';
-const EVENT_WEBGL_CONEXT_LOST = 'webglcontextlost';
+const EVENT_WEBGL_CONTEXT_LOST = 'webglcontextlost';
 
 let { userAgent } = navigator;
 let name;
@@ -184,7 +184,7 @@ class Browser {
         if (!gl) {
             const canvas = document.createElement('canvas');
             // Should stop 'Rats! WebGL hit a snag' error when checking WebGL support
-            canvas.addEventListener(EVENT_WEBGL_CONEXT_LOST, (e) => {
+            canvas.addEventListener(EVENT_WEBGL_CONTEXT_LOST, (e) => {
                 /* istanbul ignore next */
                 e.preventDefault();
                 /* istanbul ignore next */
@@ -353,10 +353,8 @@ class Browser {
             swf: Browser.hasFlash(),
             svg: Browser.hasSVG(),
             mse: Browser.hasMSE(),
-            webgl: Browser.hasWebGL(),
             mp3: Browser.canPlayMP3(),
             dash: Browser.canPlayDash(),
-            box3d: Browser.supportsModel3D(),
             h264: {
                 baseline: Browser.canPlayH264Baseline(),
                 main: Browser.canPlayH264Main(),

--- a/src/lib/__tests__/Browser-test.js
+++ b/src/lib/__tests__/Browser-test.js
@@ -500,4 +500,21 @@ describe('lib/Browser', () => {
             expect(hasIssue).to.be.false;
         });
     });
+
+    describe('getBrowserInfo()', () => {
+        it('should return browser capabilities', () => {
+            const browserInfo = Browser.getBrowserInfo();
+            const expectedFields = [
+                'name',
+                'swf',
+                'svg',
+                'mse',
+                'mp3',
+                'dash',
+                'h264'
+            ];
+
+            expect(expectedFields.every((field) => typeof browserInfo[field] !== 'undefined')).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
We don't use metrics associated with whether the user's browser supports WebGL or 3D rendering, so this removes the WebGL checks from the browser info check for every Preview instance and isolates them to 3D and 360 files, which should reduce instances of the `Rats! WebGL hit a snag.` error.