### PR TITLE
Chore: Allow load metrics emission without file info

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1525,15 +1525,8 @@ class Preview extends EventEmitter {
         const downloadTag = Timer.createTag(this.file.id, LOAD_METRIC.downloadResponseTime);
         const fullLoadTag = Timer.createTag(this.file.id, LOAD_METRIC.fullDocumentLoadTime);
 
-        // Do nothing if there is nothing worth logging.
-        const infoTime = Timer.get(infoTag) || {};
-        if (!infoTime.elapsed) {
-            Timer.reset([infoTag, convertTag, downloadTag, fullLoadTag]);
-            return;
-        }
-
         const timerList = [
-            infoTime,
+            Timer.get(infoTag) || {},
             Timer.get(convertTag) || {},
             Timer.get(downloadTag) || {},
             Timer.get(fullLoadTag) || {}

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -44,7 +44,6 @@ export const ERROR_CODE = {
     FLASH_NOT_ENABLED: 'error_flash_not_enabled'
 };
 
-export const PREVIEW_LOAD_EVENT = '';
 // Event fired from Preview with error details
 export const PREVIEW_ERROR = 'preview_error';
 // Event fired from Preview with performance metrics


### PR DESCRIPTION
Allows for file info to be request external to preview, and still report timings. 

*Note: Updates are required in Box UI Elements before this can be merged, otherwise false reports will be generated.*