### PR TITLE
Fix: Get response as text from axios

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -51,6 +51,8 @@ const api = {
         return response.data;
     },
 
+    transformTextResponse: (data) => data,
+
     /**
      * Wrapper function for XHR post put and delete
      *
@@ -60,7 +62,13 @@ const api = {
      * @return {Promise} - XHR promise
      */
     xhr(url, options = {}) {
-        return axios(url, api.filterOptions(options))
+        let transformResponse;
+
+        if (options.responseType === 'text') {
+            transformResponse = api.transformTextResponse;
+        }
+
+        return axios(url, api.filterOptions({ transformResponse, ...options }))
             .then(api.parseResponse)
             .catch(api.handleError);
     },


### PR DESCRIPTION
For some reason, when specifying `responseType: 'text'` axios still returns the response data as parsed json, so adding a `transformResponse` option to get the text back for PlainTextViewer content