### PR TITLE
Update: Emit thumbnails[Open|Close] viewer event

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -693,7 +693,7 @@ class DocBaseViewer extends BaseViewer {
         }
 
         // Save page and return after resize
-        const { currentPageNumber } = this.pdfViewer.currentPageNumber;
+        const { currentPageNumber } = this.pdfViewer;
 
         this.pdfViewer.currentScaleValue = this.pdfViewer.currentScaleValue || 'auto';
         this.pdfViewer.update();
@@ -1297,10 +1297,19 @@ class DocBaseViewer extends BaseViewer {
         this.thumbnailsSidebarEl.classList.toggle(CLASS_HIDDEN);
 
         const { pagesCount } = this.pdfViewer;
-        const metricName = this.thumbnailsSidebarEl.classList.contains(CLASS_HIDDEN)
-            ? USER_DOCUMENT_THUMBNAIL_EVENTS.CLOSE
-            : USER_DOCUMENT_THUMBNAIL_EVENTS.OPEN;
+
+        let metricName;
+        let eventName;
+        if (this.thumbnailsSidebarEl.classList.contains(CLASS_HIDDEN)) {
+            metricName = USER_DOCUMENT_THUMBNAIL_EVENTS.CLOSE;
+            eventName = 'thumbnailsClose';
+        } else {
+            metricName = USER_DOCUMENT_THUMBNAIL_EVENTS.OPEN;
+            eventName = 'thumbnailsOpen';
+        }
+
         this.emitMetric({ name: metricName, data: pagesCount });
+        this.emit(eventName);
 
         this.resize();
     }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2096,9 +2096,10 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         beforeEach(() => {
             sandbox.stub(docBase, 'resize');
             sandbox.stub(docBase, 'emitMetric');
+            sandbox.stub(docBase, 'emit');
         });
 
-        it('should do nothing if thumbnails sidebar does not exit', () => {
+        it('should do nothing if thumbnails sidebar does not exist', () => {
             docBase.thumbnailsSidebarEl = undefined;
 
             docBase.toggleThumbnails();
@@ -2117,6 +2118,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(thumbnailsSidebarEl.classList.contains(CLASS_HIDDEN)).to.be.false;
             expect(docBase.resize).to.be.called;
             expect(docBase.emitMetric).to.be.calledWith({ name: USER_DOCUMENT_THUMBNAIL_EVENTS.OPEN, data: 10 });
+            expect(docBase.emit).to.be.calledWith('thumbnailsOpen');
         });
 
         it('should toggle close and resize the viewer', () => {
@@ -2131,6 +2133,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(thumbnailsSidebarEl.classList.contains(CLASS_HIDDEN)).to.be.true;
             expect(docBase.resize).to.be.called;
             expect(docBase.emitMetric).to.be.calledWith({ name: USER_DOCUMENT_THUMBNAIL_EVENTS.CLOSE, data: 10 });
+            expect(docBase.emit).to.be.calledWith('thumbnailsClose');
         });
     });
 


### PR DESCRIPTION
Emits new viewer events `thumbnailsOpen` and `thumbnailsClose` when the thumbnails sidebar is toggled opened and closed.