### PR TITLE
Fix: Navigation buttons should not cover scrollbar

### DIFF
--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -1,4 +1,4 @@
-$navigationBtnWidth: 50px;
+$navigationBtnWidth: 40px;
 
 .bp-is-fullscreen .bp-navigate {
     display: none;
@@ -39,6 +39,11 @@ $navigationBtnWidth: 50px;
         box-shadow: none;
         outline: none;
     }
+
+    & > svg {
+        margin-left: -5px;
+        width: 50px;
+    }
 }
 
 .bp-is-navigation-visible .bp-navigate {
@@ -52,9 +57,10 @@ $navigationBtnWidth: 50px;
 .bp-navigate-left {
     border-radius: 0 2px 2px 0;
     left: 0;
+    left: 10px;
 }
 
 .bp-navigate-right {
     border-radius: 2px 0 0 2px;
-    right: 0;
+    right: 10px;
 }


### PR DESCRIPTION
Made the navigation buttons skinnier (though visibly in the same place) to allow room for the scrollbar of the preview content to be clickable to the right of the next file button