### PR TITLE
Chore: Fix fullscreen nav and hide toggle thumbnail button

### DIFF
--- a/src/lib/_common.scss
+++ b/src/lib/_common.scss
@@ -149,6 +149,7 @@ $header-height: 48px;
         align-items: center;
         display: flex;
         flex: 1 1 auto;
+        min-width: 100%;
         position: relative;
     }
 }

--- a/src/lib/shell.html
+++ b/src/lib/shell.html
@@ -33,7 +33,7 @@
             </div>
         </div>
     </div>
-    <div class="bp" data-testid="bp">
+    <div class="bp" tabindex="0" data-testid="bp">
         <div class="bp-loading-wrapper">
             <div class="bp-loading">
                 <div class="bp-icon bp-icon-file"></div>

--- a/src/lib/shell.html
+++ b/src/lib/shell.html
@@ -33,7 +33,7 @@
             </div>
         </div>
     </div>
-    <div class="bp" tabindex="0" data-testid="bp">
+    <div class="bp" data-testid="bp">
         <div class="bp-loading-wrapper">
             <div class="bp-loading">
                 <div class="bp-icon bp-icon-file"></div>
@@ -50,7 +50,7 @@
                 <button class="bp-btn-plain bp-btn-loading-download bp-is-invisible"></button>
             </div>
         </div>
-        <div class="bp-content" data-testid="bp-content">
+        <div class="bp-content" tabindex="0" data-testid="bp-content">
             <button class="bp-btn-plain bp-navigate bp-navigate-left bp-is-hidden">
                 <svg viewBox="0 0 48 48" focusable="false">
                     <path fill="#494949" stroke="#DCDCDC" stroke-miterlimit="10" d="M30.8,33.2L21.7,24l9.2-9.2L28,12L16,24l12,12L30.8,33.2z"/>

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -178,3 +178,8 @@ $thumbnail-border-radius: 4px;
         display: block;
     }
 }
+
+// Hide the toggle thumbnails button when in fullscreen
+.bp-content.bp-is-fullscreen .bp-toggle-thumbnails-icon {
+    display: none;
+}


### PR DESCRIPTION
* Re-enables keyboard nav while in fullscreen
* Hides the toggle thumbnail button from the document controls while in fullscreen because thumbnail sidebar is not visible anyway
* applies a `min-width` to the `.bp-content` div so that fullscreen works in Safari