### PR TITLE
Fix: add min-width to video

### DIFF
--- a/src/lib/viewers/media/Dash.scss
+++ b/src/lib/viewers/media/Dash.scss
@@ -4,9 +4,9 @@
     video {
         cursor: none;
         display: block;
-        min-width: 460px;
         max-height: 100%;
         max-width: 100%;
+        min-width: 460px;
         width: 100%;
     }
 

--- a/src/lib/viewers/media/Dash.scss
+++ b/src/lib/viewers/media/Dash.scss
@@ -4,6 +4,7 @@
     video {
         cursor: none;
         display: block;
+        min-width: 460px;
         max-height: 100%;
         max-width: 100%;
         width: 100%;

--- a/src/lib/viewers/media/MediaControls.scss
+++ b/src/lib/viewers/media/MediaControls.scss
@@ -165,16 +165,14 @@
 .bp-media-controls-cc-icon-text {
     background-color: rgba($black, .3); // Anything less than .3 looks too transparent on IE/Edge
     border-radius: 4px;
-    bottom: 2px;
     color: $white;
     display: inline-block;
     font-size: 12px;
     font-weight: 600;
-    height: 22px;
+    height: 24px;
     letter-spacing: .1em;
-    line-height: 22px;
+    line-height: 24px;
     padding: 0 0 0 1px; // Padding left 1px because text isn't perfectly centered on Safari/Firefox even with text-align:center. Looks fine with extra-padding on Chrome/IE/Edge
-    position: relative; // For lining up the bottom with other buttons in the controls bar
     width: 24px;
 
     &:hover {


### PR DESCRIPTION
Issue is that on minimum sized videos, the video controls get too cramped once you max out the content to be displayed. This means that the video needs have a length in hours, not minutes, as well as close captioning as an option. This is only observed when the hover over the volume control expands out to the right. From experimenting, it appears that no matter how small the video is that is uploaded, the conversion upscales it to minimum 480p and when it's rendered is at least 420px wide.

Before:
<img width="463" alt="before min width" src="https://user-images.githubusercontent.com/17791289/44821295-b76d0c80-aba9-11e8-96e3-dbc9cb13526f.png">

After:
<img width="538" alt="after min width" src="https://user-images.githubusercontent.com/17791289/44821308-bd62ed80-aba9-11e8-880c-42465d07c352.png">

The fix was to set a min-width on the video element to be 460px which seems to be wide enough to comfortably render the volume slider, the time display in hours, and the CC button (along with the other default controls).
