### PR TITLE
Fix: Only execute viewer setup if not already setup

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,7 +92,7 @@
                 }
 
                 /* global Box */
-                var preview = new Box.Preview();
+                preview = new Box.Preview();
 
                 var previewOptions = options || {
                     enableThumbnailsSidebar: true,

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1161,6 +1161,9 @@ class Preview extends EventEmitter {
         // Add listeners for viewer events
         this.attachViewerListeners();
 
+        // Setup the viewer DOM
+        this.viewer.setup();
+
         // Load the representation into the viewer
         this.viewer.load();
 
@@ -1471,6 +1474,9 @@ class Preview extends EventEmitter {
 
         // Instantiate the error viewer
         this.viewer = this.getErrorViewer();
+
+        // Setup error viewer
+        this.viewer.setup();
 
         // Add listeners for viewer events
         this.attachViewerListeners();

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1577,7 +1577,8 @@ describe('lib/Preview', () => {
             stubs.viewer = {
                 load: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getName: sandbox.stub()
+                getName: sandbox.stub(),
+                setup: sandbox.stub()
             };
 
             /* eslint-disable require-jsdoc */
@@ -2163,7 +2164,8 @@ describe('lib/Preview', () => {
     describe('triggerError()', () => {
         const ErrorViewer = {
             load: sandbox.stub(),
-            addListener: sandbox.stub()
+            addListener: sandbox.stub(),
+            setup: sandbox.stub()
         };
 
         beforeEach(() => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -9,7 +9,6 @@ export const CLASS_BOX_PREVIEW_CONTENT = 'bp-content';
 export const CLASS_BOX_PREVIEW_FIND_BAR = 'bp-find-bar';
 export const CLASS_BOX_PREVIEW_HAS_HEADER = 'bp-has-header';
 export const CLASS_BOX_PREVIEW_HAS_NAVIGATION = 'bp-has-navigation';
-export const CLASS_BOX_PREVIEW_HAS_VIEWER = 'bp-has-viewer';
 export const CLASS_BOX_PREVIEW_HEADER = 'bp-header';
 export const CLASS_BOX_PREVIEW_HEADER_CONTAINER = 'bp-header-container';
 export const CLASS_BOX_PREVIEW_BASE_HEADER = 'bp-base-header';

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -9,6 +9,7 @@ export const CLASS_BOX_PREVIEW_CONTENT = 'bp-content';
 export const CLASS_BOX_PREVIEW_FIND_BAR = 'bp-find-bar';
 export const CLASS_BOX_PREVIEW_HAS_HEADER = 'bp-has-header';
 export const CLASS_BOX_PREVIEW_HAS_NAVIGATION = 'bp-has-navigation';
+export const CLASS_BOX_PREVIEW_HAS_VIEWER = 'bp-has-viewer';
 export const CLASS_BOX_PREVIEW_HEADER = 'bp-header';
 export const CLASS_BOX_PREVIEW_HEADER_CONTAINER = 'bp-header-container';
 export const CLASS_BOX_PREVIEW_BASE_HEADER = 'bp-base-header';

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -18,6 +18,7 @@ import {
     replacePlaceholders
 } from '../util';
 import {
+    ANNOTATOR_EVENT,
     CLASS_BOX_PREVIEW_MOBILE,
     CLASS_HIDDEN,
     FILE_OPTION_START,
@@ -26,11 +27,9 @@ import {
     SELECTOR_BOX_PREVIEW_CONTENT,
     SELECTOR_BOX_PREVIEW_CRAWLER_WRAPPER,
     SELECTOR_BOX_PREVIEW_ICON,
-    STATUS_SUCCESS,
-    STATUS_VIEWABLE,
     SELECTOR_BOX_PREVIEW,
-    ANNOTATOR_EVENT,
-    CLASS_BOX_PREVIEW_HAS_VIEWER
+    STATUS_SUCCESS,
+    STATUS_VIEWABLE
 } from '../constants';
 import { getIconFromExtension, getIconFromName } from '../icons/icons';
 import { VIEWER_EVENT, ERROR_CODE, LOAD_METRIC, DOWNLOAD_REACHABILITY_METRICS } from '../events';
@@ -115,6 +114,9 @@ class BaseViewer extends EventEmitter {
     /** @property {HTMLElement} - The .bp-content which is the container for the viewer's content */
     containerEl;
 
+    /** @property {boolean} - Stores whether the Viewer has been setup yet. */
+    isSetup = false;
+
     /**
      * [constructor]
      *
@@ -157,7 +159,7 @@ class BaseViewer extends EventEmitter {
      * @return {void}
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -198,14 +200,8 @@ class BaseViewer extends EventEmitter {
                 this.annotatorPromiseResolver = resolve;
             });
         }
-    }
 
-    /**
-     * Checks to see whether the viewer has been setup already
-     * @return {boolean} - Boolean whether the viewer has been set up yet
-     */
-    isSetup() {
-        return this.containerEl && this.containerEl.classList.contains(CLASS_BOX_PREVIEW_HAS_VIEWER);
+        this.isSetup = true;
     }
 
     /**
@@ -247,7 +243,6 @@ class BaseViewer extends EventEmitter {
         if (this.containerEl) {
             this.containerEl.removeEventListener('contextmenu', this.preventDefault);
             this.containerEl.innerHTML = '';
-            this.containerEl.classList.remove(CLASS_BOX_PREVIEW_HAS_VIEWER);
         }
 
         // Destroy the annotator
@@ -1163,8 +1158,6 @@ class BaseViewer extends EventEmitter {
             // file buttons on top of the previewed content
             addedElement = this.containerEl.insertBefore(element, firstChildEl);
         }
-
-        this.containerEl.classList.add(CLASS_BOX_PREVIEW_HAS_VIEWER);
 
         return addedElement;
     }

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -29,7 +29,8 @@ import {
     STATUS_SUCCESS,
     STATUS_VIEWABLE,
     SELECTOR_BOX_PREVIEW,
-    ANNOTATOR_EVENT
+    ANNOTATOR_EVENT,
+    CLASS_BOX_PREVIEW_HAS_VIEWER
 } from '../constants';
 import { getIconFromExtension, getIconFromName } from '../icons/icons';
 import { VIEWER_EVENT, ERROR_CODE, LOAD_METRIC, DOWNLOAD_REACHABILITY_METRICS } from '../events';
@@ -156,6 +157,10 @@ class BaseViewer extends EventEmitter {
      * @return {void}
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         if (this.options.file) {
             const fileExt = this.options.file.extension;
             this.fileLoadingIcon = getIconFromExtension(fileExt);
@@ -193,6 +198,14 @@ class BaseViewer extends EventEmitter {
                 this.annotatorPromiseResolver = resolve;
             });
         }
+    }
+
+    /**
+     * Checks to see whether the viewer has been setup already
+     * @return {boolean} - Boolean whether the viewer has been set up yet
+     */
+    isSetup() {
+        return this.containerEl && this.containerEl.classList.contains(CLASS_BOX_PREVIEW_HAS_VIEWER);
     }
 
     /**
@@ -234,6 +247,7 @@ class BaseViewer extends EventEmitter {
         if (this.containerEl) {
             this.containerEl.removeEventListener('contextmenu', this.preventDefault);
             this.containerEl.innerHTML = '';
+            this.containerEl.classList.remove(CLASS_BOX_PREVIEW_HAS_VIEWER);
         }
 
         // Destroy the annotator
@@ -1149,6 +1163,8 @@ class BaseViewer extends EventEmitter {
             // file buttons on top of the previewed content
             addedElement = this.containerEl.insertBefore(element, firstChildEl);
         }
+
+        this.containerEl.classList.add(CLASS_BOX_PREVIEW_HAS_VIEWER);
 
         return addedElement;
     }

--- a/src/lib/viewers/box3d/Box3DViewer.js
+++ b/src/lib/viewers/box3d/Box3DViewer.js
@@ -62,6 +62,10 @@ class Box3DViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/box3d/Box3DViewer.js
+++ b/src/lib/viewers/box3d/Box3DViewer.js
@@ -62,7 +62,7 @@ class Box3DViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -183,7 +183,6 @@ class Box3DViewer extends BaseViewer {
      * @return {Promise} to load assets and representation
      */
     load() {
-        this.setup();
         super.load();
         return Promise.all([this.loadAssets(JS), this.getRepStatus().getPromise()])
             .then(this.postLoad)

--- a/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
+++ b/src/lib/viewers/box3d/__tests__/Box3DViewer-test.js
@@ -358,7 +358,6 @@ describe('lib/viewers/box3d/Box3DViewer', () => {
         });
 
         it('should call renderer.load()', () => {
-            Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
             box3d.containerEl = document.querySelector(SELECTOR_BOX_PREVIEW_CONTENT);
             Object.defineProperty(BaseViewer.prototype, 'load', { value: sandbox.mock() });
             sandbox.stub(box3d, 'loadAssets').returns(Promise.resolve());

--- a/src/lib/viewers/box3d/image360/Image360Viewer.js
+++ b/src/lib/viewers/box3d/image360/Image360Viewer.js
@@ -11,7 +11,7 @@ class Image360Viewer extends Box3DViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/box3d/image360/Image360Viewer.js
+++ b/src/lib/viewers/box3d/image360/Image360Viewer.js
@@ -11,6 +11,10 @@ class Image360Viewer extends Box3DViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/box3d/model3d/Model3DViewer.js
+++ b/src/lib/viewers/box3d/model3d/Model3DViewer.js
@@ -59,7 +59,7 @@ class Model3DViewer extends Box3DViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/box3d/model3d/Model3DViewer.js
+++ b/src/lib/viewers/box3d/model3d/Model3DViewer.js
@@ -59,6 +59,10 @@ class Model3DViewer extends Box3DViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -46,6 +46,10 @@ class Video360Viewer extends DashViewer {
 
     /** @inheritdoc */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -46,7 +46,7 @@ class Video360Viewer extends DashViewer {
 
     /** @inheritdoc */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -100,6 +100,10 @@ class DocBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -190,6 +190,8 @@ class DocBaseViewer extends BaseViewer {
 
         if (this.thumbnailsSidebar) {
             this.thumbnailsSidebar.destroy();
+            this.thumbnailsSidebarEl.remove();
+            this.thumbnailsSidebarEl = null;
         }
 
         super.destroy();

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -100,7 +100,7 @@ class DocBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -307,7 +307,6 @@ class DocBaseViewer extends BaseViewer {
      * @return {Promise} Promise to resolve assets
      */
     load() {
-        this.setup();
         super.load();
         this.showPreload();
 

--- a/src/lib/viewers/doc/DocumentViewer.js
+++ b/src/lib/viewers/doc/DocumentViewer.js
@@ -12,6 +12,10 @@ class DocumentViewer extends DocBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
         this.docEl.classList.add('bp-doc-document');

--- a/src/lib/viewers/doc/DocumentViewer.js
+++ b/src/lib/viewers/doc/DocumentViewer.js
@@ -12,7 +12,7 @@ class DocumentViewer extends DocBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -30,7 +30,7 @@ class PresentationViewer extends DocBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -30,6 +30,10 @@ class PresentationViewer extends DocBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
         this.docEl.classList.add('bp-doc-presentation');

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -494,7 +494,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             return docBase.load().then(() => {
                 expect(docBase.loadAssets).to.be.called;
-                expect(docBase.setup).to.be.called;
+                expect(docBase.setup).not.to.be.called;
                 expect(docBase.createContentUrlWithAuthParams).to.be.calledWith('foo');
                 expect(docBase.handleAssetAndRepLoad).to.be.called;
             });

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -21,7 +21,7 @@ class PreviewErrorViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -69,8 +69,6 @@ class PreviewErrorViewer extends BaseViewer {
      * @return {void}
      */
     load(err) {
-        this.setup();
-
         const error =
             err instanceof PreviewError
                 ? err

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -21,6 +21,10 @@ class PreviewErrorViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -29,6 +29,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
         });
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
         error.containerEl = containerEl;
+        error.setup();
     });
 
     afterEach(() => {
@@ -45,7 +46,6 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
     describe('setup()', () => {
         it('should set appropriate properties', () => {
-            error.setup();
             expect(error.infoEl.classList.contains('bp-error')).to.be.true;
             expect(error.iconEl instanceof HTMLElement).to.be.true;
             expect(error.iconEl.parentNode).to.equal(error.infoEl);
@@ -55,12 +55,7 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
     });
 
     describe('load()', () => {
-        [
-            ['zip', true],
-            ['tgz', true],
-            ['flv', true],
-            ['blah', false]
-        ].forEach((testCase) => {
+        [['zip', true], ['tgz', true], ['flv', true], ['blah', false]].forEach((testCase) => {
             it('should set appropriate icon', () => {
                 const getIconFromExtensionStub = sandbox.stub(icons, 'getIconFromExtension');
                 const getIconFromNameStub = sandbox.stub(icons, 'getIconFromName');
@@ -132,11 +127,9 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
             error.load(err);
 
-            expect(error.emit).to.be.calledWith(
-                VIEWER_EVENT.load, {
-                    error: 'this is bad'
-                }
-            );
+            expect(error.emit).to.be.calledWith(VIEWER_EVENT.load, {
+                error: 'this is bad'
+            });
         });
 
         it('should broadcast the display message if there is no error message', () => {
@@ -145,32 +138,31 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
             error.load(err);
 
-            expect(error.emit).to.be.calledWith(
-                VIEWER_EVENT.load, {
-                    error: 'display message!'
-                }
-            );
+            expect(error.emit).to.be.calledWith(VIEWER_EVENT.load, {
+                error: 'display message!'
+            });
         });
 
         it('should filter out access tokens before broadcasting', () => {
             sandbox.stub(error, 'emit');
-            const err = new PreviewError('some_code', 'display', {},
+            const err = new PreviewError(
+                'some_code',
+                'display',
+                {},
                 'Unexpected server response (0) while retrieving PDF "www.box.com?access_token=blah&test=okay"'
             );
 
             error.load(err);
 
-            expect(error.emit).to.be.calledWith(
-                VIEWER_EVENT.load, {
-                    error: 'Unexpected server response (0) while retrieving PDF "www.box.com?access_token=[FILTERED]&test=okay"'
-                }
-            );
+            expect(error.emit).to.be.calledWith(VIEWER_EVENT.load, {
+                error:
+                    'Unexpected server response (0) while retrieving PDF "www.box.com?access_token=[FILTERED]&test=okay"'
+            });
         });
     });
 
     describe('addLinkButton()', () => {
         it('should add a link button with the appropriate message and URL', () => {
-            error.setup();
             error.addLinkButton('test', 'someUrl');
             const linkBtnEl = error.infoEl.querySelector('a');
 
@@ -183,7 +175,6 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
     describe('addDownloadButton()', () => {
         it('should add a download button and attach a download click handler', () => {
-            error.setup();
             sandbox.stub(error, 'download');
 
             error.addDownloadButton();
@@ -201,7 +192,6 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
     describe('download()', () => {
         it('should emit download', () => {
-            error.setup();
             sandbox.stub(error, 'emit');
             error.download();
             expect(error.emit).to.be.calledWith(VIEWER_EVENT.download);
@@ -210,7 +200,6 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
 
     describe('destroy()', () => {
         it('should remove download button click handler', () => {
-            error.setup();
             sandbox.stub(error, 'download');
 
             error.addDownloadButton();

--- a/src/lib/viewers/iframe/IFrameViewer.js
+++ b/src/lib/viewers/iframe/IFrameViewer.js
@@ -6,6 +6,10 @@ class IFrameViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/iframe/IFrameViewer.js
+++ b/src/lib/viewers/iframe/IFrameViewer.js
@@ -6,7 +6,7 @@ class IFrameViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -27,8 +27,6 @@ class IFrameViewer extends BaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
-
         let src = '';
         const { file, sharedLink = '', appHost } = this.options;
         const { extension } = file;

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -25,6 +25,7 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
         iframe.containerEl = containerEl;
+        iframe.setup();
     });
 
     afterEach(() => {
@@ -41,7 +42,6 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
     describe('setup()', () => {
         it('should setup iframe element and load timeout', () => {
-            iframe.setup();
             expect(iframe.iframeEl).to.be.instanceof(HTMLElement);
             expect(iframe.iframeEl).to.have.attribute('width', '100%');
             expect(iframe.iframeEl).to.have.attribute('height', '100%');

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -28,6 +28,10 @@ class ImageViewer extends ImageBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -28,7 +28,7 @@ class ImageViewer extends ImageBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -53,7 +53,6 @@ class ImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
         super.load();
 
         const { representation, viewer } = this.options;

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -29,6 +29,10 @@ class MultiImageViewer extends ImageBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -29,7 +29,7 @@ class MultiImageViewer extends ImageBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -76,7 +76,6 @@ class MultiImageViewer extends ImageBaseViewer {
      * @return {Promise} Promise to load bunch of images
      */
     load() {
-        this.setup();
         super.load();
 
         // Hides images until content is loaded

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -236,6 +236,7 @@ describe('lib/viewers/image/ImageViewer', () => {
             image.wrapperEl.style.height = '50px';
 
             sandbox.stub(image, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
+            image.setup();
             image.load(imageUrl).catch(() => {});
         });
 

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -67,6 +67,7 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             value: sandbox.stub().returns(Promise.resolve())
         });
         multiImage.containerEl = containerEl;
+        multiImage.setup();
     });
 
     afterEach(() => {

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -44,6 +44,10 @@ class DashViewer extends VideoBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -44,7 +44,7 @@ class DashViewer extends VideoBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -104,7 +104,6 @@ class DashViewer extends VideoBaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
         this.mediaUrl = this.options.representation.content.url_template;
         this.watermarkCacheBust = Date.now();
         this.mediaEl.addEventListener('loadeddata', this.loadeddataHandler);

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -8,7 +8,7 @@ class MP3Viewer extends MediaBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -8,6 +8,10 @@ class MP3Viewer extends MediaBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -8,6 +8,10 @@ class MP4Viewer extends VideoBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -8,7 +8,7 @@ class MP4Viewer extends VideoBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -50,7 +50,7 @@ class MediaBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -154,7 +154,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {Promise} Promise to load representations
      */
     load() {
-        this.setup();
         super.load();
 
         const template = this.options.representation.content.url_template;

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -50,6 +50,10 @@ class MediaBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -26,6 +26,10 @@ class VideoBaseViewer extends MediaBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -26,7 +26,7 @@ class VideoBaseViewer extends MediaBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -35,6 +35,10 @@ class OfficeViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
 

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -35,7 +35,7 @@ class OfficeViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -76,7 +76,6 @@ class OfficeViewer extends BaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
         super.load();
         // Negligible load timer
         this.startLoadTimer();

--- a/src/lib/viewers/office/__tests__/OfficeViewer-test.js
+++ b/src/lib/viewers/office/__tests__/OfficeViewer-test.js
@@ -109,13 +109,13 @@ describe('lib/viewers/office/OfficeViewer', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: loadFunc });
         });
 
-        it('should call setup and load the Office viewer', () => {
+        it('should not call setup and load the Office viewer', () => {
             const setupStub = sandbox.stub(office, 'setup');
             Object.defineProperty(BaseViewer.prototype, 'load', { value: sandbox.stub() });
 
             office.load();
 
-            expect(setupStub).to.be.called;
+            expect(setupStub).not.to.be.called;
             expect(BaseViewer.prototype.load).to.be.called;
         });
 

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -19,7 +19,7 @@ class SWFViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -36,7 +36,6 @@ class SWFViewer extends BaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
         super.load();
         return this.loadAssets(JS)
             .then(this.postLoad)

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -19,6 +19,10 @@ class SWFViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
         this.playerEl = this.createViewer(document.createElement('div'));

--- a/src/lib/viewers/swf/__tests__/SWFViewer-test.js
+++ b/src/lib/viewers/swf/__tests__/SWFViewer-test.js
@@ -63,7 +63,7 @@ describe('lib/viewers/SWFViewer', () => {
             sandbox.stub(swf, 'setup');
 
             return swf.load().then(() => {
-                expect(swf.setup).to.be.called;
+                expect(swf.setup).not.to.be.called;
                 expect(swf.postLoad).to.be.called;
             });
         });
@@ -85,26 +85,29 @@ describe('lib/viewers/SWFViewer', () => {
     describe('postLoad()', () => {
         it('should call embedSWF', () => {
             const contentUrl = 'someurl';
-            sandbox.mock(swfobject).expects('embedSWF').withArgs(
-                contentUrl,
-                'flash-player',
-                '100%',
-                '100%',
-                '9',
-                null,
-                null,
-                {
-                    allowfullscreen: 'true',
-                    allowFullScreen: 'true',
-                    allownetworking: 'none',
-                    allowNetworking: 'none',
-                    allowscriptaccess: 'never',
-                    allowScriptAccess: 'never',
-                    wmode: 'transparent'
-                },
-                null,
-                sinon.match.func
-            );
+            sandbox
+                .mock(swfobject)
+                .expects('embedSWF')
+                .withArgs(
+                    contentUrl,
+                    'flash-player',
+                    '100%',
+                    '100%',
+                    '9',
+                    null,
+                    null,
+                    {
+                        allowfullscreen: 'true',
+                        allowFullScreen: 'true',
+                        allownetworking: 'none',
+                        allowNetworking: 'none',
+                        allowscriptaccess: 'never',
+                        allowScriptAccess: 'never',
+                        wmode: 'transparent'
+                    },
+                    null,
+                    sinon.match.func
+                );
             sandbox.stub(swf, 'createContentUrlWithAuthParams').returns(contentUrl);
 
             swf.postLoad();

--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -13,6 +13,10 @@ class CSVViewer extends TextBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -13,7 +13,7 @@ class CSVViewer extends TextBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 
@@ -42,7 +42,6 @@ class CSVViewer extends TextBaseViewer {
      * @return {void}
      */
     load() {
-        this.setup();
         super.load();
 
         const { representation, location } = this.options;

--- a/src/lib/viewers/text/MarkdownViewer.js
+++ b/src/lib/viewers/text/MarkdownViewer.js
@@ -12,6 +12,10 @@ class MarkdownViewer extends PlainTextViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/text/MarkdownViewer.js
+++ b/src/lib/viewers/text/MarkdownViewer.js
@@ -12,7 +12,7 @@ class MarkdownViewer extends PlainTextViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -106,6 +106,10 @@ class PlainTextViewer extends TextBaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() first to set up common layout
         super.setup();
 

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -47,7 +47,6 @@ class PlainTextViewer extends TextBaseViewer {
      * @return {Promise} to load text representation and assets
      */
     load() {
-        this.setup();
         super.load();
 
         const loadAssetsPromise = this.loadAssets(this.getJS(), this.getCSS());
@@ -106,7 +105,7 @@ class PlainTextViewer extends TextBaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -20,6 +20,10 @@ class TextBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
+        if (this.isSetup()) {
+            return;
+        }
+
         // Call super() to set up common layout
         super.setup();
     }

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -20,7 +20,7 @@ class TextBaseViewer extends BaseViewer {
      * @inheritdoc
      */
     setup() {
-        if (this.isSetup()) {
+        if (this.isSetup) {
             return;
         }
 

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -115,7 +115,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             sandbox.stub(text, 'setup');
 
             return text.load().then(() => {
-                expect(text.setup).to.be.called;
+                expect(text.setup).not.to.be.called;
                 expect(text.postLoad).to.be.called;
             });
         });

--- a/test/integration/sanity/Sanity.e2e.test.js
+++ b/test/integration/sanity/Sanity.e2e.test.js
@@ -12,4 +12,29 @@ describe('Preview Sanity', () => {
         cy.getPreviewPage(1);
         cy.contains('The Content Platform for Your Apps');
     });
+
+    it('Should reload without server update', () => {
+        cy.showPreview(token, fileId);
+        cy.getPreviewPage(1);
+        cy.contains('The Content Platform for Your Apps');
+
+        cy.window().then((win) => {
+            win.preview.reload(true);
+            cy.getByTestId('bp-content').find('.bp-loading-wrapper').should('be.visible');
+            cy.getPreviewPage(1);
+            cy.contains('The Content Platform for Your Apps');
+        });
+    });
+
+    it('Should reload with server update', () => {
+        cy.showPreview(token, fileId);
+        cy.getPreviewPage(1);
+        cy.contains('The Content Platform for Your Apps');
+
+        cy.window().then((win) => {
+            win.preview.reload();
+            cy.getPreviewPage(1);
+            cy.contains('The Content Platform for Your Apps');
+        });
+    });
 });

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -6,7 +6,7 @@ Cypress.Commands.add('getPreviewPage', (pageNum) => {
         .as('previewPage')
         // Adding timeout here because sometimes it takes more than the Cypress
         // default timeout to render the preview
-        .find('[data-testid="page-loading-indicator"]', { timeout: 15000 })
+        .find('.loadingIcon', { timeout: 15000 })
         .should('not.exist');
 
     return cy.get('@previewPage');


### PR DESCRIPTION
Fixes an issue where if any viewer's attempt to download the content first fails and then succeeds the second attempt would run `setup()` twice and duplicate any DOM elements added to the `bp-content` div. 

This fix decouples `setup` from `load` in the viewers and also checks an instance variable `isSetup` to determine whether setup needs to be executed again.

TODO:
- [x] unit tests
- [x] e2e tests