### PR TITLE
New: Emit metric when missing xrefs

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -86,3 +86,5 @@ export const USER_DOCUMENT_THUMBNAIL_EVENTS = {
     NAVIGATE: 'user_document_thumbnails_navigate',
     OPEN: 'user_document_thumbnails_open'
 };
+
+export const MISSING_EXTERNAL_REFS = 'missing_x_refs';

--- a/src/lib/metadataAPI.js
+++ b/src/lib/metadataAPI.js
@@ -17,12 +17,13 @@ const metadataAPI = {
             return Promise.reject(new Error('id and template are required parameters'));
         }
 
-        return metadataAPI.getMetadata(id, SCOPE_GLOBAL, template, options).then((response) => {
-            // The hasxrefs value is returned as a string 'false' or 'true' so we want
-            // to convert this to a boolean
-            const { [FIELD_HASXREFS]: hasXrefsValue } = response;
-            return { ...response, [FIELD_HASXREFS]: hasXrefsValue === 'true' };
-        });
+        return metadataAPI
+            .getMetadata(id, SCOPE_GLOBAL, template, options)
+            .then(({ [FIELD_HASXREFS]: hasXrefsValue, ...rest }) => {
+                // The hasxrefs value is returned as a string 'false' or 'true' so we want
+                // to convert this to a boolean
+                return { ...rest, [FIELD_HASXREFS]: hasXrefsValue === 'true' };
+            });
     },
 
     /**

--- a/src/lib/viewers/doc/AutoCADViewer.js
+++ b/src/lib/viewers/doc/AutoCADViewer.js
@@ -1,6 +1,7 @@
 import DocumentViewer from './DocumentViewer';
 import metadataAPI from '../../metadataAPI';
 import { METADATA } from '../../constants';
+import { MISSING_EXTERNAL_REFS } from '../../events';
 
 const { FIELD_HASXREFS, TEMPLATE_AUTOCAD } = METADATA;
 
@@ -19,11 +20,16 @@ class AutoCADViewer extends DocumentViewer {
      * @return {void}
      */
     checkForXrefs() {
-        const { id } = this.options.file;
+        const { extension, id } = this.options.file;
 
         metadataAPI.getXrefsMetadata(id, TEMPLATE_AUTOCAD, this.options).then(({ [FIELD_HASXREFS]: hasxrefsValue }) => {
             if (hasxrefsValue) {
                 this.options.ui.showNotification(__('has_x_refs'), null, true);
+
+                this.emitMetric({
+                    name: MISSING_EXTERNAL_REFS,
+                    data: extension
+                });
             }
         });
     }

--- a/src/lib/viewers/doc/DocLoader.js
+++ b/src/lib/viewers/doc/DocLoader.js
@@ -1,12 +1,12 @@
 import AssetLoader from '../AssetLoader';
 import { getRepresentation } from '../../file';
+import AutoCADViewer from './AutoCADViewer';
 import DocumentViewer from './DocumentViewer';
 import PresentationViewer from './PresentationViewer';
 import SinglePageViewer from './SinglePageViewer';
 import RepStatus from '../../RepStatus';
 import { ORIGINAL_REP_NAME, STATUS_SUCCESS } from '../../constants';
 import { DOCUMENT_EXTENSIONS } from '../../extensions';
-import AutoCADViewer from './AutoCADViewer';
 
 // Order of the viewers matters. For example, a PDF file can be previewed by using the preferred optimized 'pdf' rep
 // or the original as a fallback. Additionally, we include multiple entries for the presentation viewer so that it can be

--- a/src/lib/viewers/doc/__tests__/AutoCADViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/AutoCADViewer-test.js
@@ -3,8 +3,10 @@ import DocumentViewer from '../DocumentViewer';
 import AutoCADViewer from '../AutoCADViewer';
 import metadataAPI from '../../../metadataAPI';
 import { METADATA } from '../../../constants';
+import { MISSING_EXTERNAL_REFS } from '../../../events';
 
 const { FIELD_HASXREFS, TEMPLATE_AUTOCAD } = METADATA;
+const EXTENSION = 'dwg';
 const sandbox = sinon.sandbox.create();
 
 let containerEl;
@@ -23,10 +25,12 @@ describe('lib/viewers/doc/AutoCADViewer', () => {
 
         stubs.getXrefsMetadata = sandbox.stub(metadataAPI, 'getXrefsMetadata');
         stubs.showNotification = sandbox.stub();
+        stubs.emitMetric = sandbox.stub(autocad, 'emitMetric');
 
         autocad.options = {
             file: {
-                id: '123'
+                id: '123',
+                extension: EXTENSION
             },
             ui: {
                 showNotification: stubs.showNotification
@@ -63,6 +67,7 @@ describe('lib/viewers/doc/AutoCADViewer', () => {
 
             return xrefsPromise.then(() => {
                 expect(stubs.showNotification).to.have.been.called;
+                expect(stubs.emitMetric).to.have.been.calledWith({ name: MISSING_EXTERNAL_REFS, data: EXTENSION });
             });
         });
 
@@ -76,6 +81,7 @@ describe('lib/viewers/doc/AutoCADViewer', () => {
 
             return xrefsPromise.then(() => {
                 expect(stubs.showNotification).not.to.have.been.called;
+                expect(stubs.emitMetric).not.to.have.been.called;
             });
         });
     });


### PR DESCRIPTION
When dwg file has missing external references, will emit an event `missing_x_refs` with file extension as the data