### PR TITLE
Chore: Remove outline from preview container

### DIFF
--- a/src/lib/_common.scss
+++ b/src/lib/_common.scss
@@ -127,6 +127,7 @@ $header-height: 48px;
     justify-content: center;
     left: 0;
     margin: 0;
+    outline: none;
     -webkit-overflow-scrolling: touch;
     padding: 0;
     position: absolute;


### PR DESCRIPTION
Adding the tabindex caused the outline to appear on the preview container

<img width="853" alt="screen shot 2018-11-07 at 1 34 04 pm" src="https://user-images.githubusercontent.com/17791289/48162434-eda5c700-e291-11e8-97f7-d08d68534d1a.png">
