### PR TITLE
Chore: Remove unused babel-polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,14 +306,14 @@ Development Setup
 -----------------
 1. Install Node v8.9.4 or higher.
 2. Install yarn package manager `https://yarnpkg.com/en/docs/install`. Alternatively, you can replace any `yarn` command with `npm`.
-2. Fork the upstream repo `https://github.com/box/box-content-preview`.
-3. Clone your fork locally `git clone git@github.com:[YOUR GITHUB USERNAME]/box-content-preview.git`.
-4. Navigate to the cloned folder `cd box-content-preview`
-5. Add the upstream repo to your remotes `git remote add upstream git@github.com:box/box-content-preview.git`.
-6. Verify your remotes are properly set up `git remote -v`. You should pull updates from the Box repo `upstream` and push changes to your fork `origin`.
-7. Install dependencies `yarn install`
-8. Test your first build! `yarn run build`
-9. To automatically rsync files after a Webpack build, add a build/rsync.json file with a `location` field. This file should look like:
+3. Fork the upstream repo `https://github.com/box/box-content-preview`.
+4. Clone your fork locally `git clone git@github.com:[YOUR GITHUB USERNAME]/box-content-preview.git`.
+5. Navigate to the cloned folder `cd box-content-preview`
+6. Add the upstream repo to your remotes `git remote add upstream git@github.com:box/box-content-preview.git`.
+7. Verify your remotes are properly set up `git remote -v`. You should pull updates from the Box repo `upstream` and push changes to your fork `origin`.
+8. Install dependencies `yarn install`
+9. Test your first build! `yarn run build`
+10. To automatically rsync files after a Webpack build, add a build/rsync.json file with a `location` field. This file should look like:
 ```
 {
     "location": "YOUR_DESIRED_RSYNC_LOCATION_HERE"

--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -94,8 +94,8 @@ module.exports = (config) => config.set({
     ],
 
     files: [
+        'https://cdn01.boxcdn.net/polyfills/core-js/2.5.3/core.min.js',
         `src/third-party/model3d/${MODEL3D_STATIC_ASSETS_VERSION}/three.min.js`,
-        'node_modules/babel-polyfill/dist/polyfill.js',
         `src/third-party/doc/${DOC_STATIC_ASSETS_VERSION}/**/*.js`,
         `src/third-party/media/${MEDIA_STATIC_ASSETS_VERSION}/**/*.js`,
         `src/third-party/model3d/${MODEL3D_STATIC_ASSETS_VERSION}/**/*.js`,

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -1,5 +1,3 @@
-require('babel-polyfill');
-
 const isRelease = process.env.NODE_ENV === 'production';
 const isDev = process.env.NODE_ENV === 'dev';
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-require-ignore": "^0.1.1",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,7 +1054,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@6.26.0, babel-polyfill@^6.23.0:
+babel-polyfill@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:


### PR DESCRIPTION
With Node v8+ we no longer need babel-polyfill for Webpack.