### PR TITLE
Fix: Remove bg color for cc button on hover

### DIFF
--- a/src/lib/viewers/media/MediaControls.scss
+++ b/src/lib/viewers/media/MediaControls.scss
@@ -175,11 +175,6 @@
     padding: 0 0 0 1px; // Padding left 1px because text isn't perfectly centered on Safari/Firefox even with text-align:center. Looks fine with extra-padding on Chrome/IE/Edge
     width: 24px;
 
-    &:hover {
-        background-color: $box-blue;
-        color: $white;
-    }
-
     .bp-media-settings-subtitles-on & {
         background-color: $box-blue;
         color: $white;


### PR DESCRIPTION
1. Adding bg color on hover for CC button doesn't play nicely on mobile devices.
2. Other buttons in media player don't have bg color on hover.
3. When CC is turned off, user doesn't know because the button is still blue because of the hover effect.

Removing `:hover` style solves all the above issues.