### PR TITLE
Fix: Don't wait when rep status is none

### DIFF
--- a/src/lib/RepStatus.js
+++ b/src/lib/RepStatus.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import { get, appendAuthParams } from './util';
-import { STATUS_SUCCESS, STATUS_VIEWABLE } from './constants';
+import { STATUS_SUCCESS, STATUS_VIEWABLE, STATUS_PENDING, STATUS_NONE } from './constants';
 import PreviewError from './PreviewError';
 import Timer from './Timer';
 import { ERROR_CODE, LOAD_METRIC } from './events';
@@ -142,8 +142,8 @@ class RepStatus extends EventEmitter {
                 this.resolve();
                 break;
 
-            case 'none':
-            case 'pending':
+            case STATUS_NONE:
+            case STATUS_PENDING:
                 // If we are doing some logging, log that the file needed conversion
                 if (this.logger) {
                     this.logger.setUnConverted();
@@ -151,10 +151,12 @@ class RepStatus extends EventEmitter {
 
                 this.emit('conversionpending');
 
-                // Check status again after delay
+                // Check status again after delay or
+                // If status is none, request immediately since conversion
+                // won't kick of until representation is requested
                 this.statusTimeout = setTimeout(() => {
                     this.updateStatus();
-                }, STATUS_UPDATE_INTERVAL_MS);
+                }, status === STATUS_NONE ? 0 : STATUS_UPDATE_INTERVAL_MS);
                 break;
 
             default:

--- a/src/lib/RepStatus.js
+++ b/src/lib/RepStatus.js
@@ -153,7 +153,7 @@ class RepStatus extends EventEmitter {
 
                 // Check status again after delay or
                 // If status is none, request immediately since conversion
-                // won't kick of until representation is requested
+                // won't kick off until representation is requested
                 this.statusTimeout = setTimeout(() => {
                     this.updateStatus();
                 }, status === STATUS_NONE ? 0 : STATUS_UPDATE_INTERVAL_MS);

--- a/src/lib/__tests__/RepStatus-test.js
+++ b/src/lib/__tests__/RepStatus-test.js
@@ -250,7 +250,7 @@ describe('lib/RepStatus', () => {
             expect(repStatus.emit).to.be.calledWith('conversionpending');
         });
 
-        it('should update status after a timeout', () => {
+        it('should update status after a timeout and update interval when pending', () => {
             const clock = sinon.useFakeTimers();
             repStatus.logger = false;
             sandbox.mock(repStatus).expects('updateStatus');
@@ -258,6 +258,17 @@ describe('lib/RepStatus', () => {
 
             repStatus.handleResponse();
             clock.tick(STATUS_UPDATE_INTERVAL_MS + 1);
+            clock.restore();
+        });
+
+        it('should update status immediately after a timeout when none', () => {
+            const clock = sinon.useFakeTimers();
+            repStatus.logger = false;
+            sandbox.mock(repStatus).expects('updateStatus');
+            repStatus.representation.status.state = 'none';
+
+            repStatus.handleResponse();
+            clock.tick(1);
             clock.restore();
         });
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -78,9 +78,10 @@ export const ORIGINAL_REP_NAME = 'ORIGINAL';
 export const PRELOAD_REP_NAME = 'jpg';
 
 export const STATUS_ERROR = 'error';
+export const STATUS_NONE = 'none';
+export const STATUS_PENDING = 'pending';
 export const STATUS_SUCCESS = 'success';
 export const STATUS_VIEWABLE = 'viewable';
-export const STATUS_PENDING = 'pending';
 
 // X-Rep-Hints for Representations API
 export const X_REP_HINT_BASE = '[3d][pdf][text][mp3]';


### PR DESCRIPTION
If representation does not yet exist for a file (status is 'none') don't delay in fetching rep in order to kick off conversion asap.