### PR TITLE
Fix: construct annotator when BoxAnnotations loads

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -861,6 +861,10 @@ class BaseViewer extends EventEmitter {
         const boxAnnotations = this.options.boxAnnotations || new global.BoxAnnotations(viewerOptions);
         this.annotatorConf = boxAnnotations.determineAnnotator(this.options, this.viewerConfig);
 
+        if (!this.annotatorConf) {
+            return;
+        }
+
         const annotatorOptions = this.createAnnotatorOptions({
             annotator: this.annotatorConf,
             modeButtons: ANNOTATION_BUTTONS

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -835,17 +835,17 @@ class BaseViewer extends EventEmitter {
      * Loads the BoxAnnotations static assets
      *
      * @protected
-     * @return {void}
+     * @return {Promise} promise that is resolved when the assets are loaded
      */
     loadBoxAnnotations() {
         if (
             !this.options.showAnnotations ||
             (window.BoxAnnotations && this.options.boxAnnotations instanceof window.BoxAnnotations)
         ) {
-            return;
+            return Promise.resolve();
         }
 
-        this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS], false).then(this.createAnnotator);
+        return this.loadAssets([ANNOTATIONS_JS], [ANNOTATIONS_CSS], false);
     }
 
     /**
@@ -856,6 +856,10 @@ class BaseViewer extends EventEmitter {
      * @return {void}
      */
     createAnnotator() {
+        if (!this.options.showAnnotations) {
+            return;
+        }
+
         // Set viewer-specific annotation options
         const viewerOptions = {};
         viewerOptions[this.options.viewer.NAME] = this.viewerConfig;

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -79,7 +79,8 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.addCommonListeners).to.be.called;
             expect(getIconFromExtensionStub).to.be.called;
             expect(base.loadTimeout).to.be.a('number');
-            expect(base.loadBoxAnnotations).to.be.called;
+            expect(base.annotatorPromise).to.not.be.undefined;
+            expect(base.annotatorPromiseResolver).to.not.be.undefined;
         });
 
         it('should add a mobile class to the container if on mobile', () => {
@@ -1013,9 +1014,16 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.loadAssets).to.not.be.calledWith(['annotations.js']);
         });
 
-        it('should load the annotations assets', () => {
+        it('should load the annotations assets if showAnnotations option is true', () => {
+            base.options.showAnnotations = true;
             base.loadBoxAnnotations();
             expect(base.loadAssets).to.be.calledWith(['annotations.js'], ['annotations.css'], false);
+        });
+
+        it('should not load the annotations assets if showAnnotations option is false', () => {
+            base.options.showAnnotations = false;
+            base.loadBoxAnnotations();
+            expect(base.loadAssets).to.not.be.called;
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -277,9 +277,9 @@ class DocBaseViewer extends BaseViewer {
         const template = this.options.representation.content.url_template;
         this.pdfUrl = this.createContentUrlWithAuthParams(template);
 
-        return Promise.all([this.boxAnnotationsPromise, this.loadAssets(JS, CSS), this.getRepStatus().getPromise()])
+        return Promise.all([this.loadAssets(JS, CSS), this.getRepStatus().getPromise()])
             .then(this.handleAssetAndRepLoad)
-            .then(this.createAnnotator)
+            .then(this.loadBoxAnnotations)
             .catch(this.handleAssetError);
     }
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -280,6 +280,7 @@ class DocBaseViewer extends BaseViewer {
         return Promise.all([this.loadAssets(JS, CSS), this.getRepStatus().getPromise()])
             .then(this.handleAssetAndRepLoad)
             .then(this.loadBoxAnnotations)
+            .then(this.createAnnotator)
             .catch(this.handleAssetError);
     }
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -277,8 +277,9 @@ class DocBaseViewer extends BaseViewer {
         const template = this.options.representation.content.url_template;
         this.pdfUrl = this.createContentUrlWithAuthParams(template);
 
-        return Promise.all([this.loadAssets(JS, CSS), this.getRepStatus().getPromise()])
+        return Promise.all([this.boxAnnotationsPromise, this.loadAssets(JS, CSS), this.getRepStatus().getPromise()])
             .then(this.handleAssetAndRepLoad)
+            .then(this.createAnnotator)
             .catch(this.handleAssetError);
     }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -410,12 +410,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             sandbox.stub(docBase, 'handleAssetAndRepLoad');
             sandbox.stub(docBase, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             sandbox.stub(docBase, 'loadAssets');
+            sandbox.stub(docBase, 'loadBoxAnnotations');
 
             return docBase.load().then(() => {
                 expect(docBase.loadAssets).to.be.called;
                 expect(docBase.setup).to.be.called;
                 expect(docBase.createContentUrlWithAuthParams).to.be.calledWith('foo');
                 expect(docBase.handleAssetAndRepLoad).to.be.called;
+                expect(docBase.loadBoxAnnotations).to.be.called;
             });
         });
     });

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -56,12 +56,13 @@ class ImageViewer extends ImageBaseViewer {
         const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
-        return Promise.all([this.boxAnnotationsPromise, this.getRepStatus().getPromise()])
+        return this.getRepStatus()
+            .getPromise()
             .then(() => {
                 this.startLoadTimer();
                 this.imageEl.src = downloadUrl;
             })
-            .then(this.createAnnotator)
+            .then(this.loadBoxAnnotations)
             .catch(this.handleAssetError);
     }
 

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -63,6 +63,7 @@ class ImageViewer extends ImageBaseViewer {
                 this.imageEl.src = downloadUrl;
             })
             .then(this.loadBoxAnnotations)
+            .then(this.createAnnotator)
             .catch(this.handleAssetError);
     }
 

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -56,12 +56,12 @@ class ImageViewer extends ImageBaseViewer {
         const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
-        return this.getRepStatus()
-            .getPromise()
+        return Promise.all([this.boxAnnotationsPromise, this.getRepStatus().getPromise()])
             .then(() => {
                 this.startLoadTimer();
                 this.imageEl.src = downloadUrl;
             })
+            .then(this.createAnnotator)
             .catch(this.handleAssetError);
     }
 


### PR DESCRIPTION
Instead of waiting for the Preview viewer to finish loading before constructing the Annotator (which fetches the annotations for the file) we construct the Annotator as soon as the BoxAnnotations static assets are loaded.

From testing on my computer, saw a slight boost of 200-300ms in loading preview with annotations with caching disabled (or about the time it takes to do a network roundtrip for the annotations call). With caching there wasn't much of a time difference since the BoxAnnotations assets were already fetched.