### PR TITLE
Update: box-annotations to v3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "^3.7.0",
+    "box-annotations": "^3.7.1",
     "box-locales": "^0.0.1",
     "box-react-ui": "^22.7.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.23.0",
-    "box-annotations": "2.3.0",
+    "box-annotations": "^3.7.0",
     "box-locales": "^0.0.1",
     "box-react-ui": "^22.7.0",
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,10 +1533,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-3.7.0.tgz#876e1df25c7ac3cc533644813caf7f24154c9e8d"
-  integrity sha512-IU8JZpTdiYg4fvNCu8GAW8gzMFmh7rZJaMs6+IXCc8Jo7olHR/vFQ1rOJs68ly+Lo+S39VAkQaD8mqljKFxy+g==
+box-annotations@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-3.7.1.tgz#e059c6d8d87dee8fd22591ed08dc64fb63daffeb"
+  integrity sha512-ImLp5u6g2GVtPL/zHhW90w3EWz5+VXUcYinq1+soqbxiSusOAArktP+KOQ/c+4qh7IILngWJwKup1zKRBVBeGg==
 
 box-locales@^0.0.1:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,10 +1533,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-box-annotations@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-2.3.0.tgz#5cac38171f7f8d9283659e2b243310f19d5ab7d3"
-  integrity sha512-Ea7tPgyJjX7vcnmZIfCorbzHd6oYx/OHVMPnZVQL/dUHR5vRKhLM0610xqwmVlUpk627sqHw5x/APaa+kt4SXg==
+box-annotations@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-3.7.0.tgz#876e1df25c7ac3cc533644813caf7f24154c9e8d"
+  integrity sha512-IU8JZpTdiYg4fvNCu8GAW8gzMFmh7rZJaMs6+IXCc8Jo7olHR/vFQ1rOJs68ly+Lo+S39VAkQaD8mqljKFxy+g==
 
 box-locales@^0.0.1:
   version "0.0.1"


### PR DESCRIPTION
https://github.com/box/box-annotations/releases/tag/v3.7.1

