### PR TITLE
Fix: Embedded notes in Box WebApp

### DIFF
--- a/src/lib/viewers/iframe/IFrameViewer.js
+++ b/src/lib/viewers/iframe/IFrameViewer.js
@@ -30,7 +30,7 @@ class IFrameViewer extends BaseViewer {
         const { extension } = file;
 
         if (extension === 'boxnote') {
-            src = `${appHost}/notes/${file.id}?isReadonly=1&is_preview=1`;
+            src = `${appHost}/notes_embedded/${file.id}?isReadonly=1&is_preview=1`;
 
             // Append shared name if needed, Box Notes uses ?s=SHARED_NAME
             const sharedNameIndex = sharedLink.indexOf('/s/');

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -57,7 +57,7 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
         it('should load a boxnote and fire load event', (done) => {
             iframe.on('load', () => {
-                assert.equal(iframe.iframeEl.src, 'https://app.box.com/notes/123?isReadonly=1&is_preview=1');
+                assert.equal(iframe.iframeEl.src, 'https://app.box.com/notes_embedded/123?isReadonly=1&is_preview=1');
                 done();
             });
 
@@ -68,7 +68,10 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
             iframe.options.sharedLink = 'https://app.box.com/s/foobar';
 
             iframe.on('load', () => {
-                assert.equal(iframe.iframeEl.src, 'https://app.box.com/notes/123?isReadonly=1&is_preview=1&s=foobar');
+                assert.equal(
+                    iframe.iframeEl.src,
+                    'https://app.box.com/notes_embedded/123?isReadonly=1&is_preview=1&s=foobar'
+                );
                 done();
             });
 


### PR DESCRIPTION
Use /notes_embedded instead of /notes to resolve X-Frame-Origin issue.