### PR TITLE
Fix: Show next/previous buttons for file collections in error viewer

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1472,6 +1472,9 @@ class Preview extends EventEmitter {
         // Destroy anything still showing
         this.destroy();
 
+        // Setup the preview ui for next/previous buttons
+        this.setupUI();
+
         // Instantiate the error viewer
         this.viewer = this.getErrorViewer();
 

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -2180,6 +2180,7 @@ describe('lib/Preview', () => {
             stubs.emit = sandbox.stub(preview, 'emit');
             stubs.emitPreviewError = sandbox.stub(preview, 'emitPreviewError');
             stubs.attachViewerListeners = sandbox.stub(preview, 'attachViewerListeners');
+            stubs.setupUI = sandbox.stub(preview, 'setupUI');
 
             preview.open = true;
         });
@@ -2205,6 +2206,7 @@ describe('lib/Preview', () => {
             expect(preview.open).to.be.false;
             expect(stubs.uncacheFile).to.be.called;
             expect(stubs.destroy).to.be.called;
+            expect(stubs.setupUI).to.be.called;
         });
 
         it('should get the error viewer, attach viewer listeners, and load the error viewer', () => {


### PR DESCRIPTION
The next/previous buttons currently don't show at all when previewing a collection with files that produce an error (such as unsupported, password protected, etc.).