## 3.7.1 (2019-01-25)
* Update Translations (#328) ([39805b8](box/box-annotations@39805b8)), closes [#328](box/box-annotations#328)
* Chore: Add escape hotkey on AnnotationPopover (#327) ([e92ec85](box/box-annotations@e92ec85)), closes [#327](box/box-annotations#327)
* Fix: Highlight selection on Surface (#326) ([6a3b83a](box/box-annotations@6a3b83a)), closes [#326](box/box-annotations#326)
* Fix: Import correct styling for flyout component (#325) ([14d65f6](box/box-annotations@14d65f6)), closes [#325](box/box-annotations#325)
## 3.7.0 (2019-01-22)
* Fix: Creation of highlights on Edge/IE11/Firefox browsers (#322) ([3d9ee7f](https://github.com/box/box-annotations/commit/3d9ee7f)), closes [#322](https://github.com/box/box-annotations/issues/322)
* Docs: Update badges (#324) ([daf18a7](https://github.com/box/box-annotations/commit/daf18a7)), closes [#324](https://github.com/box/box-annotations/issues/324)
## 3.6.0 (2019-01-15)
* Fix: Don't display @mention selector in ACF (#323) ([a474251](https://github.com/box/box-annotations/commit/a474251)), closes [#323](https://github.com/box/box-annotations/issues/323)
* Fix: Drawing threads now destroy their event handlers properly (#317) ([ba3795d](https://github.com/box/box-annotations/commit/ba3795d)), closes [#317](https://github.com/box/box-annotations/issues/317)
* Fix: Functional tests (#320) ([bba4a9c](https://github.com/box/box-annotations/commit/bba4a9c)), closes [#320](https://github.com/box/box-annotations/issues/320)
* Fix: Only unbind listeners from existing DOM elements (#321) ([6a71a9e](https://github.com/box/box-annotations/commit/6a71a9e)), closes [#321](https://github.com/box/box-annotations/issues/321)
* Update: Improve and simplify annotation button and icon styles (#318) ([538fbd2](https://github.com/box/box-annotations/commit/538fbd2)), closes [#318](https://github.com/box/box-annotations/issues/318)
* Chore: Add webpack-dev-server and basic fixture for local dev (#316) ([7e3c01b](https://github.com/box/box-annotations/commit/7e3c01b)), closes [#316](https://github.com/box/box-annotations/issues/316)
* Chore: Update doc and test fixtures to support IE11 (#319) ([6f9d783](https://github.com/box/box-annotations/commit/6f9d783)), closes [#319](https://github.com/box/box-annotations/issues/319)
## 3.5.0 (2018-12-13)
* Fix: AnnotationPopover CSS to not hide popover svgs (#304) ([83ca5b7](https://github.com/box/box-annotations/commit/83ca5b7)), closes [#304](https://github.com/box/box-annotations/issues/304)
* Fix: date appears incorrectly for point annotations in IE11 (#312) ([bcd6ae5](https://github.com/box/box-annotations/commit/bcd6ae5)), closes [#312](https://github.com/box/box-annotations/issues/312)
* Fix: Don't render until AFTER all are fetched (#311) ([0e3fbff](https://github.com/box/box-annotations/commit/0e3fbff)), closes [#311](https://github.com/box/box-annotations/issues/311)
* Fix: Ensure dialog is still visible on undo/redo (#302) ([1c8a7e2](https://github.com/box/box-annotations/commit/1c8a7e2)), closes [#302](https://github.com/box/box-annotations/issues/302)
* Fix: Ensure thread number is persisted for annotation replies (#307) ([734fc6c](https://github.com/box/box-annotations/commit/734fc6c)), closes [#307](https://github.com/box/box-annotations/issues/307)
* Fix: Functional tests to work with React components (#303) ([4f0418e](https://github.com/box/box-annotations/commit/4f0418e)), closes [#303](https://github.com/box/box-annotations/issues/303)
* Fix: Get mode button from header element rather than container (#308) ([b50d72b](https://github.com/box/box-annotations/commit/b50d72b)), closes [#308](https://github.com/box/box-annotations/issues/308)
* Fix: Point image annotations popover should be on annotated element (#305) ([6d71dee](https://github.com/box/box-annotations/commit/6d71dee)), closes [#305](https://github.com/box/box-annotations/issues/305)
* Fix: Reset current annotation thread immediately on save (#313) ([19c89cc](https://github.com/box/box-annotations/commit/19c89cc)), closes [#313](https://github.com/box/box-annotations/issues/313)
* Fix: Reset undo/redo buttons on drawing save/delete (#306) ([441f0f2](https://github.com/box/box-annotations/commit/441f0f2)), closes [#306](https://github.com/box/box-annotations/issues/306)
* Fix: Show comment list scrollbars only on overflow (#314) ([83c143e](https://github.com/box/box-annotations/commit/83c143e)), closes [#314](https://github.com/box/box-annotations/issues/314)
* Chore: Remove NSP from build (defunct) (#315) ([720802f](https://github.com/box/box-annotations/commit/720802f)), closes [#315](https://github.com/box/box-annotations/issues/315)
* Chore: Update test page for annotations 3.4 (#301) ([71afd21](https://github.com/box/box-annotations/commit/71afd21)), closes [#301](https://github.com/box/box-annotations/issues/301)
* Update: CSS className constants for react classNames (#299) ([b472a2e](https://github.com/box/box-annotations/commit/b472a2e)), closes [#299](https://github.com/box/box-annotations/issues/299)
## 3.4.0 (2018-11-28)
* Fix: Dialog not showing when creating points (#295) ([c0ee86f](https://github.com/box/box-annotations/commit/c0ee86f)), closes [#295](https://github.com/box/box-annotations/issues/295)
* Fix: Don't clear selection  if selecting outside of annotated element (#298) ([5e277a0](https://github.com/box/box-annotations/commit/5e277a0)), closes [#298](https://github.com/box/box-annotations/issues/298)
* Fix: Fix test site for IE 11 (#300) ([359bda3](https://github.com/box/box-annotations/commit/359bda3)), closes [#300](https://github.com/box/box-annotations/issues/300)
* Fix: Positioning of undo/redo drawing buttons in header on mobile (#296) ([873394f](https://github.com/box/box-annotations/commit/873394f)), closes [#296](https://github.com/box/box-annotations/issues/296)
* Chore: Add Annotations test page to be hosted by github pages (#294) ([b91ade9](https://github.com/box/box-annotations/commit/b91ade9)), closes [#294](https://github.com/box/box-annotations/issues/294)
* Chore: Ignore js and json in i18n (#297) ([e691bdc](https://github.com/box/box-annotations/commit/e691bdc)), closes [#297](https://github.com/box/box-annotations/issues/297)
## 3.3.0 (2018-11-20)
* Fix: Clear highlight selection on mousedown and hideAnnotations() (#293) ([b60bc56](https://github.com/box/box-annotations/commit/b60bc56)), closes [#293](https://github.com/box/box-annotations/issues/293)
* Fix: Ensure deleteSuccessHandler destroys thread when necessary (#289) ([e972a72](https://github.com/box/box-annotations/commit/e972a72)), closes [#289](https://github.com/box/box-annotations/issues/289)
* Fix: Ensure popover parent element is determined correctly (#292) ([eab98ec](https://github.com/box/box-annotations/commit/eab98ec)), closes [#292](https://github.com/box/box-annotations/issues/292)
* Fix: Popover CSS issues  (#287) ([e64b3f8](https://github.com/box/box-annotations/commit/e64b3f8)), closes [#287](https://github.com/box/box-annotations/issues/287)
* Fix: Reset create highlight UI when mouse hasn't moved on mouseup (#290) ([4abd611](https://github.com/box/box-annotations/commit/4abd611)), closes [#290](https://github.com/box/box-annotations/issues/290)
* Fix: Reset popover UI on re-render/scale events (#284) ([43e5cb0](https://github.com/box/box-annotations/commit/43e5cb0)), closes [#284](https://github.com/box/box-annotations/issues/284)
* Fix: Unfocus textarea on comment post/cancel (#286) ([448347c](https://github.com/box/box-annotations/commit/448347c)), closes [#286](https://github.com/box/box-annotations/issues/286)
* Fix: Unregister drawing on mode cancel (#288) ([12d5f6d](https://github.com/box/box-annotations/commit/12d5f6d)), closes [#288](https://github.com/box/box-annotations/issues/288)
* Chore: Remove unecesary highlightThread.onMouseDown() (#291) ([a01db9f](https://github.com/box/box-annotations/commit/a01db9f)), closes [#291](https://github.com/box/box-annotations/issues/291)
* Update: Husky scripts (#285) ([eaff0f0](https://github.com/box/box-annotations/commit/eaff0f0)), closes [#285](https://github.com/box/box-annotations/issues/285)
* Mojito: Update translations (#283) ([529bbc0](https://github.com/box/box-annotations/commit/529bbc0)), closes [#283](https://github.com/box/box-annotations/issues/283)
## 3.2.0 (2018-11-13)
* Mojito: Update translations (#282) ([48d2f8f](https://github.com/box/box-annotations/commit/48d2f8f)), closes [#282](https://github.com/box/box-annotations/issues/282)
## 3.1.0 (2018-11-07)
* Fix: Alignment of createdAt timestamp and user's name (#277) ([b4980fb](https://github.com/box/box-annotations/commit/b4980fb)), closes [#277](https://github.com/box/box-annotations/issues/277)
* Fix: Ensure drawings are only registered once with the controller (#278) ([feedc87](https://github.com/box/box-annotations/commit/feedc87)), closes [#278](https://github.com/box/box-annotations/issues/278)
* Fix: Ensure onSelectionChange isn't triggered while creating highlights (#281) ([3130210](https://github.com/box/box-annotations/commit/3130210)), closes [#281](https://github.com/box/box-annotations/issues/281)
* Fix: Remove clickHandler from DrawingModeController (#280) ([0c7fe0f](https://github.com/box/box-annotations/commit/0c7fe0f)), closes [#280](https://github.com/box/box-annotations/issues/280)
* Fix: Remove focus trap on AnnotationPopover on mobile (#279) ([a14fe6b](https://github.com/box/box-annotations/commit/a14fe6b)), closes [#279](https://github.com/box/box-annotations/issues/279)
* Chore: Fix publish script (#275) ([25c40f7](https://github.com/box/box-annotations/commit/25c40f7)), closes [#275](https://github.com/box/box-annotations/issues/275)
* Chore: Upgrade husky (#276) ([14bda8a](https://github.com/box/box-annotations/commit/14bda8a)), closes [#276](https://github.com/box/box-annotations/issues/276)
## 3.0.0 (2018-10-31)
* Chore: Adding rsync to yarn run watch (#241) ([afe6ab6](https://github.com/box/box-annotations/commit/afe6ab6)), closes [#241](https://github.com/box/box-annotations/issues/241)
* Chore: Cleanup flow types (#274) ([33adb47](https://github.com/box/box-annotations/commit/33adb47)), closes [#274](https://github.com/box/box-annotations/issues/274)
* Chore: Reduce redundant point creation via buffering (#237) ([2bfc2f1](https://github.com/box/box-annotations/commit/2bfc2f1)), closes [#237](https://github.com/box/box-annotations/issues/237)
* Breaking: Migrate Annotations UI into React (#251) ([d853b80](https://github.com/box/box-annotations/commit/d853b80)), closes [#251](https://github.com/box/box-annotations/issues/251)
## 2.3.0 (2018-10-16)
* Chore: Add supported excel types. Remove greenkeeper badge (#227) ([8bd1bb9](https://github.com/box/box-annotations/commit/8bd1bb9)), closes [#227](https://github.com/box/box-annotations/issues/227)
* Chore: break text to fit into dialog (#230) ([3a5cc86](https://github.com/box/box-annotations/commit/3a5cc86)), closes [#230](https://github.com/box/box-annotations/issues/230)
* Chore: Remove unused thread.mouseoutHandler() (#206) ([1017082](https://github.com/box/box-annotations/commit/1017082)), closes [#206](https://github.com/box/box-annotations/issues/206)
* Chore: Replace Karma with Jest for testing framework (#199) ([a847b01](https://github.com/box/box-annotations/commit/a847b01)), closes [#199](https://github.com/box/box-annotations/issues/199)
* Chore: Update preview version to 1.54.0 in functional tests (#239) ([6de2cf4](https://github.com/box/box-annotations/commit/6de2cf4)), closes [#239](https://github.com/box/box-annotations/issues/239)
* Fix: Cursor type in annotation dialog (#195) ([b568288](https://github.com/box/box-annotations/commit/b568288)), closes [#195](https://github.com/box/box-annotations/issues/195)
* Fix: Functional tests scripts ([2dfc22e](https://github.com/box/box-annotations/commit/2dfc22e))
* Fix: travis.yml config (#203) ([a71ecb6](https://github.com/box/box-annotations/commit/a71ecb6)), closes [#203](https://github.com/box/box-annotations/issues/203)
* Update: Annotations with header (#233) ([91cdce3](https://github.com/box/box-annotations/commit/91cdce3)), closes [#233](https://github.com/box/box-annotations/issues/233)
* Update: box-react-ui to v25.6.0 (#204) ([398b4c3](https://github.com/box/box-annotations/commit/398b4c3)), closes [#204](https://github.com/box/box-annotations/issues/204)
* Update: Filter multi-image functional tests separately from image tests ([b15a007](https://github.com/box/box-annotations/commit/b15a007))
* Update: Test yaml changes ([bb58296](https://github.com/box/box-annotations/commit/bb58296))
* Update: Webpack 4 + dependencies (#208) ([b2ba5df](https://github.com/box/box-annotations/commit/b2ba5df)), closes [#208](https://github.com/box/box-annotations/issues/208)
* Update .travis.yml ([9c09e8e](https://github.com/box/box-annotations/commit/9c09e8e))
* Update .travis.yml ([236c383](https://github.com/box/box-annotations/commit/236c383))
* Update add-annotation-type.md ([fcceb3e](https://github.com/box/box-annotations/commit/fcceb3e))
* Update add-annotation-type.md ([ca5c6f0](https://github.com/box/box-annotations/commit/ca5c6f0))
* Update webpack.selenium.config.js ([e008f68](https://github.com/box/box-annotations/commit/e008f68))
* New: Add functional tests for image files (#197) ([7c7b39e](https://github.com/box/box-annotations/commit/7c7b39e)), closes [#197](https://github.com/box/box-annotations/issues/197)