### PR TITLE
Fix: Thumbnail navigation now animates correctly in IE11

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -90,24 +90,24 @@ $thumbnail-sidebar-width: 226px;
         }
     }
 
+    @keyframes bp-thumbnails-open {
+        0% {
+            display: none;
+            transform: translateX(-$thumbnail-sidebar-width);
+        }
+
+        1% {
+            display: flex;
+            transform: translateX(-$thumbnail-sidebar-width);
+        }
+
+        100% {
+            transform: translateX(0);
+        }
+    }
+
     @include bp-breakpoint-medium {
         $bp-thumbnails-animation: 300ms cubic-bezier(.4, 0, .2, 1);
-
-        @keyframes bp-thumbnails-open {
-            0% {
-                display: none;
-                transform: translateX(-$thumbnail-sidebar-width);
-            }
-
-            1% {
-                display: flex;
-                transform: translateX(-$thumbnail-sidebar-width);
-            }
-
-            100% {
-                transform: translateX(0);
-            }
-        }
 
         &.bp-loaded {
             .bp-content {


### PR DESCRIPTION
TIL that animations defined within a media query don't work in IE11 ([source - known issues tab](https://caniuse.com/#search=keyframe)).

>IE10 and IE11 do not support CSS keyframe blocks inside media queries. Must be defined outside of media query definitions