### PR TITLE
Fix: Print poup and buffering DOM references

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -849,7 +849,7 @@ class DocBaseViewer extends BaseViewer {
      * @return {void}
      */
     initPrint() {
-        this.printPopup = new Popup(this.containerEl);
+        this.printPopup = new Popup(this.rootEl);
 
         const printCheckmark = document.createElement('div');
         printCheckmark.className = `bp-print-check ${CLASS_HIDDEN}`;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -76,23 +76,25 @@
 }
 
 // When media is buffering, show only the crawler
-.bp-is-buffering .bp-loading-wrapper,
-.bp-is-buffering.bp-loaded .bp-loading-wrapper {
-    // Show loading indicator immediately
-    animation-name: none;
-    display: block;
+.bp {
+    &.bp-loaded .bp-is-buffering .bp-loading-wrapper,
+    .bp-is-buffering .bp-loading-wrapper {
+        // Show loading indicator immediately
+        animation-name: none;
+        display: flex;
 
-    .bp-icon,
-    .bp-loading-text,
-    .bp-loading-btn-container {
-        display: none;
-    }
+        .bp-icon,
+        .bp-loading-text,
+        .bp-loading-btn-container {
+            display: none;
+        }
 
-    .bp-crawler-wrapper {
-        position: static;
+        .bp-crawler-wrapper {
+            position: static;
 
-        .bp-crawler div {
-            background-color: $box-blue;
+            .bp-crawler div {
+                background-color: $box-blue;
+            }
         }
     }
 }

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -77,23 +77,25 @@
 
 // When media is buffering, show only the crawler
 .bp {
-    &.bp-loaded .bp-is-buffering .bp-loading-wrapper,
-    .bp-is-buffering .bp-loading-wrapper {
-        // Show loading indicator immediately
-        animation-name: none;
-        display: flex;
+    &,
+    &.bp-loaded {
+        .bp-is-buffering .bp-loading-wrapper {
+            // Show loading indicator immediately
+            animation-name: none;
+            display: flex;
 
-        .bp-icon,
-        .bp-loading-text,
-        .bp-loading-btn-container {
-            display: none;
-        }
+            .bp-icon,
+            .bp-loading-text,
+            .bp-loading-btn-container {
+                display: none;
+            }
 
-        .bp-crawler-wrapper {
-            position: static;
+            .bp-crawler-wrapper {
+                position: static;
 
-            .bp-crawler div {
-                background-color: $box-blue;
+                .bp-crawler div {
+                    background-color: $box-blue;
+                }
             }
         }
     }

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -131,7 +131,7 @@ class OfficeViewer extends BaseViewer {
      * @return {void}
      */
     initPrint() {
-        this.printPopup = new Popup(this.containerEl);
+        this.printPopup = new Popup(this.rootEl);
 
         const printCheckmark = document.createElement('div');
         printCheckmark.className = `bp-print-check ${CLASS_HIDDEN}`;

--- a/src/lib/viewers/office/__tests__/OfficeViewer-test.js
+++ b/src/lib/viewers/office/__tests__/OfficeViewer-test.js
@@ -4,7 +4,7 @@ import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
 import Location from '../../../Location';
 import OfficeViewer from '../OfficeViewer';
-import { CLASS_HIDDEN } from '../../../constants';
+import { CLASS_HIDDEN, SELECTOR_BOX_PREVIEW } from '../../../constants';
 import { ICON_PRINT_CHECKMARK } from '../../../icons/icons';
 
 const PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
@@ -16,6 +16,7 @@ const sandbox = sinon.sandbox.create();
 let office;
 let stubs = {};
 let containerEl;
+let rootEl;
 
 describe('lib/viewers/office/OfficeViewer', () => {
     let clock;
@@ -28,6 +29,7 @@ describe('lib/viewers/office/OfficeViewer', () => {
     beforeEach(() => {
         fixture.load('viewers/office/__tests__/OfficeViewer-test.html');
         containerEl = document.querySelector('.container');
+        rootEl = document.querySelector(SELECTOR_BOX_PREVIEW);
         office = new OfficeViewer({
             container: containerEl,
             file: {
@@ -51,6 +53,7 @@ describe('lib/viewers/office/OfficeViewer', () => {
         clock = sinon.useFakeTimers();
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
         office.containerEl = containerEl;
+        office.rootEl = rootEl;
     });
 
     afterEach(() => {

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -258,7 +258,7 @@ class PlainTextViewer extends TextBaseViewer {
      * @return {void}
      */
     initPrint() {
-        this.printPopup = new Popup(this.containerEl);
+        this.printPopup = new Popup(this.rootEl);
 
         const printCheckmark = document.createElement('div');
         printCheckmark.className = `bp-print-check ${CLASS_HIDDEN}`;

--- a/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
+++ b/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
@@ -2,12 +2,13 @@
 import MarkdownViewer from '../MarkdownViewer';
 import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
-import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
+import { TEXT_STATIC_ASSETS_VERSION, SELECTOR_BOX_PREVIEW } from '../../../constants';
 import { VIEWER_EVENT } from '../../../events';
 
 let containerEl;
 let markdown;
 const sandbox = sinon.sandbox.create();
+let rootEl;
 
 describe('lib/viewers/text/MarkdownViewer', () => {
     const setupFunc = BaseViewer.prototype.setup;
@@ -19,6 +20,7 @@ describe('lib/viewers/text/MarkdownViewer', () => {
     beforeEach(() => {
         fixture.load('viewers/text/__tests__/MarkdownViewer-test.html');
         containerEl = document.querySelector('.container');
+        rootEl = document.querySelector(SELECTOR_BOX_PREVIEW);
         markdown = new MarkdownViewer({
             file: {
                 id: 0
@@ -28,6 +30,7 @@ describe('lib/viewers/text/MarkdownViewer', () => {
 
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
         markdown.containerEl = containerEl;
+        markdown.rootEl = rootEl;
         markdown.setup();
     });
 

--- a/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
+++ b/src/lib/viewers/text/__tests__/MarkdownViewer-test.js
@@ -5,9 +5,9 @@ import Popup from '../../../Popup';
 import { TEXT_STATIC_ASSETS_VERSION, SELECTOR_BOX_PREVIEW } from '../../../constants';
 import { VIEWER_EVENT } from '../../../events';
 
+const sandbox = sinon.sandbox.create();
 let containerEl;
 let markdown;
-const sandbox = sinon.sandbox.create();
 let rootEl;
 
 describe('lib/viewers/text/MarkdownViewer', () => {

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -6,12 +6,13 @@ import BaseViewer from '../../BaseViewer';
 import Popup from '../../../Popup';
 import TextBaseViewer from '../TextBaseViewer';
 import * as util from '../../../util';
-import { TEXT_STATIC_ASSETS_VERSION } from '../../../constants';
+import { TEXT_STATIC_ASSETS_VERSION, SELECTOR_BOX_PREVIEW } from '../../../constants';
 import { VIEWER_EVENT } from '../../../events';
 
 let containerEl;
 let text;
 const sandbox = sinon.sandbox.create();
+let rootEl;
 
 describe('lib/viewers/text/PlainTextViewer', () => {
     const setupFunc = BaseViewer.prototype.setup;
@@ -23,6 +24,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
     beforeEach(() => {
         fixture.load('viewers/text/__tests__/PlainTextViewer-test.html');
         containerEl = document.querySelector('.container');
+        rootEl = document.querySelector(SELECTOR_BOX_PREVIEW);
         text = new PlainTextViewer({
             file: {
                 id: 0,
@@ -40,6 +42,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
 
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
         text.containerEl = containerEl;
+        text.rootEl = rootEl;
         text.setup();
     });
 
@@ -304,6 +307,7 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             });
             Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.stub() });
             text.containerEl = containerEl;
+            text.rootEl = rootEl;
             text.setup();
         });
 

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -9,9 +9,9 @@ import * as util from '../../../util';
 import { TEXT_STATIC_ASSETS_VERSION, SELECTOR_BOX_PREVIEW } from '../../../constants';
 import { VIEWER_EVENT } from '../../../events';
 
+const sandbox = sinon.sandbox.create();
 let containerEl;
 let text;
-const sandbox = sinon.sandbox.create();
 let rootEl;
 
 describe('lib/viewers/text/PlainTextViewer', () => {


### PR DESCRIPTION
Print popup is now centered with respect to the `.bp` div

Previously:
<img width="1276" alt="old print popup" src="https://user-images.githubusercontent.com/17791289/55751533-c008a980-59fa-11e9-98c1-723e6e84ea05.png">

Now:
<img width="1273" alt="after print popup" src="https://user-images.githubusercontent.com/17791289/55751535-c39c3080-59fa-11e9-8519-f7cd4cda6bc4.png">

Also adjusted media styles for `bp-is-buffering`

TODO:
- [x] unit tests