### PR TITLE
BFMVP-7637 Use original representation only for PDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ preview.show(fileId, accessToken, {
 | fixDependencies | false | Temporarily patches AMD to properly load Preview's dependencies. You may need to enable this if your project uses RequireJS |
 | disableEventLog | false | Disables client-side `preview` event log. Previewing with this option enabled will not increment access stats (content access is still logged server-side) |
 | fileOptions | {} | Mapping of file ID to file-level options. See the file option table below for details |
+| useOriginalRepresentation | false | For PDF files only. Use Original representation over PDF representation |
 
 | File Option | Description |
 | --- | --- |

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -880,6 +880,11 @@ class Preview extends EventEmitter {
         // Options that are applicable to certain file ids
         this.options.fileOptions = options.fileOptions || {};
 
+        // BFMVP-7637
+        // Force viewer to use the Original representation instead of the other performant representations
+        // till Box fixes them to render correctly
+        this.options.useOriginalRepresentation = options.useOriginalRepresentation || false;
+
         // Prefix any user created loaders before our default ones
         this.loaders = (options.loaders || []).concat(loaderList);
 
@@ -1081,7 +1086,7 @@ class Preview extends EventEmitter {
         this.logger.setType(viewer.NAME);
 
         // Determine the representation to use
-        const representation = loader.determineRepresentation(this.file, viewer);
+        const representation = loader.determineRepresentation(this.file, viewer, this.options.useOriginalRepresentation);
 
         // Instantiate the viewer
         const viewerOptions = this.createViewerOptions({

--- a/src/lib/viewers/doc/DocLoader.js
+++ b/src/lib/viewers/doc/DocLoader.js
@@ -76,9 +76,14 @@ class DocLoader extends AssetLoader {
      *
      * @param {Object} file - Box file
      * @param {Object} viewer - Chosen Preview viewer
+     * @param {Boolen} useOriginalRepresentation - Use original representation over PDF representation
      * @return {Object} The representation to load
      */
-    determineRepresentation(file, viewer) {
+    determineRepresentation(file, viewer, useOriginalRepresentation) {
+        if (useOriginalRepresentation) {
+            return getRepresentation(file, ORIGINAL_REP_NAME);
+        }
+
         let repOverride;
 
         // For PDF files, use original rep unless PDF rep is successful since it'll be faster


### PR DESCRIPTION
This temporarily fixes https://bonfirehub.atlassian.net/browse/BFMVP-7637.

Some PDF files are not being rendered correctly using their PDF representation, hence we need to use only the original representation while Box fixes this issue. Instead of completely changing the `DocLoader.js` - `determineRepresentation`, I have modified it such that we can pass in an option to use only the original representation.