### PR TITLE
Chore: Downgrade annotations to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^3.3.0",
+    "box-annotations": "2.3.0",
     "box-locales": "^0.0.1",
     "box-react-ui": "^22.7.0",
     "chai": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,10 +1519,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-3.3.0.tgz#1ba56b8039ea697e1eb1b883938570888f648800"
-  integrity sha512-u6PcWds1sb6lMOV4qVaw+n2eF5z99j3JARh6IsLtXtPBJgbFSWV8s5/WIkC2gZWGQQADhfPfrUZoRTWNa/uKqg==
+box-annotations@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-2.3.0.tgz#5cac38171f7f8d9283659e2b243310f19d5ab7d3"
+  integrity sha512-Ea7tPgyJjX7vcnmZIfCorbzHd6oYx/OHVMPnZVQL/dUHR5vRKhLM0610xqwmVlUpk627sqHw5x/APaa+kt4SXg==
 
 box-locales@^0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Will leave it at 2.3 until React Annotations bugs are fully resolved.