### PR TITLE
Chore: Move loading wrapper inside bp-content

### DIFF
--- a/src/lib/_loading.scss
+++ b/src/lib/_loading.scss
@@ -57,7 +57,6 @@
     color: $twos;
     position: relative;
     text-align: center;
-    z-index: 1;
 }
 
 .bp-loading-btn-container {

--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -13,6 +13,7 @@ $navigationBtnWidth: 50px;
     margin: 0;
     opacity: 0;
     overflow: hidden;
+    pointer-events: all;
     position: absolute;
     text-decoration: none;
     top: 50%;

--- a/src/lib/shell.html
+++ b/src/lib/shell.html
@@ -34,23 +34,23 @@
         </div>
     </div>
     <div class="bp" tabindex="0" data-testid="bp">
-        <div class="bp-loading-wrapper">
-            <div class="bp-loading">
-                <div class="bp-icon bp-icon-file"></div>
-                <div class="bp-crawler-wrapper">
-                    <div class="bp-crawler">
-                        <div></div>
-                        <div></div>
-                        <div></div>
-                    </div>
-                </div>
-                <span class="bp-loading-text"></span>
-            </div>
-            <div class="bp-loading-btn-container">
-                <button class="bp-btn-plain bp-btn-loading-download bp-is-invisible"></button>
-            </div>
-        </div>
         <div class="bp-content" tabindex="0" data-testid="bp-content">
+            <div class="bp-loading-wrapper">
+                <div class="bp-loading">
+                    <div class="bp-icon bp-icon-file"></div>
+                    <div class="bp-crawler-wrapper">
+                        <div class="bp-crawler">
+                            <div></div>
+                            <div></div>
+                            <div></div>
+                        </div>
+                    </div>
+                    <span class="bp-loading-text"></span>
+                </div>
+                <div class="bp-loading-btn-container">
+                    <button class="bp-btn-plain bp-btn-loading-download bp-is-invisible"></button>
+                </div>
+            </div>
             <button class="bp-btn-plain bp-navigate bp-navigate-left bp-is-hidden">
                 <svg viewBox="0 0 48 48" focusable="false">
                     <path fill="#494949" stroke="#DCDCDC" stroke-miterlimit="10" d="M30.8,33.2L21.7,24l9.2-9.2L28,12L16,24l12,12L30.8,33.2z"/>


### PR DESCRIPTION
Fixes the issue where the file navigation buttons were not clickable while the viewer was loading.

The issue is that before the viewer is loaded `pointer-events: none` is applied to `.bp` div and is inherited by all the descendants except for the `.bp-loading-wrapper` child which sets `pointer-events: all` and `z-index: 1` (to appear above the viewer div). 

The solution here is to move the `.bp-loading-wrapper` inside of `.bp-content` instead of being a peer and override the `pointer-events` property on the navigation buttons so that they're always clickable