### PR TITLE
Fix: Center video element and maintain its size and ratio

### DIFF
--- a/src/lib/viewers/media/Dash.scss
+++ b/src/lib/viewers/media/Dash.scss
@@ -4,6 +4,8 @@
     video {
         cursor: none;
         display: block;
+        margin-left: auto;
+        margin-right: auto;
         max-height: 100%;
         max-width: 100%;
         width: 100%;

--- a/src/lib/viewers/media/MP4.scss
+++ b/src/lib/viewers/media/MP4.scss
@@ -4,6 +4,8 @@
     video {
         cursor: none;
         display: block;
+        margin-left: auto;
+        margin-right: auto;
         max-height: 100%;
         max-width: 100%;
         width: 100%;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -24,8 +24,6 @@
 }
 
 .bp-media-container {
-    display: flex;
-    justify-content: center;
     min-width: 300px; // Prevent media controls from overflowing on small screens
     outline: 0 none;
     position: relative;


### PR DESCRIPTION
The previous change caused videos to render at their natural height, even in fullscreen, rather than allowing them to expand. This change will center the video element without affecting its displayed size or ability to expand while still limiting it and its controls to a minimum width of 300 pixels.