### PR TITLE
Fix: Resize preview when thumbnails open

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1144,6 +1144,7 @@ class DocBaseViewer extends BaseViewer {
 
                 if (this.options.enableThumbnailsSidebar) {
                     this.initThumbnails();
+                    this.resize();
                 }
             }
         }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1789,6 +1789,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 stubs.emit = sandbox.stub(docBase, 'emit');
                 stubs.initThumbnails = sandbox.stub(docBase, 'initThumbnails');
                 stubs.hidePreload = sandbox.stub(docBase, 'hidePreload');
+                stubs.resize = sandbox.stub(docBase, 'resize');
             });
 
             it('should emit the pagerender event', () => {
@@ -1808,6 +1809,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.initThumbnails).to.be.called;
                 expect(stubs.hidePreload).to.be.called;
                 expect(docBase.somePageRendered).to.be.true;
+                expect(docBase.resize).to.be.called;
             });
 
             it('should not init thumbnails if not enabled', () => {


### PR DESCRIPTION
The initial resize may happen before the document is ready, so resizing when we decleare the document 'loaded' will ensure that the PDF is resized, not the preload image. The initial resize is preserved so that preload image will be resized when the thumbnails open.