### PR TITLE
Fix: Media controls now visible for videos in narrow window

### DIFF
--- a/src/lib/viewers/media/Dash.scss
+++ b/src/lib/viewers/media/Dash.scss
@@ -1,12 +1,17 @@
 @import 'mediaBase';
 
+.bp-media-container {
+    display: flex;
+    justify-content: center;
+    min-width: 320px; // Prevent media controls from overflowing on small screens
+}
+
 .bp-media-dash {
     video {
         cursor: none;
         display: block;
         max-height: 100%;
         max-width: 100%;
-        min-width: 460px;
         width: 100%;
     }
 

--- a/src/lib/viewers/media/Dash.scss
+++ b/src/lib/viewers/media/Dash.scss
@@ -1,11 +1,5 @@
 @import 'mediaBase';
 
-.bp-media-container {
-    display: flex;
-    justify-content: center;
-    min-width: 320px; // Prevent media controls from overflowing on small screens
-}
-
 .bp-media-dash {
     video {
         cursor: none;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -26,10 +26,10 @@
 .bp-media-container {
     display: flex;
     justify-content: center;
+    min-width: 300px; // Prevent media controls from overflowing on small screens
     outline: 0 none;
     position: relative;
     user-select: none;  // Prevents copy paste dialog from appearing on mobile
-    width: 100%; // Prevent media controls from overflowing on small screens
 }
 
 .bp-media-play-button {

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -24,9 +24,12 @@
 }
 
 .bp-media-container {
+    display: flex;
+    justify-content: center;
     outline: 0 none;
     position: relative;
     user-select: none;  // Prevents copy paste dialog from appearing on mobile
+    width: 100%; // Prevent media controls from overflowing on small screens
 }
 
 .bp-media-play-button {


### PR DESCRIPTION
It looks like vertical videos are affected due to a min-width set on the video element which maintains its aspect ratio on narrow screens. Unfortunately, this causes the media controls to overflow past the edge of the viewport.