### PR TITLE
Fix: Retry logic

### DIFF
--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1092,13 +1092,6 @@ describe('lib/Preview', () => {
             stubs.cacheFile = sandbox.stub(file, 'cacheFile');
         });
 
-        it('should short circuit and load from server if it is a retry', () => {
-            preview.retryCount = 1;
-
-            preview.handleTokenResponse({});
-            expect(stubs.loadFromServer).to.be.called;
-        });
-
         it('should set the token option', () => {
             preview.retryCount = 0;
             const TOKEN = 'bar';
@@ -1999,7 +1992,10 @@ describe('lib/Preview', () => {
     });
 
     describe('handleFetchError()', () => {
+        let clock;
+
         beforeEach(() => {
+            clock = sandbox.useFakeTimers();
             stubs.uncacheFile = sandbox.stub(file, 'uncacheFile');
             stubs.triggerError = sandbox.stub(preview, 'triggerError');
             stubs.load = sandbox.stub(preview, 'load');
@@ -2008,6 +2004,10 @@ describe('lib/Preview', () => {
                     status: 400
                 }
             };
+        });
+
+        afterEach(() => {
+            clock.restore();
         });
 
         it('should do nothing if the preview is closed', () => {
@@ -2061,7 +2061,6 @@ describe('lib/Preview', () => {
             preview.file = {
                 id: '0'
             };
-            const clock = sinon.useFakeTimers();
             preview.open = true;
             preview.retryCount = 1;
             preview.file.id = 1;
@@ -2077,7 +2076,6 @@ describe('lib/Preview', () => {
             preview.file = {
                 id: '0'
             };
-            const clock = sinon.useFakeTimers();
             preview.open = true;
             preview.retryCount = 3;
 
@@ -2097,7 +2095,6 @@ describe('lib/Preview', () => {
                     .withArgs('Retry-After')
                     .returns(5)
             };
-            const clock = sinon.useFakeTimers();
             preview.open = true;
             preview.retryCount = 1;
 


### PR DESCRIPTION
- Remove incorrect short-circuit-on-retry logic. This short circuit was being called any time you called preview on the same file twice and subsequent loads would always fail because the short circuit happened before an access token was assigned
- Set up fake clock in beforeEach of tests for handleFetchError() - not resetting the timer was causing weird issues