### PR TITLE
Fix: navigation buttons shouldn't cover scrollbar

### DIFF
--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -55,10 +55,10 @@ $navigationBtnWidth: 50px;
 
 .bp-navigate-left {
     border-radius: 0 2px 2px 0;
-    left: 15px;
+    left: 20px;
 }
 
 .bp-navigate-right {
     border-radius: 2px 0 0 2px;
-    right: 15px;
+    right: 20px;
 }

--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -1,4 +1,4 @@
-$navigationBtnWidth: 50px;
+$navigationBtnWidth: 40px;
 
 .bp-is-fullscreen .bp-navigate {
     display: none;
@@ -39,6 +39,11 @@ $navigationBtnWidth: 50px;
         box-shadow: none;
         outline: none;
     }
+
+    & > svg {
+        margin-left: -5px;
+        width: 50px;
+    }
 }
 
 .bp-is-navigation-visible .bp-navigate {
@@ -52,9 +57,10 @@ $navigationBtnWidth: 50px;
 .bp-navigate-left {
     border-radius: 0 2px 2px 0;
     left: 0;
+    left: 10px;
 }
 
 .bp-navigate-right {
     border-radius: 2px 0 0 2px;
-    right: 0;
+    right: 10px;
 }

--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -39,10 +39,6 @@ $navigationBtnWidth: 50px;
         box-shadow: none;
         outline: none;
     }
-
-    & > svg {
-        width: 50px;
-    }
 }
 
 .bp-is-navigation-visible .bp-navigate {

--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -1,4 +1,4 @@
-$navigationBtnWidth: 40px;
+$navigationBtnWidth: 50px;
 
 .bp-is-fullscreen .bp-navigate {
     display: none;
@@ -41,7 +41,6 @@ $navigationBtnWidth: 40px;
     }
 
     & > svg {
-        margin-left: -5px;
         width: 50px;
     }
 }
@@ -56,11 +55,10 @@ $navigationBtnWidth: 40px;
 
 .bp-navigate-left {
     border-radius: 0 2px 2px 0;
-    left: 0;
-    left: 10px;
+    left: 15px;
 }
 
 .bp-navigate-right {
     border-radius: 2px 0 0 2px;
-    right: 10px;
+    right: 15px;
 }


### PR DESCRIPTION
Made the navigation buttons skinner, in particular the next file navigation button, in order to allow room for the preview content scrollbar to be clickable