### PR TITLE
Chore(compression): Test for disabling gzip for Japan

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -798,7 +798,9 @@ class DocBaseViewer extends BaseViewer {
         // more than the additional time for a continuous request. This also overrides any range request
         // disabling that may be set by pdf.js's compatibility checking since the browsers we support
         // should all be able to properly handle range requests.
-        PDFJS.disableRange = location.locale !== 'en-US' && size < MINIMUM_RANGE_REQUEST_FILE_SIZE_NON_US;
+        // TEST - Also disabling for Japan to compare GZIP compression results
+        PDFJS.disableRange =
+            location.locale !== 'en-US' && location.locale !== 'ja-JP' && size < MINIMUM_RANGE_REQUEST_FILE_SIZE_NON_US;
 
         // Disable range requests for watermarked files since they are streamed
         PDFJS.disableRange = PDFJS.disableRange || (watermarkInfo && watermarkInfo.is_watermarked);

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -607,7 +607,8 @@ class DocBaseViewer extends BaseViewer {
         let rangeChunkSize = this.getViewerOption('rangeChunkSize');
 
         // If range requests are disabled, request the gzip compressed version of the representation
-        this.encoding = PDFJS.disableRange ? ENCODING_TYPES.GZIP : undefined;
+        this.encoding =
+            PDFJS.disableRange && this.options.location.locale !== 'ja-JP' ? ENCODING_TYPES.GZIP : undefined;
 
         // Otherwise, use large chunk size if locale is en-US and the default,
         // smaller chunk size if not. This is using a rough assumption that
@@ -799,8 +800,7 @@ class DocBaseViewer extends BaseViewer {
         // disabling that may be set by pdf.js's compatibility checking since the browsers we support
         // should all be able to properly handle range requests.
         // TEST - Also disabling for Japan to compare GZIP compression results
-        PDFJS.disableRange =
-            location.locale !== 'en-US' && location.locale !== 'ja-JP' && size < MINIMUM_RANGE_REQUEST_FILE_SIZE_NON_US;
+        PDFJS.disableRange = location.locale !== 'en-US' && size < MINIMUM_RANGE_REQUEST_FILE_SIZE_NON_US;
 
         // Disable range requests for watermarked files since they are streamed
         PDFJS.disableRange = PDFJS.disableRange || (watermarkInfo && watermarkInfo.is_watermarked);

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1321,16 +1321,22 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             expect(PDFJS.disableRange).to.be.false;
         });
 
+        it('should not disable range requests if the locale is ja-JP', () => {
+            docBase.options.location.locale = 'ja-JP';
+            docBase.setupPdfjs();
+            expect(PDFJS.disableRange).to.be.false;
+        });
+
         it('should disable range requests if locale is not en-US, the file is smaller than 25MB and is not an Excel file', () => {
             docBase.options.file.size = 26000000;
             docBase.options.extension = 'pdf';
-            docBase.options.location.locale = 'ja-JP';
+            docBase.options.location.locale = 'en-UK';
             docBase.setupPdfjs();
             expect(PDFJS.disableRange).to.be.true;
         });
 
         it('should enable range requests if locale is not en-US, the file is greater than 25MB and is not watermarked', () => {
-            docBase.options.location.locale = 'ja-JP';
+            docBase.options.location.locale = 'en-UK';
             docBase.options.file.size = 26500000;
             docBase.options.extension = 'pdf';
             docBase.options.file.watermark_info.is_watermarked = false;
@@ -1339,7 +1345,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
 
         it('should disable range requests if the file is watermarked', () => {
-            docBase.options.location.locale = 'ja-JP';
+            docBase.options.location.locale = 'en-UK';
             docBase.options.file.watermark_info.is_watermarked = true;
             docBase.setupPdfjs();
             expect(PDFJS.disableRange).to.be.true;


### PR DESCRIPTION
Note that we're allowing for watermarked content to still be served as usual.