### PR TITLE
Fix: Download watermarked

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -505,9 +505,11 @@ class Preview extends EventEmitter {
                 return;
             }
 
+            // This allows the browser to download representation content
+            const params = Object.assign({ response_content_disposition_type: 'attachment' }, queryParams);
             const downloadUrl = appendQueryParams(
-                this.viewer.createContentUrlWithAuthParams(contentUrlTemplate, this.viewer.options.viewer.ASSET),
-                queryParams
+                this.viewer.createContentUrlWithAuthParams(contentUrlTemplate, this.viewer.getAssetPath()),
+                params
             );
 
             DownloadReachability.downloadWithReachabilityCheck(downloadUrl);

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -766,6 +766,7 @@ describe('lib/Preview', () => {
             };
             preview.viewer = {
                 getRepresentation: sandbox.stub(),
+                getAssetPath: sandbox.stub(),
                 createContentUrlWithAuthParams: sandbox.stub(),
                 options: {
                     viewer: {
@@ -815,12 +816,14 @@ describe('lib/Preview', () => {
             const url = 'someurl';
 
             preview.viewer.getRepresentation.returns(representation);
-            preview.viewer.createContentUrlWithAuthParams.withArgs(template, '').returns(url);
+            preview.viewer.getAssetPath.returns('1.jpg');
+            preview.viewer.createContentUrlWithAuthParams.withArgs(template, '1.jpg').returns(url);
 
-            util.appendQueryParams.withArgs(url).returns(url);
+            util.appendQueryParams.returns(url);
 
             preview.download();
 
+            expect(util.appendQueryParams).to.be.calledWith(url, { response_content_disposition_type: 'attachment' });
             expect(DownloadReachability.downloadWithReachabilityCheck).to.be.calledWith(url);
         });
 
@@ -829,7 +832,7 @@ describe('lib/Preview', () => {
             file.shouldDownloadWM.returns(false);
 
             const url = 'someurl';
-            util.appendQueryParams.withArgs(url).returns(url);
+            util.appendQueryParams.returns(url);
 
             const promise = Promise.resolve({
                 download_url: url

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -783,6 +783,24 @@ class BaseViewer extends EventEmitter {
         }
     }
 
+    /**
+     * Returns the representation used for Preview.
+     *
+     * @return {Object} Box representation used/to be used by Preview
+     */
+    getRepresentation() {
+        return this.options.representation;
+    }
+
+    /**
+     * Returns the asset path to access representation content for Preview.
+     *
+     * @return {string} Asset path
+     */
+    getAssetPath() {
+        return getProp(this, 'options.viewer.ASSET', '');
+    }
+
     //--------------------------------------------------------------------------
     // Annotations
     //--------------------------------------------------------------------------
@@ -1027,15 +1045,6 @@ class BaseViewer extends EventEmitter {
                 localizedStrings
             })
         );
-    }
-
-    /**
-     * Returns the representation used for Preview.
-     *
-     * @return {Object} Box representation used/to be used by Preview
-     */
-    getRepresentation() {
-        return this.options.representation;
     }
 }
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -954,6 +954,27 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
+    describe('getRepresentation()', () => {
+        it('should return the representation the viewer is/will use to preview', () => {
+            base.options.representation = { some: 'stuff' };
+            expect(base.getRepresentation()).to.equal(base.options.representation);
+        });
+    });
+
+    describe('getAssetPath()', () => {
+        it('should return the asset path the viewer is/will use for preview representation content', () => {
+            base.options.viewer = {
+                ASSET: '1.jpg'
+            };
+            expect(base.getAssetPath()).to.equal(base.options.viewer.ASSET);
+        });
+
+        it('should return empty string if viewer does not have a special asset path', () => {
+            base.options.viewer = {};
+            expect(base.getAssetPath()).to.equal('');
+        });
+    });
+
     describe('loadAnnotator()', () => {
         const conf = {
             annotationsEnabled: true,
@@ -1323,13 +1344,6 @@ describe('lib/viewers/BaseViewer', () => {
             expect(combinedOptions.location).to.deep.equal({ locale: 'en-US' });
             expect(combinedOptions.randomOption).to.equal('derp');
             expect(combinedOptions.localizedStrings).to.not.be.undefined;
-        });
-    });
-
-    describe('getRepresentation()', () => {
-        it('should return the representation the viewer is/will use to preview', () => {
-            base.options.representation = { some: 'stuff' };
-            expect(base.getRepresentation()).to.equal(base.options.representation);
         });
     });
 });


### PR DESCRIPTION
- Send content disposition header to force representation to be downloaded as attachment
- Expose asset path as method on viewer instead of directly accessing