### PR TITLE
Chore: Only reset to upstream/master for major/minor releases

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -14,6 +14,9 @@ patch_release=false
 
 reset_tags() {
     # Wipe tags
+    echo "----------------------------------------------------------------------"
+    echo "Wiping local tags"
+    echo "----------------------------------------------------------------------"
     git tag -l | xargs git tag -d || return 1
 
     # Add the upstream remote if it is not present
@@ -22,6 +25,9 @@ reset_tags() {
     fi
 
     # Fetch latest code with tags
+    echo "----------------------------------------------------------------------"
+    echo "Fetching latest upstream code + tags"
+    echo "----------------------------------------------------------------------"
     git fetch --tags github-upstream || return 1;
 }
 
@@ -38,6 +44,9 @@ reset_to_previous_version() {
     reset_tags || return 1;
 
     # Reset to previous release version and clear unstashed changes
+    echo "----------------------------------------------------------------------"
+    echo "Resetting to v" $OLD_VERSION
+    echo "----------------------------------------------------------------------"
     git reset --hard OLD_VERSION || return 1
     git clean -f  || return 1
 }
@@ -51,6 +60,9 @@ reset_to_master() {
     reset_tags || return 1;
 
     # Reset to latest code and clear unstashed changes
+    echo "----------------------------------------------------------------------"
+    echo "Resetting to upstream/master"
+    echo "----------------------------------------------------------------------"
     git reset --hard github-upstream/master || return 1
     git clean -f  || return 1
 }

--- a/build/release.sh
+++ b/build/release.sh
@@ -66,6 +66,14 @@ increment_version() {
     # Old version
     OLD_VERSION=$(./build/current_version.sh)
 
+    # The master branch should not match the previous release tag
+    if [[ $(git log --oneline ...v$OLD_VERSION) == "" ]] ; then
+        echo "----------------------------------------------------"
+        echo "Your release has no new commits!"
+        echo "----------------------------------------------------"
+        exit 1
+    fi
+
     if $major_release; then
         echo "----------------------------------------------------------------------"
         echo "Bumping major version..."

--- a/build/release.sh
+++ b/build/release.sh
@@ -78,7 +78,7 @@ increment_version() {
     # Old version
     OLD_VERSION=$(./build/current_version.sh)
 
-    # The master branch should not match the previous release tag
+    # The current branch should not match the previous release tag
     if [[ $(git log --oneline ...v$OLD_VERSION) == "" ]] ; then
         echo "----------------------------------------------------"
         echo "Your release has no new commits!"


### PR DESCRIPTION
This will prevent patch releases from resetting to upstream/master. Instead, it will reset to the previous version of Preview (if available).

TODO: replicate the same logic in BoxAnnotations

Copy of https://github.com/box/box-content-preview/pull/745