### PR TITLE
New: add preview.load callback option

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -690,10 +690,10 @@ class Preview extends EventEmitter {
      *
      * @private
      * @param {string|Object} fileIdOrFile - Box File ID or well-formed Box File object
-     * @param {Function} callback - Optional load callback
+     * @param {Function} loadCallback - Optional load callback
      * @return {void}
      */
-    load(fileIdOrFile, callback) {
+    load(fileIdOrFile, loadCallback) {
         // Clean up any existing previews before loading
         this.destroy();
 
@@ -776,7 +776,7 @@ class Preview extends EventEmitter {
         // combine Box Elements + Preview. This could potentially break if we have Box Elements fetch the file object
         // and pass the well-formed file object directly to the preview library to render.
         const isPreviewOffline = typeof fileIdOrFile === 'object' && this.options.skipServerUpdate;
-        callback = callback || function() {};
+        const callback = loadCallback || function () {};
         if (isPreviewOffline) {
             this.handleTokenResponse({});
             callback();

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -248,7 +248,7 @@ class Preview extends EventEmitter {
         this.parseOptions(this.previewOptions);
 
         // Load the preview
-        this.load(fileIdOrFile);
+        this.load(fileIdOrFile, options.callback);
     }
 
     /**
@@ -690,9 +690,10 @@ class Preview extends EventEmitter {
      *
      * @private
      * @param {string|Object} fileIdOrFile - Box File ID or well-formed Box File object
+     * @param {Function} callback - Optional load callback
      * @return {void}
      */
-    load(fileIdOrFile) {
+    load(fileIdOrFile, callback) {
         // Clean up any existing previews before loading
         this.destroy();
 
@@ -775,12 +776,15 @@ class Preview extends EventEmitter {
         // combine Box Elements + Preview. This could potentially break if we have Box Elements fetch the file object
         // and pass the well-formed file object directly to the preview library to render.
         const isPreviewOffline = typeof fileIdOrFile === 'object' && this.options.skipServerUpdate;
+        callback = callback || function() {};
         if (isPreviewOffline) {
             this.handleTokenResponse({});
+            callback();
         } else {
             // Fetch access tokens before proceeding
             getTokens(this.file.id, this.previewOptions.token)
                 .then(this.handleTokenResponse)
+                .then(callback)
                 .catch(this.handleFetchError);
         }
     }


### PR DESCRIPTION
Hi, I need to do some operations at the end of the preview html loading but preview.show ends without that html loaded.

I realized that preview.show calls preview.load that calls getTokens without waiting for the end of that promise. So i'm adding an optional callback in the options parameter of preview.show, that it's passed as a parameter for preview.load.
So now using preview.show("123", "token", { callback: onHtmlLoad }); i can move the operations depending on the html loading in the callback parameter.

Maybe you know a simpler way of listening the end of this preview html loading. I would be happy of know it.