### PR TITLE
Fix: Load images via img elements to avoid CORS issues with XHRs

### DIFF
--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -13,9 +13,6 @@ const CSS_CLASS_ZOOMABLE = 'zoomable';
 const CSS_CLASS_PANNABLE = 'pannable';
 
 class ImageBaseViewer extends BaseViewer {
-    /** @property {string} - Url used to download an image representation */
-    downloadUrl;
-
     /** @inheritdoc */
     constructor(options) {
         super(options);
@@ -323,8 +320,9 @@ class ImageBaseViewer extends BaseViewer {
         // eslint-disable-next-line
         console.error(err);
 
-        const genericDownloadError = new PreviewError(ERROR_CODE.CONTENT_DOWNLOAD, __('error_refresh'), err.message);
-        super.handleDownloadError(err instanceof PreviewError ? err : genericDownloadError, imgUrl);
+        // Display a generic error message but log the real one
+        const error = new PreviewError(ERROR_CODE.CONTENT_DOWNLOAD, __('error_refresh'), {}, err.message);
+        super.handleDownloadError(error, imgUrl);
     }
 
     /**

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -57,12 +57,12 @@ class ImageViewer extends ImageBaseViewer {
 
         const { representation, viewer } = this.options;
         const template = representation.content.url_template;
-        this.downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
+        const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
         return this.getRepStatus()
             .getPromise()
-            .then(this.handleAssetAndRepLoad)
+            .then(() => this.handleAssetAndRepLoad(downloadUrl))
             .catch(this.handleAssetError);
     }
 
@@ -72,17 +72,11 @@ class ImageViewer extends ImageBaseViewer {
      * @override
      * @return {void}
      */
-    handleAssetAndRepLoad() {
+    handleAssetAndRepLoad(downloadUrl) {
         this.startLoadTimer();
+        this.imageEl.src = downloadUrl;
 
-        return util
-            .fetchRepresentationAsBlob(this.downloadUrl)
-            .then((blob) => {
-                const srcUrl = URL.createObjectURL(blob);
-                this.imageEl.src = srcUrl;
-                super.handleAssetAndRepLoad();
-            })
-            .catch(this.handleImageDownloadError);
+        super.handleAssetAndRepLoad();
     }
 
     /**
@@ -380,7 +374,7 @@ class ImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     handleImageDownloadError(err) {
-        this.handleDownloadError(err, this.downloadUrl);
+        this.handleDownloadError(err, this.imageEl.src);
     }
 
     /**

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -3,7 +3,7 @@ import PageControls from '../../PageControls';
 import './MultiImage.scss';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT } from '../../icons/icons';
 import { CLASS_INVISIBLE, CLASS_MULTI_IMAGE_PAGE, CLASS_IS_SCROLLABLE } from '../../constants';
-import { pageNumberFromScroll, fetchRepresentationAsBlob } from '../../util';
+import { pageNumberFromScroll } from '../../util';
 
 const PADDING_BUFFER = 100;
 const CSS_CLASS_IMAGE = 'bp-images';
@@ -148,15 +148,7 @@ class MultiImageViewer extends ImageBaseViewer {
         // Set page number. Page is index + 1.
         this.singleImageEls[index].setAttribute('data-page-number', index + 1);
         this.singleImageEls[index].classList.add(CLASS_MULTI_IMAGE_PAGE);
-
-        this.downloadUrl = imageUrl;
-
-        fetchRepresentationAsBlob(imageUrl)
-            .then((blob) => {
-                const srcUrl = URL.createObjectURL(blob);
-                this.singleImageEls[index].src = srcUrl;
-            })
-            .catch(this.handleMultiImageDownloadError);
+        this.singleImageEls[index].src = imageUrl;
     }
 
     /** @inheritdoc */
@@ -275,18 +267,17 @@ class MultiImageViewer extends ImageBaseViewer {
      * @return {void}
      */
     handleMultiImageDownloadError(err) {
-        if (this.isDestroyed()) {
-            return;
-        }
-
         this.singleImageEls.forEach((el, index) => {
             this.unbindImageListeners(index);
         });
 
+        // Since we're using the src to get the hostname, we can always use the src of the first page
+        const { src } = this.singleImageEls[0];
+
         // Clear any images we may have started to load.
         this.singleImageEls = [];
 
-        this.handleDownloadError(err, this.downloadUrl);
+        this.handleDownloadError(err, src);
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -210,17 +210,11 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             expect(stubs.bindImageListeners).to.be.called;
         });
 
-        it('should set the download URL and fetch the page as a blob', () => {
-            stubs.fetchRepresentationAsBlob = sandbox
-                .stub(util, 'fetchRepresentationAsBlob')
-                .returns(Promise.resolve('foo'));
+        it('should set the image source', () => {
             multiImage.singleImageEls = [stubs.singleImageEl];
-            const repUrl = 'file/100/content/{page}.png';
 
-            multiImage.setupImageEls(repUrl, 0);
-
-            expect(multiImage.downloadUrl).to.be.equal(repUrl);
-            expect(stubs.fetchRepresentationAsBlob).to.be.called;
+            multiImage.setupImageEls('file/100/content/{page}.png', 0);
+            expect(multiImage.singleImageEls[0].src).to.be.equal('file/100/content/{page}.png');
         });
 
         it('should set the page number for each image el', () => {
@@ -410,22 +404,13 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             sandbox.stub(multiImage, 'unbindImageListeners');
         });
 
-        it('should do nothing if the viewer is already destroyed', () => {
-            sandbox.stub(multiImage, 'isDestroyed').returns(true);
-            multiImage.downloadUrl = multiImage.singleImageEls[0];
-            multiImage.handleMultiImageDownloadError('err');
-
-            expect(multiImage.handleDownloadError).to.not.be.called;
-            expect(multiImage.unbindImageListeners).to.not.be.called;
-        });
-
         it('unbind the image listeners, clear the image Els array, and handle the download error', () => {
-            multiImage.downloadUrl = multiImage.singleImageEls[0];
+            const { src } = multiImage.singleImageEls[0];
 
             multiImage.handleMultiImageDownloadError('err');
 
             expect(multiImage.singleImageEls).to.deep.equal([]);
-            expect(multiImage.handleDownloadError).to.be.calledWith('err', multiImage.downloadUrl);
+            expect(multiImage.handleDownloadError).to.be.calledWith('err', src);
             expect(multiImage.unbindImageListeners).to.be.calledTwice;
         });
     });

--- a/test/integration/sanity/DeletedReps.e2e.test.js
+++ b/test/integration/sanity/DeletedReps.e2e.test.js
@@ -3,9 +3,7 @@ describe('Previewing a file with deleted representations', () => {
     const token = Cypress.env('ACCESS_TOKEN');
 
     const fileIdDoc = Cypress.env('FILE_ID_DOC');
-    const fileIdImage = Cypress.env('FILE_ID_IMAGE');
     const fileIdPresentation = Cypress.env('FILE_ID_PRESENTATION');
-    const fileIdTiff = Cypress.env('FILE_ID_TIFF');
 
     const REPS_ERROR = 'error_deleted_reps';
 
@@ -55,16 +53,8 @@ describe('Previewing a file with deleted representations', () => {
         {
             viewer: 'Presentation',
             fileId: fileIdPresentation
-        },
-        {
-            viewer: 'Image',
-            fileId: fileIdImage
-        },
-        {
-            viewer: 'MultiImage',
-            fileId: fileIdTiff
         }
-    ].forEach((test) => { 
+    ].forEach((test) => {
         it(test.viewer, () => {
             helpers.checkDeletedRepError();
             


### PR DESCRIPTION
This change reverts portions of https://github.com/box/box-content-preview/pull/964 due to an issue where XHRs to cached image files are throwing CORS errors in the Embed Widget.