### PR TITLE
Fix: Correct media settings checkmark icon color on hover

### DIFF
--- a/src/lib/viewers/media/Settings.scss
+++ b/src/lib/viewers/media/Settings.scss
@@ -84,6 +84,10 @@ $item-hover-color: #f6fafd;
     &:hover {
         background-color: $item-hover-color;
 
+        .bp-media-settings-icon svg {
+            fill: $blue-steel;
+        }
+
         .bp-media-settings-label {
             color: lighten($blue-steel, 50%);
         }
@@ -200,9 +204,5 @@ $item-hover-color: #f6fafd;
 
     .bp-media-settings-selected & svg {
         visibility: visible;
-    }
-
-    &:hover svg {
-        fill: $white;
     }
 }


### PR DESCRIPTION
Also verified that an item receiving keyboard focus still turns the background blue and the icon white, as before.