### PR TITLE
Fix: Position bp-content left in fullscreen

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -143,6 +143,10 @@ $thumbnail-sidebar-width: 226px;
         &.bp-thumbnails-open {
             .bp-content {
                 left: $thumbnail-sidebar-width;
+
+                &.bp-is-fullscreen {
+                    left: 0;
+                }
             }
 
             .bp-thumbnails-container {


### PR DESCRIPTION
This fixes an issue in ie11 where a black section appears on the left in fullscreen while the thumbnails sidebar is toggled open