### PR TITLE
build(release): Update conventional-github-releaser to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1452 +1,1346 @@
 <a name="2.14.0"></a>
+
 ## 2.14.0 (2019-07-08)
 
-* Fix: Chrome Print Preview Fix (#1030) ([0fee384](https://github.com/box/box-content-preview/commit/0fee384)), closes [#1030](https://github.com/box/box-content-preview/issues/1030)
-* Fix: Set dimensions for close button svg (#1032) ([2c2d479](https://github.com/box/box-content-preview/commit/2c2d479)), closes [#1032](https://github.com/box/box-content-preview/issues/1032)
-* Upgrade: Bump handlebars from 4.0.11 to 4.1.2 (#1033) ([3ce93e6](https://github.com/box/box-content-preview/commit/3ce93e6)), closes [#1033](https://github.com/box/box-content-preview/issues/1033)
-* Chore: Update CLA link (#1031) ([8717624](https://github.com/box/box-content-preview/commit/8717624)), closes [#1031](https://github.com/box/box-content-preview/issues/1031)
-* Update Translations ([85d67d3](https://github.com/box/box-content-preview/commit/85d67d3))
-
-
+- Fix: Chrome Print Preview Fix (#1030) ([0fee384](https://github.com/box/box-content-preview/commit/0fee384)), closes [#1030](https://github.com/box/box-content-preview/issues/1030)
+- Fix: Set dimensions for close button svg (#1032) ([2c2d479](https://github.com/box/box-content-preview/commit/2c2d479)), closes [#1032](https://github.com/box/box-content-preview/issues/1032)
+- Upgrade: Bump handlebars from 4.0.11 to 4.1.2 (#1033) ([3ce93e6](https://github.com/box/box-content-preview/commit/3ce93e6)), closes [#1033](https://github.com/box/box-content-preview/issues/1033)
+- Chore: Update CLA link (#1031) ([8717624](https://github.com/box/box-content-preview/commit/8717624)), closes [#1031](https://github.com/box/box-content-preview/issues/1031)
+- Update Translations ([85d67d3](https://github.com/box/box-content-preview/commit/85d67d3))
 
 <a name="2.13.0"></a>
+
 ## 2.13.0 (2019-06-25)
 
-* Update Translations ([4ed5e57](https://github.com/box/box-content-preview/commit/4ed5e57))
-* Update Translations ([17cb8b8](https://github.com/box/box-content-preview/commit/17cb8b8))
-* Update Translations (#1018) ([72eddb1](https://github.com/box/box-content-preview/commit/72eddb1)), closes [#1018](https://github.com/box/box-content-preview/issues/1018)
-* Update Translations (#1022) ([4f7a10c](https://github.com/box/box-content-preview/commit/4f7a10c)), closes [#1022](https://github.com/box/box-content-preview/issues/1022)
-* Update Translations (#1027) ([58c6e0d](https://github.com/box/box-content-preview/commit/58c6e0d)), closes [#1027](https://github.com/box/box-content-preview/issues/1027)
-* Fix: Move notification to be child of preview content (#1019) ([fde40a0](https://github.com/box/box-content-preview/commit/fde40a0)), closes [#1019](https://github.com/box/box-content-preview/issues/1019)
-* Fix: OfficeViewer no pdfUrl for .xlsb files ([c877dfa](https://github.com/box/box-content-preview/commit/c877dfa))
-* Fix: Remove bg color for cc button on hover (#1025) ([d41c05b](https://github.com/box/box-content-preview/commit/d41c05b)), closes [#1025](https://github.com/box/box-content-preview/issues/1025)
-* Upgrade: Bump macaddress from 0.2.8 to 0.2.9 (#1021) ([f9aaf5e](https://github.com/box/box-content-preview/commit/f9aaf5e)), closes [#1021](https://github.com/box/box-content-preview/issues/1021)
-* Upgrade: Bump stringstream from 0.0.5 to 0.0.6 (#1026) ([49b1ce0](https://github.com/box/box-content-preview/commit/49b1ce0)), closes [#1026](https://github.com/box/box-content-preview/issues/1026)
-* New(preview): Adding preview with excel online for xlsb & xlsm files (#1001) ([c6359cd](https://github.com/box/box-content-preview/commit/c6359cd)), closes [#1001](https://github.com/box/box-content-preview/issues/1001)
-* Chore: Update autocad xref language (#1020) ([8533e99](https://github.com/box/box-content-preview/commit/8533e99)), closes [#1020](https://github.com/box/box-content-preview/issues/1020)
-* Build: Add Mergify configuration (#1023) ([5f10915](https://github.com/box/box-content-preview/commit/5f10915)), closes [#1023](https://github.com/box/box-content-preview/issues/1023)
-
-
+- Update Translations ([4ed5e57](https://github.com/box/box-content-preview/commit/4ed5e57))
+- Update Translations ([17cb8b8](https://github.com/box/box-content-preview/commit/17cb8b8))
+- Update Translations (#1018) ([72eddb1](https://github.com/box/box-content-preview/commit/72eddb1)), closes [#1018](https://github.com/box/box-content-preview/issues/1018)
+- Update Translations (#1022) ([4f7a10c](https://github.com/box/box-content-preview/commit/4f7a10c)), closes [#1022](https://github.com/box/box-content-preview/issues/1022)
+- Update Translations (#1027) ([58c6e0d](https://github.com/box/box-content-preview/commit/58c6e0d)), closes [#1027](https://github.com/box/box-content-preview/issues/1027)
+- Fix: Move notification to be child of preview content (#1019) ([fde40a0](https://github.com/box/box-content-preview/commit/fde40a0)), closes [#1019](https://github.com/box/box-content-preview/issues/1019)
+- Fix: OfficeViewer no pdfUrl for .xlsb files ([c877dfa](https://github.com/box/box-content-preview/commit/c877dfa))
+- Fix: Remove bg color for cc button on hover (#1025) ([d41c05b](https://github.com/box/box-content-preview/commit/d41c05b)), closes [#1025](https://github.com/box/box-content-preview/issues/1025)
+- Upgrade: Bump macaddress from 0.2.8 to 0.2.9 (#1021) ([f9aaf5e](https://github.com/box/box-content-preview/commit/f9aaf5e)), closes [#1021](https://github.com/box/box-content-preview/issues/1021)
+- Upgrade: Bump stringstream from 0.0.5 to 0.0.6 (#1026) ([49b1ce0](https://github.com/box/box-content-preview/commit/49b1ce0)), closes [#1026](https://github.com/box/box-content-preview/issues/1026)
+- New(preview): Adding preview with excel online for xlsb & xlsm files (#1001) ([c6359cd](https://github.com/box/box-content-preview/commit/c6359cd)), closes [#1001](https://github.com/box/box-content-preview/issues/1001)
+- Chore: Update autocad xref language (#1020) ([8533e99](https://github.com/box/box-content-preview/commit/8533e99)), closes [#1020](https://github.com/box/box-content-preview/issues/1020)
+- Build: Add Mergify configuration (#1023) ([5f10915](https://github.com/box/box-content-preview/commit/5f10915)), closes [#1023](https://github.com/box/box-content-preview/issues/1023)
 
 <a name="2.12.0"></a>
+
 ## 2.12.0 (2019-06-11)
 
-* New: Autocad svg (#1016) ([a2508e6](https://github.com/box/box-content-preview/commit/a2508e6)), closes [#1016](https://github.com/box/box-content-preview/issues/1016)
-* New: Emit metric when missing xrefs (#1015) ([eca5b2c](https://github.com/box/box-content-preview/commit/eca5b2c)), closes [#1015](https://github.com/box/box-content-preview/issues/1015)
-* New: metadataAPI.js (#1010) ([5e4de5f](https://github.com/box/box-content-preview/commit/5e4de5f)), closes [#1010](https://github.com/box/box-content-preview/issues/1010)
-* New: Show banner when doc has xrefs (#1013) ([6f9fca7](https://github.com/box/box-content-preview/commit/6f9fca7)), closes [#1013](https://github.com/box/box-content-preview/issues/1013)
-* Update Translations ([54b0eb9](https://github.com/box/box-content-preview/commit/54b0eb9))
-* Update Translations (#1014) ([0f278dc](https://github.com/box/box-content-preview/commit/0f278dc)), closes [#1014](https://github.com/box/box-content-preview/issues/1014)
-* Docs: Add fileOptions example ([6b72ec9](https://github.com/box/box-content-preview/commit/6b72ec9))
-
-
+- New: Autocad svg (#1016) ([a2508e6](https://github.com/box/box-content-preview/commit/a2508e6)), closes [#1016](https://github.com/box/box-content-preview/issues/1016)
+- New: Emit metric when missing xrefs (#1015) ([eca5b2c](https://github.com/box/box-content-preview/commit/eca5b2c)), closes [#1015](https://github.com/box/box-content-preview/issues/1015)
+- New: metadataAPI.js (#1010) ([5e4de5f](https://github.com/box/box-content-preview/commit/5e4de5f)), closes [#1010](https://github.com/box/box-content-preview/issues/1010)
+- New: Show banner when doc has xrefs (#1013) ([6f9fca7](https://github.com/box/box-content-preview/commit/6f9fca7)), closes [#1013](https://github.com/box/box-content-preview/issues/1013)
+- Update Translations ([54b0eb9](https://github.com/box/box-content-preview/commit/54b0eb9))
+- Update Translations (#1014) ([0f278dc](https://github.com/box/box-content-preview/commit/0f278dc)), closes [#1014](https://github.com/box/box-content-preview/issues/1014)
+- Docs: Add fileOptions example ([6b72ec9](https://github.com/box/box-content-preview/commit/6b72ec9))
 
 <a name="2.11.0"></a>
+
 ## 2.11.0 (2019-06-05)
 
-* Fix: Add type to preview buttons ([155e0cc](https://github.com/box/box-content-preview/commit/155e0cc))
-* Fix: Resize preview when thumbnails open ([01c549b](https://github.com/box/box-content-preview/commit/01c549b))
-* Fix: updated error text for unsupported file types (#1002) ([4f4a8f1](https://github.com/box/box-content-preview/commit/4f4a8f1)), closes [#1002](https://github.com/box/box-content-preview/issues/1002)
-* Update Translations ([a8a7d44](https://github.com/box/box-content-preview/commit/a8a7d44))
-* Update: Upgrade axios to address security vulnerability (#1003) ([6bfb3c4](https://github.com/box/box-content-preview/commit/6bfb3c4)), closes [#1003](https://github.com/box/box-content-preview/issues/1003)
-
-
+- Fix: Add type to preview buttons ([155e0cc](https://github.com/box/box-content-preview/commit/155e0cc))
+- Fix: Resize preview when thumbnails open ([01c549b](https://github.com/box/box-content-preview/commit/01c549b))
+- Fix: updated error text for unsupported file types (#1002) ([4f4a8f1](https://github.com/box/box-content-preview/commit/4f4a8f1)), closes [#1002](https://github.com/box/box-content-preview/issues/1002)
+- Update Translations ([a8a7d44](https://github.com/box/box-content-preview/commit/a8a7d44))
+- Update: Upgrade axios to address security vulnerability (#1003) ([6bfb3c4](https://github.com/box/box-content-preview/commit/6bfb3c4)), closes [#1003](https://github.com/box/box-content-preview/issues/1003)
 
 <a name="2.10.0"></a>
+
 ## 2.10.0 (2019-05-21)
 
-* Fix: Fix resize logic during preload and opening of thumbnails ([2b72679](https://github.com/box/box-content-preview/commit/2b72679))
-* Fix: Prevent focus loss in IE when navigating thumbnails ([685b4b5](https://github.com/box/box-content-preview/commit/685b4b5))
-
-
+- Fix: Fix resize logic during preload and opening of thumbnails ([2b72679](https://github.com/box/box-content-preview/commit/2b72679))
+- Fix: Prevent focus loss in IE when navigating thumbnails ([685b4b5](https://github.com/box/box-content-preview/commit/685b4b5))
 
 <a name="2.9.0"></a>
+
 ## 2.9.0 (2019-05-14)
 
-* Update: Support .dwg files in the DocumentViewer (#992) ([6c8b630](https://github.com/box/box-content-preview/commit/6c8b630)), closes [#992](https://github.com/box/box-content-preview/issues/992)
-* Fix: Center video element and maintain its size and ratio (#995) ([dd7a6ec](https://github.com/box/box-content-preview/commit/dd7a6ec)), closes [#995](https://github.com/box/box-content-preview/issues/995)
-* Fix: Keyboard shortcuts for thumbnails sidebar ([62eb6ca](https://github.com/box/box-content-preview/commit/62eb6ca))
-* Chore: Update readme with new codepen domains (#996) ([e1e03b7](https://github.com/box/box-content-preview/commit/e1e03b7)), closes [#996](https://github.com/box/box-content-preview/issues/996)
-* Docs: Update self host instructions with new commands (#993) ([adc2064](https://github.com/box/box-content-preview/commit/adc2064)), closes [#993](https://github.com/box/box-content-preview/issues/993)
-
-
+- Update: Support .dwg files in the DocumentViewer (#992) ([6c8b630](https://github.com/box/box-content-preview/commit/6c8b630)), closes [#992](https://github.com/box/box-content-preview/issues/992)
+- Fix: Center video element and maintain its size and ratio (#995) ([dd7a6ec](https://github.com/box/box-content-preview/commit/dd7a6ec)), closes [#995](https://github.com/box/box-content-preview/issues/995)
+- Fix: Keyboard shortcuts for thumbnails sidebar ([62eb6ca](https://github.com/box/box-content-preview/commit/62eb6ca))
+- Chore: Update readme with new codepen domains (#996) ([e1e03b7](https://github.com/box/box-content-preview/commit/e1e03b7)), closes [#996](https://github.com/box/box-content-preview/issues/996)
+- Docs: Update self host instructions with new commands (#993) ([adc2064](https://github.com/box/box-content-preview/commit/adc2064)), closes [#993](https://github.com/box/box-content-preview/issues/993)
 
 <a name="2.8.0"></a>
+
 ## 2.8.0 (2019-04-23)
 
-* Fix: Avoid adding thumbnail sidebar classes if option is disabled (#990) ([c5eac30](https://github.com/box/box-content-preview/commit/c5eac30)), closes [#990](https://github.com/box/box-content-preview/issues/990)
-* Fix: Load images via img elements to avoid CORS issues with XHRs (#988) ([fa6e82a](https://github.com/box/box-content-preview/commit/fa6e82a)), closes [#988](https://github.com/box/box-content-preview/issues/988)
-* Fix: Media controls now visible for videos in narrow window (#987) ([753fc14](https://github.com/box/box-content-preview/commit/753fc14)), closes [#987](https://github.com/box/box-content-preview/issues/987)
-* Fix: Show next/previous buttons for file collections in error viewer (#989) ([ce3e834](https://github.com/box/box-content-preview/commit/ce3e834)), closes [#989](https://github.com/box/box-content-preview/issues/989)
-
-
+- Fix: Avoid adding thumbnail sidebar classes if option is disabled (#990) ([c5eac30](https://github.com/box/box-content-preview/commit/c5eac30)), closes [#990](https://github.com/box/box-content-preview/issues/990)
+- Fix: Load images via img elements to avoid CORS issues with XHRs (#988) ([fa6e82a](https://github.com/box/box-content-preview/commit/fa6e82a)), closes [#988](https://github.com/box/box-content-preview/issues/988)
+- Fix: Media controls now visible for videos in narrow window (#987) ([753fc14](https://github.com/box/box-content-preview/commit/753fc14)), closes [#987](https://github.com/box/box-content-preview/issues/987)
+- Fix: Show next/previous buttons for file collections in error viewer (#989) ([ce3e834](https://github.com/box/box-content-preview/commit/ce3e834)), closes [#989](https://github.com/box/box-content-preview/issues/989)
 
 <a name="2.7.0"></a>
+
 ## 2.7.0 (2019-04-16)
 
-* Fix: Temporarily remove focus outline from scrollable content ([a8e574b](https://github.com/box/box-content-preview/commit/a8e574b))
-* Docs: Add comment around cypress auth (#985) ([bd51d09](https://github.com/box/box-content-preview/commit/bd51d09)), closes [#985](https://github.com/box/box-content-preview/issues/985)
-* Update: Thumbnails default closed for single page docs (#984) ([207140b](https://github.com/box/box-content-preview/commit/207140b)), closes [#984](https://github.com/box/box-content-preview/issues/984)
-
-
+- Fix: Temporarily remove focus outline from scrollable content ([a8e574b](https://github.com/box/box-content-preview/commit/a8e574b))
+- Docs: Add comment around cypress auth (#985) ([bd51d09](https://github.com/box/box-content-preview/commit/bd51d09)), closes [#985](https://github.com/box/box-content-preview/issues/985)
+- Update: Thumbnails default closed for single page docs (#984) ([207140b](https://github.com/box/box-content-preview/commit/207140b)), closes [#984](https://github.com/box/box-content-preview/issues/984)
 
 <a name="2.6.0"></a>
+
 ## 2.6.0 (2019-04-10)
 
-* Update: emit thumbnailsOpen in DocBaseViewer (#977) ([979a912](https://github.com/box/box-content-preview/commit/979a912)), closes [#977](https://github.com/box/box-content-preview/issues/977)
-* Update: Higher resolution thumbnails (#982) ([975c1ee](https://github.com/box/box-content-preview/commit/975c1ee)), closes [#982](https://github.com/box/box-content-preview/issues/982)
-* Chore: Update script names to latest conventions (#981) ([b9eae0a](https://github.com/box/box-content-preview/commit/b9eae0a)), closes [#981](https://github.com/box/box-content-preview/issues/981)
-* Fix: Adding file nav button transition (#974) ([3b09559](https://github.com/box/box-content-preview/commit/3b09559)), closes [#974](https://github.com/box/box-content-preview/issues/974)
-* Fix: Allow scrollable viewers to accept keyboard input when focused ([47eadd9](https://github.com/box/box-content-preview/commit/47eadd9))
-* Fix: Check correct DOM element in 'checkDocumentLoaded()' ([5e33773](https://github.com/box/box-content-preview/commit/5e33773))
-* Fix: Cleanup the thumbnail sidebar when preview errors (#976) ([05fa0a2](https://github.com/box/box-content-preview/commit/05fa0a2)), closes [#976](https://github.com/box/box-content-preview/issues/976)
-* Fix: On Thumbnails initial render, scroll item into view (#975) ([55ad49d](https://github.com/box/box-content-preview/commit/55ad49d)), closes [#975](https://github.com/box/box-content-preview/issues/975)
-* Fix: Position bp-content left in fullscreen (#979) ([2f191b8](https://github.com/box/box-content-preview/commit/2f191b8)), closes [#979](https://github.com/box/box-content-preview/issues/979)
-* Fix: Print poup and buffering DOM references (#980) ([cbc57a1](https://github.com/box/box-content-preview/commit/cbc57a1)), closes [#980](https://github.com/box/box-content-preview/issues/980)
-
-
+- Update: emit thumbnailsOpen in DocBaseViewer (#977) ([979a912](https://github.com/box/box-content-preview/commit/979a912)), closes [#977](https://github.com/box/box-content-preview/issues/977)
+- Update: Higher resolution thumbnails (#982) ([975c1ee](https://github.com/box/box-content-preview/commit/975c1ee)), closes [#982](https://github.com/box/box-content-preview/issues/982)
+- Chore: Update script names to latest conventions (#981) ([b9eae0a](https://github.com/box/box-content-preview/commit/b9eae0a)), closes [#981](https://github.com/box/box-content-preview/issues/981)
+- Fix: Adding file nav button transition (#974) ([3b09559](https://github.com/box/box-content-preview/commit/3b09559)), closes [#974](https://github.com/box/box-content-preview/issues/974)
+- Fix: Allow scrollable viewers to accept keyboard input when focused ([47eadd9](https://github.com/box/box-content-preview/commit/47eadd9))
+- Fix: Check correct DOM element in 'checkDocumentLoaded()' ([5e33773](https://github.com/box/box-content-preview/commit/5e33773))
+- Fix: Cleanup the thumbnail sidebar when preview errors (#976) ([05fa0a2](https://github.com/box/box-content-preview/commit/05fa0a2)), closes [#976](https://github.com/box/box-content-preview/issues/976)
+- Fix: On Thumbnails initial render, scroll item into view (#975) ([55ad49d](https://github.com/box/box-content-preview/commit/55ad49d)), closes [#975](https://github.com/box/box-content-preview/issues/975)
+- Fix: Position bp-content left in fullscreen (#979) ([2f191b8](https://github.com/box/box-content-preview/commit/2f191b8)), closes [#979](https://github.com/box/box-content-preview/issues/979)
+- Fix: Print poup and buffering DOM references (#980) ([cbc57a1](https://github.com/box/box-content-preview/commit/cbc57a1)), closes [#980](https://github.com/box/box-content-preview/issues/980)
 
 <a name="2.5.0"></a>
+
 ## 2.5.0 (2019-04-02)
 
-* Docs: update latest version in readme ([c3830f9](https://github.com/box/box-content-preview/commit/c3830f9))
-* Update: Open Preview Thumbnails by default (#971) ([5be09ef](https://github.com/box/box-content-preview/commit/5be09ef)), closes [#971](https://github.com/box/box-content-preview/issues/971)
-* Fix: Fail intentionally when preview image files with deleted reps (#964) ([f5c4de4](https://github.com/box/box-content-preview/commit/f5c4de4)), closes [#964](https://github.com/box/box-content-preview/issues/964)
-* Fix: Handle failed document preload for deleted representations (#968) ([0a1d0ef](https://github.com/box/box-content-preview/commit/0a1d0ef)), closes [#968](https://github.com/box/box-content-preview/issues/968)
-* Fix: Hide thumbnails in mobile portrait (#967) ([8d5cbb8](https://github.com/box/box-content-preview/commit/8d5cbb8)), closes [#967](https://github.com/box/box-content-preview/issues/967)
-* Fix: Keyboard navigation should only focus meaningful elements (#970) ([cb6fe25](https://github.com/box/box-content-preview/commit/cb6fe25)), closes [#970](https://github.com/box/box-content-preview/issues/970)
-* Fix: Thumbnail navigation now animates correctly in IE11 (#972) ([cf53a79](https://github.com/box/box-content-preview/commit/cf53a79)), closes [#972](https://github.com/box/box-content-preview/issues/972)
-
-
+- Docs: update latest version in readme ([c3830f9](https://github.com/box/box-content-preview/commit/c3830f9))
+- Update: Open Preview Thumbnails by default (#971) ([5be09ef](https://github.com/box/box-content-preview/commit/5be09ef)), closes [#971](https://github.com/box/box-content-preview/issues/971)
+- Fix: Fail intentionally when preview image files with deleted reps (#964) ([f5c4de4](https://github.com/box/box-content-preview/commit/f5c4de4)), closes [#964](https://github.com/box/box-content-preview/issues/964)
+- Fix: Handle failed document preload for deleted representations (#968) ([0a1d0ef](https://github.com/box/box-content-preview/commit/0a1d0ef)), closes [#968](https://github.com/box/box-content-preview/issues/968)
+- Fix: Hide thumbnails in mobile portrait (#967) ([8d5cbb8](https://github.com/box/box-content-preview/commit/8d5cbb8)), closes [#967](https://github.com/box/box-content-preview/issues/967)
+- Fix: Keyboard navigation should only focus meaningful elements (#970) ([cb6fe25](https://github.com/box/box-content-preview/commit/cb6fe25)), closes [#970](https://github.com/box/box-content-preview/issues/970)
+- Fix: Thumbnail navigation now animates correctly in IE11 (#972) ([cf53a79](https://github.com/box/box-content-preview/commit/cf53a79)), closes [#972](https://github.com/box/box-content-preview/issues/972)
 
 <a name="2.4.0"></a>
+
 ## 2.4.0 (2019-03-26)
 
-* Update: Add hover state to thumbnails (#965) ([096b183](https://github.com/box/box-content-preview/commit/096b183)), closes [#965](https://github.com/box/box-content-preview/issues/965)
-* Update: Wider thumbnails (#963) ([6f2200a](https://github.com/box/box-content-preview/commit/6f2200a)), closes [#963](https://github.com/box/box-content-preview/issues/963)
-* Fix: Fail gracefully when previewing a doc with deleted reps (#962) ([d8cd848](https://github.com/box/box-content-preview/commit/d8cd848)), closes [#962](https://github.com/box/box-content-preview/issues/962)
-
-
+- Update: Add hover state to thumbnails (#965) ([096b183](https://github.com/box/box-content-preview/commit/096b183)), closes [#965](https://github.com/box/box-content-preview/issues/965)
+- Update: Wider thumbnails (#963) ([6f2200a](https://github.com/box/box-content-preview/commit/6f2200a)), closes [#963](https://github.com/box/box-content-preview/issues/963)
+- Fix: Fail gracefully when previewing a doc with deleted reps (#962) ([d8cd848](https://github.com/box/box-content-preview/commit/d8cd848)), closes [#962](https://github.com/box/box-content-preview/issues/962)
 
 <a name="2.3.0"></a>
+
 ## 2.3.0 (2019-03-15)
 
-* Chore: Add e2e Thumbnail tests for large doc (#959) ([6557229](https://github.com/box/box-content-preview/commit/6557229)), closes [#959](https://github.com/box/box-content-preview/issues/959)
-* Chore: Add test for internal presentation links (#951) ([ebb6e75](https://github.com/box/box-content-preview/commit/ebb6e75)), closes [#951](https://github.com/box/box-content-preview/issues/951)
-* Chore: Text Viewer e2e tests (#958) ([eadedf1](https://github.com/box/box-content-preview/commit/eadedf1)), closes [#958](https://github.com/box/box-content-preview/issues/958)
-* Fix: Get response as text from axios (#957) ([68fa4d1](https://github.com/box/box-content-preview/commit/68fa4d1)), closes [#957](https://github.com/box/box-content-preview/issues/957)
-* Fix: Only execute viewer setup if not already setup (#955) ([8c2b193](https://github.com/box/box-content-preview/commit/8c2b193)), closes [#955](https://github.com/box/box-content-preview/issues/955)
-* Update: Animate Thumbnails Sidebar transition (#948) ([5616b74](https://github.com/box/box-content-preview/commit/5616b74)), closes [#948](https://github.com/box/box-content-preview/issues/948)
-* Update: Thumbnails Sidebar dark mode (#952) ([f2da5da](https://github.com/box/box-content-preview/commit/f2da5da)), closes [#952](https://github.com/box/box-content-preview/issues/952)
-* Update Translations (#956) ([eb3dbfd](https://github.com/box/box-content-preview/commit/eb3dbfd)), closes [#956](https://github.com/box/box-content-preview/issues/956)
-
-
+- Chore: Add e2e Thumbnail tests for large doc (#959) ([6557229](https://github.com/box/box-content-preview/commit/6557229)), closes [#959](https://github.com/box/box-content-preview/issues/959)
+- Chore: Add test for internal presentation links (#951) ([ebb6e75](https://github.com/box/box-content-preview/commit/ebb6e75)), closes [#951](https://github.com/box/box-content-preview/issues/951)
+- Chore: Text Viewer e2e tests (#958) ([eadedf1](https://github.com/box/box-content-preview/commit/eadedf1)), closes [#958](https://github.com/box/box-content-preview/issues/958)
+- Fix: Get response as text from axios (#957) ([68fa4d1](https://github.com/box/box-content-preview/commit/68fa4d1)), closes [#957](https://github.com/box/box-content-preview/issues/957)
+- Fix: Only execute viewer setup if not already setup (#955) ([8c2b193](https://github.com/box/box-content-preview/commit/8c2b193)), closes [#955](https://github.com/box/box-content-preview/issues/955)
+- Update: Animate Thumbnails Sidebar transition (#948) ([5616b74](https://github.com/box/box-content-preview/commit/5616b74)), closes [#948](https://github.com/box/box-content-preview/issues/948)
+- Update: Thumbnails Sidebar dark mode (#952) ([f2da5da](https://github.com/box/box-content-preview/commit/f2da5da)), closes [#952](https://github.com/box/box-content-preview/issues/952)
+- Update Translations (#956) ([eb3dbfd](https://github.com/box/box-content-preview/commit/eb3dbfd)), closes [#956](https://github.com/box/box-content-preview/issues/956)
 
 <a name="2.2.0"></a>
+
 ## 2.2.0 (2019-03-05)
 
-* Fix: DownloadReachability regex (#950) ([9cb9f7c](https://github.com/box/box-content-preview/commit/9cb9f7c)), closes [#950](https://github.com/box/box-content-preview/issues/950)
-* Fix: Fix internal presentation links (#946) ([e575a89](https://github.com/box/box-content-preview/commit/e575a89)), closes [#946](https://github.com/box/box-content-preview/issues/946)
-* Chore: Update test file location (#949) ([904d452](https://github.com/box/box-content-preview/commit/904d452)), closes [#949](https://github.com/box/box-content-preview/issues/949)
-* Update Translations (#947) ([7e3b86c](https://github.com/box/box-content-preview/commit/7e3b86c)), closes [#947](https://github.com/box/box-content-preview/issues/947)
-
-
+- Fix: DownloadReachability regex (#950) ([9cb9f7c](https://github.com/box/box-content-preview/commit/9cb9f7c)), closes [#950](https://github.com/box/box-content-preview/issues/950)
+- Fix: Fix internal presentation links (#946) ([e575a89](https://github.com/box/box-content-preview/commit/e575a89)), closes [#946](https://github.com/box/box-content-preview/issues/946)
+- Chore: Update test file location (#949) ([904d452](https://github.com/box/box-content-preview/commit/904d452)), closes [#949](https://github.com/box/box-content-preview/issues/949)
+- Update Translations (#947) ([7e3b86c](https://github.com/box/box-content-preview/commit/7e3b86c)), closes [#947](https://github.com/box/box-content-preview/issues/947)
 
 <a name="2.1.0"></a>
+
 ## 2.1.0 (2019-02-26)
 
-* Update: Moving thumbnail page numbers (#943) ([3a48a14](https://github.com/box/box-content-preview/commit/3a48a14)), closes [#943](https://github.com/box/box-content-preview/issues/943)
-* Chore: Address Security updates (#945) ([98c585a](https://github.com/box/box-content-preview/commit/98c585a)), closes [#945](https://github.com/box/box-content-preview/issues/945)
-* Chore: Downgrade annotations to 2.3.0 (#941) ([1af4c75](https://github.com/box/box-content-preview/commit/1af4c75)), closes [#941](https://github.com/box/box-content-preview/issues/941)
-* Chore: Replace loading doc loading animation with a GIF (#923) ([35fb9f7](https://github.com/box/box-content-preview/commit/35fb9f7)), closes [#923](https://github.com/box/box-content-preview/issues/923)
-* Fix: Apply new loading GIF to presentations (#938) ([f0507bb](https://github.com/box/box-content-preview/commit/f0507bb)), closes [#938](https://github.com/box/box-content-preview/issues/938)
-* Fix: Do not destroy fullscreen on viewer destroy (#935) ([adca14f](https://github.com/box/box-content-preview/commit/adca14f)), closes [#935](https://github.com/box/box-content-preview/issues/935)
-* Fix: Manually dispatch scroll event (#940) ([8954639](https://github.com/box/box-content-preview/commit/8954639)), closes [#940](https://github.com/box/box-content-preview/issues/940)
-* Fix: Remove .bp-content outline (#933) ([a523125](https://github.com/box/box-content-preview/commit/a523125)), closes [#933](https://github.com/box/box-content-preview/issues/933)
-* Fix: Use pointer for Thumbnails cursor (#936) ([a53d450](https://github.com/box/box-content-preview/commit/a53d450)), closes [#936](https://github.com/box/box-content-preview/issues/936)
-* Update Translations (#934) ([3121a48](https://github.com/box/box-content-preview/commit/3121a48)), closes [#934](https://github.com/box/box-content-preview/issues/934)
-* Update Translations (#942) ([bf9c94f](https://github.com/box/box-content-preview/commit/bf9c94f)), closes [#942](https://github.com/box/box-content-preview/issues/942)
-* Upgrade: Migrate from whatwg-fetch to axios for all requests (#939) ([fb76b13](https://github.com/box/box-content-preview/commit/fb76b13)), closes [#939](https://github.com/box/box-content-preview/issues/939)
-
-
+- Update: Moving thumbnail page numbers (#943) ([3a48a14](https://github.com/box/box-content-preview/commit/3a48a14)), closes [#943](https://github.com/box/box-content-preview/issues/943)
+- Chore: Address Security updates (#945) ([98c585a](https://github.com/box/box-content-preview/commit/98c585a)), closes [#945](https://github.com/box/box-content-preview/issues/945)
+- Chore: Downgrade annotations to 2.3.0 (#941) ([1af4c75](https://github.com/box/box-content-preview/commit/1af4c75)), closes [#941](https://github.com/box/box-content-preview/issues/941)
+- Chore: Replace loading doc loading animation with a GIF (#923) ([35fb9f7](https://github.com/box/box-content-preview/commit/35fb9f7)), closes [#923](https://github.com/box/box-content-preview/issues/923)
+- Fix: Apply new loading GIF to presentations (#938) ([f0507bb](https://github.com/box/box-content-preview/commit/f0507bb)), closes [#938](https://github.com/box/box-content-preview/issues/938)
+- Fix: Do not destroy fullscreen on viewer destroy (#935) ([adca14f](https://github.com/box/box-content-preview/commit/adca14f)), closes [#935](https://github.com/box/box-content-preview/issues/935)
+- Fix: Manually dispatch scroll event (#940) ([8954639](https://github.com/box/box-content-preview/commit/8954639)), closes [#940](https://github.com/box/box-content-preview/issues/940)
+- Fix: Remove .bp-content outline (#933) ([a523125](https://github.com/box/box-content-preview/commit/a523125)), closes [#933](https://github.com/box/box-content-preview/issues/933)
+- Fix: Use pointer for Thumbnails cursor (#936) ([a53d450](https://github.com/box/box-content-preview/commit/a53d450)), closes [#936](https://github.com/box/box-content-preview/issues/936)
+- Update Translations (#934) ([3121a48](https://github.com/box/box-content-preview/commit/3121a48)), closes [#934](https://github.com/box/box-content-preview/issues/934)
+- Update Translations (#942) ([bf9c94f](https://github.com/box/box-content-preview/commit/bf9c94f)), closes [#942](https://github.com/box/box-content-preview/issues/942)
+- Upgrade: Migrate from whatwg-fetch to axios for all requests (#939) ([fb76b13](https://github.com/box/box-content-preview/commit/fb76b13)), closes [#939](https://github.com/box/box-content-preview/issues/939)
 
 <a name="2.0.0"></a>
+
 ## 2.0.0 (2019-02-19)
 
-* New: Thumbnails Sidebar (#932) ([4d3ecc3](https://github.com/box/box-content-preview/commit/4d3ecc3)), closes [#932](https://github.com/box/box-content-preview/issues/932)
-* Fix: Fullscreen classes are now removed when pressing escape (#927) ([66ed344](https://github.com/box/box-content-preview/commit/66ed344)), closes [#927](https://github.com/box/box-content-preview/issues/927)
-
-
+- New: Thumbnails Sidebar (#932) ([4d3ecc3](https://github.com/box/box-content-preview/commit/4d3ecc3)), closes [#932](https://github.com/box/box-content-preview/issues/932)
+- Fix: Fullscreen classes are now removed when pressing escape (#927) ([66ed344](https://github.com/box/box-content-preview/commit/66ed344)), closes [#927](https://github.com/box/box-content-preview/issues/927)
 
 <a name="1.65.0"></a>
+
 ## 1.65.0 (2019-02-12)
 
-* Chore(metrics): add new timer for full preview load time tracking (#922) ([7da1899](https://github.com/box/box-content-preview/commit/7da1899)), closes [#922](https://github.com/box/box-content-preview/issues/922)
-* Fix: Prevent overwrite of cached page on presentation preview init (#916) ([9256dcc](https://github.com/box/box-content-preview/commit/9256dcc)), closes [#916](https://github.com/box/box-content-preview/issues/916)
-* Upgrade: Upgrade box-annotations to v3.10.0 (#918) ([214e366](https://github.com/box/box-content-preview/commit/214e366)), closes [#918](https://github.com/box/box-content-preview/issues/918)
-
-
+- Chore(metrics): add new timer for full preview load time tracking (#922) ([7da1899](https://github.com/box/box-content-preview/commit/7da1899)), closes [#922](https://github.com/box/box-content-preview/issues/922)
+- Fix: Prevent overwrite of cached page on presentation preview init (#916) ([9256dcc](https://github.com/box/box-content-preview/commit/9256dcc)), closes [#916](https://github.com/box/box-content-preview/issues/916)
+- Upgrade: Upgrade box-annotations to v3.10.0 (#918) ([214e366](https://github.com/box/box-content-preview/commit/214e366)), closes [#918](https://github.com/box/box-content-preview/issues/918)
 
 <a name="1.64.0"></a>
+
 ## 1.64.0 (2019-02-05)
 
-* Chore: Add preload metric to Document viewers (#907) ([f4956aa](https://github.com/box/box-content-preview/commit/f4956aa)), closes [#907](https://github.com/box/box-content-preview/issues/907)
-* Chore: Add support for integration testing with Cypress (#909) ([68e962e](https://github.com/box/box-content-preview/commit/68e962e)), closes [#909](https://github.com/box/box-content-preview/issues/909)
-* Chore: Adding Cypress tests to cover existing functional tests (#912) ([0093c93](https://github.com/box/box-content-preview/commit/0093c93)), closes [#912](https://github.com/box/box-content-preview/issues/912)
-* Chore: Downgrade annotations to 2.3 (#914) ([bdef1a3](https://github.com/box/box-content-preview/commit/bdef1a3)), closes [#914](https://github.com/box/box-content-preview/issues/914)
-* Chore: removing functional tests (#913) ([c2f5d97](https://github.com/box/box-content-preview/commit/c2f5d97)), closes [#913](https://github.com/box/box-content-preview/issues/913)
-* Chore: track encoding type for documents (#911) ([d2a0e46](https://github.com/box/box-content-preview/commit/d2a0e46)), closes [#911](https://github.com/box/box-content-preview/issues/911)
-* Fix: Display bullets for unordered list in markdown previews (#910) ([a18002b](https://github.com/box/box-content-preview/commit/a18002b)), closes [#910](https://github.com/box/box-content-preview/issues/910)
-
-
+- Chore: Add preload metric to Document viewers (#907) ([f4956aa](https://github.com/box/box-content-preview/commit/f4956aa)), closes [#907](https://github.com/box/box-content-preview/issues/907)
+- Chore: Add support for integration testing with Cypress (#909) ([68e962e](https://github.com/box/box-content-preview/commit/68e962e)), closes [#909](https://github.com/box/box-content-preview/issues/909)
+- Chore: Adding Cypress tests to cover existing functional tests (#912) ([0093c93](https://github.com/box/box-content-preview/commit/0093c93)), closes [#912](https://github.com/box/box-content-preview/issues/912)
+- Chore: Downgrade annotations to 2.3 (#914) ([bdef1a3](https://github.com/box/box-content-preview/commit/bdef1a3)), closes [#914](https://github.com/box/box-content-preview/issues/914)
+- Chore: removing functional tests (#913) ([c2f5d97](https://github.com/box/box-content-preview/commit/c2f5d97)), closes [#913](https://github.com/box/box-content-preview/issues/913)
+- Chore: track encoding type for documents (#911) ([d2a0e46](https://github.com/box/box-content-preview/commit/d2a0e46)), closes [#911](https://github.com/box/box-content-preview/issues/911)
+- Fix: Display bullets for unordered list in markdown previews (#910) ([a18002b](https://github.com/box/box-content-preview/commit/a18002b)), closes [#910](https://github.com/box/box-content-preview/issues/910)
 
 <a name="1.63.0"></a>
+
 ## 1.63.0 (2019-01-29)
 
-* Fix: Prevent Annotations errors from triggering a Preview failure (#904) ([0db8b4b](https://github.com/box/box-content-preview/commit/0db8b4b)), closes [#904](https://github.com/box/box-content-preview/issues/904)
-* Fixing self hosting instructions (#905) ([72bf820](https://github.com/box/box-content-preview/commit/72bf820)), closes [#905](https://github.com/box/box-content-preview/issues/905)
-* Updating README to latest release ([0c93444](https://github.com/box/box-content-preview/commit/0c93444))
-* Update: box-annotations to v3.7.1 (#897) ([8e2fb91](https://github.com/box/box-content-preview/commit/8e2fb91)), closes [#897](https://github.com/box/box-content-preview/issues/897)
-* Chore: Add webpack-dev-server to support local development (#902) ([568842c](https://github.com/box/box-content-preview/commit/568842c)), closes [#902](https://github.com/box/box-content-preview/issues/902)
-* Chore: Improve fullscreen logic to use fscreen for compatibility (#903) ([aa13d00](https://github.com/box/box-content-preview/commit/aa13d00)), closes [#903](https://github.com/box/box-content-preview/issues/903)
-* Chore: upgrade node-sass to 4.9.3, to match other projects (#899) ([3b7f40a](https://github.com/box/box-content-preview/commit/3b7f40a)), closes [#899](https://github.com/box/box-content-preview/issues/899)
-
-
+- Fix: Prevent Annotations errors from triggering a Preview failure (#904) ([0db8b4b](https://github.com/box/box-content-preview/commit/0db8b4b)), closes [#904](https://github.com/box/box-content-preview/issues/904)
+- Fixing self hosting instructions (#905) ([72bf820](https://github.com/box/box-content-preview/commit/72bf820)), closes [#905](https://github.com/box/box-content-preview/issues/905)
+- Updating README to latest release ([0c93444](https://github.com/box/box-content-preview/commit/0c93444))
+- Update: box-annotations to v3.7.1 (#897) ([8e2fb91](https://github.com/box/box-content-preview/commit/8e2fb91)), closes [#897](https://github.com/box/box-content-preview/issues/897)
+- Chore: Add webpack-dev-server to support local development (#902) ([568842c](https://github.com/box/box-content-preview/commit/568842c)), closes [#902](https://github.com/box/box-content-preview/issues/902)
+- Chore: Improve fullscreen logic to use fscreen for compatibility (#903) ([aa13d00](https://github.com/box/box-content-preview/commit/aa13d00)), closes [#903](https://github.com/box/box-content-preview/issues/903)
+- Chore: upgrade node-sass to 4.9.3, to match other projects (#899) ([3b7f40a](https://github.com/box/box-content-preview/commit/3b7f40a)), closes [#899](https://github.com/box/box-content-preview/issues/899)
 
 <a name="1.62.0"></a>
+
 ## 1.62.0 (2019-01-22)
 
-* Chore: Upgrade deps and scripts to work with node 10 (#893) ([279fc2e](https://github.com/box/box-content-preview/commit/279fc2e)), closes [#893](https://github.com/box/box-content-preview/issues/893)
-* Chore: Upgrade to React 16.7 (#895) ([06c9a31](https://github.com/box/box-content-preview/commit/06c9a31)), closes [#895](https://github.com/box/box-content-preview/issues/895)
-
-
+- Chore: Upgrade deps and scripts to work with node 10 (#893) ([279fc2e](https://github.com/box/box-content-preview/commit/279fc2e)), closes [#893](https://github.com/box/box-content-preview/issues/893)
+- Chore: Upgrade to React 16.7 (#895) ([06c9a31](https://github.com/box/box-content-preview/commit/06c9a31)), closes [#895](https://github.com/box/box-content-preview/issues/895)
 
 <a name="1.61.0"></a>
+
 ## 1.61.0 (2019-01-15)
 
-* Update: Continuous progress bar through retries (#883) ([6782e47](https://github.com/box/box-content-preview/commit/6782e47)), closes [#883](https://github.com/box/box-content-preview/issues/883)
-*  Chore: change functional tests to use puppeteer (#881) ([725ca3d](https://github.com/box/box-content-preview/commit/725ca3d)), closes [#881](https://github.com/box/box-content-preview/issues/881)
-* Chore: Copy doc assets to new  bundle (#872) ([acce333](https://github.com/box/box-content-preview/commit/acce333)), closes [#872](https://github.com/box/box-content-preview/issues/872)
-* Chore: Downgrade annotations to 2.3.0 (#873) ([fc61785](https://github.com/box/box-content-preview/commit/fc61785)), closes [#873](https://github.com/box/box-content-preview/issues/873)
-* Chore: Remove nsp (#878) ([7a3030d](https://github.com/box/box-content-preview/commit/7a3030d)), closes [#878](https://github.com/box/box-content-preview/issues/878)
-
-
+- Update: Continuous progress bar through retries (#883) ([6782e47](https://github.com/box/box-content-preview/commit/6782e47)), closes [#883](https://github.com/box/box-content-preview/issues/883)
+- Chore: change functional tests to use puppeteer (#881) ([725ca3d](https://github.com/box/box-content-preview/commit/725ca3d)), closes [#881](https://github.com/box/box-content-preview/issues/881)
+- Chore: Copy doc assets to new bundle (#872) ([acce333](https://github.com/box/box-content-preview/commit/acce333)), closes [#872](https://github.com/box/box-content-preview/issues/872)
+- Chore: Downgrade annotations to 2.3.0 (#873) ([fc61785](https://github.com/box/box-content-preview/commit/fc61785)), closes [#873](https://github.com/box/box-content-preview/issues/873)
+- Chore: Remove nsp (#878) ([7a3030d](https://github.com/box/box-content-preview/commit/7a3030d)), closes [#878](https://github.com/box/box-content-preview/issues/878)
 
 <a name="1.60.0"></a>
+
 ## 1.60.0 (2018-11-28)
 
-* Fix: Add NodeList.forEach polyfill for IE (#869) ([8f3a024](https://github.com/box/box-content-preview/commit/8f3a024)), closes [#869](https://github.com/box/box-content-preview/issues/869)
-* Fix: Don't wait when rep status is none (#871) ([893e724](https://github.com/box/box-content-preview/commit/893e724)), closes [#871](https://github.com/box/box-content-preview/issues/871)
-* Mojito: Update translations (#865) ([258f3f5](https://github.com/box/box-content-preview/commit/258f3f5)), closes [#865](https://github.com/box/box-content-preview/issues/865)
-* Chore: Update media player docs to reflect userInitiated change (#870) ([1a71790](https://github.com/box/box-content-preview/commit/1a71790)), closes [#870](https://github.com/box/box-content-preview/issues/870)
-
-
+- Fix: Add NodeList.forEach polyfill for IE (#869) ([8f3a024](https://github.com/box/box-content-preview/commit/8f3a024)), closes [#869](https://github.com/box/box-content-preview/issues/869)
+- Fix: Don't wait when rep status is none (#871) ([893e724](https://github.com/box/box-content-preview/commit/893e724)), closes [#871](https://github.com/box/box-content-preview/issues/871)
+- Mojito: Update translations (#865) ([258f3f5](https://github.com/box/box-content-preview/commit/258f3f5)), closes [#865](https://github.com/box/box-content-preview/issues/865)
+- Chore: Update media player docs to reflect userInitiated change (#870) ([1a71790](https://github.com/box/box-content-preview/commit/1a71790)), closes [#870](https://github.com/box/box-content-preview/issues/870)
 
 <a name="1.59.0"></a>
+
 ## 1.59.0 (2018-11-20)
 
-* Update: box-annotations to 3.3.0 (#867) ([712a3db](https://github.com/box/box-content-preview/commit/712a3db)), closes [#867](https://github.com/box/box-content-preview/issues/867)
-* Chore: Emit pause event with flag if initiated by user  (#861) ([8d7091c](https://github.com/box/box-content-preview/commit/8d7091c)), closes [#861](https://github.com/box/box-content-preview/issues/861)
-* Fix: Better error message for file of unknown type (#862) ([de1246a](https://github.com/box/box-content-preview/commit/de1246a)), closes [#862](https://github.com/box/box-content-preview/issues/862)
-* Fix: Downgrade annotations to 2.3.0 (#866) ([0589f23](https://github.com/box/box-content-preview/commit/0589f23)), closes [#866](https://github.com/box/box-content-preview/issues/866)
-* Fix: Focus on correct element when entering fullscreen in Firefox (#864) ([3d7cf79](https://github.com/box/box-content-preview/commit/3d7cf79)), closes [#864](https://github.com/box/box-content-preview/issues/864)
-
-
+- Update: box-annotations to 3.3.0 (#867) ([712a3db](https://github.com/box/box-content-preview/commit/712a3db)), closes [#867](https://github.com/box/box-content-preview/issues/867)
+- Chore: Emit pause event with flag if initiated by user (#861) ([8d7091c](https://github.com/box/box-content-preview/commit/8d7091c)), closes [#861](https://github.com/box/box-content-preview/issues/861)
+- Fix: Better error message for file of unknown type (#862) ([de1246a](https://github.com/box/box-content-preview/commit/de1246a)), closes [#862](https://github.com/box/box-content-preview/issues/862)
+- Fix: Downgrade annotations to 2.3.0 (#866) ([0589f23](https://github.com/box/box-content-preview/commit/0589f23)), closes [#866](https://github.com/box/box-content-preview/issues/866)
+- Fix: Focus on correct element when entering fullscreen in Firefox (#864) ([3d7cf79](https://github.com/box/box-content-preview/commit/3d7cf79)), closes [#864](https://github.com/box/box-content-preview/issues/864)
 
 <a name="1.58.0"></a>
+
 ## 1.58.0 (2018-11-13)
 
-* Update: box-annotations to v3.2.0 (#863) ([18b7832](https://github.com/box/box-content-preview/commit/18b7832)), closes [#863](https://github.com/box/box-content-preview/issues/863)
-* New: Enable PDF Signatures in PDF.js (#853) ([15fc355](https://github.com/box/box-content-preview/commit/15fc355)), closes [#853](https://github.com/box/box-content-preview/issues/853)
-
-
+- Update: box-annotations to v3.2.0 (#863) ([18b7832](https://github.com/box/box-content-preview/commit/18b7832)), closes [#863](https://github.com/box/box-content-preview/issues/863)
+- New: Enable PDF Signatures in PDF.js (#853) ([15fc355](https://github.com/box/box-content-preview/commit/15fc355)), closes [#853](https://github.com/box/box-content-preview/issues/853)
 
 <a name="1.57.0"></a>
+
 ## 1.57.0 (2018-11-07)
 
-* Chore: Remove outline from preview container (#860) ([5d9415e](https://github.com/box/box-content-preview/commit/5d9415e)), closes [#860](https://github.com/box/box-content-preview/issues/860)
-* Update: box-annotations to v3.1.0 (#859) ([64c5806](https://github.com/box/box-content-preview/commit/64c5806)), closes [#859](https://github.com/box/box-content-preview/issues/859)
-* Fix: Add tabindex to preview container (#858) ([a37fdb7](https://github.com/box/box-content-preview/commit/a37fdb7)), closes [#858](https://github.com/box/box-content-preview/issues/858)
-
-
+- Chore: Remove outline from preview container (#860) ([5d9415e](https://github.com/box/box-content-preview/commit/5d9415e)), closes [#860](https://github.com/box/box-content-preview/issues/860)
+- Update: box-annotations to v3.1.0 (#859) ([64c5806](https://github.com/box/box-content-preview/commit/64c5806)), closes [#859](https://github.com/box/box-content-preview/issues/859)
+- Fix: Add tabindex to preview container (#858) ([a37fdb7](https://github.com/box/box-content-preview/commit/a37fdb7)), closes [#858](https://github.com/box/box-content-preview/issues/858)
 
 <a name="1.56.0"></a>
+
 ## 1.56.0 (2018-10-31)
 
-* Chore: Add test to check PDFjs headers to avoid preflight (#855) ([d8077f5](https://github.com/box/box-content-preview/commit/d8077f5)), closes [#855](https://github.com/box/box-content-preview/issues/855)
-* Chore: Enable PDF signatures in future builds of PDF.js (#852) ([4d61afa](https://github.com/box/box-content-preview/commit/4d61afa)), closes [#852](https://github.com/box/box-content-preview/issues/852)
-* Chore: Upgrade Box Annotations to v3.0.0 (#856) ([3d4bd9e](https://github.com/box/box-content-preview/commit/3d4bd9e)), closes [#856](https://github.com/box/box-content-preview/issues/856)
-* Fix: Prevent extra multi image page padding added by preview consumers (#854) ([3f8ee16](https://github.com/box/box-content-preview/commit/3f8ee16)), closes [#854](https://github.com/box/box-content-preview/issues/854)
-
-
+- Chore: Add test to check PDFjs headers to avoid preflight (#855) ([d8077f5](https://github.com/box/box-content-preview/commit/d8077f5)), closes [#855](https://github.com/box/box-content-preview/issues/855)
+- Chore: Enable PDF signatures in future builds of PDF.js (#852) ([4d61afa](https://github.com/box/box-content-preview/commit/4d61afa)), closes [#852](https://github.com/box/box-content-preview/issues/852)
+- Chore: Upgrade Box Annotations to v3.0.0 (#856) ([3d4bd9e](https://github.com/box/box-content-preview/commit/3d4bd9e)), closes [#856](https://github.com/box/box-content-preview/issues/856)
+- Fix: Prevent extra multi image page padding added by preview consumers (#854) ([3f8ee16](https://github.com/box/box-content-preview/commit/3f8ee16)), closes [#854](https://github.com/box/box-content-preview/issues/854)
 
 <a name="1.55.0"></a>
+
 ## 1.55.0 (2018-10-16)
 
-* Update: box-annotations to v2.3.0 (#851) ([ed4d81e](https://github.com/box/box-content-preview/commit/ed4d81e)), closes [#851](https://github.com/box/box-content-preview/issues/851)
-* Fix: Adding annotations back to MultiImageViewer (#847) ([6e0ecb0](https://github.com/box/box-content-preview/commit/6e0ecb0)), closes [#847](https://github.com/box/box-content-preview/issues/847)
-* Fix: Pass shaka data to error detail so it can be logged (#848) ([8fdd344](https://github.com/box/box-content-preview/commit/8fdd344)), closes [#848](https://github.com/box/box-content-preview/issues/848)
-* Fix: resize preload in document viewer (#850) ([d29afa6](https://github.com/box/box-content-preview/commit/d29afa6)), closes [#850](https://github.com/box/box-content-preview/issues/850)
-
-
+- Update: box-annotations to v2.3.0 (#851) ([ed4d81e](https://github.com/box/box-content-preview/commit/ed4d81e)), closes [#851](https://github.com/box/box-content-preview/issues/851)
+- Fix: Adding annotations back to MultiImageViewer (#847) ([6e0ecb0](https://github.com/box/box-content-preview/commit/6e0ecb0)), closes [#847](https://github.com/box/box-content-preview/issues/847)
+- Fix: Pass shaka data to error detail so it can be logged (#848) ([8fdd344](https://github.com/box/box-content-preview/commit/8fdd344)), closes [#848](https://github.com/box/box-content-preview/issues/848)
+- Fix: resize preload in document viewer (#850) ([d29afa6](https://github.com/box/box-content-preview/commit/d29afa6)), closes [#850](https://github.com/box/box-content-preview/issues/850)
 
 <a name="1.54.0"></a>
+
 ## 1.54.0 (2018-10-09)
 
-* Chore: Moving header into container (#849) ([9528761](https://github.com/box/box-content-preview/commit/9528761)), closes [#849](https://github.com/box/box-content-preview/issues/849)
-* Update: adding the headerElement option to Preview.show (#846) ([70eae04](https://github.com/box/box-content-preview/commit/70eae04)), closes [#846](https://github.com/box/box-content-preview/issues/846)
-* New: Add gzip encoding param to pdf reps (#845) ([5137a01](https://github.com/box/box-content-preview/commit/5137a01)), closes [#845](https://github.com/box/box-content-preview/issues/845)
-* Fix: Check to see if viewers want to show annotations (#843) ([2aa9914](https://github.com/box/box-content-preview/commit/2aa9914)), closes [#843](https://github.com/box/box-content-preview/issues/843)
-
-
+- Chore: Moving header into container (#849) ([9528761](https://github.com/box/box-content-preview/commit/9528761)), closes [#849](https://github.com/box/box-content-preview/issues/849)
+- Update: adding the headerElement option to Preview.show (#846) ([70eae04](https://github.com/box/box-content-preview/commit/70eae04)), closes [#846](https://github.com/box/box-content-preview/issues/846)
+- New: Add gzip encoding param to pdf reps (#845) ([5137a01](https://github.com/box/box-content-preview/commit/5137a01)), closes [#845](https://github.com/box/box-content-preview/issues/845)
+- Fix: Check to see if viewers want to show annotations (#843) ([2aa9914](https://github.com/box/box-content-preview/commit/2aa9914)), closes [#843](https://github.com/box/box-content-preview/issues/843)
 
 <a name="1.53.0"></a>
+
 ## 1.53.0 (2018-09-18)
 
-* Fix: init annotations after file rep is fetched (#842) ([20cc3c5](https://github.com/box/box-content-preview/commit/20cc3c5)), closes [#842](https://github.com/box/box-content-preview/issues/842)
-
-
+- Fix: init annotations after file rep is fetched (#842) ([20cc3c5](https://github.com/box/box-content-preview/commit/20cc3c5)), closes [#842](https://github.com/box/box-content-preview/issues/842)
 
 <a name="1.52.0"></a>
+
 ## 1.52.0 (2018-09-11)
 
-* Chore: remove x-box-accept-encoding header to prevent OPTIONS call (#841) ([8ebf984](https://github.com/box/box-content-preview/commit/8ebf984)), closes [#841](https://github.com/box/box-content-preview/issues/841)
-
-
+- Chore: remove x-box-accept-encoding header to prevent OPTIONS call (#841) ([8ebf984](https://github.com/box/box-content-preview/commit/8ebf984)), closes [#841](https://github.com/box/box-content-preview/issues/841)
 
 <a name="1.51.0"></a>
+
 ## 1.51.0 (2018-09-04)
 
-* Mojito: Update translations (#830) ([bdb45e9](https://github.com/box/box-content-preview/commit/bdb45e9)), closes [#830](https://github.com/box/box-content-preview/issues/830)
-* Fix: add min-width to video (#839) ([b655d90](https://github.com/box/box-content-preview/commit/b655d90)), closes [#839](https://github.com/box/box-content-preview/issues/839)
-* Fix: navigation buttons shouldn't cover scrollbar (#838) ([55b4d8e](https://github.com/box/box-content-preview/commit/55b4d8e)), closes [#838](https://github.com/box/box-content-preview/issues/838)
-* Chore: Allow load metrics emission without file info (#828) ([863be29](https://github.com/box/box-content-preview/commit/863be29)), closes [#828](https://github.com/box/box-content-preview/issues/828)
-* New: Adding NodeJS version check to Release script (#834) ([f28558c](https://github.com/box/box-content-preview/commit/f28558c)), closes [#834](https://github.com/box/box-content-preview/issues/834)
-
-
+- Mojito: Update translations (#830) ([bdb45e9](https://github.com/box/box-content-preview/commit/bdb45e9)), closes [#830](https://github.com/box/box-content-preview/issues/830)
+- Fix: add min-width to video (#839) ([b655d90](https://github.com/box/box-content-preview/commit/b655d90)), closes [#839](https://github.com/box/box-content-preview/issues/839)
+- Fix: navigation buttons shouldn't cover scrollbar (#838) ([55b4d8e](https://github.com/box/box-content-preview/commit/55b4d8e)), closes [#838](https://github.com/box/box-content-preview/issues/838)
+- Chore: Allow load metrics emission without file info (#828) ([863be29](https://github.com/box/box-content-preview/commit/863be29)), closes [#828](https://github.com/box/box-content-preview/issues/828)
+- New: Adding NodeJS version check to Release script (#834) ([f28558c](https://github.com/box/box-content-preview/commit/f28558c)), closes [#834](https://github.com/box/box-content-preview/issues/834)
 
 <a name="1.50.0"></a>
+
 ## 1.50.0 (2018-08-28)
 
-* Chore: Adding find bar metrics (#835) ([15f6984](https://github.com/box/box-content-preview/commit/15f6984)), closes [#835](https://github.com/box/box-content-preview/issues/835)
-* Fix: Preview should not auto focus itself unless told to do so (#833) ([d5ce4ef](https://github.com/box/box-content-preview/commit/d5ce4ef)), closes [#833](https://github.com/box/box-content-preview/issues/833)
-
-
+- Chore: Adding find bar metrics (#835) ([15f6984](https://github.com/box/box-content-preview/commit/15f6984)), closes [#835](https://github.com/box/box-content-preview/issues/835)
+- Fix: Preview should not auto focus itself unless told to do so (#833) ([d5ce4ef](https://github.com/box/box-content-preview/commit/d5ce4ef)), closes [#833](https://github.com/box/box-content-preview/issues/833)
 
 <a name="1.49.0"></a>
+
 ## 1.49.0 (2018-08-21)
 
-* Revert "Release: 1.49.0" (#831) ([acb4523](https://github.com/box/box-content-preview/commit/acb4523)), closes [#831](https://github.com/box/box-content-preview/issues/831)
-* Revert "Release: 1.49.0" (#832) ([9bcf3c0](https://github.com/box/box-content-preview/commit/9bcf3c0)), closes [#832](https://github.com/box/box-content-preview/issues/832)
-* Release: 1.49.0 ([32e2c1d](https://github.com/box/box-content-preview/commit/32e2c1d))
-* Release: 1.49.0 ([47cf6f4](https://github.com/box/box-content-preview/commit/47cf6f4))
-* Fix: Display correct error when handling an asset error (#829) ([2f70273](https://github.com/box/box-content-preview/commit/2f70273)), closes [#829](https://github.com/box/box-content-preview/issues/829)
-
-
+- Revert "Release: 1.49.0" (#831) ([acb4523](https://github.com/box/box-content-preview/commit/acb4523)), closes [#831](https://github.com/box/box-content-preview/issues/831)
+- Revert "Release: 1.49.0" (#832) ([9bcf3c0](https://github.com/box/box-content-preview/commit/9bcf3c0)), closes [#832](https://github.com/box/box-content-preview/issues/832)
+- Release: 1.49.0 ([32e2c1d](https://github.com/box/box-content-preview/commit/32e2c1d))
+- Release: 1.49.0 ([47cf6f4](https://github.com/box/box-content-preview/commit/47cf6f4))
+- Fix: Display correct error when handling an asset error (#829) ([2f70273](https://github.com/box/box-content-preview/commit/2f70273)), closes [#829](https://github.com/box/box-content-preview/issues/829)
 
 <a name="1.48.0"></a>
+
 ## 1.48.0 (2018-07-26)
 
-* Chore: Support auto captions in legacy and edited captions (#825) ([7b23933](https://github.com/box/box-content-preview/commit/7b23933)), closes [#825](https://github.com/box/box-content-preview/issues/825)
-* Fix: Fix scenario where skills are present with no transcript (#824) ([26b8c9b](https://github.com/box/box-content-preview/commit/26b8c9b)), closes [#824](https://github.com/box/box-content-preview/issues/824)
-
-
+- Chore: Support auto captions in legacy and edited captions (#825) ([7b23933](https://github.com/box/box-content-preview/commit/7b23933)), closes [#825](https://github.com/box/box-content-preview/issues/825)
+- Fix: Fix scenario where skills are present with no transcript (#824) ([26b8c9b](https://github.com/box/box-content-preview/commit/26b8c9b)), closes [#824](https://github.com/box/box-content-preview/issues/824)
 
 <a name="1.47.0"></a>
+
 ## 1.47.0 (2018-07-18)
 
-* Revert "Release: 1.47.0" (#822) ([b4fd3ac](https://github.com/box/box-content-preview/commit/b4fd3ac)), closes [#822](https://github.com/box/box-content-preview/issues/822)
-* Revert "Upgrade: packages (#813)" (#823) ([b3f1421](https://github.com/box/box-content-preview/commit/b3f1421)), closes [#813](https://github.com/box/box-content-preview/issues/813) [#823](https://github.com/box/box-content-preview/issues/823)
-* Release: 1.47.0 ([2953369](https://github.com/box/box-content-preview/commit/2953369))
-* Mojito: Update translations (#812) ([f557e5e](https://github.com/box/box-content-preview/commit/f557e5e)), closes [#812](https://github.com/box/box-content-preview/issues/812)
-* Mojito: Update translations (#818) ([6a17036](https://github.com/box/box-content-preview/commit/6a17036)), closes [#818](https://github.com/box/box-content-preview/issues/818)
-* Mojito: Update translations (#821) ([f8a5205](https://github.com/box/box-content-preview/commit/f8a5205)), closes [#821](https://github.com/box/box-content-preview/issues/821)
-* Fix: Downgrade optimize-css-assets-webpack-plugin package (#819) ([a3391a9](https://github.com/box/box-content-preview/commit/a3391a9)), closes [#819](https://github.com/box/box-content-preview/issues/819)
-* Fix: Flaky ImageViewer test (#811) ([7ac4797](https://github.com/box/box-content-preview/commit/7ac4797)), closes [#811](https://github.com/box/box-content-preview/issues/811)
-* New: Auto-generated captions (#816) ([a5cd36f](https://github.com/box/box-content-preview/commit/a5cd36f)), closes [#816](https://github.com/box/box-content-preview/issues/816)
-* Build: Hide rsync file list (#815) ([e1e4b57](https://github.com/box/box-content-preview/commit/e1e4b57)), closes [#815](https://github.com/box/box-content-preview/issues/815)
-* Upgrade: packages (#813) ([d865b59](https://github.com/box/box-content-preview/commit/d865b59)), closes [#813](https://github.com/box/box-content-preview/issues/813)
-
-
+- Revert "Release: 1.47.0" (#822) ([b4fd3ac](https://github.com/box/box-content-preview/commit/b4fd3ac)), closes [#822](https://github.com/box/box-content-preview/issues/822)
+- Revert "Upgrade: packages (#813)" (#823) ([b3f1421](https://github.com/box/box-content-preview/commit/b3f1421)), closes [#813](https://github.com/box/box-content-preview/issues/813) [#823](https://github.com/box/box-content-preview/issues/823)
+- Release: 1.47.0 ([2953369](https://github.com/box/box-content-preview/commit/2953369))
+- Mojito: Update translations (#812) ([f557e5e](https://github.com/box/box-content-preview/commit/f557e5e)), closes [#812](https://github.com/box/box-content-preview/issues/812)
+- Mojito: Update translations (#818) ([6a17036](https://github.com/box/box-content-preview/commit/6a17036)), closes [#818](https://github.com/box/box-content-preview/issues/818)
+- Mojito: Update translations (#821) ([f8a5205](https://github.com/box/box-content-preview/commit/f8a5205)), closes [#821](https://github.com/box/box-content-preview/issues/821)
+- Fix: Downgrade optimize-css-assets-webpack-plugin package (#819) ([a3391a9](https://github.com/box/box-content-preview/commit/a3391a9)), closes [#819](https://github.com/box/box-content-preview/issues/819)
+- Fix: Flaky ImageViewer test (#811) ([7ac4797](https://github.com/box/box-content-preview/commit/7ac4797)), closes [#811](https://github.com/box/box-content-preview/issues/811)
+- New: Auto-generated captions (#816) ([a5cd36f](https://github.com/box/box-content-preview/commit/a5cd36f)), closes [#816](https://github.com/box/box-content-preview/issues/816)
+- Build: Hide rsync file list (#815) ([e1e4b57](https://github.com/box/box-content-preview/commit/e1e4b57)), closes [#815](https://github.com/box/box-content-preview/issues/815)
+- Upgrade: packages (#813) ([d865b59](https://github.com/box/box-content-preview/commit/d865b59)), closes [#813](https://github.com/box/box-content-preview/issues/813)
 
 <a name="1.46.0"></a>
+
 ## 1.46.0 (2018-06-20)
 
-* Fix: Retry logic (#808) ([906d47a](https://github.com/box/box-content-preview/commit/906d47a)), closes [#808](https://github.com/box/box-content-preview/issues/808)
-* Add docs for token generator function (#807) ([8791f4e](https://github.com/box/box-content-preview/commit/8791f4e)), closes [#807](https://github.com/box/box-content-preview/issues/807)
-* Update README.md ([35b2462](https://github.com/box/box-content-preview/commit/35b2462))
-* Mojito: Update translations (#806) ([18b5fde](https://github.com/box/box-content-preview/commit/18b5fde)), closes [#806](https://github.com/box/box-content-preview/issues/806)
-* Mojito: Update translations (#809) ([2a83b31](https://github.com/box/box-content-preview/commit/2a83b31)), closes [#809](https://github.com/box/box-content-preview/issues/809)
-
-
+- Fix: Retry logic (#808) ([906d47a](https://github.com/box/box-content-preview/commit/906d47a)), closes [#808](https://github.com/box/box-content-preview/issues/808)
+- Add docs for token generator function (#807) ([8791f4e](https://github.com/box/box-content-preview/commit/8791f4e)), closes [#807](https://github.com/box/box-content-preview/issues/807)
+- Update README.md ([35b2462](https://github.com/box/box-content-preview/commit/35b2462))
+- Mojito: Update translations (#806) ([18b5fde](https://github.com/box/box-content-preview/commit/18b5fde)), closes [#806](https://github.com/box/box-content-preview/issues/806)
+- Mojito: Update translations (#809) ([2a83b31](https://github.com/box/box-content-preview/commit/2a83b31)), closes [#809](https://github.com/box/box-content-preview/issues/809)
 
 <a name="1.45.0"></a>
+
 ## 1.45.0 (2018-06-05)
 
-* Update: box-annotations to v2.2.0 (#804) ([bc61f9f](https://github.com/box/box-content-preview/commit/bc61f9f)), closes [#804](https://github.com/box/box-content-preview/issues/804)
-* Fix: Preview well-formed file in offline (fixes #793) (#799) ([fac6e9c](https://github.com/box/box-content-preview/commit/fac6e9c)), closes [#793](https://github.com/box/box-content-preview/issues/793) [#799](https://github.com/box/box-content-preview/issues/799) [#793](https://github.com/box/box-content-preview/issues/793)
-* Fix: Show file undownloadable error for cached previews (#802) ([29318d8](https://github.com/box/box-content-preview/commit/29318d8)), closes [#802](https://github.com/box/box-content-preview/issues/802)
-* Fix: video controls are cut off (#801) ([bab0c98](https://github.com/box/box-content-preview/commit/bab0c98)), closes [#801](https://github.com/box/box-content-preview/issues/801)
-* Chore: update codeceptjs dependencies (#795) ([78daa71](https://github.com/box/box-content-preview/commit/78daa71)), closes [#795](https://github.com/box/box-content-preview/issues/795)
-
-
+- Update: box-annotations to v2.2.0 (#804) ([bc61f9f](https://github.com/box/box-content-preview/commit/bc61f9f)), closes [#804](https://github.com/box/box-content-preview/issues/804)
+- Fix: Preview well-formed file in offline (fixes #793) (#799) ([fac6e9c](https://github.com/box/box-content-preview/commit/fac6e9c)), closes [#793](https://github.com/box/box-content-preview/issues/793) [#799](https://github.com/box/box-content-preview/issues/799) [#793](https://github.com/box/box-content-preview/issues/793)
+- Fix: Show file undownloadable error for cached previews (#802) ([29318d8](https://github.com/box/box-content-preview/commit/29318d8)), closes [#802](https://github.com/box/box-content-preview/issues/802)
+- Fix: video controls are cut off (#801) ([bab0c98](https://github.com/box/box-content-preview/commit/bab0c98)), closes [#801](https://github.com/box/box-content-preview/issues/801)
+- Chore: update codeceptjs dependencies (#795) ([78daa71](https://github.com/box/box-content-preview/commit/78daa71)), closes [#795](https://github.com/box/box-content-preview/issues/795)
 
 <a name="1.44.0"></a>
+
 ## 1.44.0 (2018-05-29)
 
-* Update: box-annotations to v2.0.1 (#798) ([20023dc](https://github.com/box/box-content-preview/commit/20023dc)), closes [#798](https://github.com/box/box-content-preview/issues/798)
-* Update: box-annotations to v2.1.0 (#803) ([0826bf9](https://github.com/box/box-content-preview/commit/0826bf9)), closes [#803](https://github.com/box/box-content-preview/issues/803)
-* Fix: Add HEIC to image icon list (#800) ([736966e](https://github.com/box/box-content-preview/commit/736966e)), closes [#800](https://github.com/box/box-content-preview/issues/800)
-
-
+- Update: box-annotations to v2.0.1 (#798) ([20023dc](https://github.com/box/box-content-preview/commit/20023dc)), closes [#798](https://github.com/box/box-content-preview/issues/798)
+- Update: box-annotations to v2.1.0 (#803) ([0826bf9](https://github.com/box/box-content-preview/commit/0826bf9)), closes [#803](https://github.com/box/box-content-preview/issues/803)
+- Fix: Add HEIC to image icon list (#800) ([736966e](https://github.com/box/box-content-preview/commit/736966e)), closes [#800](https://github.com/box/box-content-preview/issues/800)
 
 <a name="1.43.0"></a>
+
 ## 1.43.0 (2018-05-15)
 
-* New: Enable HEIC preview (#796) ([b80833a](https://github.com/box/box-content-preview/commit/b80833a)), closes [#796](https://github.com/box/box-content-preview/issues/796)
-* Update: box-annotations to v2.0.0 (#797) ([678bd85](https://github.com/box/box-content-preview/commit/678bd85)), closes [#797](https://github.com/box/box-content-preview/issues/797)
-* Chore: Move access token to environment variable (#785) ([2f446cc](https://github.com/box/box-content-preview/commit/2f446cc)), closes [#785](https://github.com/box/box-content-preview/issues/785)
-* Chore: Update issue templates (#791) ([a5533cc](https://github.com/box/box-content-preview/commit/a5533cc)), closes [#791](https://github.com/box/box-content-preview/issues/791)
-* Update issue templates (#792) ([2124b3c](https://github.com/box/box-content-preview/commit/2124b3c)), closes [#792](https://github.com/box/box-content-preview/issues/792)
-* Fix: Correct media settings checkmark icon color on hover (#790) ([708082a](https://github.com/box/box-content-preview/commit/708082a)), closes [#790](https://github.com/box/box-content-preview/issues/790)
-
-
+- New: Enable HEIC preview (#796) ([b80833a](https://github.com/box/box-content-preview/commit/b80833a)), closes [#796](https://github.com/box/box-content-preview/issues/796)
+- Update: box-annotations to v2.0.0 (#797) ([678bd85](https://github.com/box/box-content-preview/commit/678bd85)), closes [#797](https://github.com/box/box-content-preview/issues/797)
+- Chore: Move access token to environment variable (#785) ([2f446cc](https://github.com/box/box-content-preview/commit/2f446cc)), closes [#785](https://github.com/box/box-content-preview/issues/785)
+- Chore: Update issue templates (#791) ([a5533cc](https://github.com/box/box-content-preview/commit/a5533cc)), closes [#791](https://github.com/box/box-content-preview/issues/791)
+- Update issue templates (#792) ([2124b3c](https://github.com/box/box-content-preview/commit/2124b3c)), closes [#792](https://github.com/box/box-content-preview/issues/792)
+- Fix: Correct media settings checkmark icon color on hover (#790) ([708082a](https://github.com/box/box-content-preview/commit/708082a)), closes [#790](https://github.com/box/box-content-preview/issues/790)
 
 <a name="1.42.0"></a>
+
 ## 1.42.0 (2018-05-01)
 
-* Update: box-annotations to v1.6.0 (#789) ([f3ea47c](https://github.com/box/box-content-preview/commit/f3ea47c)), closes [#789](https://github.com/box/box-content-preview/issues/789)
-* Fix: Embedded notes in Box WebApp (#788) ([223c0b8](https://github.com/box/box-content-preview/commit/223c0b8)), closes [#788](https://github.com/box/box-content-preview/issues/788)
-* Fix: Guard session/local storage usage in download reachability (#784) ([65ec0b5](https://github.com/box/box-content-preview/commit/65ec0b5)), closes [#784](https://github.com/box/box-content-preview/issues/784)
-* Chore: Adding preview end and download attempt metrics (#781) ([8166c25](https://github.com/box/box-content-preview/commit/8166c25)), closes [#781](https://github.com/box/box-content-preview/issues/781)
-* Chore: Round timer values to integers (#786) ([740181c](https://github.com/box/box-content-preview/commit/740181c)), closes [#786](https://github.com/box/box-content-preview/issues/786)
-
-
+- Update: box-annotations to v1.6.0 (#789) ([f3ea47c](https://github.com/box/box-content-preview/commit/f3ea47c)), closes [#789](https://github.com/box/box-content-preview/issues/789)
+- Fix: Embedded notes in Box WebApp (#788) ([223c0b8](https://github.com/box/box-content-preview/commit/223c0b8)), closes [#788](https://github.com/box/box-content-preview/issues/788)
+- Fix: Guard session/local storage usage in download reachability (#784) ([65ec0b5](https://github.com/box/box-content-preview/commit/65ec0b5)), closes [#784](https://github.com/box/box-content-preview/issues/784)
+- Chore: Adding preview end and download attempt metrics (#781) ([8166c25](https://github.com/box/box-content-preview/commit/8166c25)), closes [#781](https://github.com/box/box-content-preview/issues/781)
+- Chore: Round timer values to integers (#786) ([740181c](https://github.com/box/box-content-preview/commit/740181c)), closes [#786](https://github.com/box/box-content-preview/issues/786)
 
 <a name="1.41.0"></a>
+
 ## 1.41.0 (2018-04-24)
 
-* Update: box-annotations to v1.5.0 (#783) ([097fe86](https://github.com/box/box-content-preview/commit/097fe86)), closes [#783](https://github.com/box/box-content-preview/issues/783)
-* Chore: build tweaks to remove stages to speed up cron (#766) ([5de7093](https://github.com/box/box-content-preview/commit/5de7093)), closes [#766](https://github.com/box/box-content-preview/issues/766)
-* Chore: functional test running tweaks (#767) ([c3ea1e6](https://github.com/box/box-content-preview/commit/c3ea1e6)), closes [#767](https://github.com/box/box-content-preview/issues/767)
-* Chore: improve functional test reliability by unhiding controls (#777) ([67d8e8c](https://github.com/box/box-content-preview/commit/67d8e8c)), closes [#777](https://github.com/box/box-content-preview/issues/777)
-* Chore: Refactor functional tests (#774) ([10d7cba](https://github.com/box/box-content-preview/commit/10d7cba)), closes [#774](https://github.com/box/box-content-preview/issues/774)
-* Chore: Refactor Timer to allow a reset of multiple tags (#778) ([4f2f577](https://github.com/box/box-content-preview/commit/4f2f577)), closes [#778](https://github.com/box/box-content-preview/issues/778)
-* Chore: update timeouts for saucelabs for hanging builds (#780) ([95f9fd4](https://github.com/box/box-content-preview/commit/95f9fd4)), closes [#780](https://github.com/box/box-content-preview/issues/780)
-* Fix: .bp-page-num-input CSS (#779) ([31265d8](https://github.com/box/box-content-preview/commit/31265d8)), closes [#779](https://github.com/box/box-content-preview/issues/779)
-* New: Navigation arrows now remain visible when focused (#775) ([6f4af87](https://github.com/box/box-content-preview/commit/6f4af87)), closes [#775](https://github.com/box/box-content-preview/issues/775)
-
-
+- Update: box-annotations to v1.5.0 (#783) ([097fe86](https://github.com/box/box-content-preview/commit/097fe86)), closes [#783](https://github.com/box/box-content-preview/issues/783)
+- Chore: build tweaks to remove stages to speed up cron (#766) ([5de7093](https://github.com/box/box-content-preview/commit/5de7093)), closes [#766](https://github.com/box/box-content-preview/issues/766)
+- Chore: functional test running tweaks (#767) ([c3ea1e6](https://github.com/box/box-content-preview/commit/c3ea1e6)), closes [#767](https://github.com/box/box-content-preview/issues/767)
+- Chore: improve functional test reliability by unhiding controls (#777) ([67d8e8c](https://github.com/box/box-content-preview/commit/67d8e8c)), closes [#777](https://github.com/box/box-content-preview/issues/777)
+- Chore: Refactor functional tests (#774) ([10d7cba](https://github.com/box/box-content-preview/commit/10d7cba)), closes [#774](https://github.com/box/box-content-preview/issues/774)
+- Chore: Refactor Timer to allow a reset of multiple tags (#778) ([4f2f577](https://github.com/box/box-content-preview/commit/4f2f577)), closes [#778](https://github.com/box/box-content-preview/issues/778)
+- Chore: update timeouts for saucelabs for hanging builds (#780) ([95f9fd4](https://github.com/box/box-content-preview/commit/95f9fd4)), closes [#780](https://github.com/box/box-content-preview/issues/780)
+- Fix: .bp-page-num-input CSS (#779) ([31265d8](https://github.com/box/box-content-preview/commit/31265d8)), closes [#779](https://github.com/box/box-content-preview/issues/779)
+- New: Navigation arrows now remain visible when focused (#775) ([6f4af87](https://github.com/box/box-content-preview/commit/6f4af87)), closes [#775](https://github.com/box/box-content-preview/issues/775)
 
 <a name="1.40.0"></a>
+
 ## 1.40.0 (2018-04-17)
 
-* Update: box-annotations to v1.3.1 (#765) ([60e2af4](https://github.com/box/box-content-preview/commit/60e2af4)), closes [#765](https://github.com/box/box-content-preview/issues/765)
-* Update: box-annotations to v1.4.0 (#776) ([d72f75c](https://github.com/box/box-content-preview/commit/d72f75c)), closes [#776](https://github.com/box/box-content-preview/issues/776)
-* Chore: Add rep_type to logs (#773) ([5142e45](https://github.com/box/box-content-preview/commit/5142e45)), closes [#773](https://github.com/box/box-content-preview/issues/773)
-* Mojito: Update translations (#771) ([bd2e74f](https://github.com/box/box-content-preview/commit/bd2e74f)), closes [#771](https://github.com/box/box-content-preview/issues/771)
-* Docs: Update functional tests README.md (#768) ([5ed871e](https://github.com/box/box-content-preview/commit/5ed871e)), closes [#768](https://github.com/box/box-content-preview/issues/768)
-* Revert "Fix: Add blend mode fallbacks if not supported (#758)" (#769) ([b80dafc](https://github.com/box/box-content-preview/commit/b80dafc)), closes [#758](https://github.com/box/box-content-preview/issues/758) [#769](https://github.com/box/box-content-preview/issues/769)
-
-
+- Update: box-annotations to v1.3.1 (#765) ([60e2af4](https://github.com/box/box-content-preview/commit/60e2af4)), closes [#765](https://github.com/box/box-content-preview/issues/765)
+- Update: box-annotations to v1.4.0 (#776) ([d72f75c](https://github.com/box/box-content-preview/commit/d72f75c)), closes [#776](https://github.com/box/box-content-preview/issues/776)
+- Chore: Add rep_type to logs (#773) ([5142e45](https://github.com/box/box-content-preview/commit/5142e45)), closes [#773](https://github.com/box/box-content-preview/issues/773)
+- Mojito: Update translations (#771) ([bd2e74f](https://github.com/box/box-content-preview/commit/bd2e74f)), closes [#771](https://github.com/box/box-content-preview/issues/771)
+- Docs: Update functional tests README.md (#768) ([5ed871e](https://github.com/box/box-content-preview/commit/5ed871e)), closes [#768](https://github.com/box/box-content-preview/issues/768)
+- Revert "Fix: Add blend mode fallbacks if not supported (#758)" (#769) ([b80dafc](https://github.com/box/box-content-preview/commit/b80dafc)), closes [#758](https://github.com/box/box-content-preview/issues/758) [#769](https://github.com/box/box-content-preview/issues/769)
 
 <a name="1.39.0"></a>
+
 ## 1.39.0 (2018-04-10)
 
-* Update: box-annotations to v1.3.0 (#764) ([77bb4cc](https://github.com/box/box-content-preview/commit/77bb4cc)), closes [#764](https://github.com/box/box-content-preview/issues/764)
-* Update: Issue template (#762) ([23a0059](https://github.com/box/box-content-preview/commit/23a0059)), closes [#762](https://github.com/box/box-content-preview/issues/762)
-* Fix: Add blend mode fallbacks if not supported (#758) ([95def3b](https://github.com/box/box-content-preview/commit/95def3b)), closes [#758](https://github.com/box/box-content-preview/issues/758)
-* Fix: release script (#757) ([203e55d](https://github.com/box/box-content-preview/commit/203e55d)), closes [#757](https://github.com/box/box-content-preview/issues/757)
-* Fix: Remove use of manifest loaded event (#763) ([99edac8](https://github.com/box/box-content-preview/commit/99edac8)), closes [#763](https://github.com/box/box-content-preview/issues/763)
-* Fix: Revert media duration setting to on loadeddata (#759) ([df798d1](https://github.com/box/box-content-preview/commit/df798d1)), closes [#759](https://github.com/box/box-content-preview/issues/759)
-
-
+- Update: box-annotations to v1.3.0 (#764) ([77bb4cc](https://github.com/box/box-content-preview/commit/77bb4cc)), closes [#764](https://github.com/box/box-content-preview/issues/764)
+- Update: Issue template (#762) ([23a0059](https://github.com/box/box-content-preview/commit/23a0059)), closes [#762](https://github.com/box/box-content-preview/issues/762)
+- Fix: Add blend mode fallbacks if not supported (#758) ([95def3b](https://github.com/box/box-content-preview/commit/95def3b)), closes [#758](https://github.com/box/box-content-preview/issues/758)
+- Fix: release script (#757) ([203e55d](https://github.com/box/box-content-preview/commit/203e55d)), closes [#757](https://github.com/box/box-content-preview/issues/757)
+- Fix: Remove use of manifest loaded event (#763) ([99edac8](https://github.com/box/box-content-preview/commit/99edac8)), closes [#763](https://github.com/box/box-content-preview/issues/763)
+- Fix: Revert media duration setting to on loadeddata (#759) ([df798d1](https://github.com/box/box-content-preview/commit/df798d1)), closes [#759](https://github.com/box/box-content-preview/issues/759)
 
 <a name="1.38.0"></a>
+
 ## 1.38.0 (2018-04-03)
 
-* Mojito: Update translations (#755) ([94e605f](https://github.com/box/box-content-preview/commit/94e605f)), closes [#755](https://github.com/box/box-content-preview/issues/755)
-* Update: box-annotations to v1.2.0 (#756) ([9a2fd61](https://github.com/box/box-content-preview/commit/9a2fd61)), closes [#756](https://github.com/box/box-content-preview/issues/756)
-* Chore: Add nsp package and include with CI build (#748) ([f3b83d6](https://github.com/box/box-content-preview/commit/f3b83d6)), closes [#748](https://github.com/box/box-content-preview/issues/748)
-* Chore: Only reset to upstream/master for major/minor releases (#750) ([aa2b8ab](https://github.com/box/box-content-preview/commit/aa2b8ab)), closes [#750](https://github.com/box/box-content-preview/issues/750)
-* Docs: Updating issue template (#753) ([a90bc73](https://github.com/box/box-content-preview/commit/a90bc73)), closes [#753](https://github.com/box/box-content-preview/issues/753)
-* Fix: presentation viewer keyboard shortcuts (#754) ([9014bad](https://github.com/box/box-content-preview/commit/9014bad)), closes [#754](https://github.com/box/box-content-preview/issues/754)
-* Fix: Retain quality setting when setting/switching audio tracks (#720) ([adc84e1](https://github.com/box/box-content-preview/commit/adc84e1)), closes [#720](https://github.com/box/box-content-preview/issues/720)
-
-
+- Mojito: Update translations (#755) ([94e605f](https://github.com/box/box-content-preview/commit/94e605f)), closes [#755](https://github.com/box/box-content-preview/issues/755)
+- Update: box-annotations to v1.2.0 (#756) ([9a2fd61](https://github.com/box/box-content-preview/commit/9a2fd61)), closes [#756](https://github.com/box/box-content-preview/issues/756)
+- Chore: Add nsp package and include with CI build (#748) ([f3b83d6](https://github.com/box/box-content-preview/commit/f3b83d6)), closes [#748](https://github.com/box/box-content-preview/issues/748)
+- Chore: Only reset to upstream/master for major/minor releases (#750) ([aa2b8ab](https://github.com/box/box-content-preview/commit/aa2b8ab)), closes [#750](https://github.com/box/box-content-preview/issues/750)
+- Docs: Updating issue template (#753) ([a90bc73](https://github.com/box/box-content-preview/commit/a90bc73)), closes [#753](https://github.com/box/box-content-preview/issues/753)
+- Fix: presentation viewer keyboard shortcuts (#754) ([9014bad](https://github.com/box/box-content-preview/commit/9014bad)), closes [#754](https://github.com/box/box-content-preview/issues/754)
+- Fix: Retain quality setting when setting/switching audio tracks (#720) ([adc84e1](https://github.com/box/box-content-preview/commit/adc84e1)), closes [#720](https://github.com/box/box-content-preview/issues/720)
 
 <a name="1.37.0"></a>
+
 ## 1.37.0 (2018-03-28)
 
-* Fix: Download watermarked (#746) ([de4475d](https://github.com/box/box-content-preview/commit/de4475d)), closes [#746](https://github.com/box/box-content-preview/issues/746)
-* Fix: Only check flash for SWF files (#747) ([85b8ee4](https://github.com/box/box-content-preview/commit/85b8ee4)), closes [#747](https://github.com/box/box-content-preview/issues/747)
-* Update: box-annotations to v1.1.1 (#751) ([8b267aa](https://github.com/box/box-content-preview/commit/8b267aa)), closes [#751](https://github.com/box/box-content-preview/issues/751)
-* Chore: Remove unused babel-polyfill (#737) ([85f6d7e](https://github.com/box/box-content-preview/commit/85f6d7e)), closes [#737](https://github.com/box/box-content-preview/issues/737)
-* Chore: Use key decoder from box react ui to prevent duplication (#749) ([575821f](https://github.com/box/box-content-preview/commit/575821f)), closes [#749](https://github.com/box/box-content-preview/issues/749)
-
-
+- Fix: Download watermarked (#746) ([de4475d](https://github.com/box/box-content-preview/commit/de4475d)), closes [#746](https://github.com/box/box-content-preview/issues/746)
+- Fix: Only check flash for SWF files (#747) ([85b8ee4](https://github.com/box/box-content-preview/commit/85b8ee4)), closes [#747](https://github.com/box/box-content-preview/issues/747)
+- Update: box-annotations to v1.1.1 (#751) ([8b267aa](https://github.com/box/box-content-preview/commit/8b267aa)), closes [#751](https://github.com/box/box-content-preview/issues/751)
+- Chore: Remove unused babel-polyfill (#737) ([85f6d7e](https://github.com/box/box-content-preview/commit/85f6d7e)), closes [#737](https://github.com/box/box-content-preview/issues/737)
+- Chore: Use key decoder from box react ui to prevent duplication (#749) ([575821f](https://github.com/box/box-content-preview/commit/575821f)), closes [#749](https://github.com/box/box-content-preview/issues/749)
 
 <a name="1.36.0"></a>
+
 ## 1.36.0 (2018-03-27)
 
-* Update: box-annotations to v1.1.0 (#744) ([03e889c](https://github.com/box/box-content-preview/commit/03e889c)), closes [#744](https://github.com/box/box-content-preview/issues/744)
-* Chore: Add header for pdf compression (#591) ([ad97a90](https://github.com/box/box-content-preview/commit/ad97a90)), closes [#591](https://github.com/box/box-content-preview/issues/591)
-* Chore: Cleanup docs (#743) ([a902138](https://github.com/box/box-content-preview/commit/a902138)), closes [#743](https://github.com/box/box-content-preview/issues/743)
-* Chore: document controls functional tests + improve reliability (#716) ([67e1b71](https://github.com/box/box-content-preview/commit/67e1b71)), closes [#716](https://github.com/box/box-content-preview/issues/716)
-* Chore: enable eslint for unit tests (#738) ([234feb0](https://github.com/box/box-content-preview/commit/234feb0)), closes [#738](https://github.com/box/box-content-preview/issues/738)
-* Mojito: Update translations (#736) ([42b9fb6](https://github.com/box/box-content-preview/commit/42b9fb6)), closes [#736](https://github.com/box/box-content-preview/issues/736)
-* Mojito: Update translations (#742) ([98c7c4c](https://github.com/box/box-content-preview/commit/98c7c4c)), closes [#742](https://github.com/box/box-content-preview/issues/742)
-* Fix: Cleanup baseViewer.hasAnnotationPermissions() and tests (#685) ([daa8e86](https://github.com/box/box-content-preview/commit/daa8e86)), closes [#685](https://github.com/box/box-content-preview/issues/685)
-* Fix: display error when previewing flash and not enabled (#733) ([794a053](https://github.com/box/box-content-preview/commit/794a053)), closes [#733](https://github.com/box/box-content-preview/issues/733)
-* Fix: Document controls functional tests (#735) ([c914237](https://github.com/box/box-content-preview/commit/c914237)), closes [#735](https://github.com/box/box-content-preview/issues/735)
-* Fix: document findbar no longer ignores useHotkeys (#724) ([4e0bddc](https://github.com/box/box-content-preview/commit/4e0bddc)), closes [#724](https://github.com/box/box-content-preview/issues/724)
-* Fix: fix functional tests (#734) ([d0f7a34](https://github.com/box/box-content-preview/commit/d0f7a34)), closes [#734](https://github.com/box/box-content-preview/issues/734)
-* Fix: parse options during show instead of after token response (#725) ([312c300](https://github.com/box/box-content-preview/commit/312c300)), closes [#725](https://github.com/box/box-content-preview/issues/725)
-* Fix: Reduce WebGL checks to reduce instances of Rats! error (#728) ([f2b389f](https://github.com/box/box-content-preview/commit/f2b389f)), closes [#728](https://github.com/box/box-content-preview/issues/728)
-* New: Enable Preview support for iWork file types (#741) ([8039f1d](https://github.com/box/box-content-preview/commit/8039f1d)), closes [#741](https://github.com/box/box-content-preview/issues/741)
-* Docs: Watermarking preferences (#729) ([626ccfa](https://github.com/box/box-content-preview/commit/626ccfa)), closes [#729](https://github.com/box/box-content-preview/issues/729)
-
-
+- Update: box-annotations to v1.1.0 (#744) ([03e889c](https://github.com/box/box-content-preview/commit/03e889c)), closes [#744](https://github.com/box/box-content-preview/issues/744)
+- Chore: Add header for pdf compression (#591) ([ad97a90](https://github.com/box/box-content-preview/commit/ad97a90)), closes [#591](https://github.com/box/box-content-preview/issues/591)
+- Chore: Cleanup docs (#743) ([a902138](https://github.com/box/box-content-preview/commit/a902138)), closes [#743](https://github.com/box/box-content-preview/issues/743)
+- Chore: document controls functional tests + improve reliability (#716) ([67e1b71](https://github.com/box/box-content-preview/commit/67e1b71)), closes [#716](https://github.com/box/box-content-preview/issues/716)
+- Chore: enable eslint for unit tests (#738) ([234feb0](https://github.com/box/box-content-preview/commit/234feb0)), closes [#738](https://github.com/box/box-content-preview/issues/738)
+- Mojito: Update translations (#736) ([42b9fb6](https://github.com/box/box-content-preview/commit/42b9fb6)), closes [#736](https://github.com/box/box-content-preview/issues/736)
+- Mojito: Update translations (#742) ([98c7c4c](https://github.com/box/box-content-preview/commit/98c7c4c)), closes [#742](https://github.com/box/box-content-preview/issues/742)
+- Fix: Cleanup baseViewer.hasAnnotationPermissions() and tests (#685) ([daa8e86](https://github.com/box/box-content-preview/commit/daa8e86)), closes [#685](https://github.com/box/box-content-preview/issues/685)
+- Fix: display error when previewing flash and not enabled (#733) ([794a053](https://github.com/box/box-content-preview/commit/794a053)), closes [#733](https://github.com/box/box-content-preview/issues/733)
+- Fix: Document controls functional tests (#735) ([c914237](https://github.com/box/box-content-preview/commit/c914237)), closes [#735](https://github.com/box/box-content-preview/issues/735)
+- Fix: document findbar no longer ignores useHotkeys (#724) ([4e0bddc](https://github.com/box/box-content-preview/commit/4e0bddc)), closes [#724](https://github.com/box/box-content-preview/issues/724)
+- Fix: fix functional tests (#734) ([d0f7a34](https://github.com/box/box-content-preview/commit/d0f7a34)), closes [#734](https://github.com/box/box-content-preview/issues/734)
+- Fix: parse options during show instead of after token response (#725) ([312c300](https://github.com/box/box-content-preview/commit/312c300)), closes [#725](https://github.com/box/box-content-preview/issues/725)
+- Fix: Reduce WebGL checks to reduce instances of Rats! error (#728) ([f2b389f](https://github.com/box/box-content-preview/commit/f2b389f)), closes [#728](https://github.com/box/box-content-preview/issues/728)
+- New: Enable Preview support for iWork file types (#741) ([8039f1d](https://github.com/box/box-content-preview/commit/8039f1d)), closes [#741](https://github.com/box/box-content-preview/issues/741)
+- Docs: Watermarking preferences (#729) ([626ccfa](https://github.com/box/box-content-preview/commit/626ccfa)), closes [#729](https://github.com/box/box-content-preview/issues/729)
 
 <a name="1.35.0"></a>
+
 ## 1.35.0 (2018-03-20)
 
-* Update: box-annotations to v1.0.0 (#727) ([272038c](https://github.com/box/box-content-preview/commit/272038c)), closes [#727](https://github.com/box/box-content-preview/issues/727)
-* Mojito: Update translations (#726) ([ea62af8](https://github.com/box/box-content-preview/commit/ea62af8)), closes [#726](https://github.com/box/box-content-preview/issues/726)
-* New: Watermarking preferences (#721) ([a49f234](https://github.com/box/box-content-preview/commit/a49f234)), closes [#721](https://github.com/box/box-content-preview/issues/721)
-* Use correct property for handle viewer event (#722) ([61fa208](https://github.com/box/box-content-preview/commit/61fa208)), closes [#722](https://github.com/box/box-content-preview/issues/722)
-* Fix: Allow annotation text to be selectable (#719) ([929e5bf](https://github.com/box/box-content-preview/commit/929e5bf)), closes [#719](https://github.com/box/box-content-preview/issues/719)
-* Docs: Fix docs for prefetchViewers() (#718) ([f656064](https://github.com/box/box-content-preview/commit/f656064)), closes [#718](https://github.com/box/box-content-preview/issues/718)
-
-
+- Update: box-annotations to v1.0.0 (#727) ([272038c](https://github.com/box/box-content-preview/commit/272038c)), closes [#727](https://github.com/box/box-content-preview/issues/727)
+- Mojito: Update translations (#726) ([ea62af8](https://github.com/box/box-content-preview/commit/ea62af8)), closes [#726](https://github.com/box/box-content-preview/issues/726)
+- New: Watermarking preferences (#721) ([a49f234](https://github.com/box/box-content-preview/commit/a49f234)), closes [#721](https://github.com/box/box-content-preview/issues/721)
+- Use correct property for handle viewer event (#722) ([61fa208](https://github.com/box/box-content-preview/commit/61fa208)), closes [#722](https://github.com/box/box-content-preview/issues/722)
+- Fix: Allow annotation text to be selectable (#719) ([929e5bf](https://github.com/box/box-content-preview/commit/929e5bf)), closes [#719](https://github.com/box/box-content-preview/issues/719)
+- Docs: Fix docs for prefetchViewers() (#718) ([f656064](https://github.com/box/box-content-preview/commit/f656064)), closes [#718](https://github.com/box/box-content-preview/issues/718)
 
 <a name="1.34.0"></a>
+
 ## 1.34.0 (2018-03-14)
 
-* Update: box-annotations to v0.16.0 (#717) ([8763a4a](https://github.com/box/box-content-preview/commit/8763a4a)), closes [#717](https://github.com/box/box-content-preview/issues/717)
-* Update: Uppercase unsupported file types (#710) ([b3ddc6a](https://github.com/box/box-content-preview/commit/b3ddc6a)), closes [#710](https://github.com/box/box-content-preview/issues/710)
-* Fix: Avoid use of Number.isFinite() (#711) ([0f31aee](https://github.com/box/box-content-preview/commit/0f31aee)), closes [#711](https://github.com/box/box-content-preview/issues/711)
-* Fix: HD gear icon when manually changing quality (#706) ([7c27360](https://github.com/box/box-content-preview/commit/7c27360)), closes [#706](https://github.com/box/box-content-preview/issues/706)
-* Fix: startAt should disable document preload (#714) ([8c38180](https://github.com/box/box-content-preview/commit/8c38180)), closes [#714](https://github.com/box/box-content-preview/issues/714)
-* Chore: Add util tests and fix file tests (#709) ([1102077](https://github.com/box/box-content-preview/commit/1102077)), closes [#709](https://github.com/box/box-content-preview/issues/709)
-* Chore: Adding download reachability checks to other viewers (#705) ([ac73b92](https://github.com/box/box-content-preview/commit/ac73b92)), closes [#705](https://github.com/box/box-content-preview/issues/705)
-* Chore: update status for jobs in saucelabs (#713) ([d133dc0](https://github.com/box/box-content-preview/commit/d133dc0)), closes [#713](https://github.com/box/box-content-preview/issues/713)
-* Chore: Use box-locales to get the locale list (#708) ([cac7279](https://github.com/box/box-content-preview/commit/cac7279)), closes [#708](https://github.com/box/box-content-preview/issues/708)
-* Mojito: Update translations (#707) ([14de771](https://github.com/box/box-content-preview/commit/14de771)), closes [#707](https://github.com/box/box-content-preview/issues/707)
-* Mojito: Update translations (#712) ([7da455b](https://github.com/box/box-content-preview/commit/7da455b)), closes [#712](https://github.com/box/box-content-preview/issues/712)
-
-
+- Update: box-annotations to v0.16.0 (#717) ([8763a4a](https://github.com/box/box-content-preview/commit/8763a4a)), closes [#717](https://github.com/box/box-content-preview/issues/717)
+- Update: Uppercase unsupported file types (#710) ([b3ddc6a](https://github.com/box/box-content-preview/commit/b3ddc6a)), closes [#710](https://github.com/box/box-content-preview/issues/710)
+- Fix: Avoid use of Number.isFinite() (#711) ([0f31aee](https://github.com/box/box-content-preview/commit/0f31aee)), closes [#711](https://github.com/box/box-content-preview/issues/711)
+- Fix: HD gear icon when manually changing quality (#706) ([7c27360](https://github.com/box/box-content-preview/commit/7c27360)), closes [#706](https://github.com/box/box-content-preview/issues/706)
+- Fix: startAt should disable document preload (#714) ([8c38180](https://github.com/box/box-content-preview/commit/8c38180)), closes [#714](https://github.com/box/box-content-preview/issues/714)
+- Chore: Add util tests and fix file tests (#709) ([1102077](https://github.com/box/box-content-preview/commit/1102077)), closes [#709](https://github.com/box/box-content-preview/issues/709)
+- Chore: Adding download reachability checks to other viewers (#705) ([ac73b92](https://github.com/box/box-content-preview/commit/ac73b92)), closes [#705](https://github.com/box/box-content-preview/issues/705)
+- Chore: update status for jobs in saucelabs (#713) ([d133dc0](https://github.com/box/box-content-preview/commit/d133dc0)), closes [#713](https://github.com/box/box-content-preview/issues/713)
+- Chore: Use box-locales to get the locale list (#708) ([cac7279](https://github.com/box/box-content-preview/commit/cac7279)), closes [#708](https://github.com/box/box-content-preview/issues/708)
+- Mojito: Update translations (#707) ([14de771](https://github.com/box/box-content-preview/commit/14de771)), closes [#707](https://github.com/box/box-content-preview/issues/707)
+- Mojito: Update translations (#712) ([7da455b](https://github.com/box/box-content-preview/commit/7da455b)), closes [#712](https://github.com/box/box-content-preview/issues/712)
 
 <a name="1.33.0"></a>
+
 # 1.33.0 (2018-03-07)
 
-* Create load timeout error and guard trigger error (#693) ([8f66050](https://github.com/box/box-content-preview/commit/8f66050))
-* Chore: add unit test for prefetching actual viewers (#692) ([a7fc08c](https://github.com/box/box-content-preview/commit/a7fc08c))
-* Chore: Adding download reachability checks to Downloads, Document and Image Viewers (#669) ([6468d63](https://github.com/box/box-content-preview/commit/6468d63))
-* Chore: support for numeric file id (#695) ([040d148](https://github.com/box/box-content-preview/commit/040d148))
-* Chore: use handViewerMetrics() to log successful/failed preview (#700) ([621ab20](https://github.com/box/box-content-preview/commit/621ab20))
-* Fix: move startAt from constructor to setup (#690) ([164e036](https://github.com/box/box-content-preview/commit/164e036))
-* Fix: Polyfill Reflect.construct and Array.from for IE11 (#694) ([3f136a7](https://github.com/box/box-content-preview/commit/3f136a7))
-* Fix: Preview error viewer in platform and IE11 (#696) ([cc09a61](https://github.com/box/box-content-preview/commit/cc09a61))
-* Fix: Removing reliance on String includes (#699) ([6724275](https://github.com/box/box-content-preview/commit/6724275))
-* Update: box-annotations to v0.15.0 (#704) ([b1a0e03](https://github.com/box/box-content-preview/commit/b1a0e03))
-* Upgrade: shaka player to 2.3.3 (#703) ([de8d73f](https://github.com/box/box-content-preview/commit/de8d73f))
-* New: timestamp unit for startAt (#691) ([79ec9da](https://github.com/box/box-content-preview/commit/79ec9da))
-* Mojito: Update translations (#697) ([4d43624](https://github.com/box/box-content-preview/commit/4d43624))
-* Mojito: Update translations (#701) ([bd97236](https://github.com/box/box-content-preview/commit/bd97236))
-
-
+- Create load timeout error and guard trigger error (#693) ([8f66050](https://github.com/box/box-content-preview/commit/8f66050))
+- Chore: add unit test for prefetching actual viewers (#692) ([a7fc08c](https://github.com/box/box-content-preview/commit/a7fc08c))
+- Chore: Adding download reachability checks to Downloads, Document and Image Viewers (#669) ([6468d63](https://github.com/box/box-content-preview/commit/6468d63))
+- Chore: support for numeric file id (#695) ([040d148](https://github.com/box/box-content-preview/commit/040d148))
+- Chore: use handViewerMetrics() to log successful/failed preview (#700) ([621ab20](https://github.com/box/box-content-preview/commit/621ab20))
+- Fix: move startAt from constructor to setup (#690) ([164e036](https://github.com/box/box-content-preview/commit/164e036))
+- Fix: Polyfill Reflect.construct and Array.from for IE11 (#694) ([3f136a7](https://github.com/box/box-content-preview/commit/3f136a7))
+- Fix: Preview error viewer in platform and IE11 (#696) ([cc09a61](https://github.com/box/box-content-preview/commit/cc09a61))
+- Fix: Removing reliance on String includes (#699) ([6724275](https://github.com/box/box-content-preview/commit/6724275))
+- Update: box-annotations to v0.15.0 (#704) ([b1a0e03](https://github.com/box/box-content-preview/commit/b1a0e03))
+- Upgrade: shaka player to 2.3.3 (#703) ([de8d73f](https://github.com/box/box-content-preview/commit/de8d73f))
+- New: timestamp unit for startAt (#691) ([79ec9da](https://github.com/box/box-content-preview/commit/79ec9da))
+- Mojito: Update translations (#697) ([4d43624](https://github.com/box/box-content-preview/commit/4d43624))
+- Mojito: Update translations (#701) ([bd97236](https://github.com/box/box-content-preview/commit/bd97236))
 
 <a name="1.32.0"></a>
+
 # 1.32.0 (2018-02-28)
 
-* Update: box-annotations to v0.14.0 (#689) ([b789807](https://github.com/box/box-content-preview/commit/b789807))
-* Update: Change undownloadable error message (#681) ([fea0cbe](https://github.com/box/box-content-preview/commit/fea0cbe))
-* Update: Modify file info retry logic (#675) ([565f675](https://github.com/box/box-content-preview/commit/565f675))
-* Mojito: Update translations (#683) ([aeae547](https://github.com/box/box-content-preview/commit/aeae547))
-* Mojito: Update translations (#688) ([d13b39b](https://github.com/box/box-content-preview/commit/d13b39b))
-* New: startAt file option support for media and document viewers (#663) ([34e7e37](https://github.com/box/box-content-preview/commit/34e7e37))
-* Fix: Downgrade pdf.js (#687) ([018f71c](https://github.com/box/box-content-preview/commit/018f71c))
-* Fix: filmstrip on previously played video (#680) ([d701f65](https://github.com/box/box-content-preview/commit/d701f65))
-* Chore: Adding yarn install before common package.json scripts (#682) ([5e8bacc](https://github.com/box/box-content-preview/commit/5e8bacc))
-* Chore: Allow viewers to emit metrics (#679) ([4ed0168](https://github.com/box/box-content-preview/commit/4ed0168))
-* Chore: Refactor preview errors (#674) ([ee559fc](https://github.com/box/box-content-preview/commit/ee559fc))
-
-
+- Update: box-annotations to v0.14.0 (#689) ([b789807](https://github.com/box/box-content-preview/commit/b789807))
+- Update: Change undownloadable error message (#681) ([fea0cbe](https://github.com/box/box-content-preview/commit/fea0cbe))
+- Update: Modify file info retry logic (#675) ([565f675](https://github.com/box/box-content-preview/commit/565f675))
+- Mojito: Update translations (#683) ([aeae547](https://github.com/box/box-content-preview/commit/aeae547))
+- Mojito: Update translations (#688) ([d13b39b](https://github.com/box/box-content-preview/commit/d13b39b))
+- New: startAt file option support for media and document viewers (#663) ([34e7e37](https://github.com/box/box-content-preview/commit/34e7e37))
+- Fix: Downgrade pdf.js (#687) ([018f71c](https://github.com/box/box-content-preview/commit/018f71c))
+- Fix: filmstrip on previously played video (#680) ([d701f65](https://github.com/box/box-content-preview/commit/d701f65))
+- Chore: Adding yarn install before common package.json scripts (#682) ([5e8bacc](https://github.com/box/box-content-preview/commit/5e8bacc))
+- Chore: Allow viewers to emit metrics (#679) ([4ed0168](https://github.com/box/box-content-preview/commit/4ed0168))
+- Chore: Refactor preview errors (#674) ([ee559fc](https://github.com/box/box-content-preview/commit/ee559fc))
 
 <a name="1.31.0"></a>
+
 # 1.31.0 (2018-02-20)
 
-* Release: 1.31.0 ([be3d597](https://github.com/box/box-content-preview/commit/be3d597))
-* Release: 1.32.0 ([18add25](https://github.com/box/box-content-preview/commit/18add25))
-* Mojito: Update translations (#656) ([8f823e0](https://github.com/box/box-content-preview/commit/8f823e0))
-* Mojito: Update translations (#672) ([45e17df](https://github.com/box/box-content-preview/commit/45e17df))
-* Update: Add un-downloadable error case (#667) ([28a64aa](https://github.com/box/box-content-preview/commit/28a64aa))
-* Update: Rename `pauseRequireJS` option to `fixDependencies` (#631) ([77fa2e2](https://github.com/box/box-content-preview/commit/77fa2e2))
-* Chore: change travis notifications (#661) ([efe8b04](https://github.com/box/box-content-preview/commit/efe8b04))
-* Chore: modify email for travis notifications (#664) ([120adc9](https://github.com/box/box-content-preview/commit/120adc9))
-* Chore: pass file id to RepStatus for easier timers (#660) ([6bfb193](https://github.com/box/box-content-preview/commit/6bfb193))
-* Chore: update readme and changlog to reflect correct versions (#671) ([f5bbc39](https://github.com/box/box-content-preview/commit/f5bbc39))
-* Fix: define check (#668) ([2edc0ff](https://github.com/box/box-content-preview/commit/2edc0ff))
-* Fix: markdown ul and ol css overrides (#651) ([822a98c](https://github.com/box/box-content-preview/commit/822a98c))
-* Upgrade: pdf.js 2.0.363 (#659) ([754faa4](https://github.com/box/box-content-preview/commit/754faa4))
-* Upgrade: Shaka Player 2.3.2 (#657) ([58f15cf](https://github.com/box/box-content-preview/commit/58f15cf))
-* Revert "Chore: modify email for travis notifications (#664)" (#666) ([1a5c04b](https://github.com/box/box-content-preview/commit/1a5c04b))
-* Docs: Add documentation for singlePageViewer (#662) ([78a0b52](https://github.com/box/box-content-preview/commit/78a0b52))
-
-
+- Release: 1.31.0 ([be3d597](https://github.com/box/box-content-preview/commit/be3d597))
+- Release: 1.32.0 ([18add25](https://github.com/box/box-content-preview/commit/18add25))
+- Mojito: Update translations (#656) ([8f823e0](https://github.com/box/box-content-preview/commit/8f823e0))
+- Mojito: Update translations (#672) ([45e17df](https://github.com/box/box-content-preview/commit/45e17df))
+- Update: Add un-downloadable error case (#667) ([28a64aa](https://github.com/box/box-content-preview/commit/28a64aa))
+- Update: Rename `pauseRequireJS` option to `fixDependencies` (#631) ([77fa2e2](https://github.com/box/box-content-preview/commit/77fa2e2))
+- Chore: change travis notifications (#661) ([efe8b04](https://github.com/box/box-content-preview/commit/efe8b04))
+- Chore: modify email for travis notifications (#664) ([120adc9](https://github.com/box/box-content-preview/commit/120adc9))
+- Chore: pass file id to RepStatus for easier timers (#660) ([6bfb193](https://github.com/box/box-content-preview/commit/6bfb193))
+- Chore: update readme and changlog to reflect correct versions (#671) ([f5bbc39](https://github.com/box/box-content-preview/commit/f5bbc39))
+- Fix: define check (#668) ([2edc0ff](https://github.com/box/box-content-preview/commit/2edc0ff))
+- Fix: markdown ul and ol css overrides (#651) ([822a98c](https://github.com/box/box-content-preview/commit/822a98c))
+- Upgrade: pdf.js 2.0.363 (#659) ([754faa4](https://github.com/box/box-content-preview/commit/754faa4))
+- Upgrade: Shaka Player 2.3.2 (#657) ([58f15cf](https://github.com/box/box-content-preview/commit/58f15cf))
+- Revert "Chore: modify email for travis notifications (#664)" (#666) ([1a5c04b](https://github.com/box/box-content-preview/commit/1a5c04b))
+- Docs: Add documentation for singlePageViewer (#662) ([78a0b52](https://github.com/box/box-content-preview/commit/78a0b52))
 
 <a name="1.30.0"></a>
+
 # 1.30.0 (2018-02-13)
 
-* Update: box-annotations to v0.13.0 (#655) ([ebeb0fc](https://github.com/box/box-content-preview/commit/ebeb0fc))
-* New: Emit preview metric and error messages (#648) ([d5606d1](https://github.com/box/box-content-preview/commit/d5606d1))
-* Revert "Chore: Add download reachability checks to Document and Image viewers (#611)" (#654) ([ddcbdbb](https://github.com/box/box-content-preview/commit/ddcbdbb))
-* Mojito: Update translations (#642) ([ad4a4ff](https://github.com/box/box-content-preview/commit/ad4a4ff))
-* Mojito: Update translations (#652) ([fa6e736](https://github.com/box/box-content-preview/commit/fa6e736))
-* Chore: add config for saucelabs naming (#638) ([beee7ea](https://github.com/box/box-content-preview/commit/beee7ea))
-* Chore: Add download reachability checks to Document and Image viewers (#611) ([dd259b0](https://github.com/box/box-content-preview/commit/dd259b0))
-* Chore: add promise polyfill to functional tests (#644) ([6671431](https://github.com/box/box-content-preview/commit/6671431))
-* Chore: add retries to functional tests (#646) ([fe5ebdc](https://github.com/box/box-content-preview/commit/fe5ebdc))
-* Chore: change functional tests to keep browser state between tests (#645) ([e68af74](https://github.com/box/box-content-preview/commit/e68af74))
-* Chore: functional test framework using CodeceptJS (#628) ([8cab696](https://github.com/box/box-content-preview/commit/8cab696))
-* Chore: modify browser in codecept config (#643) ([ce3d50c](https://github.com/box/box-content-preview/commit/ce3d50c))
-* Chore: Removing soon to be deprecated JWT addon in travis (#637) ([46d7720](https://github.com/box/box-content-preview/commit/46d7720))
-* Chore: Replace slack notifications with email (#649) ([8d8cb0a](https://github.com/box/box-content-preview/commit/8d8cb0a))
-* Chore: update functional tests to add mobile tag (#639) ([9d2e5be](https://github.com/box/box-content-preview/commit/9d2e5be))
-* Chore: update node version in development setup (#635) ([48ae594](https://github.com/box/box-content-preview/commit/48ae594))
-* Chore: update travis config for saucelabs (#647) ([c15c454](https://github.com/box/box-content-preview/commit/c15c454))
-* Fix: remove filesystem helper from codecept config (#636) ([fd1fc62](https://github.com/box/box-content-preview/commit/fd1fc62))
-
-
+- Update: box-annotations to v0.13.0 (#655) ([ebeb0fc](https://github.com/box/box-content-preview/commit/ebeb0fc))
+- New: Emit preview metric and error messages (#648) ([d5606d1](https://github.com/box/box-content-preview/commit/d5606d1))
+- Revert "Chore: Add download reachability checks to Document and Image viewers (#611)" (#654) ([ddcbdbb](https://github.com/box/box-content-preview/commit/ddcbdbb))
+- Mojito: Update translations (#642) ([ad4a4ff](https://github.com/box/box-content-preview/commit/ad4a4ff))
+- Mojito: Update translations (#652) ([fa6e736](https://github.com/box/box-content-preview/commit/fa6e736))
+- Chore: add config for saucelabs naming (#638) ([beee7ea](https://github.com/box/box-content-preview/commit/beee7ea))
+- Chore: Add download reachability checks to Document and Image viewers (#611) ([dd259b0](https://github.com/box/box-content-preview/commit/dd259b0))
+- Chore: add promise polyfill to functional tests (#644) ([6671431](https://github.com/box/box-content-preview/commit/6671431))
+- Chore: add retries to functional tests (#646) ([fe5ebdc](https://github.com/box/box-content-preview/commit/fe5ebdc))
+- Chore: change functional tests to keep browser state between tests (#645) ([e68af74](https://github.com/box/box-content-preview/commit/e68af74))
+- Chore: functional test framework using CodeceptJS (#628) ([8cab696](https://github.com/box/box-content-preview/commit/8cab696))
+- Chore: modify browser in codecept config (#643) ([ce3d50c](https://github.com/box/box-content-preview/commit/ce3d50c))
+- Chore: Removing soon to be deprecated JWT addon in travis (#637) ([46d7720](https://github.com/box/box-content-preview/commit/46d7720))
+- Chore: Replace slack notifications with email (#649) ([8d8cb0a](https://github.com/box/box-content-preview/commit/8d8cb0a))
+- Chore: update functional tests to add mobile tag (#639) ([9d2e5be](https://github.com/box/box-content-preview/commit/9d2e5be))
+- Chore: update node version in development setup (#635) ([48ae594](https://github.com/box/box-content-preview/commit/48ae594))
+- Chore: update travis config for saucelabs (#647) ([c15c454](https://github.com/box/box-content-preview/commit/c15c454))
+- Fix: remove filesystem helper from codecept config (#636) ([fd1fc62](https://github.com/box/box-content-preview/commit/fd1fc62))
 
 <a name="1.29.0"></a>
+
 # 1.29.0 (2018-02-06)
 
-* Update: Add annotation button strings for localizing (#623) ([ed63a02](https://github.com/box/box-content-preview/commit/ed63a02))
-* Update: box-annotations to v0.11.1 (#620) ([149f1b6](https://github.com/box/box-content-preview/commit/149f1b6))
-* Update: box-annotations to v0.12.0 (#632) ([be4a532](https://github.com/box/box-content-preview/commit/be4a532))
-* Chore: No longer silently handle errors in callbacks (#626) ([7d4146b](https://github.com/box/box-content-preview/commit/7d4146b))
-* Chore: Refactor lodash (#627) ([e6297a7](https://github.com/box/box-content-preview/commit/e6297a7))
-* New: Add in SinglePageViewer for pdfs (#606) ([1ad415c](https://github.com/box/box-content-preview/commit/1ad415c))
-* New: Option to disable `preview` event log (#630) ([79c0290](https://github.com/box/box-content-preview/commit/79c0290)), closes [#471](https://github.com/box/box-content-preview/issues/471)
-* New: Support previews of non-current file versions (#608) ([e7e154c](https://github.com/box/box-content-preview/commit/e7e154c)), closes [#570](https://github.com/box/box-content-preview/issues/570)
-* Fix: Annotations upgrade script (#613) ([9d086a9](https://github.com/box/box-content-preview/commit/9d086a9))
-* Fix: Bind close method in DocFindBar (#615) ([faac9c0](https://github.com/box/box-content-preview/commit/faac9c0)), closes [#615](https://github.com/box/box-content-preview/issues/615)
-* Fix: Generate i18n json files before running prod webpack build (#616) ([fbdeb78](https://github.com/box/box-content-preview/commit/fbdeb78))
-* Fix: No longer account for header above notification wrapper (#621) ([d29f320](https://github.com/box/box-content-preview/commit/d29f320))
-* Fix: use getBoundingClientRect in settings menu to prevent scrollbar when zoomed (#622) ([943269c](https://github.com/box/box-content-preview/commit/943269c))
-* Mojito: Update translations (#625) ([01b7d83](https://github.com/box/box-content-preview/commit/01b7d83))
-
-
+- Update: Add annotation button strings for localizing (#623) ([ed63a02](https://github.com/box/box-content-preview/commit/ed63a02))
+- Update: box-annotations to v0.11.1 (#620) ([149f1b6](https://github.com/box/box-content-preview/commit/149f1b6))
+- Update: box-annotations to v0.12.0 (#632) ([be4a532](https://github.com/box/box-content-preview/commit/be4a532))
+- Chore: No longer silently handle errors in callbacks (#626) ([7d4146b](https://github.com/box/box-content-preview/commit/7d4146b))
+- Chore: Refactor lodash (#627) ([e6297a7](https://github.com/box/box-content-preview/commit/e6297a7))
+- New: Add in SinglePageViewer for pdfs (#606) ([1ad415c](https://github.com/box/box-content-preview/commit/1ad415c))
+- New: Option to disable `preview` event log (#630) ([79c0290](https://github.com/box/box-content-preview/commit/79c0290)), closes [#471](https://github.com/box/box-content-preview/issues/471)
+- New: Support previews of non-current file versions (#608) ([e7e154c](https://github.com/box/box-content-preview/commit/e7e154c)), closes [#570](https://github.com/box/box-content-preview/issues/570)
+- Fix: Annotations upgrade script (#613) ([9d086a9](https://github.com/box/box-content-preview/commit/9d086a9))
+- Fix: Bind close method in DocFindBar (#615) ([faac9c0](https://github.com/box/box-content-preview/commit/faac9c0)), closes [#615](https://github.com/box/box-content-preview/issues/615)
+- Fix: Generate i18n json files before running prod webpack build (#616) ([fbdeb78](https://github.com/box/box-content-preview/commit/fbdeb78))
+- Fix: No longer account for header above notification wrapper (#621) ([d29f320](https://github.com/box/box-content-preview/commit/d29f320))
+- Fix: use getBoundingClientRect in settings menu to prevent scrollbar when zoomed (#622) ([943269c](https://github.com/box/box-content-preview/commit/943269c))
+- Mojito: Update translations (#625) ([01b7d83](https://github.com/box/box-content-preview/commit/01b7d83))
 
 <a name="1.28.0"></a>
+
 # 1.28.0 (2018-01-31)
 
-* Update: box-annotations to v0.11.0 (#612) ([cb281a6](https://github.com/box/box-content-preview/commit/cb281a6))
-* Chore: Add safety check in util.replaceHeader() (#610) ([3a47c2e](https://github.com/box/box-content-preview/commit/3a47c2e))
-* Chore: Allow notifications to persist (#605) ([e8992c7](https://github.com/box/box-content-preview/commit/e8992c7))
-* Chore: remove useless event unbinding (#604) ([618f106](https://github.com/box/box-content-preview/commit/618f106))
-* Fix: Image viewer flickering in IE11 during reset zoom (#594) ([d43094f](https://github.com/box/box-content-preview/commit/d43094f))
-* Fix: Prevent navigation on empty collections (#607) ([217fbce](https://github.com/box/box-content-preview/commit/217fbce))
-* Mojito: Update translations (#602) ([fd711bb](https://github.com/box/box-content-preview/commit/fd711bb))
-
-
+- Update: box-annotations to v0.11.0 (#612) ([cb281a6](https://github.com/box/box-content-preview/commit/cb281a6))
+- Chore: Add safety check in util.replaceHeader() (#610) ([3a47c2e](https://github.com/box/box-content-preview/commit/3a47c2e))
+- Chore: Allow notifications to persist (#605) ([e8992c7](https://github.com/box/box-content-preview/commit/e8992c7))
+- Chore: remove useless event unbinding (#604) ([618f106](https://github.com/box/box-content-preview/commit/618f106))
+- Fix: Image viewer flickering in IE11 during reset zoom (#594) ([d43094f](https://github.com/box/box-content-preview/commit/d43094f))
+- Fix: Prevent navigation on empty collections (#607) ([217fbce](https://github.com/box/box-content-preview/commit/217fbce))
+- Mojito: Update translations (#602) ([fd711bb](https://github.com/box/box-content-preview/commit/fd711bb))
 
 <a name="1.27.0"></a>
+
 # 1.27.0 (2018-01-24)
 
-* Event names into separate file (#589) ([3805904](https://github.com/box/box-content-preview/commit/3805904))
-* Fix settings menu title cut off by scrollbar (#599) ([cdb627e](https://github.com/box/box-content-preview/commit/cdb627e)), closes [#599](https://github.com/box/box-content-preview/issues/599)
-* Update README.md ([e590ff9](https://github.com/box/box-content-preview/commit/e590ff9))
-* Update: box-annotations to v0.10.0 (#601) ([a2397ce](https://github.com/box/box-content-preview/commit/a2397ce))
-* Fix: Disable annotations if user has neither annotate nor view permissions (#598) ([d8c4ebd](https://github.com/box/box-content-preview/commit/d8c4ebd))
-* Fix: mobile audio controls overlap with navigation (#590) ([a7ed4fc](https://github.com/box/box-content-preview/commit/a7ed4fc))
-* Fix: Properly binding imageViewer.updatePannability() (#600) ([e18aeb6](https://github.com/box/box-content-preview/commit/e18aeb6))
-* Docs: Add self-hosting instructions to README.md (#597) ([56cbb11](https://github.com/box/box-content-preview/commit/56cbb11))
-* Mojito: Update translations (#596) ([fd635b2](https://github.com/box/box-content-preview/commit/fd635b2))
-* New: Specific error messages for unsupported/tariff restricted files (#593) ([941070e](https://github.com/box/box-content-preview/commit/941070e))
-
-
+- Event names into separate file (#589) ([3805904](https://github.com/box/box-content-preview/commit/3805904))
+- Fix settings menu title cut off by scrollbar (#599) ([cdb627e](https://github.com/box/box-content-preview/commit/cdb627e)), closes [#599](https://github.com/box/box-content-preview/issues/599)
+- Update README.md ([e590ff9](https://github.com/box/box-content-preview/commit/e590ff9))
+- Update: box-annotations to v0.10.0 (#601) ([a2397ce](https://github.com/box/box-content-preview/commit/a2397ce))
+- Fix: Disable annotations if user has neither annotate nor view permissions (#598) ([d8c4ebd](https://github.com/box/box-content-preview/commit/d8c4ebd))
+- Fix: mobile audio controls overlap with navigation (#590) ([a7ed4fc](https://github.com/box/box-content-preview/commit/a7ed4fc))
+- Fix: Properly binding imageViewer.updatePannability() (#600) ([e18aeb6](https://github.com/box/box-content-preview/commit/e18aeb6))
+- Docs: Add self-hosting instructions to README.md (#597) ([56cbb11](https://github.com/box/box-content-preview/commit/56cbb11))
+- Mojito: Update translations (#596) ([fd635b2](https://github.com/box/box-content-preview/commit/fd635b2))
+- New: Specific error messages for unsupported/tariff restricted files (#593) ([941070e](https://github.com/box/box-content-preview/commit/941070e))
 
 <a name="1.26.0"></a>
+
 # 1.26.0 (2018-01-18)
 
-* Update: Annotations upgrade script to push to new remotes if needed (#566) ([1422ba0](https://github.com/box/box-content-preview/commit/1422ba0))
-* Update: Filter out access tokens from error messages (#581) ([afc0844](https://github.com/box/box-content-preview/commit/afc0844))
-* Update: Respect 'Retry-After' header if present (#582) ([2b6fa14](https://github.com/box/box-content-preview/commit/2b6fa14))
-* Fix: Check correct options when passing in BoxAnnotations instance (#584) ([30e171e](https://github.com/box/box-content-preview/commit/30e171e))
-* Fix: Ensure only loading wrapper is interactable preview container (#583) ([eba78eb](https://github.com/box/box-content-preview/commit/eba78eb))
-* Fix: fullscreen controls not shown in IE11 (#588) ([e3d0f5c](https://github.com/box/box-content-preview/commit/e3d0f5c))
-* Fix: Set up notification in Preview.finishLoading() (#579) ([efd0621](https://github.com/box/box-content-preview/commit/efd0621)), closes [#563](https://github.com/box/box-content-preview/issues/563)
-* Fix: Temporarily disable requireJS if specified to load 3rd party deps (#561) ([3f26c81](https://github.com/box/box-content-preview/commit/3f26c81))
-* Update README.md (#568) ([27d3972](https://github.com/box/box-content-preview/commit/27d3972))
-* New: Enhanced pinch to zoom (#567) ([b59b453](https://github.com/box/box-content-preview/commit/b59b453))
-
-
+- Update: Annotations upgrade script to push to new remotes if needed (#566) ([1422ba0](https://github.com/box/box-content-preview/commit/1422ba0))
+- Update: Filter out access tokens from error messages (#581) ([afc0844](https://github.com/box/box-content-preview/commit/afc0844))
+- Update: Respect 'Retry-After' header if present (#582) ([2b6fa14](https://github.com/box/box-content-preview/commit/2b6fa14))
+- Fix: Check correct options when passing in BoxAnnotations instance (#584) ([30e171e](https://github.com/box/box-content-preview/commit/30e171e))
+- Fix: Ensure only loading wrapper is interactable preview container (#583) ([eba78eb](https://github.com/box/box-content-preview/commit/eba78eb))
+- Fix: fullscreen controls not shown in IE11 (#588) ([e3d0f5c](https://github.com/box/box-content-preview/commit/e3d0f5c))
+- Fix: Set up notification in Preview.finishLoading() (#579) ([efd0621](https://github.com/box/box-content-preview/commit/efd0621)), closes [#563](https://github.com/box/box-content-preview/issues/563)
+- Fix: Temporarily disable requireJS if specified to load 3rd party deps (#561) ([3f26c81](https://github.com/box/box-content-preview/commit/3f26c81))
+- Update README.md (#568) ([27d3972](https://github.com/box/box-content-preview/commit/27d3972))
+- New: Enhanced pinch to zoom (#567) ([b59b453](https://github.com/box/box-content-preview/commit/b59b453))
 
 <a name="1.25.0"></a>
+
 # 1.25.0 (2018-01-11)
 
-* Update: box-annotations to v0.8.1 (#575) ([1f98c92](https://github.com/box/box-content-preview/commit/1f98c92))
-* Update: box-annotations to v0.9.0 (#578) ([c1bdd28](https://github.com/box/box-content-preview/commit/c1bdd28))
-* Mojito: Update translations (#574) ([5689492](https://github.com/box/box-content-preview/commit/5689492))
-* Chore: Setup viewer notifications in the correct location (#563) ([2b37a36](https://github.com/box/box-content-preview/commit/2b37a36))
-* New: Add preview support for Google Slides (#302) ([f914930](https://github.com/box/box-content-preview/commit/f914930))
-
-
+- Update: box-annotations to v0.8.1 (#575) ([1f98c92](https://github.com/box/box-content-preview/commit/1f98c92))
+- Update: box-annotations to v0.9.0 (#578) ([c1bdd28](https://github.com/box/box-content-preview/commit/c1bdd28))
+- Mojito: Update translations (#574) ([5689492](https://github.com/box/box-content-preview/commit/5689492))
+- Chore: Setup viewer notifications in the correct location (#563) ([2b37a36](https://github.com/box/box-content-preview/commit/2b37a36))
+- New: Add preview support for Google Slides (#302) ([f914930](https://github.com/box/box-content-preview/commit/f914930))
 
 <a name="1.24.0"></a>
+
 # 1.24.0 (2018-01-03)
 
-* Update: box-annotations to v0.7.2 (#558) ([0fb95c1](https://github.com/box/box-content-preview/commit/0fb95c1))
-* Update: box-annotations to v0.7.3 (#559) ([8c1f6a7](https://github.com/box/box-content-preview/commit/8c1f6a7))
-* Update: box-annotations to v0.8.0 (#565) ([df38a05](https://github.com/box/box-content-preview/commit/df38a05))
-* Update: Link to specific Annotations release tag in commit (#564) ([907599b](https://github.com/box/box-content-preview/commit/907599b))
-* Chore: Add safety check for annotatorConfig (#554) ([c1f0bc0](https://github.com/box/box-content-preview/commit/c1f0bc0))
-* Chore: setOriginalImageSize() for multi image viewer (#547) ([697b03c](https://github.com/box/box-content-preview/commit/697b03c))
-* Fix: Auto hide scrollbars for CSV on IE/Edge (#546) ([9509619](https://github.com/box/box-content-preview/commit/9509619))
-* Fix: Never cache watermarked files, add reload() method (#562) ([3302906](https://github.com/box/box-content-preview/commit/3302906))
-
-
+- Update: box-annotations to v0.7.2 (#558) ([0fb95c1](https://github.com/box/box-content-preview/commit/0fb95c1))
+- Update: box-annotations to v0.7.3 (#559) ([8c1f6a7](https://github.com/box/box-content-preview/commit/8c1f6a7))
+- Update: box-annotations to v0.8.0 (#565) ([df38a05](https://github.com/box/box-content-preview/commit/df38a05))
+- Update: Link to specific Annotations release tag in commit (#564) ([907599b](https://github.com/box/box-content-preview/commit/907599b))
+- Chore: Add safety check for annotatorConfig (#554) ([c1f0bc0](https://github.com/box/box-content-preview/commit/c1f0bc0))
+- Chore: setOriginalImageSize() for multi image viewer (#547) ([697b03c](https://github.com/box/box-content-preview/commit/697b03c))
+- Fix: Auto hide scrollbars for CSV on IE/Edge (#546) ([9509619](https://github.com/box/box-content-preview/commit/9509619))
+- Fix: Never cache watermarked files, add reload() method (#562) ([3302906](https://github.com/box/box-content-preview/commit/3302906))
 
 <a name="1.23.0"></a>
+
 # 1.23.0 (2017-12-20)
 
-* Fix: Add bindings for more audio-track and subtitles controls (#550) ([2028939](https://github.com/box/box-content-preview/commit/2028939))
-* Fix: Rename "watermark-cache" query param to "watermark_content" (#557) ([a8639a9](https://github.com/box/box-content-preview/commit/a8639a9))
-* Update: box-annotations to v0.7.1 (#555) ([00fd0cb](https://github.com/box/box-content-preview/commit/00fd0cb))
-* Chore: Update documentation to include disabling presentation viewer (#552) ([0c47805](https://github.com/box/box-content-preview/commit/0c47805))
-
-
+- Fix: Add bindings for more audio-track and subtitles controls (#550) ([2028939](https://github.com/box/box-content-preview/commit/2028939))
+- Fix: Rename "watermark-cache" query param to "watermark_content" (#557) ([a8639a9](https://github.com/box/box-content-preview/commit/a8639a9))
+- Update: box-annotations to v0.7.1 (#555) ([00fd0cb](https://github.com/box/box-content-preview/commit/00fd0cb))
+- Chore: Update documentation to include disabling presentation viewer (#552) ([0c47805](https://github.com/box/box-content-preview/commit/0c47805))
 
 <a name="1.22.0"></a>
+
 # 1.22.0 (2017-12-12)
 
-* Update: box-annotations to v0.7.0 (#545) ([414113a](https://github.com/box/box-content-preview/commit/414113a))
-* Update: Do not prefetch for mp4 and mp3 viewers (#536) ([f5e487f](https://github.com/box/box-content-preview/commit/f5e487f))
-* Fix: build-rb required before building ci (#538) ([85215b5](https://github.com/box/box-content-preview/commit/85215b5))
-* Fix: Building preview before running tests (#537) ([a0e4e0c](https://github.com/box/box-content-preview/commit/a0e4e0c))
-* Fix: Validate passed in boxAnnotations is instance of the proper type (#542) ([3a1ae72](https://github.com/box/box-content-preview/commit/3a1ae72))
-* New: Allow BoxAnnotations to be passed in as a Preview option (#539) ([e3281cf](https://github.com/box/box-content-preview/commit/e3281cf))
-* Chore: Add multiple travis steps so we can run UI tests in a 'cron' case (#532) ([65e35f1](https://github.com/box/box-content-preview/commit/65e35f1))
-* Chore: add slack notifications for failed cron jobs (#541) ([a2763af](https://github.com/box/box-content-preview/commit/a2763af))
-* Chore: Add tests for annotationsLoadHandler (#540) ([ae68bcb](https://github.com/box/box-content-preview/commit/ae68bcb))
-* Chore: Increasing wait time and test timeouts (#535) ([2220c1c](https://github.com/box/box-content-preview/commit/2220c1c))
-* Chore: Lazy load annotations using new chunk (#516) ([062ea38](https://github.com/box/box-content-preview/commit/062ea38))
-
-
+- Update: box-annotations to v0.7.0 (#545) ([414113a](https://github.com/box/box-content-preview/commit/414113a))
+- Update: Do not prefetch for mp4 and mp3 viewers (#536) ([f5e487f](https://github.com/box/box-content-preview/commit/f5e487f))
+- Fix: build-rb required before building ci (#538) ([85215b5](https://github.com/box/box-content-preview/commit/85215b5))
+- Fix: Building preview before running tests (#537) ([a0e4e0c](https://github.com/box/box-content-preview/commit/a0e4e0c))
+- Fix: Validate passed in boxAnnotations is instance of the proper type (#542) ([3a1ae72](https://github.com/box/box-content-preview/commit/3a1ae72))
+- New: Allow BoxAnnotations to be passed in as a Preview option (#539) ([e3281cf](https://github.com/box/box-content-preview/commit/e3281cf))
+- Chore: Add multiple travis steps so we can run UI tests in a 'cron' case (#532) ([65e35f1](https://github.com/box/box-content-preview/commit/65e35f1))
+- Chore: add slack notifications for failed cron jobs (#541) ([a2763af](https://github.com/box/box-content-preview/commit/a2763af))
+- Chore: Add tests for annotationsLoadHandler (#540) ([ae68bcb](https://github.com/box/box-content-preview/commit/ae68bcb))
+- Chore: Increasing wait time and test timeouts (#535) ([2220c1c](https://github.com/box/box-content-preview/commit/2220c1c))
+- Chore: Lazy load annotations using new chunk (#516) ([062ea38](https://github.com/box/box-content-preview/commit/062ea38))
 
 <a name="1.21.0"></a>
+
 # 1.21.0 (2017-12-06)
 
-* Fix: Bind download function in Preview.js (#520) ([359abcf](https://github.com/box/box-content-preview/commit/359abcf))
-* Fix: Enable HD settings only if HD rep is available (#495) ([e4302e3](https://github.com/box/box-content-preview/commit/e4302e3))
-* Fix: Fix inheritance and add bindings for controls options (#523) ([942329d](https://github.com/box/box-content-preview/commit/942329d)), closes [#523](https://github.com/box/box-content-preview/issues/523)
-* Fix: Only remove the timeupdate listener if it has been bound before (#525) ([5c8dffa](https://github.com/box/box-content-preview/commit/5c8dffa))
-* Fix: Properly bind download button in PreviewErrorViewer (#527) ([122e0c9](https://github.com/box/box-content-preview/commit/122e0c9))
-* Fix: Revert source-map change to fix imported values (#530) ([66c71b1](https://github.com/box/box-content-preview/commit/66c71b1)), closes [#530](https://github.com/box/box-content-preview/issues/530)
-* Update: box-annotations to v0.5.1 (#524) ([518f42b](https://github.com/box/box-content-preview/commit/518f42b))
-* Update: box-annotations to v0.6.0 (#531) ([1f26be5](https://github.com/box/box-content-preview/commit/1f26be5))
-* Update: Sinon to v4.1.2 & remove deprecated methods from tests (#529) ([b1596ee](https://github.com/box/box-content-preview/commit/b1596ee))
-* Mojito: adding Bengali, Hindi and Latin America Spanish (#526) ([96916a6](https://github.com/box/box-content-preview/commit/96916a6))
-* Mojito: Update translations (#515) ([5503738](https://github.com/box/box-content-preview/commit/5503738))
-* Chore: Change webpack source maps to 'inline-cheap-source-map' (#513) ([fc71416](https://github.com/box/box-content-preview/commit/fc71416))
-* Chore: only use source maps when running unit tests in debug mode (#514) ([06e390d](https://github.com/box/box-content-preview/commit/06e390d))
-
-
+- Fix: Bind download function in Preview.js (#520) ([359abcf](https://github.com/box/box-content-preview/commit/359abcf))
+- Fix: Enable HD settings only if HD rep is available (#495) ([e4302e3](https://github.com/box/box-content-preview/commit/e4302e3))
+- Fix: Fix inheritance and add bindings for controls options (#523) ([942329d](https://github.com/box/box-content-preview/commit/942329d)), closes [#523](https://github.com/box/box-content-preview/issues/523)
+- Fix: Only remove the timeupdate listener if it has been bound before (#525) ([5c8dffa](https://github.com/box/box-content-preview/commit/5c8dffa))
+- Fix: Properly bind download button in PreviewErrorViewer (#527) ([122e0c9](https://github.com/box/box-content-preview/commit/122e0c9))
+- Fix: Revert source-map change to fix imported values (#530) ([66c71b1](https://github.com/box/box-content-preview/commit/66c71b1)), closes [#530](https://github.com/box/box-content-preview/issues/530)
+- Update: box-annotations to v0.5.1 (#524) ([518f42b](https://github.com/box/box-content-preview/commit/518f42b))
+- Update: box-annotations to v0.6.0 (#531) ([1f26be5](https://github.com/box/box-content-preview/commit/1f26be5))
+- Update: Sinon to v4.1.2 & remove deprecated methods from tests (#529) ([b1596ee](https://github.com/box/box-content-preview/commit/b1596ee))
+- Mojito: adding Bengali, Hindi and Latin America Spanish (#526) ([96916a6](https://github.com/box/box-content-preview/commit/96916a6))
+- Mojito: Update translations (#515) ([5503738](https://github.com/box/box-content-preview/commit/5503738))
+- Chore: Change webpack source maps to 'inline-cheap-source-map' (#513) ([fc71416](https://github.com/box/box-content-preview/commit/fc71416))
+- Chore: only use source maps when running unit tests in debug mode (#514) ([06e390d](https://github.com/box/box-content-preview/commit/06e390d))
 
 <a name="1.20.0"></a>
+
 # 1.20.0 (2017-11-29)
 
-* Chore: extract file loading icons to be used globally throughout preview (#490) ([ec2fc3b](https://github.com/box/box-content-preview/commit/ec2fc3b))
-* Chore: Remove autobind for Office and Media files (#505) ([0ecfd5e](https://github.com/box/box-content-preview/commit/0ecfd5e))
-* Chore: Remove autobind from 3d controls (#508) ([5aa3bc8](https://github.com/box/box-content-preview/commit/5aa3bc8))
-* Chore: Remove autobind from 3d viewers (#503) ([411f319](https://github.com/box/box-content-preview/commit/411f319))
-* Chore: Remove autobind from BaseViewer (#502) ([6d534be](https://github.com/box/box-content-preview/commit/6d534be))
-* Chore: Remove autobind from DocFindBar (#510) ([2a750e7](https://github.com/box/box-content-preview/commit/2a750e7))
-* Chore: Remove autobind from Document and Presentation Viewers (#507) ([cd3c67e](https://github.com/box/box-content-preview/commit/cd3c67e))
-* Chore: Remove autobind from error viewer (#506) ([4fd7eda](https://github.com/box/box-content-preview/commit/4fd7eda))
-* Chore: Remove autobind from text viewers (#511) ([a2b93fd](https://github.com/box/box-content-preview/commit/a2b93fd))
-* Chore: Remove autobind-decorator (#519) ([146f55c](https://github.com/box/box-content-preview/commit/146f55c))
-* Chore: Removing autobind from Preview.js (#500) ([6d61b9d](https://github.com/box/box-content-preview/commit/6d61b9d))
-* Update: box-annotations to v0.3.1 (#489) ([a9580a6](https://github.com/box/box-content-preview/commit/a9580a6))
-* Update: box-annotations to v0.4.0 (#497) ([808270b](https://github.com/box/box-content-preview/commit/808270b))
-* Update: box-annotations to v0.5.0 (#518) ([ef82f49](https://github.com/box/box-content-preview/commit/ef82f49))
-* Remove autobind from image viewers (#501) ([3b596b0](https://github.com/box/box-content-preview/commit/3b596b0))
-* Fix: BaseViewer debounced resize handler binding (#509) ([32f3c9a](https://github.com/box/box-content-preview/commit/32f3c9a))
-* Fix: Cachebust original representation URL (#493) ([2005863](https://github.com/box/box-content-preview/commit/2005863))
-* Fix: fix full screen overflow on Windows Chrome (#491) ([eee1525](https://github.com/box/box-content-preview/commit/eee1525)), closes [#491](https://github.com/box/box-content-preview/issues/491)
-* Fix: Media player control menus show scrollbars during transition (#494) ([80e07c6](https://github.com/box/box-content-preview/commit/80e07c6))
-* Fix: Presentation preloading scales without max (#487) ([11b2277](https://github.com/box/box-content-preview/commit/11b2277))
-* Fix: Properly remove transitionend handler (#499) ([79b4576](https://github.com/box/box-content-preview/commit/79b4576))
-* Fix: Remove unhandled errors from unit tests (#498) ([2e71743](https://github.com/box/box-content-preview/commit/2e71743))
-* Fix: Reset retry count after successful preview (#488) ([a8f66ed](https://github.com/box/box-content-preview/commit/a8f66ed))
-
-
+- Chore: extract file loading icons to be used globally throughout preview (#490) ([ec2fc3b](https://github.com/box/box-content-preview/commit/ec2fc3b))
+- Chore: Remove autobind for Office and Media files (#505) ([0ecfd5e](https://github.com/box/box-content-preview/commit/0ecfd5e))
+- Chore: Remove autobind from 3d controls (#508) ([5aa3bc8](https://github.com/box/box-content-preview/commit/5aa3bc8))
+- Chore: Remove autobind from 3d viewers (#503) ([411f319](https://github.com/box/box-content-preview/commit/411f319))
+- Chore: Remove autobind from BaseViewer (#502) ([6d534be](https://github.com/box/box-content-preview/commit/6d534be))
+- Chore: Remove autobind from DocFindBar (#510) ([2a750e7](https://github.com/box/box-content-preview/commit/2a750e7))
+- Chore: Remove autobind from Document and Presentation Viewers (#507) ([cd3c67e](https://github.com/box/box-content-preview/commit/cd3c67e))
+- Chore: Remove autobind from error viewer (#506) ([4fd7eda](https://github.com/box/box-content-preview/commit/4fd7eda))
+- Chore: Remove autobind from text viewers (#511) ([a2b93fd](https://github.com/box/box-content-preview/commit/a2b93fd))
+- Chore: Remove autobind-decorator (#519) ([146f55c](https://github.com/box/box-content-preview/commit/146f55c))
+- Chore: Removing autobind from Preview.js (#500) ([6d61b9d](https://github.com/box/box-content-preview/commit/6d61b9d))
+- Update: box-annotations to v0.3.1 (#489) ([a9580a6](https://github.com/box/box-content-preview/commit/a9580a6))
+- Update: box-annotations to v0.4.0 (#497) ([808270b](https://github.com/box/box-content-preview/commit/808270b))
+- Update: box-annotations to v0.5.0 (#518) ([ef82f49](https://github.com/box/box-content-preview/commit/ef82f49))
+- Remove autobind from image viewers (#501) ([3b596b0](https://github.com/box/box-content-preview/commit/3b596b0))
+- Fix: BaseViewer debounced resize handler binding (#509) ([32f3c9a](https://github.com/box/box-content-preview/commit/32f3c9a))
+- Fix: Cachebust original representation URL (#493) ([2005863](https://github.com/box/box-content-preview/commit/2005863))
+- Fix: fix full screen overflow on Windows Chrome (#491) ([eee1525](https://github.com/box/box-content-preview/commit/eee1525)), closes [#491](https://github.com/box/box-content-preview/issues/491)
+- Fix: Media player control menus show scrollbars during transition (#494) ([80e07c6](https://github.com/box/box-content-preview/commit/80e07c6))
+- Fix: Presentation preloading scales without max (#487) ([11b2277](https://github.com/box/box-content-preview/commit/11b2277))
+- Fix: Properly remove transitionend handler (#499) ([79b4576](https://github.com/box/box-content-preview/commit/79b4576))
+- Fix: Remove unhandled errors from unit tests (#498) ([2e71743](https://github.com/box/box-content-preview/commit/2e71743))
+- Fix: Reset retry count after successful preview (#488) ([a8f66ed](https://github.com/box/box-content-preview/commit/a8f66ed))
 
 <a name="1.19.0"></a>
+
 # 1.19.0 (2017-11-14)
 
-* Update: box-annotations to v0.2.1 (#479) ([1229c0e](https://github.com/box/box-content-preview/commit/1229c0e))
-* Update: box-annotations to v0.3.0 (#485) ([a786dfe](https://github.com/box/box-content-preview/commit/a786dfe)), closes [#21](https://github.com/box/box-content-preview/issues/21) [#21](https://github.com/box/box-content-preview/issues/21)
-* Update: Disable pdf.js streaming (#483) ([5a062c1](https://github.com/box/box-content-preview/commit/5a062c1))
-* New: Updated file icons (#484) ([25d7840](https://github.com/box/box-content-preview/commit/25d7840))
-* Fix: Correctly revoke objectURL for print blob in office viewer (#482) ([bc12c53](https://github.com/box/box-content-preview/commit/bc12c53))
-* Fix: Simplify video resize logic (#480) ([b666605](https://github.com/box/box-content-preview/commit/b666605))
-* Fix: toggleannotationmode event to trigger the right method (#478) ([f27bb07](https://github.com/box/box-content-preview/commit/f27bb07))
-* Mojito: Update translations (#458) ([28fa161](https://github.com/box/box-content-preview/commit/28fa161))
-* Upgrade: pdf.js v2.0.104 (#474) ([a86618f](https://github.com/box/box-content-preview/commit/a86618f))
-*  Update: npm packages to latest versions (#472) ([26e8d7b](https://github.com/box/box-content-preview/commit/26e8d7b))
-
-
+- Update: box-annotations to v0.2.1 (#479) ([1229c0e](https://github.com/box/box-content-preview/commit/1229c0e))
+- Update: box-annotations to v0.3.0 (#485) ([a786dfe](https://github.com/box/box-content-preview/commit/a786dfe)), closes [#21](https://github.com/box/box-content-preview/issues/21) [#21](https://github.com/box/box-content-preview/issues/21)
+- Update: Disable pdf.js streaming (#483) ([5a062c1](https://github.com/box/box-content-preview/commit/5a062c1))
+- New: Updated file icons (#484) ([25d7840](https://github.com/box/box-content-preview/commit/25d7840))
+- Fix: Correctly revoke objectURL for print blob in office viewer (#482) ([bc12c53](https://github.com/box/box-content-preview/commit/bc12c53))
+- Fix: Simplify video resize logic (#480) ([b666605](https://github.com/box/box-content-preview/commit/b666605))
+- Fix: toggleannotationmode event to trigger the right method (#478) ([f27bb07](https://github.com/box/box-content-preview/commit/f27bb07))
+- Mojito: Update translations (#458) ([28fa161](https://github.com/box/box-content-preview/commit/28fa161))
+- Upgrade: pdf.js v2.0.104 (#474) ([a86618f](https://github.com/box/box-content-preview/commit/a86618f))
+- Update: npm packages to latest versions (#472) ([26e8d7b](https://github.com/box/box-content-preview/commit/26e8d7b))
 
 <a name="1.18.0"></a>
+
 # 1.18.0 (2017-11-08)
 
-* Update: box-annotations to v0.2.0 (#477) ([a7ffbb8](https://github.com/box/box-content-preview/commit/a7ffbb8))
-* Chore: Temporarily disable functional tests (#476) ([bafb699](https://github.com/box/box-content-preview/commit/bafb699))
-* Chore: Update LICENSE to generic Box SDK license (#437) ([619e2dd](https://github.com/box/box-content-preview/commit/619e2dd))
-* Fix: es-MX clean-up (We'll be using es-419 instead) (#457) ([e78cf06](https://github.com/box/box-content-preview/commit/e78cf06))
-* Fix: Instant Preview when thumbnail is pending (#473) ([a2f4f8b](https://github.com/box/box-content-preview/commit/a2f4f8b))
-* New: Add script to upgrade box-annotations version in Preview (#468) ([7de9e4a](https://github.com/box/box-content-preview/commit/7de9e4a))
-* New: Support preview of JSON files (#467) ([e758871](https://github.com/box/box-content-preview/commit/e758871))
-
-
+- Update: box-annotations to v0.2.0 (#477) ([a7ffbb8](https://github.com/box/box-content-preview/commit/a7ffbb8))
+- Chore: Temporarily disable functional tests (#476) ([bafb699](https://github.com/box/box-content-preview/commit/bafb699))
+- Chore: Update LICENSE to generic Box SDK license (#437) ([619e2dd](https://github.com/box/box-content-preview/commit/619e2dd))
+- Fix: es-MX clean-up (We'll be using es-419 instead) (#457) ([e78cf06](https://github.com/box/box-content-preview/commit/e78cf06))
+- Fix: Instant Preview when thumbnail is pending (#473) ([a2f4f8b](https://github.com/box/box-content-preview/commit/a2f4f8b))
+- New: Add script to upgrade box-annotations version in Preview (#468) ([7de9e4a](https://github.com/box/box-content-preview/commit/7de9e4a))
+- New: Support preview of JSON files (#467) ([e758871](https://github.com/box/box-content-preview/commit/e758871))
 
 <a name="1.17.0"></a>
+
 # 1.17.0 (2017-10-31)
 
-* New: Find method for documents (#460) ([3a0b868](https://github.com/box/box-content-preview/commit/3a0b868))
-* New: Make findBar optional (#438) ([3ea11cc](https://github.com/box/box-content-preview/commit/3ea11cc))
-* New: Update BaseViewer to use box-annotations npm package (#459) ([4f71ab2](https://github.com/box/box-content-preview/commit/4f71ab2))
-* Fix: Fix fullscreen icon for video (#456) ([ef5614a](https://github.com/box/box-content-preview/commit/ef5614a)), closes [#456](https://github.com/box/box-content-preview/issues/456)
-* Fix: update autoplay behavior (#461) ([c4778f8](https://github.com/box/box-content-preview/commit/c4778f8))
-* Chore: Removing annotations from Box-Content-Preview (#451) ([fa7855e](https://github.com/box/box-content-preview/commit/fa7855e))
-* Chore: Removing annotations README.md (#462) ([bdbb75a](https://github.com/box/box-content-preview/commit/bdbb75a))
-* Mojito: Update translations (#452) ([9b7bbb7](https://github.com/box/box-content-preview/commit/9b7bbb7))
-* Mojito: Update translations (#454) ([fcd3aad](https://github.com/box/box-content-preview/commit/fcd3aad))
-
-
+- New: Find method for documents (#460) ([3a0b868](https://github.com/box/box-content-preview/commit/3a0b868))
+- New: Make findBar optional (#438) ([3ea11cc](https://github.com/box/box-content-preview/commit/3ea11cc))
+- New: Update BaseViewer to use box-annotations npm package (#459) ([4f71ab2](https://github.com/box/box-content-preview/commit/4f71ab2))
+- Fix: Fix fullscreen icon for video (#456) ([ef5614a](https://github.com/box/box-content-preview/commit/ef5614a)), closes [#456](https://github.com/box/box-content-preview/issues/456)
+- Fix: update autoplay behavior (#461) ([c4778f8](https://github.com/box/box-content-preview/commit/c4778f8))
+- Chore: Removing annotations from Box-Content-Preview (#451) ([fa7855e](https://github.com/box/box-content-preview/commit/fa7855e))
+- Chore: Removing annotations README.md (#462) ([bdbb75a](https://github.com/box/box-content-preview/commit/bdbb75a))
+- Mojito: Update translations (#452) ([9b7bbb7](https://github.com/box/box-content-preview/commit/9b7bbb7))
+- Mojito: Update translations (#454) ([fcd3aad](https://github.com/box/box-content-preview/commit/fcd3aad))
 
 <a name="1.16.0"></a>
+
 # 1.16.0 (2017-10-24)
 
-* New: add autoplay to media viewers (#433) ([10982de](https://github.com/box/box-content-preview/commit/10982de))
-* New: Added enabledTypes property. Backwards compat for disabledTypes (#439) ([15a7712](https://github.com/box/box-content-preview/commit/15a7712))
-* New: Enable 360 video on desktop Safari (#445) ([62a67f9](https://github.com/box/box-content-preview/commit/62a67f9))
-* Fix: Annotations cleanup (#449) ([e8f6fd3](https://github.com/box/box-content-preview/commit/e8f6fd3))
-* Fix: controller.handleAnnotationEvent() not bound correctly (#448) ([b11f2dd](https://github.com/box/box-content-preview/commit/b11f2dd))
-* Fix: Don't revoke print URL if it doesn't exist (#444) ([9f06212](https://github.com/box/box-content-preview/commit/9f06212))
-* Fix: Don't show notification on draw mode exit (#447) ([43422e4](https://github.com/box/box-content-preview/commit/43422e4))
-* Fix: Fix draw selection and related bugs (#440) ([6a667f1](https://github.com/box/box-content-preview/commit/6a667f1)), closes [#440](https://github.com/box/box-content-preview/issues/440)
-* Fix: Setting innerHTML in annotatorUtil.generateButton() (#446) ([4035d8e](https://github.com/box/box-content-preview/commit/4035d8e))
-* Chore: Add JSDoc for Emit wrapper (#442) ([360989d](https://github.com/box/box-content-preview/commit/360989d))
-* Chore: Passing localized strings into annotations (#441) ([0ae1c47](https://github.com/box/box-content-preview/commit/0ae1c47))
-
-
+- New: add autoplay to media viewers (#433) ([10982de](https://github.com/box/box-content-preview/commit/10982de))
+- New: Added enabledTypes property. Backwards compat for disabledTypes (#439) ([15a7712](https://github.com/box/box-content-preview/commit/15a7712))
+- New: Enable 360 video on desktop Safari (#445) ([62a67f9](https://github.com/box/box-content-preview/commit/62a67f9))
+- Fix: Annotations cleanup (#449) ([e8f6fd3](https://github.com/box/box-content-preview/commit/e8f6fd3))
+- Fix: controller.handleAnnotationEvent() not bound correctly (#448) ([b11f2dd](https://github.com/box/box-content-preview/commit/b11f2dd))
+- Fix: Don't revoke print URL if it doesn't exist (#444) ([9f06212](https://github.com/box/box-content-preview/commit/9f06212))
+- Fix: Don't show notification on draw mode exit (#447) ([43422e4](https://github.com/box/box-content-preview/commit/43422e4))
+- Fix: Fix draw selection and related bugs (#440) ([6a667f1](https://github.com/box/box-content-preview/commit/6a667f1)), closes [#440](https://github.com/box/box-content-preview/issues/440)
+- Fix: Setting innerHTML in annotatorUtil.generateButton() (#446) ([4035d8e](https://github.com/box/box-content-preview/commit/4035d8e))
+- Chore: Add JSDoc for Emit wrapper (#442) ([360989d](https://github.com/box/box-content-preview/commit/360989d))
+- Chore: Passing localized strings into annotations (#441) ([0ae1c47](https://github.com/box/box-content-preview/commit/0ae1c47))
 
 <a name="1.15.0"></a>
+
 # 1.15.0 (2017-10-17)
 
-*  New: Adding README.md for Annotations codebase + cleanup (#420) ([7df251e](https://github.com/box/box-content-preview/commit/7df251e))
-* Revert "Chore: Temporarily allow draw annotations to be enabled via config (#416)" (#434) ([09c279d](https://github.com/box/box-content-preview/commit/09c279d))
-* New: Disable right click when user does not have download permissions (#427) ([b3a6407](https://github.com/box/box-content-preview/commit/b3a6407))
-* Fix: Prevent preview from erroring if  listener callback errors (#425) ([ed0efb8](https://github.com/box/box-content-preview/commit/ed0efb8))
-* Fix: Prevent SVGs from depending on CSS for sizing (#426) ([86072bd](https://github.com/box/box-content-preview/commit/86072bd))
-* Fix: Remove draw annotations flag (#436) ([87a3278](https://github.com/box/box-content-preview/commit/87a3278))
-* Fix: Use local storage to cache media settings (#432) ([e26e323](https://github.com/box/box-content-preview/commit/e26e323))
-* Chore: Add more detail to shaka error logging (#435) ([aa14549](https://github.com/box/box-content-preview/commit/aa14549))
-
-
+- New: Adding README.md for Annotations codebase + cleanup (#420) ([7df251e](https://github.com/box/box-content-preview/commit/7df251e))
+- Revert "Chore: Temporarily allow draw annotations to be enabled via config (#416)" (#434) ([09c279d](https://github.com/box/box-content-preview/commit/09c279d))
+- New: Disable right click when user does not have download permissions (#427) ([b3a6407](https://github.com/box/box-content-preview/commit/b3a6407))
+- Fix: Prevent preview from erroring if listener callback errors (#425) ([ed0efb8](https://github.com/box/box-content-preview/commit/ed0efb8))
+- Fix: Prevent SVGs from depending on CSS for sizing (#426) ([86072bd](https://github.com/box/box-content-preview/commit/86072bd))
+- Fix: Remove draw annotations flag (#436) ([87a3278](https://github.com/box/box-content-preview/commit/87a3278))
+- Fix: Use local storage to cache media settings (#432) ([e26e323](https://github.com/box/box-content-preview/commit/e26e323))
+- Chore: Add more detail to shaka error logging (#435) ([aa14549](https://github.com/box/box-content-preview/commit/aa14549))
 
 <a name="1.14.0"></a>
+
 # 1.14.0 (2017-10-11)
 
-* Fix: Ensure we are displaying a valid error string (#414) ([ec908ba](https://github.com/box/box-content-preview/commit/ec908ba))
-* Fix: Turn off rendering interactive forms (#430) ([99bdf48](https://github.com/box/box-content-preview/commit/99bdf48))
-
-
+- Fix: Ensure we are displaying a valid error string (#414) ([ec908ba](https://github.com/box/box-content-preview/commit/ec908ba))
+- Fix: Turn off rendering interactive forms (#430) ([99bdf48](https://github.com/box/box-content-preview/commit/99bdf48))
 
 <a name="1.13.0"></a>
+
 # 1.13.0 (2017-10-04)
 
-* Fix: Only call setOriginalImageSize() on single page images (#394) ([8f1cc35](https://github.com/box/box-content-preview/commit/8f1cc35))
-* Fix: Prevent canvas flickering on tap for mobile safari (#418) ([14322b8](https://github.com/box/box-content-preview/commit/14322b8))
-* Fix: Prevent unnecessary draw code from executing (#421) ([d6cdcf9](https://github.com/box/box-content-preview/commit/d6cdcf9))
-* Fix: Properly delete draw annotations threads (#412) ([529b9a4](https://github.com/box/box-content-preview/commit/529b9a4))
-* Fix: Set watermark-cache params for dash segments (#422) ([ec68fd1](https://github.com/box/box-content-preview/commit/ec68fd1))
-* Fix: Update Box3D and fix loading of Vive controller model ([eb613c6](https://github.com/box/box-content-preview/commit/eb613c6))
-* Chore: Cleaning up draw dialogs (#423) ([26813a4](https://github.com/box/box-content-preview/commit/26813a4))
-* Chore: Force threads to be inactive when the dialog hides (#424) ([90048ec](https://github.com/box/box-content-preview/commit/90048ec))
-* Chore: Temporarily allow draw annotations to be enabled via config (#416) ([bd35003](https://github.com/box/box-content-preview/commit/bd35003))
-* Chore: Upgrade packages and remove unnecessary dependencies (#410) ([150f038](https://github.com/box/box-content-preview/commit/150f038))
-* Update: Upgrade Box3D to 14.0.0 ([04d3cc7](https://github.com/box/box-content-preview/commit/04d3cc7))
-* Revert "Fix: Only call setOriginalImageSize() on single page images (#394)" (#415) ([d685dfe](https://github.com/box/box-content-preview/commit/d685dfe))
-* Mojito: Update translations (#413) ([9fd5d4b](https://github.com/box/box-content-preview/commit/9fd5d4b))
-
-
+- Fix: Only call setOriginalImageSize() on single page images (#394) ([8f1cc35](https://github.com/box/box-content-preview/commit/8f1cc35))
+- Fix: Prevent canvas flickering on tap for mobile safari (#418) ([14322b8](https://github.com/box/box-content-preview/commit/14322b8))
+- Fix: Prevent unnecessary draw code from executing (#421) ([d6cdcf9](https://github.com/box/box-content-preview/commit/d6cdcf9))
+- Fix: Properly delete draw annotations threads (#412) ([529b9a4](https://github.com/box/box-content-preview/commit/529b9a4))
+- Fix: Set watermark-cache params for dash segments (#422) ([ec68fd1](https://github.com/box/box-content-preview/commit/ec68fd1))
+- Fix: Update Box3D and fix loading of Vive controller model ([eb613c6](https://github.com/box/box-content-preview/commit/eb613c6))
+- Chore: Cleaning up draw dialogs (#423) ([26813a4](https://github.com/box/box-content-preview/commit/26813a4))
+- Chore: Force threads to be inactive when the dialog hides (#424) ([90048ec](https://github.com/box/box-content-preview/commit/90048ec))
+- Chore: Temporarily allow draw annotations to be enabled via config (#416) ([bd35003](https://github.com/box/box-content-preview/commit/bd35003))
+- Chore: Upgrade packages and remove unnecessary dependencies (#410) ([150f038](https://github.com/box/box-content-preview/commit/150f038))
+- Update: Upgrade Box3D to 14.0.0 ([04d3cc7](https://github.com/box/box-content-preview/commit/04d3cc7))
+- Revert "Fix: Only call setOriginalImageSize() on single page images (#394)" (#415) ([d685dfe](https://github.com/box/box-content-preview/commit/d685dfe))
+- Mojito: Update translations (#413) ([9fd5d4b](https://github.com/box/box-content-preview/commit/9fd5d4b))
 
 <a name="1.12.0"></a>
+
 # 1.12.0 (2017-09-26)
 
-* Fix: Document print in Chrome (#406) ([54fa047](https://github.com/box/box-content-preview/commit/54fa047))
-* Fix: Hookup cancel button (#404) ([6c7b63a](https://github.com/box/box-content-preview/commit/6c7b63a))
-* Fix: Moved guards so drawing works when highlights disabled (#409) ([f516a4f](https://github.com/box/box-content-preview/commit/f516a4f))
-* Fix: No longer relying on system time for flakey test (#398) ([1986f9a](https://github.com/box/box-content-preview/commit/1986f9a))
-* New: Add new API to preview media player to play segments (#408) ([ef60e95](https://github.com/box/box-content-preview/commit/ef60e95))
-* New: Draw annotations UI (#403) ([4cbfc0f](https://github.com/box/box-content-preview/commit/4cbfc0f))
-* Update: Support additional query params in requests (#405) ([08da16b](https://github.com/box/box-content-preview/commit/08da16b))
-
-
+- Fix: Document print in Chrome (#406) ([54fa047](https://github.com/box/box-content-preview/commit/54fa047))
+- Fix: Hookup cancel button (#404) ([6c7b63a](https://github.com/box/box-content-preview/commit/6c7b63a))
+- Fix: Moved guards so drawing works when highlights disabled (#409) ([f516a4f](https://github.com/box/box-content-preview/commit/f516a4f))
+- Fix: No longer relying on system time for flakey test (#398) ([1986f9a](https://github.com/box/box-content-preview/commit/1986f9a))
+- New: Add new API to preview media player to play segments (#408) ([ef60e95](https://github.com/box/box-content-preview/commit/ef60e95))
+- New: Draw annotations UI (#403) ([4cbfc0f](https://github.com/box/box-content-preview/commit/4cbfc0f))
+- Update: Support additional query params in requests (#405) ([08da16b](https://github.com/box/box-content-preview/commit/08da16b))
 
 <a name="1.11.0"></a>
+
 # 1.11.0 (2017-09-19)
 
-* Update: Box3D version 12.4.1 ([4e7eed1](https://github.com/box/box-content-preview/commit/4e7eed1))
-* New: Allow documents to be viewed in presentation mode (#396) ([d8956a7](https://github.com/box/box-content-preview/commit/d8956a7))
-* Fix: Additional logic to reset highlight-comment threads (#386) ([faef3df](https://github.com/box/box-content-preview/commit/faef3df))
-* Fix: Downgrade pdf.js (#397) ([b8c6706](https://github.com/box/box-content-preview/commit/b8c6706))
-* Fix: isPageNumFocused() null check (#401) ([b7eb6dc](https://github.com/box/box-content-preview/commit/b7eb6dc))
-* Mojito: Update translations (#392) ([a23df00](https://github.com/box/box-content-preview/commit/a23df00))
-* Mojito: Update translations (#399) ([ba4f354](https://github.com/box/box-content-preview/commit/ba4f354))
-* Chore: Only getBrowserInfo() once per preview instance (#393) ([ba0d1f7](https://github.com/box/box-content-preview/commit/ba0d1f7))
-
-
+- Update: Box3D version 12.4.1 ([4e7eed1](https://github.com/box/box-content-preview/commit/4e7eed1))
+- New: Allow documents to be viewed in presentation mode (#396) ([d8956a7](https://github.com/box/box-content-preview/commit/d8956a7))
+- Fix: Additional logic to reset highlight-comment threads (#386) ([faef3df](https://github.com/box/box-content-preview/commit/faef3df))
+- Fix: Downgrade pdf.js (#397) ([b8c6706](https://github.com/box/box-content-preview/commit/b8c6706))
+- Fix: isPageNumFocused() null check (#401) ([b7eb6dc](https://github.com/box/box-content-preview/commit/b7eb6dc))
+- Mojito: Update translations (#392) ([a23df00](https://github.com/box/box-content-preview/commit/a23df00))
+- Mojito: Update translations (#399) ([ba4f354](https://github.com/box/box-content-preview/commit/ba4f354))
+- Chore: Only getBrowserInfo() once per preview instance (#393) ([ba0d1f7](https://github.com/box/box-content-preview/commit/ba0d1f7))
 
 <a name="1.10.0"></a>
+
 # 1.10.0 (2017-09-13)
 
-* Chore: Adding console errors for annotation errors (#388) ([3762ead](https://github.com/box/box-content-preview/commit/3762ead))
-* Chore: Cleaning up old third party libraries (#390) ([ee0bc90](https://github.com/box/box-content-preview/commit/ee0bc90))
-* Upgrade: pdf.js 1.9.558 (#389) ([4d76bdd](https://github.com/box/box-content-preview/commit/4d76bdd))
-* Fix: Adding reply-container mobile padding + clearing currentAnnotationMode on mode exit (#370) ([05d3662](https://github.com/box/box-content-preview/commit/05d3662))
-* Fix: disableAnnotationMode cannot be called on disallowed modes (#372) ([1d5a172](https://github.com/box/box-content-preview/commit/1d5a172))
-* Fix: fix page change flickering when zoomed in (#384) ([d091704](https://github.com/box/box-content-preview/commit/d091704)), closes [#384](https://github.com/box/box-content-preview/issues/384)
-* Fix: Passing event into thread.mouseoutHandler() (#375) ([2fe3c37](https://github.com/box/box-content-preview/commit/2fe3c37))
-* Fix: Plain highlight is mispositioned when it runs off the side (#381) ([bfa50e5](https://github.com/box/box-content-preview/commit/bfa50e5))
-* Fix: Respect view permissions when viewer.initAnnotations() is called (#379) ([ec043b9](https://github.com/box/box-content-preview/commit/ec043b9))
-* Fix: Show point annotation above dialog only on hover (#383) ([63fafa5](https://github.com/box/box-content-preview/commit/63fafa5))
-* Fix: Swapping Object.values() with Object.keys() (#371) ([23527a8](https://github.com/box/box-content-preview/commit/23527a8))
-* Update: Allow passed in collections to be of file objects (#359) ([cc59009](https://github.com/box/box-content-preview/commit/cc59009))
-* Update: Update Box3D to 12.3.0 ([e5899b2](https://github.com/box/box-content-preview/commit/e5899b2))
-* Mojito: Update translations (#368) ([56fe656](https://github.com/box/box-content-preview/commit/56fe656))
-* Mojito: Update translations (#373) ([b800397](https://github.com/box/box-content-preview/commit/b800397))
-* Mojito: Update translations (#374) ([fe15754](https://github.com/box/box-content-preview/commit/fe15754))
-* Mojito: Update translations (#382) ([bef23db](https://github.com/box/box-content-preview/commit/bef23db))
-* New: drawing dialog (#364) ([5003c3d](https://github.com/box/box-content-preview/commit/5003c3d))
-* New: Emit annotation thread events to the viewer and beyond (#377) ([dec86c6](https://github.com/box/box-content-preview/commit/dec86c6))
-* New: More specific error messages from conversion (#378) ([a718718](https://github.com/box/box-content-preview/commit/a718718))
-* New: Scroll file to annotation position on 'scrolltoannotation' (#366) ([c867fc7](https://github.com/box/box-content-preview/commit/c867fc7))
-
-
+- Chore: Adding console errors for annotation errors (#388) ([3762ead](https://github.com/box/box-content-preview/commit/3762ead))
+- Chore: Cleaning up old third party libraries (#390) ([ee0bc90](https://github.com/box/box-content-preview/commit/ee0bc90))
+- Upgrade: pdf.js 1.9.558 (#389) ([4d76bdd](https://github.com/box/box-content-preview/commit/4d76bdd))
+- Fix: Adding reply-container mobile padding + clearing currentAnnotationMode on mode exit (#370) ([05d3662](https://github.com/box/box-content-preview/commit/05d3662))
+- Fix: disableAnnotationMode cannot be called on disallowed modes (#372) ([1d5a172](https://github.com/box/box-content-preview/commit/1d5a172))
+- Fix: fix page change flickering when zoomed in (#384) ([d091704](https://github.com/box/box-content-preview/commit/d091704)), closes [#384](https://github.com/box/box-content-preview/issues/384)
+- Fix: Passing event into thread.mouseoutHandler() (#375) ([2fe3c37](https://github.com/box/box-content-preview/commit/2fe3c37))
+- Fix: Plain highlight is mispositioned when it runs off the side (#381) ([bfa50e5](https://github.com/box/box-content-preview/commit/bfa50e5))
+- Fix: Respect view permissions when viewer.initAnnotations() is called (#379) ([ec043b9](https://github.com/box/box-content-preview/commit/ec043b9))
+- Fix: Show point annotation above dialog only on hover (#383) ([63fafa5](https://github.com/box/box-content-preview/commit/63fafa5))
+- Fix: Swapping Object.values() with Object.keys() (#371) ([23527a8](https://github.com/box/box-content-preview/commit/23527a8))
+- Update: Allow passed in collections to be of file objects (#359) ([cc59009](https://github.com/box/box-content-preview/commit/cc59009))
+- Update: Update Box3D to 12.3.0 ([e5899b2](https://github.com/box/box-content-preview/commit/e5899b2))
+- Mojito: Update translations (#368) ([56fe656](https://github.com/box/box-content-preview/commit/56fe656))
+- Mojito: Update translations (#373) ([b800397](https://github.com/box/box-content-preview/commit/b800397))
+- Mojito: Update translations (#374) ([fe15754](https://github.com/box/box-content-preview/commit/fe15754))
+- Mojito: Update translations (#382) ([bef23db](https://github.com/box/box-content-preview/commit/bef23db))
+- New: drawing dialog (#364) ([5003c3d](https://github.com/box/box-content-preview/commit/5003c3d))
+- New: Emit annotation thread events to the viewer and beyond (#377) ([dec86c6](https://github.com/box/box-content-preview/commit/dec86c6))
+- New: More specific error messages from conversion (#378) ([a718718](https://github.com/box/box-content-preview/commit/a718718))
+- New: Scroll file to annotation position on 'scrolltoannotation' (#366) ([c867fc7](https://github.com/box/box-content-preview/commit/c867fc7))
 
 <a name="1.9.0"></a>
+
 # 1.9.0 (2017-09-06)
 
-* Fix: annotation mode exits on wrong button and fetch annotations returns non-promise (#363) ([aed6288](https://github.com/box/box-content-preview/commit/aed6288))
-* Fix: Only hide point annotation icon when dialog is flipped (#369) ([d0ede36](https://github.com/box/box-content-preview/commit/d0ede36))
-* Fix: Point 3D viewer at newest Box3D runtime ([3420799](https://github.com/box/box-content-preview/commit/3420799))
-* Temp hide show ui for plain and comment highlights (#348) ([3dbddbf](https://github.com/box/box-content-preview/commit/3dbddbf))
-* Feature: drawing annotation deletion (#337) ([34b9da1](https://github.com/box/box-content-preview/commit/34b9da1))
-* Feature: Drawing boundary updates on each action (#356) ([8f7c2df](https://github.com/box/box-content-preview/commit/8f7c2df))
-* Feature: drawingSelectionUI (#362) ([318501f](https://github.com/box/box-content-preview/commit/318501f))
-* Chore: Add a page # for image annotations that were created without one (#357) ([bf6a6f9](https://github.com/box/box-content-preview/commit/bf6a6f9))
-* Chore: Don't hide dialog on mouseout if mouse is in annotations dialog (#352) ([e01324b](https://github.com/box/box-content-preview/commit/e01324b))
-* Chore: Position point annotation dialog based off icon location (#339) ([087350b](https://github.com/box/box-content-preview/commit/087350b))
-* Chore: Store annotation threads by threadID in the thread map (#316) ([09aa1cd](https://github.com/box/box-content-preview/commit/09aa1cd))
-* New: Flip point annotation dialog if in lower half of file (#353) ([dbe8f06](https://github.com/box/box-content-preview/commit/dbe8f06))
-* New: Separate create and view permissions for annotations (#358) ([5d39f1f](https://github.com/box/box-content-preview/commit/5d39f1f))
-* New: Support multiple audio tracks (#299) ([70f5b81](https://github.com/box/box-content-preview/commit/70f5b81))
-* Mojito: Update translations (#354) ([eab7da5](https://github.com/box/box-content-preview/commit/eab7da5))
-* Upgrade: Upgrade to shaka-player 2.1.8 (#351) ([4ec7b65](https://github.com/box/box-content-preview/commit/4ec7b65))
-
-
+- Fix: annotation mode exits on wrong button and fetch annotations returns non-promise (#363) ([aed6288](https://github.com/box/box-content-preview/commit/aed6288))
+- Fix: Only hide point annotation icon when dialog is flipped (#369) ([d0ede36](https://github.com/box/box-content-preview/commit/d0ede36))
+- Fix: Point 3D viewer at newest Box3D runtime ([3420799](https://github.com/box/box-content-preview/commit/3420799))
+- Temp hide show ui for plain and comment highlights (#348) ([3dbddbf](https://github.com/box/box-content-preview/commit/3dbddbf))
+- Feature: drawing annotation deletion (#337) ([34b9da1](https://github.com/box/box-content-preview/commit/34b9da1))
+- Feature: Drawing boundary updates on each action (#356) ([8f7c2df](https://github.com/box/box-content-preview/commit/8f7c2df))
+- Feature: drawingSelectionUI (#362) ([318501f](https://github.com/box/box-content-preview/commit/318501f))
+- Chore: Add a page # for image annotations that were created without one (#357) ([bf6a6f9](https://github.com/box/box-content-preview/commit/bf6a6f9))
+- Chore: Don't hide dialog on mouseout if mouse is in annotations dialog (#352) ([e01324b](https://github.com/box/box-content-preview/commit/e01324b))
+- Chore: Position point annotation dialog based off icon location (#339) ([087350b](https://github.com/box/box-content-preview/commit/087350b))
+- Chore: Store annotation threads by threadID in the thread map (#316) ([09aa1cd](https://github.com/box/box-content-preview/commit/09aa1cd))
+- New: Flip point annotation dialog if in lower half of file (#353) ([dbe8f06](https://github.com/box/box-content-preview/commit/dbe8f06))
+- New: Separate create and view permissions for annotations (#358) ([5d39f1f](https://github.com/box/box-content-preview/commit/5d39f1f))
+- New: Support multiple audio tracks (#299) ([70f5b81](https://github.com/box/box-content-preview/commit/70f5b81))
+- Mojito: Update translations (#354) ([eab7da5](https://github.com/box/box-content-preview/commit/eab7da5))
+- Upgrade: Upgrade to shaka-player 2.1.8 (#351) ([4ec7b65](https://github.com/box/box-content-preview/commit/4ec7b65))
 
 <a name="1.8.0"></a>
+
 # 1.8.0 (2017-08-30)
 
-* Update: Add Instant Preview loading overlay (#350) ([c361317](https://github.com/box/box-content-preview/commit/c361317))
-* Update: Update Box3D to 12.2.1 (#336) ([5a45177](https://github.com/box/box-content-preview/commit/5a45177))
-* New: Add method to get top right corner of a highlight annotation (#340) ([75b183d](https://github.com/box/box-content-preview/commit/75b183d))
-* New: Preview file from offline passed file (#326) ([8547bc8](https://github.com/box/box-content-preview/commit/8547bc8))
-* New: Turn on rendering of interactive forms (#349) ([77a38a0](https://github.com/box/box-content-preview/commit/77a38a0))
-* Selectively disable annotations (#322) ([c6dac8a](https://github.com/box/box-content-preview/commit/c6dac8a))
-* Update README.md (#335) ([886bd33](https://github.com/box/box-content-preview/commit/886bd33))
-* Video player ui disappears in 360 video (#346) ([53fa9f5](https://github.com/box/box-content-preview/commit/53fa9f5))
-* Fix: IE11 image size default (#333) ([bebdcec](https://github.com/box/box-content-preview/commit/bebdcec))
-* Fix: Minor ESLint errors (#342) ([2318581](https://github.com/box/box-content-preview/commit/2318581))
-* Fix: pass get failure through in case imageEl is a div of images (#338) ([1de741e](https://github.com/box/box-content-preview/commit/1de741e))
-* Fix: Re-scale annotation canvases on zoom (#345) ([cd8b1af](https://github.com/box/box-content-preview/commit/cd8b1af))
-* Fix: Safari font rendering issue (#332) ([847cd8c](https://github.com/box/box-content-preview/commit/847cd8c))
-* Fix: Scaling canvas context when the canvas re-scales (#347) ([1bfa954](https://github.com/box/box-content-preview/commit/1bfa954))
-* Chore: Automate simple server to make running functional tests easier (#334) ([69a585f](https://github.com/box/box-content-preview/commit/69a585f))
-* Chore: log actual error message (#343) ([f1bc217](https://github.com/box/box-content-preview/commit/f1bc217))
-* Chore: Refactor pageControls and scroll handling for multi page images (#321) ([f9f511e](https://github.com/box/box-content-preview/commit/f9f511e))
-* Chore: Updating method decorators (#311) ([9ae3853](https://github.com/box/box-content-preview/commit/9ae3853))
-* Upgrade: pdf.js 1.9.450 (#329) ([987a417](https://github.com/box/box-content-preview/commit/987a417))
-
-
+- Update: Add Instant Preview loading overlay (#350) ([c361317](https://github.com/box/box-content-preview/commit/c361317))
+- Update: Update Box3D to 12.2.1 (#336) ([5a45177](https://github.com/box/box-content-preview/commit/5a45177))
+- New: Add method to get top right corner of a highlight annotation (#340) ([75b183d](https://github.com/box/box-content-preview/commit/75b183d))
+- New: Preview file from offline passed file (#326) ([8547bc8](https://github.com/box/box-content-preview/commit/8547bc8))
+- New: Turn on rendering of interactive forms (#349) ([77a38a0](https://github.com/box/box-content-preview/commit/77a38a0))
+- Selectively disable annotations (#322) ([c6dac8a](https://github.com/box/box-content-preview/commit/c6dac8a))
+- Update README.md (#335) ([886bd33](https://github.com/box/box-content-preview/commit/886bd33))
+- Video player ui disappears in 360 video (#346) ([53fa9f5](https://github.com/box/box-content-preview/commit/53fa9f5))
+- Fix: IE11 image size default (#333) ([bebdcec](https://github.com/box/box-content-preview/commit/bebdcec))
+- Fix: Minor ESLint errors (#342) ([2318581](https://github.com/box/box-content-preview/commit/2318581))
+- Fix: pass get failure through in case imageEl is a div of images (#338) ([1de741e](https://github.com/box/box-content-preview/commit/1de741e))
+- Fix: Re-scale annotation canvases on zoom (#345) ([cd8b1af](https://github.com/box/box-content-preview/commit/cd8b1af))
+- Fix: Safari font rendering issue (#332) ([847cd8c](https://github.com/box/box-content-preview/commit/847cd8c))
+- Fix: Scaling canvas context when the canvas re-scales (#347) ([1bfa954](https://github.com/box/box-content-preview/commit/1bfa954))
+- Chore: Automate simple server to make running functional tests easier (#334) ([69a585f](https://github.com/box/box-content-preview/commit/69a585f))
+- Chore: log actual error message (#343) ([f1bc217](https://github.com/box/box-content-preview/commit/f1bc217))
+- Chore: Refactor pageControls and scroll handling for multi page images (#321) ([f9f511e](https://github.com/box/box-content-preview/commit/f9f511e))
+- Chore: Updating method decorators (#311) ([9ae3853](https://github.com/box/box-content-preview/commit/9ae3853))
+- Upgrade: pdf.js 1.9.450 (#329) ([987a417](https://github.com/box/box-content-preview/commit/987a417))
 
 <a name="1.7.0"></a>
+
 # 1.7.0 (2017-08-23)
 
-* New: Adding functional test base (#305) ([5dc3247](https://github.com/box/box-content-preview/commit/5dc3247))
-* New: Support well-formed file object in show() (#328) ([540a011](https://github.com/box/box-content-preview/commit/540a011))
-* Fix: Add page controls between zoom and fullscreen controls (#320) ([0441920](https://github.com/box/box-content-preview/commit/0441920))
-* Fix: Create annotation in API using thread rather than threadNumber (#315) ([783adbc](https://github.com/box/box-content-preview/commit/783adbc))
-* Fix: Ensure that image.handleMouseDown() is unbound in annotation mode (#319) ([fd477c7](https://github.com/box/box-content-preview/commit/fd477c7))
-* Fix: Inconsistent natural image dimensions in IE (#324) ([2889b0d](https://github.com/box/box-content-preview/commit/2889b0d))
-* Fix: Pass in the correct previousPage() for DocBaseViewer.pageControls (#318) ([27b118d](https://github.com/box/box-content-preview/commit/27b118d))
-* Fix: Point annotation cleanup (#325) ([e27c18a](https://github.com/box/box-content-preview/commit/e27c18a))
-* Fix: Re-showing viewer controls on 'annotationmodeexit' (#323) ([5900ece](https://github.com/box/box-content-preview/commit/5900ece))
-* Feature: Drawing Annotations Undo Redo (#287) ([4b5421c](https://github.com/box/box-content-preview/commit/4b5421c))
-* Chore: Cleaning up remaining annotations references outside BaseViewer (#314) ([efaa385](https://github.com/box/box-content-preview/commit/efaa385))
-
-
+- New: Adding functional test base (#305) ([5dc3247](https://github.com/box/box-content-preview/commit/5dc3247))
+- New: Support well-formed file object in show() (#328) ([540a011](https://github.com/box/box-content-preview/commit/540a011))
+- Fix: Add page controls between zoom and fullscreen controls (#320) ([0441920](https://github.com/box/box-content-preview/commit/0441920))
+- Fix: Create annotation in API using thread rather than threadNumber (#315) ([783adbc](https://github.com/box/box-content-preview/commit/783adbc))
+- Fix: Ensure that image.handleMouseDown() is unbound in annotation mode (#319) ([fd477c7](https://github.com/box/box-content-preview/commit/fd477c7))
+- Fix: Inconsistent natural image dimensions in IE (#324) ([2889b0d](https://github.com/box/box-content-preview/commit/2889b0d))
+- Fix: Pass in the correct previousPage() for DocBaseViewer.pageControls (#318) ([27b118d](https://github.com/box/box-content-preview/commit/27b118d))
+- Fix: Point annotation cleanup (#325) ([e27c18a](https://github.com/box/box-content-preview/commit/e27c18a))
+- Fix: Re-showing viewer controls on 'annotationmodeexit' (#323) ([5900ece](https://github.com/box/box-content-preview/commit/5900ece))
+- Feature: Drawing Annotations Undo Redo (#287) ([4b5421c](https://github.com/box/box-content-preview/commit/4b5421c))
+- Chore: Cleaning up remaining annotations references outside BaseViewer (#314) ([efaa385](https://github.com/box/box-content-preview/commit/efaa385))
 
 <a name="1.6.0"></a>
+
 # 1.6.0 (2017-08-17)
 
-* Chore: Cleaning up and consolidating annotation methods (#288) ([6542b5d](https://github.com/box/box-content-preview/commit/6542b5d))
-* Chore: Fixed warning (#306) ([18daaf9](https://github.com/box/box-content-preview/commit/18daaf9)), closes [#306](https://github.com/box/box-content-preview/issues/306)
-* Chore: Move getAnnotateButton() out of PreviewUI into Annotator (#312) ([715b026](https://github.com/box/box-content-preview/commit/715b026))
-* Chore: Only remove annotation listeners if enabled on viewer (#293) ([9b97fd7](https://github.com/box/box-content-preview/commit/9b97fd7))
-* Chore: Remove code supporting token in options object (#268) ([ba1ac34](https://github.com/box/box-content-preview/commit/ba1ac34))
-* Chore: Toggling annotation mode handlers using emitted messages (#307) ([8e7d49a](https://github.com/box/box-content-preview/commit/8e7d49a))
-* Chore: Updating docs.box.com links to developer.box.com in README (#282) ([b63eab2](https://github.com/box/box-content-preview/commit/b63eab2))
-* Fix: annotation handler rebinding (#294) ([2dc0200](https://github.com/box/box-content-preview/commit/2dc0200))
-* Fix: Do not display disabled annotation types on fetch (#301) ([c669375](https://github.com/box/box-content-preview/commit/c669375))
-* Fix: Files must have .360 before extension to launch in 360 viewers. (#313) ([1659c4d](https://github.com/box/box-content-preview/commit/1659c4d))
-* Fix: Fix release script after GitHub release (#295) ([00dff52](https://github.com/box/box-content-preview/commit/00dff52)), closes [#295](https://github.com/box/box-content-preview/issues/295)
-* Fix: Forcing HD/SD should disable adaptation (#292) ([8cd67c1](https://github.com/box/box-content-preview/commit/8cd67c1))
-* Fix: only hide the filmstrip if it exists (#309) ([1c70dd4](https://github.com/box/box-content-preview/commit/1c70dd4))
-* Fix: scale being unbound when annotating (#297) ([289c645](https://github.com/box/box-content-preview/commit/289c645))
-* New: Allow scrolling for multi-page image files (#308) ([37dfd4a](https://github.com/box/box-content-preview/commit/37dfd4a))
-* New: Plain and Comment highlight annotations on mobile (#276) ([5b66c82](https://github.com/box/box-content-preview/commit/5b66c82))
-* Feature: drawing annotation scaling (#267) ([2fd0655](https://github.com/box/box-content-preview/commit/2fd0655))
-* Add en-x-pseudo language to support pseudolocalization in WebApp (#300) ([4d1be4a](https://github.com/box/box-content-preview/commit/4d1be4a))
-* Update: Increase file size limit for range requests (#296) ([21f490f](https://github.com/box/box-content-preview/commit/21f490f))
-* Update: use pixelDeviceRatio to choose canvas pixel size (#286) ([9e5489d](https://github.com/box/box-content-preview/commit/9e5489d))
-* Mojito: Update translations (#290) ([deaf8f2](https://github.com/box/box-content-preview/commit/deaf8f2))
-* Mojito: Update translations (#291) ([63a7201](https://github.com/box/box-content-preview/commit/63a7201))
-
-
+- Chore: Cleaning up and consolidating annotation methods (#288) ([6542b5d](https://github.com/box/box-content-preview/commit/6542b5d))
+- Chore: Fixed warning (#306) ([18daaf9](https://github.com/box/box-content-preview/commit/18daaf9)), closes [#306](https://github.com/box/box-content-preview/issues/306)
+- Chore: Move getAnnotateButton() out of PreviewUI into Annotator (#312) ([715b026](https://github.com/box/box-content-preview/commit/715b026))
+- Chore: Only remove annotation listeners if enabled on viewer (#293) ([9b97fd7](https://github.com/box/box-content-preview/commit/9b97fd7))
+- Chore: Remove code supporting token in options object (#268) ([ba1ac34](https://github.com/box/box-content-preview/commit/ba1ac34))
+- Chore: Toggling annotation mode handlers using emitted messages (#307) ([8e7d49a](https://github.com/box/box-content-preview/commit/8e7d49a))
+- Chore: Updating docs.box.com links to developer.box.com in README (#282) ([b63eab2](https://github.com/box/box-content-preview/commit/b63eab2))
+- Fix: annotation handler rebinding (#294) ([2dc0200](https://github.com/box/box-content-preview/commit/2dc0200))
+- Fix: Do not display disabled annotation types on fetch (#301) ([c669375](https://github.com/box/box-content-preview/commit/c669375))
+- Fix: Files must have .360 before extension to launch in 360 viewers. (#313) ([1659c4d](https://github.com/box/box-content-preview/commit/1659c4d))
+- Fix: Fix release script after GitHub release (#295) ([00dff52](https://github.com/box/box-content-preview/commit/00dff52)), closes [#295](https://github.com/box/box-content-preview/issues/295)
+- Fix: Forcing HD/SD should disable adaptation (#292) ([8cd67c1](https://github.com/box/box-content-preview/commit/8cd67c1))
+- Fix: only hide the filmstrip if it exists (#309) ([1c70dd4](https://github.com/box/box-content-preview/commit/1c70dd4))
+- Fix: scale being unbound when annotating (#297) ([289c645](https://github.com/box/box-content-preview/commit/289c645))
+- New: Allow scrolling for multi-page image files (#308) ([37dfd4a](https://github.com/box/box-content-preview/commit/37dfd4a))
+- New: Plain and Comment highlight annotations on mobile (#276) ([5b66c82](https://github.com/box/box-content-preview/commit/5b66c82))
+- Feature: drawing annotation scaling (#267) ([2fd0655](https://github.com/box/box-content-preview/commit/2fd0655))
+- Add en-x-pseudo language to support pseudolocalization in WebApp (#300) ([4d1be4a](https://github.com/box/box-content-preview/commit/4d1be4a))
+- Update: Increase file size limit for range requests (#296) ([21f490f](https://github.com/box/box-content-preview/commit/21f490f))
+- Update: use pixelDeviceRatio to choose canvas pixel size (#286) ([9e5489d](https://github.com/box/box-content-preview/commit/9e5489d))
+- Mojito: Update translations (#290) ([deaf8f2](https://github.com/box/box-content-preview/commit/deaf8f2))
+- Mojito: Update translations (#291) ([63a7201](https://github.com/box/box-content-preview/commit/63a7201))
 
 <a name="1.5.0"></a>
+
 # 1.5.0 (2017-08-09)
 
-* New: 3D preview logic now loads from generated JSON file. ([4216b70](https://github.com/box/box-content-preview/commit/4216b70))
-* New: Documentation for viewer methods (#263) ([48f681d](https://github.com/box/box-content-preview/commit/48f681d))
-* Fix: Disable font face for iOS 10.3.x (#283) ([4d97d99](https://github.com/box/box-content-preview/commit/4d97d99))
-* Fix: Only initialize PreviewUI.notification after viewer is loaded (#273) ([060687b](https://github.com/box/box-content-preview/commit/060687b))
-* Chore: Cleaning up annotations methods in BaseViewer (#272) ([6f319f6](https://github.com/box/box-content-preview/commit/6f319f6))
-* Chore: Force image point dialogs to re-position on re-render (#280) ([baf9b70](https://github.com/box/box-content-preview/commit/baf9b70))
-* Chore: Removing references to annotations from individual viewers (#271) ([2a1e6cd](https://github.com/box/box-content-preview/commit/2a1e6cd))
-* Chore: Removing references to constants.js and Browser.js in Annotations code (#277) ([8d37f37](https://github.com/box/box-content-preview/commit/8d37f37))
-* Mojito: Update translations (#278) ([a02f3fe](https://github.com/box/box-content-preview/commit/a02f3fe))
-* Update: move rbush from static to npm module (#275) ([cec5410](https://github.com/box/box-content-preview/commit/cec5410))
-
-
+- New: 3D preview logic now loads from generated JSON file. ([4216b70](https://github.com/box/box-content-preview/commit/4216b70))
+- New: Documentation for viewer methods (#263) ([48f681d](https://github.com/box/box-content-preview/commit/48f681d))
+- Fix: Disable font face for iOS 10.3.x (#283) ([4d97d99](https://github.com/box/box-content-preview/commit/4d97d99))
+- Fix: Only initialize PreviewUI.notification after viewer is loaded (#273) ([060687b](https://github.com/box/box-content-preview/commit/060687b))
+- Chore: Cleaning up annotations methods in BaseViewer (#272) ([6f319f6](https://github.com/box/box-content-preview/commit/6f319f6))
+- Chore: Force image point dialogs to re-position on re-render (#280) ([baf9b70](https://github.com/box/box-content-preview/commit/baf9b70))
+- Chore: Removing references to annotations from individual viewers (#271) ([2a1e6cd](https://github.com/box/box-content-preview/commit/2a1e6cd))
+- Chore: Removing references to constants.js and Browser.js in Annotations code (#277) ([8d37f37](https://github.com/box/box-content-preview/commit/8d37f37))
+- Mojito: Update translations (#278) ([a02f3fe](https://github.com/box/box-content-preview/commit/a02f3fe))
+- Update: move rbush from static to npm module (#275) ([cec5410](https://github.com/box/box-content-preview/commit/cec5410))
 
 <a name="1.4.0"></a>
+
 # 1.4.0 (2017-08-01)
 
-* Chore: Duplicating any util.js methods used into annotatorUtil.js (#260) ([249e9f1](https://github.com/box/box-content-preview/commit/249e9f1))
-* Chore: Initializing notifications in PreviewUI once rather than in each Annotator (#262) ([721ef4e](https://github.com/box/box-content-preview/commit/721ef4e))
-* Chore: Removing initAnnotations() from DocBaseViewer (#259) ([b7cde84](https://github.com/box/box-content-preview/commit/b7cde84))
-* Update: Add aria-pressed setting for CC button (#264) ([4c52531](https://github.com/box/box-content-preview/commit/4c52531))
-* Fix: Don't trigger highlight if a new highlight is being created (#265) ([9ab6db4](https://github.com/box/box-content-preview/commit/9ab6db4))
-* Fix: Emit scale does not always pass events (#261) ([41b1af0](https://github.com/box/box-content-preview/commit/41b1af0))
-* Fix: Load annotator with the correct initial scale (#256) ([fc25534](https://github.com/box/box-content-preview/commit/fc25534))
-* Fix: thread save incorrectly rejects when no dialogue exists (#247) ([6b361ed](https://github.com/box/box-content-preview/commit/6b361ed))
-* Fix: Tweak release script ([d115c1c](https://github.com/box/box-content-preview/commit/d115c1c))
-* Mojito: Update translations (#266) ([2ee12a3](https://github.com/box/box-content-preview/commit/2ee12a3))
-* New: add annotation-noicon to allow native PDF annotations to be shown (#258) ([4de1259](https://github.com/box/box-content-preview/commit/4de1259))
-* New: Add pseudo fullscreen to mobile Safari (#246) ([b8c776d](https://github.com/box/box-content-preview/commit/b8c776d))
-
-
+- Chore: Duplicating any util.js methods used into annotatorUtil.js (#260) ([249e9f1](https://github.com/box/box-content-preview/commit/249e9f1))
+- Chore: Initializing notifications in PreviewUI once rather than in each Annotator (#262) ([721ef4e](https://github.com/box/box-content-preview/commit/721ef4e))
+- Chore: Removing initAnnotations() from DocBaseViewer (#259) ([b7cde84](https://github.com/box/box-content-preview/commit/b7cde84))
+- Update: Add aria-pressed setting for CC button (#264) ([4c52531](https://github.com/box/box-content-preview/commit/4c52531))
+- Fix: Don't trigger highlight if a new highlight is being created (#265) ([9ab6db4](https://github.com/box/box-content-preview/commit/9ab6db4))
+- Fix: Emit scale does not always pass events (#261) ([41b1af0](https://github.com/box/box-content-preview/commit/41b1af0))
+- Fix: Load annotator with the correct initial scale (#256) ([fc25534](https://github.com/box/box-content-preview/commit/fc25534))
+- Fix: thread save incorrectly rejects when no dialogue exists (#247) ([6b361ed](https://github.com/box/box-content-preview/commit/6b361ed))
+- Fix: Tweak release script ([d115c1c](https://github.com/box/box-content-preview/commit/d115c1c))
+- Mojito: Update translations (#266) ([2ee12a3](https://github.com/box/box-content-preview/commit/2ee12a3))
+- New: add annotation-noicon to allow native PDF annotations to be shown (#258) ([4de1259](https://github.com/box/box-content-preview/commit/4de1259))
+- New: Add pseudo fullscreen to mobile Safari (#246) ([b8c776d](https://github.com/box/box-content-preview/commit/b8c776d))
 
 <a name="1.3.0"></a>
+
 # 1.3.0 (2017-07-28)
 
-* Chore: Add github release notes in release script (#255) ([a2d2985](https://github.com/box/box-content-preview/commit/a2d2985))
-* Chore: Default single page images to page 1 for annotations (#249) ([6080055](https://github.com/box/box-content-preview/commit/6080055))
-* Chore: Modify patch release script (#250) ([afc51d3](https://github.com/box/box-content-preview/commit/afc51d3))
-* Chore: Renaming AnnotationThread.thread to AnnotationThread.threadNumber (#241) ([66b1d7c](https://github.com/box/box-content-preview/commit/66b1d7c))
-* Chore: Switch to git-based changelog generator (#252) ([35994b6](https://github.com/box/box-content-preview/commit/35994b6))
-* Chore: Update patch release script (#251) ([f0fa0cf](https://github.com/box/box-content-preview/commit/f0fa0cf))
-* Fix: Add clickHandlers back for all enabled annotation modes (#248) ([b3dd251](https://github.com/box/box-content-preview/commit/b3dd251))
-* Fix: Don't trigger highlight dialogs while mouse is over another dialog (#242) ([af861cf](https://github.com/box/box-content-preview/commit/af861cf))
-* Fix: Fix media query so 3D settings pullup is never truncated (#253) ([1ee02fe](https://github.com/box/box-content-preview/commit/1ee02fe)), closes [#253](https://github.com/box/box-content-preview/issues/253)
-* Fix: Fix release script ([499c06b](https://github.com/box/box-content-preview/commit/499c06b))
-* Fix: Hide filmstrip when controls hide (#239) ([0ba7804](https://github.com/box/box-content-preview/commit/0ba7804))
-* Fix: Typo in release script ([01cdf3c](https://github.com/box/box-content-preview/commit/01cdf3c))
-
-
+- Chore: Add github release notes in release script (#255) ([a2d2985](https://github.com/box/box-content-preview/commit/a2d2985))
+- Chore: Default single page images to page 1 for annotations (#249) ([6080055](https://github.com/box/box-content-preview/commit/6080055))
+- Chore: Modify patch release script (#250) ([afc51d3](https://github.com/box/box-content-preview/commit/afc51d3))
+- Chore: Renaming AnnotationThread.thread to AnnotationThread.threadNumber (#241) ([66b1d7c](https://github.com/box/box-content-preview/commit/66b1d7c))
+- Chore: Switch to git-based changelog generator (#252) ([35994b6](https://github.com/box/box-content-preview/commit/35994b6))
+- Chore: Update patch release script (#251) ([f0fa0cf](https://github.com/box/box-content-preview/commit/f0fa0cf))
+- Fix: Add clickHandlers back for all enabled annotation modes (#248) ([b3dd251](https://github.com/box/box-content-preview/commit/b3dd251))
+- Fix: Don't trigger highlight dialogs while mouse is over another dialog (#242) ([af861cf](https://github.com/box/box-content-preview/commit/af861cf))
+- Fix: Fix media query so 3D settings pullup is never truncated (#253) ([1ee02fe](https://github.com/box/box-content-preview/commit/1ee02fe)), closes [#253](https://github.com/box/box-content-preview/issues/253)
+- Fix: Fix release script ([499c06b](https://github.com/box/box-content-preview/commit/499c06b))
+- Fix: Hide filmstrip when controls hide (#239) ([0ba7804](https://github.com/box/box-content-preview/commit/0ba7804))
+- Fix: Typo in release script ([01cdf3c](https://github.com/box/box-content-preview/commit/01cdf3c))
 
 <a name="1.2.0"></a>
+
 # 1.2.0 (2017-07-25)
 
-* Release: 1.2.0 ([11b1802](https://github.com/box/box-content-preview/commit/11b1802))
-* Fix: Allow legacy annotations to render in PDF.js (#238) ([ed3b5cb](https://github.com/box/box-content-preview/commit/ed3b5cb))
-* Fix: Ensuring annotation scale is set on files without any annotations (#234) ([aa93d09](https://github.com/box/box-content-preview/commit/aa93d09))
-* Fix: Give preview some min width and height (#237) ([20f6056](https://github.com/box/box-content-preview/commit/20f6056))
-* Fix: Increase controls timeout and fix controls behavior for mobile VR (#235) ([1df8b55](https://github.com/box/box-content-preview/commit/1df8b55)), closes [#235](https://github.com/box/box-content-preview/issues/235)
-* Fix: Update box3d to fix camera reload bug (#245) ([1e1495f](https://github.com/box/box-content-preview/commit/1e1495f)), closes [#245](https://github.com/box/box-content-preview/issues/245)
-* Chore: Update translations (#240) ([cf1a799](https://github.com/box/box-content-preview/commit/cf1a799))
-* New: added support for compressed (DDS) textures to 3D preview (#244) ([4b5e203](https://github.com/box/box-content-preview/commit/4b5e203))
-* Feature: DrawingAnnotations starting code (#224) ([3960927](https://github.com/box/box-content-preview/commit/3960927))
-* Docs: Adding section of using Preview as a component (#236) ([3c3eb06](https://github.com/box/box-content-preview/commit/3c3eb06))
-
-
+- Release: 1.2.0 ([11b1802](https://github.com/box/box-content-preview/commit/11b1802))
+- Fix: Allow legacy annotations to render in PDF.js (#238) ([ed3b5cb](https://github.com/box/box-content-preview/commit/ed3b5cb))
+- Fix: Ensuring annotation scale is set on files without any annotations (#234) ([aa93d09](https://github.com/box/box-content-preview/commit/aa93d09))
+- Fix: Give preview some min width and height (#237) ([20f6056](https://github.com/box/box-content-preview/commit/20f6056))
+- Fix: Increase controls timeout and fix controls behavior for mobile VR (#235) ([1df8b55](https://github.com/box/box-content-preview/commit/1df8b55)), closes [#235](https://github.com/box/box-content-preview/issues/235)
+- Fix: Update box3d to fix camera reload bug (#245) ([1e1495f](https://github.com/box/box-content-preview/commit/1e1495f)), closes [#245](https://github.com/box/box-content-preview/issues/245)
+- Chore: Update translations (#240) ([cf1a799](https://github.com/box/box-content-preview/commit/cf1a799))
+- New: added support for compressed (DDS) textures to 3D preview (#244) ([4b5e203](https://github.com/box/box-content-preview/commit/4b5e203))
+- Feature: DrawingAnnotations starting code (#224) ([3960927](https://github.com/box/box-content-preview/commit/3960927))
+- Docs: Adding section of using Preview as a component (#236) ([3c3eb06](https://github.com/box/box-content-preview/commit/3c3eb06))
 
 <a name="1.1.1"></a>
+
 ## 1.1.1 (2017-07-20)
 
-* Release: 1.1.1 ([9487634](https://github.com/box/box-content-preview/commit/9487634))
-* Fix: Don't swallow touch start event to prevent iOS inertia scrolling (#233) ([d628c14](https://github.com/box/box-content-preview/commit/d628c14))
-* Fix: Prevent MP3 from hiding (#230) ([2a236fe](https://github.com/box/box-content-preview/commit/2a236fe))
-
-
+- Release: 1.1.1 ([9487634](https://github.com/box/box-content-preview/commit/9487634))
+- Fix: Don't swallow touch start event to prevent iOS inertia scrolling (#233) ([d628c14](https://github.com/box/box-content-preview/commit/d628c14))
+- Fix: Prevent MP3 from hiding (#230) ([2a236fe](https://github.com/box/box-content-preview/commit/2a236fe))
 
 <a name="1.1.0"></a>
+
 # 1.1.0 (2017-07-18)
 
-* Release: 1.1.0 ([a8e1216](https://github.com/box/box-content-preview/commit/a8e1216))
-* Docs: Add issue reporting template (#228) ([135e717](https://github.com/box/box-content-preview/commit/135e717))
-* Docs: More README updates ([00821c4](https://github.com/box/box-content-preview/commit/00821c4))
-* Docs: Update document viewer event name ([eae3c74](https://github.com/box/box-content-preview/commit/eae3c74))
-* Docs: Update project status badge (#212) ([f50be16](https://github.com/box/box-content-preview/commit/f50be16))
-* Docs: Update shield for UI Elements ([271cbbb](https://github.com/box/box-content-preview/commit/271cbbb))
-* Docs: Update support section in README ([94c17d4](https://github.com/box/box-content-preview/commit/94c17d4))
-* Fix: Limit iOS font fix to 10.3.1 (#225) ([b17054a](https://github.com/box/box-content-preview/commit/b17054a)), closes [#225](https://github.com/box/box-content-preview/issues/225)
-* Fix: Media controls and usability fixes for mobile (#217) ([38ecce7](https://github.com/box/box-content-preview/commit/38ecce7)), closes [#217](https://github.com/box/box-content-preview/issues/217)
-* Fix: Prevent double tap zoom in control bar (#227) ([14996a0](https://github.com/box/box-content-preview/commit/14996a0))
-* Fix: Restore crawler for buffering video (#218) ([800692d](https://github.com/box/box-content-preview/commit/800692d))
-* New: Add ts and flv formats to MediaLoader.js (#226) ([be35a75](https://github.com/box/box-content-preview/commit/be35a75))
-* Update: Render Vera-protected HTML files (#220) ([78423ac](https://github.com/box/box-content-preview/commit/78423ac))
-* Chore: Cleaning up annotation strings/classes (#215) ([0cfcaf7](https://github.com/box/box-content-preview/commit/0cfcaf7))
-* Chore: Fix webpack errors and upgrade some packages (#221) ([c309da1](https://github.com/box/box-content-preview/commit/c309da1)), closes [#221](https://github.com/box/box-content-preview/issues/221)
-* Chore: Full pass of prettier formatting (#223) ([814aa75](https://github.com/box/box-content-preview/commit/814aa75))
-* Chore: Update .travis.yml to only build master (#214) ([f10b14c](https://github.com/box/box-content-preview/commit/f10b14c))
-* Chore: Update Travis config (#219) ([a6fe4b6](https://github.com/box/box-content-preview/commit/a6fe4b6))
-* Fix settings pullup for model3D files on mobile (#222) ([f285ba8](https://github.com/box/box-content-preview/commit/f285ba8)), closes [#222](https://github.com/box/box-content-preview/issues/222)
-
-
+- Release: 1.1.0 ([a8e1216](https://github.com/box/box-content-preview/commit/a8e1216))
+- Docs: Add issue reporting template (#228) ([135e717](https://github.com/box/box-content-preview/commit/135e717))
+- Docs: More README updates ([00821c4](https://github.com/box/box-content-preview/commit/00821c4))
+- Docs: Update document viewer event name ([eae3c74](https://github.com/box/box-content-preview/commit/eae3c74))
+- Docs: Update project status badge (#212) ([f50be16](https://github.com/box/box-content-preview/commit/f50be16))
+- Docs: Update shield for UI Elements ([271cbbb](https://github.com/box/box-content-preview/commit/271cbbb))
+- Docs: Update support section in README ([94c17d4](https://github.com/box/box-content-preview/commit/94c17d4))
+- Fix: Limit iOS font fix to 10.3.1 (#225) ([b17054a](https://github.com/box/box-content-preview/commit/b17054a)), closes [#225](https://github.com/box/box-content-preview/issues/225)
+- Fix: Media controls and usability fixes for mobile (#217) ([38ecce7](https://github.com/box/box-content-preview/commit/38ecce7)), closes [#217](https://github.com/box/box-content-preview/issues/217)
+- Fix: Prevent double tap zoom in control bar (#227) ([14996a0](https://github.com/box/box-content-preview/commit/14996a0))
+- Fix: Restore crawler for buffering video (#218) ([800692d](https://github.com/box/box-content-preview/commit/800692d))
+- New: Add ts and flv formats to MediaLoader.js (#226) ([be35a75](https://github.com/box/box-content-preview/commit/be35a75))
+- Update: Render Vera-protected HTML files (#220) ([78423ac](https://github.com/box/box-content-preview/commit/78423ac))
+- Chore: Cleaning up annotation strings/classes (#215) ([0cfcaf7](https://github.com/box/box-content-preview/commit/0cfcaf7))
+- Chore: Fix webpack errors and upgrade some packages (#221) ([c309da1](https://github.com/box/box-content-preview/commit/c309da1)), closes [#221](https://github.com/box/box-content-preview/issues/221)
+- Chore: Full pass of prettier formatting (#223) ([814aa75](https://github.com/box/box-content-preview/commit/814aa75))
+- Chore: Update .travis.yml to only build master (#214) ([f10b14c](https://github.com/box/box-content-preview/commit/f10b14c))
+- Chore: Update Travis config (#219) ([a6fe4b6](https://github.com/box/box-content-preview/commit/a6fe4b6))
+- Fix settings pullup for model3D files on mobile (#222) ([f285ba8](https://github.com/box/box-content-preview/commit/f285ba8)), closes [#222](https://github.com/box/box-content-preview/issues/222)
 
 <a name="1.0.0"></a>
+
 # 1.0.0 (2017-07-12)
 
-* Release: 1.0.0 ([b599cd2](https://github.com/box/box-content-preview/commit/b599cd2))
-
-
+- Release: 1.0.0 ([b599cd2](https://github.com/box/box-content-preview/commit/b599cd2))
 
 <a name="0.131.2"></a>
+
 ## 0.131.2 (2017-07-11)
 
-* Release: 0.131.2 ([1021c8e](https://github.com/box/box-content-preview/commit/1021c8e))
-* Fix: Ensure that annotation scale is never being set to auto (#208) ([9899f94](https://github.com/box/box-content-preview/commit/9899f94))
-* Fix: Search preview container for mobile annotations dialog (#209) ([56e026a](https://github.com/box/box-content-preview/commit/56e026a))
-
-
+- Release: 0.131.2 ([1021c8e](https://github.com/box/box-content-preview/commit/1021c8e))
+- Fix: Ensure that annotation scale is never being set to auto (#208) ([9899f94](https://github.com/box/box-content-preview/commit/9899f94))
+- Fix: Search preview container for mobile annotations dialog (#209) ([56e026a](https://github.com/box/box-content-preview/commit/56e026a))
 
 <a name="0.131.1"></a>
+
 ## 0.131.1 (2017-07-11)
 
-* Release: 0.131.1 ([6eeb432](https://github.com/box/box-content-preview/commit/6eeb432))
-* Fix: Properly scope typography CSS (#207) ([816ed15](https://github.com/box/box-content-preview/commit/816ed15))
-* Chore: Cleaning up annotations code comments (#206) ([9e042c1](https://github.com/box/box-content-preview/commit/9e042c1))
-
-
+- Release: 0.131.1 ([6eeb432](https://github.com/box/box-content-preview/commit/6eeb432))
+- Fix: Properly scope typography CSS (#207) ([816ed15](https://github.com/box/box-content-preview/commit/816ed15))
+- Chore: Cleaning up annotations code comments (#206) ([9e042c1](https://github.com/box/box-content-preview/commit/9e042c1))
 
 <a name="0.131.0"></a>
+
 # 0.131.0 (2017-07-07)
 
-* Release: 0.131.0 ([5b8539f](https://github.com/box/box-content-preview/commit/5b8539f))
-* Chore: Fix ESLint warnings (JSDoc cleanup) (#199) ([d4303aa](https://github.com/box/box-content-preview/commit/d4303aa)), closes [#199](https://github.com/box/box-content-preview/issues/199)
-* Chore: Page num input uses numeric keyboard on mobile devices (#200) ([6acf8fa](https://github.com/box/box-content-preview/commit/6acf8fa))
-* Chore: Preview Cleanup (#202) ([18e5969](https://github.com/box/box-content-preview/commit/18e5969))
-* Chore: Preview UI as instance (#204) ([5d06fb3](https://github.com/box/box-content-preview/commit/5d06fb3))
-* Chore: Remove padding for CSV files (#194) ([762896e](https://github.com/box/box-content-preview/commit/762896e))
-* Chore: Removing unused 'active' & 'active-hover' states for annotations (#189) ([3c46e05](https://github.com/box/box-content-preview/commit/3c46e05))
-* Chore: Scrubber/Media fixes for mobile (#185) ([884799c](https://github.com/box/box-content-preview/commit/884799c)), closes [#185](https://github.com/box/box-content-preview/issues/185)
-* Chore: Update README to include token scope information (#203) ([a26d600](https://github.com/box/box-content-preview/commit/a26d600))
-* Chore: Update to new 'Elements' branding (#193) ([4995798](https://github.com/box/box-content-preview/commit/4995798))
-* Cleanup for 1.0 for 3D (#205) ([78c11f2](https://github.com/box/box-content-preview/commit/78c11f2))
-* Fix/notification message timeout (#201) ([5d42af4](https://github.com/box/box-content-preview/commit/5d42af4))
-* Fix: Allow panning on mobile while zooming into ppt files (#192) ([68091e3](https://github.com/box/box-content-preview/commit/68091e3))
-* Fix: Ensures highlight buttons are hidden on mobile devices (#196) ([ef8db6e](https://github.com/box/box-content-preview/commit/ef8db6e))
-* Fix: Tree shaking bug workaround for csv bundle (#191) ([edd11e4](https://github.com/box/box-content-preview/commit/edd11e4))
-* Update: pdf.js 1.8.514 (#197) ([bf10569](https://github.com/box/box-content-preview/commit/bf10569))
-* Docs: Update contributing.md (#195) ([08eb9e9](https://github.com/box/box-content-preview/commit/08eb9e9))
-
-
+- Release: 0.131.0 ([5b8539f](https://github.com/box/box-content-preview/commit/5b8539f))
+- Chore: Fix ESLint warnings (JSDoc cleanup) (#199) ([d4303aa](https://github.com/box/box-content-preview/commit/d4303aa)), closes [#199](https://github.com/box/box-content-preview/issues/199)
+- Chore: Page num input uses numeric keyboard on mobile devices (#200) ([6acf8fa](https://github.com/box/box-content-preview/commit/6acf8fa))
+- Chore: Preview Cleanup (#202) ([18e5969](https://github.com/box/box-content-preview/commit/18e5969))
+- Chore: Preview UI as instance (#204) ([5d06fb3](https://github.com/box/box-content-preview/commit/5d06fb3))
+- Chore: Remove padding for CSV files (#194) ([762896e](https://github.com/box/box-content-preview/commit/762896e))
+- Chore: Removing unused 'active' & 'active-hover' states for annotations (#189) ([3c46e05](https://github.com/box/box-content-preview/commit/3c46e05))
+- Chore: Scrubber/Media fixes for mobile (#185) ([884799c](https://github.com/box/box-content-preview/commit/884799c)), closes [#185](https://github.com/box/box-content-preview/issues/185)
+- Chore: Update README to include token scope information (#203) ([a26d600](https://github.com/box/box-content-preview/commit/a26d600))
+- Chore: Update to new 'Elements' branding (#193) ([4995798](https://github.com/box/box-content-preview/commit/4995798))
+- Cleanup for 1.0 for 3D (#205) ([78c11f2](https://github.com/box/box-content-preview/commit/78c11f2))
+- Fix/notification message timeout (#201) ([5d42af4](https://github.com/box/box-content-preview/commit/5d42af4))
+- Fix: Allow panning on mobile while zooming into ppt files (#192) ([68091e3](https://github.com/box/box-content-preview/commit/68091e3))
+- Fix: Ensures highlight buttons are hidden on mobile devices (#196) ([ef8db6e](https://github.com/box/box-content-preview/commit/ef8db6e))
+- Fix: Tree shaking bug workaround for csv bundle (#191) ([edd11e4](https://github.com/box/box-content-preview/commit/edd11e4))
+- Update: pdf.js 1.8.514 (#197) ([bf10569](https://github.com/box/box-content-preview/commit/bf10569))
+- Docs: Update contributing.md (#195) ([08eb9e9](https://github.com/box/box-content-preview/commit/08eb9e9))
 
 <a name="0.130.0"></a>
+
 # 0.130.0 (2017-06-28)
 
-* Release: 0.130.0 ([53527c0](https://github.com/box/box-content-preview/commit/53527c0))
-* Fix: Buttons fail to display when adding a comment to plain highlight (#183) ([a344153](https://github.com/box/box-content-preview/commit/a344153))
-* Fix: Fix focus for new page number input (#187) ([5f82f15](https://github.com/box/box-content-preview/commit/5f82f15)), closes [#187](https://github.com/box/box-content-preview/issues/187)
-* Fix: Fix hiding on Android Chrome (#190) ([897abcd](https://github.com/box/box-content-preview/commit/897abcd)), closes [#190](https://github.com/box/box-content-preview/issues/190)
-* Fix: Fixes issues with adding annotations on tablets (#186) ([e6e6c3b](https://github.com/box/box-content-preview/commit/e6e6c3b)), closes [#186](https://github.com/box/box-content-preview/issues/186)
-* Fix: Sets the pdf scale after page render rather than on resize (#178) ([8457621](https://github.com/box/box-content-preview/commit/8457621))
-* Create highlight dialog (#184) ([59c0bbb](https://github.com/box/box-content-preview/commit/59c0bbb))
-* Chore: Add Webpack bundle visualizer (#188) ([8fa744e](https://github.com/box/box-content-preview/commit/8fa744e))
-* Chore: Make page number input more visible (#179) ([3b585d8](https://github.com/box/box-content-preview/commit/3b585d8))
-* Chore: Refactor controls for mobile (#174) ([066a3d4](https://github.com/box/box-content-preview/commit/066a3d4))
-* New: Allowing users to add new mobile point annotations (#177) ([56bbbf9](https://github.com/box/box-content-preview/commit/56bbbf9))
-* Update: Readme with new badges (#180) ([fc51f75](https://github.com/box/box-content-preview/commit/fc51f75))
-* Update: Remove 0.25x playback on media files (#182) ([896c755](https://github.com/box/box-content-preview/commit/896c755))
-
-
+- Release: 0.130.0 ([53527c0](https://github.com/box/box-content-preview/commit/53527c0))
+- Fix: Buttons fail to display when adding a comment to plain highlight (#183) ([a344153](https://github.com/box/box-content-preview/commit/a344153))
+- Fix: Fix focus for new page number input (#187) ([5f82f15](https://github.com/box/box-content-preview/commit/5f82f15)), closes [#187](https://github.com/box/box-content-preview/issues/187)
+- Fix: Fix hiding on Android Chrome (#190) ([897abcd](https://github.com/box/box-content-preview/commit/897abcd)), closes [#190](https://github.com/box/box-content-preview/issues/190)
+- Fix: Fixes issues with adding annotations on tablets (#186) ([e6e6c3b](https://github.com/box/box-content-preview/commit/e6e6c3b)), closes [#186](https://github.com/box/box-content-preview/issues/186)
+- Fix: Sets the pdf scale after page render rather than on resize (#178) ([8457621](https://github.com/box/box-content-preview/commit/8457621))
+- Create highlight dialog (#184) ([59c0bbb](https://github.com/box/box-content-preview/commit/59c0bbb))
+- Chore: Add Webpack bundle visualizer (#188) ([8fa744e](https://github.com/box/box-content-preview/commit/8fa744e))
+- Chore: Make page number input more visible (#179) ([3b585d8](https://github.com/box/box-content-preview/commit/3b585d8))
+- Chore: Refactor controls for mobile (#174) ([066a3d4](https://github.com/box/box-content-preview/commit/066a3d4))
+- New: Allowing users to add new mobile point annotations (#177) ([56bbbf9](https://github.com/box/box-content-preview/commit/56bbbf9))
+- Update: Readme with new badges (#180) ([fc51f75](https://github.com/box/box-content-preview/commit/fc51f75))
+- Update: Remove 0.25x playback on media files (#182) ([896c755](https://github.com/box/box-content-preview/commit/896c755))
 
 <a name="0.129.2"></a>
+
 ## 0.129.2 (2017-06-20)
 
-* Release: 0.129.2 ([ef39c99](https://github.com/box/box-content-preview/commit/ef39c99))
-* Fix: Fix shared links previewed in other subdomains (#173) ([ab04be5](https://github.com/box/box-content-preview/commit/ab04be5)), closes [#173](https://github.com/box/box-content-preview/issues/173)
-* Chore: Tweak fade-in timing of file loading animation (#175) ([1e9cebe](https://github.com/box/box-content-preview/commit/1e9cebe))
-* Chore: Update ESLint rules and VSCode settings (#176) ([28ec823](https://github.com/box/box-content-preview/commit/28ec823))
-* Docs: Update README editor plugins ([b0be367](https://github.com/box/box-content-preview/commit/b0be367))
-
-
+- Release: 0.129.2 ([ef39c99](https://github.com/box/box-content-preview/commit/ef39c99))
+- Fix: Fix shared links previewed in other subdomains (#173) ([ab04be5](https://github.com/box/box-content-preview/commit/ab04be5)), closes [#173](https://github.com/box/box-content-preview/issues/173)
+- Chore: Tweak fade-in timing of file loading animation (#175) ([1e9cebe](https://github.com/box/box-content-preview/commit/1e9cebe))
+- Chore: Update ESLint rules and VSCode settings (#176) ([28ec823](https://github.com/box/box-content-preview/commit/28ec823))
+- Docs: Update README editor plugins ([b0be367](https://github.com/box/box-content-preview/commit/b0be367))
 
 <a name="0.129.1"></a>
+
 ## 0.129.1 (2017-06-16)
 
-* Release: 0.129.1 ([d6f5878](https://github.com/box/box-content-preview/commit/d6f5878))
-* Fix: Box3D bug prevented loading video texture from video tag ([55d3ca2](https://github.com/box/box-content-preview/commit/55d3ca2))
-
-
+- Release: 0.129.1 ([d6f5878](https://github.com/box/box-content-preview/commit/d6f5878))
+- Fix: Box3D bug prevented loading video texture from video tag ([55d3ca2](https://github.com/box/box-content-preview/commit/55d3ca2))
 
 <a name="0.129.0"></a>
+
 # 0.129.0 (2017-06-14)
 
-* Release: 0.129.0 ([d38e6df](https://github.com/box/box-content-preview/commit/d38e6df))
-* Mojito: Update translations (#167) ([4210077](https://github.com/box/box-content-preview/commit/4210077))
-* New: File specific loading icons (#170) ([16af34d](https://github.com/box/box-content-preview/commit/16af34d))
-* Fix: Catch loss of WebGL context in Box3D and reload preview ([0de993e](https://github.com/box/box-content-preview/commit/0de993e))
-* Fix: Fix removeEventListener in MediaBaseViewer (#169) ([5760a12](https://github.com/box/box-content-preview/commit/5760a12)), closes [#169](https://github.com/box/box-content-preview/issues/169)
-* Chore: Refactoring Controls for mobile (#159) ([98ad9cc](https://github.com/box/box-content-preview/commit/98ad9cc))
-
-
+- Release: 0.129.0 ([d38e6df](https://github.com/box/box-content-preview/commit/d38e6df))
+- Mojito: Update translations (#167) ([4210077](https://github.com/box/box-content-preview/commit/4210077))
+- New: File specific loading icons (#170) ([16af34d](https://github.com/box/box-content-preview/commit/16af34d))
+- Fix: Catch loss of WebGL context in Box3D and reload preview ([0de993e](https://github.com/box/box-content-preview/commit/0de993e))
+- Fix: Fix removeEventListener in MediaBaseViewer (#169) ([5760a12](https://github.com/box/box-content-preview/commit/5760a12)), closes [#169](https://github.com/box/box-content-preview/issues/169)
+- Chore: Refactoring Controls for mobile (#159) ([98ad9cc](https://github.com/box/box-content-preview/commit/98ad9cc))
 
 <a name="0.128.0"></a>
+
 # 0.128.0 (2017-06-06)
 
-* Release: 0.128.0 ([a0fc5ae](https://github.com/box/box-content-preview/commit/a0fc5ae))
-* Upgrade: Upgrade Shaka-player to fix infinite 401 issue (#164) ([5646a79](https://github.com/box/box-content-preview/commit/5646a79)), closes [#164](https://github.com/box/box-content-preview/issues/164)
-* Update: Add support for 'ly' Lilypond musical annotation files (#165) ([4212692](https://github.com/box/box-content-preview/commit/4212692))
-* Update: Change Preview loading message (#166) ([a8457f0](https://github.com/box/box-content-preview/commit/a8457f0))
-* Update: Displaying file type unsupported error (#163) ([59765e8](https://github.com/box/box-content-preview/commit/59765e8))
-* Chore: Optimizations for highlightMousemoveEvent (#121) ([4d31542](https://github.com/box/box-content-preview/commit/4d31542))
-* Chore: refactored and renamed getPageElAndPageNumber (#162) ([00dedab](https://github.com/box/box-content-preview/commit/00dedab))
-* Animate annotation dialog (#161) ([b7217c6](https://github.com/box/box-content-preview/commit/b7217c6))
-* Mojito: Update translations (#160) ([fbb3989](https://github.com/box/box-content-preview/commit/fbb3989))
-* Docs: Use ISO date format for LICENSE (#158) ([e856302](https://github.com/box/box-content-preview/commit/e856302))
-
-
+- Release: 0.128.0 ([a0fc5ae](https://github.com/box/box-content-preview/commit/a0fc5ae))
+- Upgrade: Upgrade Shaka-player to fix infinite 401 issue (#164) ([5646a79](https://github.com/box/box-content-preview/commit/5646a79)), closes [#164](https://github.com/box/box-content-preview/issues/164)
+- Update: Add support for 'ly' Lilypond musical annotation files (#165) ([4212692](https://github.com/box/box-content-preview/commit/4212692))
+- Update: Change Preview loading message (#166) ([a8457f0](https://github.com/box/box-content-preview/commit/a8457f0))
+- Update: Displaying file type unsupported error (#163) ([59765e8](https://github.com/box/box-content-preview/commit/59765e8))
+- Chore: Optimizations for highlightMousemoveEvent (#121) ([4d31542](https://github.com/box/box-content-preview/commit/4d31542))
+- Chore: refactored and renamed getPageElAndPageNumber (#162) ([00dedab](https://github.com/box/box-content-preview/commit/00dedab))
+- Animate annotation dialog (#161) ([b7217c6](https://github.com/box/box-content-preview/commit/b7217c6))
+- Mojito: Update translations (#160) ([fbb3989](https://github.com/box/box-content-preview/commit/fbb3989))
+- Docs: Use ISO date format for LICENSE (#158) ([e856302](https://github.com/box/box-content-preview/commit/e856302))
 
 <a name="0.127.0"></a>
+
 # 0.127.0 (2017-05-30)
 
-* Release: 0.127.0 ([07d036f](https://github.com/box/box-content-preview/commit/07d036f))
-* Fix: Disables annotations after 'load' event on shared links (#150) ([77cf5bb](https://github.com/box/box-content-preview/commit/77cf5bb))
-* Fix: Ensure point annotation mode button is hidden on rotated images (#151) ([e322c6a](https://github.com/box/box-content-preview/commit/e322c6a))
-* Fix: Error content jumps on error if download button is absent (#152) ([2cd6fed](https://github.com/box/box-content-preview/commit/2cd6fed))
-* Fix: Image scaling/rotation is broken when an image has annotations (#156) ([c91e9f9](https://github.com/box/box-content-preview/commit/c91e9f9))
-* Fix: Support disabling DASH viewer in DASH-supported environment (#140) ([b292666](https://github.com/box/box-content-preview/commit/b292666))
-* Chore: Re-enabling controls for mobile viewers (#157) ([a9e1c52](https://github.com/box/box-content-preview/commit/a9e1c52))
-* Chore: Use whatwg-fetch instead of isomorphic-fetch (#155) ([5a8f4f2](https://github.com/box/box-content-preview/commit/5a8f4f2))
-* Mojito: Update translations (#154) ([2e512ed](https://github.com/box/box-content-preview/commit/2e512ed))
-* New: Initial mobile optimization of annotation dialogs (#146) ([d693991](https://github.com/box/box-content-preview/commit/d693991))
-
-
+- Release: 0.127.0 ([07d036f](https://github.com/box/box-content-preview/commit/07d036f))
+- Fix: Disables annotations after 'load' event on shared links (#150) ([77cf5bb](https://github.com/box/box-content-preview/commit/77cf5bb))
+- Fix: Ensure point annotation mode button is hidden on rotated images (#151) ([e322c6a](https://github.com/box/box-content-preview/commit/e322c6a))
+- Fix: Error content jumps on error if download button is absent (#152) ([2cd6fed](https://github.com/box/box-content-preview/commit/2cd6fed))
+- Fix: Image scaling/rotation is broken when an image has annotations (#156) ([c91e9f9](https://github.com/box/box-content-preview/commit/c91e9f9))
+- Fix: Support disabling DASH viewer in DASH-supported environment (#140) ([b292666](https://github.com/box/box-content-preview/commit/b292666))
+- Chore: Re-enabling controls for mobile viewers (#157) ([a9e1c52](https://github.com/box/box-content-preview/commit/a9e1c52))
+- Chore: Use whatwg-fetch instead of isomorphic-fetch (#155) ([5a8f4f2](https://github.com/box/box-content-preview/commit/5a8f4f2))
+- Mojito: Update translations (#154) ([2e512ed](https://github.com/box/box-content-preview/commit/2e512ed))
+- New: Initial mobile optimization of annotation dialogs (#146) ([d693991](https://github.com/box/box-content-preview/commit/d693991))
 
 <a name="0.126.1"></a>
+
 ## 0.126.1 (2017-05-26)
 
-* Release: 0.126.1 ([e269605](https://github.com/box/box-content-preview/commit/e269605))
-* Fix: Fixing vanity urls for excel online on IE11 (#153) ([ff6ae22](https://github.com/box/box-content-preview/commit/ff6ae22))
-* Fix: Reinforcing release script (#148) ([c7137a0](https://github.com/box/box-content-preview/commit/c7137a0))
-* Update: Make media viewer settings menu larger so scrollbars don't show (#149) ([7da7efc](https://github.com/box/box-content-preview/commit/7da7efc))
-* Chore: Fix changelog (#144) ([be0d2b0](https://github.com/box/box-content-preview/commit/be0d2b0)), closes [#144](https://github.com/box/box-content-preview/issues/144)
-* Chore: Format all source code with prettier (#143) ([d2a6835](https://github.com/box/box-content-preview/commit/d2a6835))
-* Add toggle and metadata for box3d grid ([d139a15](https://github.com/box/box-content-preview/commit/d139a15))
-
-
+- Release: 0.126.1 ([e269605](https://github.com/box/box-content-preview/commit/e269605))
+- Fix: Fixing vanity urls for excel online on IE11 (#153) ([ff6ae22](https://github.com/box/box-content-preview/commit/ff6ae22))
+- Fix: Reinforcing release script (#148) ([c7137a0](https://github.com/box/box-content-preview/commit/c7137a0))
+- Update: Make media viewer settings menu larger so scrollbars don't show (#149) ([7da7efc](https://github.com/box/box-content-preview/commit/7da7efc))
+- Chore: Fix changelog (#144) ([be0d2b0](https://github.com/box/box-content-preview/commit/be0d2b0)), closes [#144](https://github.com/box/box-content-preview/issues/144)
+- Chore: Format all source code with prettier (#143) ([d2a6835](https://github.com/box/box-content-preview/commit/d2a6835))
+- Add toggle and metadata for box3d grid ([d139a15](https://github.com/box/box-content-preview/commit/d139a15))
 
 <a name="0.126.0"></a>
+
 # 0.126.0 (2017-05-24)
 
-* Release: 0.126.0 ([22cd9b1](https://github.com/box/box-content-preview/commit/22cd9b1))
-* Chore: Update translations (#142) ([b084505](https://github.com/box/box-content-preview/commit/b084505))
-
-
+- Release: 0.126.0 ([22cd9b1](https://github.com/box/box-content-preview/commit/22cd9b1))
+- Chore: Update translations (#142) ([b084505](https://github.com/box/box-content-preview/commit/b084505))
 
 <a name="0.125.0"></a>
+
 # 0.125.0 (2017-05-24)
 
-* Release: 0.125.0 ([b77af71](https://github.com/box/box-content-preview/commit/b77af71))
-* Build: Update build script to tag release commits (#141) ([15c0034](https://github.com/box/box-content-preview/commit/15c0034))
-* Chore: Add prettier code formatter (#133) ([c3cb7b6](https://github.com/box/box-content-preview/commit/c3cb7b6))
-* Chore: Deleting old third-party packages (#127) ([d45bb83](https://github.com/box/box-content-preview/commit/d45bb83))
-* Chore: Settings.js - Declare class properties at class-level (#134) ([2cacedd](https://github.com/box/box-content-preview/commit/2cacedd))
-* Chore: Update license formatting (#135) ([61b8bbd](https://github.com/box/box-content-preview/commit/61b8bbd))
-* Chore: Update prettier line width to 80 (#139) ([e7fb14b](https://github.com/box/box-content-preview/commit/e7fb14b))
-* Chore: Update translations (#132) ([f5fc6a5](https://github.com/box/box-content-preview/commit/f5fc6a5))
-* Update: Adding more languages for subtitles (#130) ([b55988c](https://github.com/box/box-content-preview/commit/b55988c))
-* Update: Improve subtitle selection algorithm (#129) ([561cb73](https://github.com/box/box-content-preview/commit/561cb73))
-* Update: Show rate limit specific error message when a 429 occurs (#137) ([67b589c](https://github.com/box/box-content-preview/commit/67b589c))
-* Update: Some UI changes for video player (#128) ([81802c1](https://github.com/box/box-content-preview/commit/81802c1))
-* Update: Update Box3D with new material default (#136) ([97fe7a1](https://github.com/box/box-content-preview/commit/97fe7a1))
-* Fix: fix excel setup when enabling the Office viewer via options (#126) ([e8145f5](https://github.com/box/box-content-preview/commit/e8145f5)), closes [#126](https://github.com/box/box-content-preview/issues/126)
-* Fix: Seek time doesn't match filmstrip timecode (#131) ([fb1fdd0](https://github.com/box/box-content-preview/commit/fb1fdd0))
-* Docs: Update changelog ([0a19275](https://github.com/box/box-content-preview/commit/0a19275))
-* Docs: Update Contributing.md (#125) ([d717883](https://github.com/box/box-content-preview/commit/d717883))
-* Docs: Update license to Box Software License Agreement (#124) ([b8c6080](https://github.com/box/box-content-preview/commit/b8c6080))
-* Docs: Update README to point to new CodePen demo ([5e20db3](https://github.com/box/box-content-preview/commit/5e20db3))
-* Mojito: Update translations (#123) ([86c8475](https://github.com/box/box-content-preview/commit/86c8475))
-
-
+- Release: 0.125.0 ([b77af71](https://github.com/box/box-content-preview/commit/b77af71))
+- Build: Update build script to tag release commits (#141) ([15c0034](https://github.com/box/box-content-preview/commit/15c0034))
+- Chore: Add prettier code formatter (#133) ([c3cb7b6](https://github.com/box/box-content-preview/commit/c3cb7b6))
+- Chore: Deleting old third-party packages (#127) ([d45bb83](https://github.com/box/box-content-preview/commit/d45bb83))
+- Chore: Settings.js - Declare class properties at class-level (#134) ([2cacedd](https://github.com/box/box-content-preview/commit/2cacedd))
+- Chore: Update license formatting (#135) ([61b8bbd](https://github.com/box/box-content-preview/commit/61b8bbd))
+- Chore: Update prettier line width to 80 (#139) ([e7fb14b](https://github.com/box/box-content-preview/commit/e7fb14b))
+- Chore: Update translations (#132) ([f5fc6a5](https://github.com/box/box-content-preview/commit/f5fc6a5))
+- Update: Adding more languages for subtitles (#130) ([b55988c](https://github.com/box/box-content-preview/commit/b55988c))
+- Update: Improve subtitle selection algorithm (#129) ([561cb73](https://github.com/box/box-content-preview/commit/561cb73))
+- Update: Show rate limit specific error message when a 429 occurs (#137) ([67b589c](https://github.com/box/box-content-preview/commit/67b589c))
+- Update: Some UI changes for video player (#128) ([81802c1](https://github.com/box/box-content-preview/commit/81802c1))
+- Update: Update Box3D with new material default (#136) ([97fe7a1](https://github.com/box/box-content-preview/commit/97fe7a1))
+- Fix: fix excel setup when enabling the Office viewer via options (#126) ([e8145f5](https://github.com/box/box-content-preview/commit/e8145f5)), closes [#126](https://github.com/box/box-content-preview/issues/126)
+- Fix: Seek time doesn't match filmstrip timecode (#131) ([fb1fdd0](https://github.com/box/box-content-preview/commit/fb1fdd0))
+- Docs: Update changelog ([0a19275](https://github.com/box/box-content-preview/commit/0a19275))
+- Docs: Update Contributing.md (#125) ([d717883](https://github.com/box/box-content-preview/commit/d717883))
+- Docs: Update license to Box Software License Agreement (#124) ([b8c6080](https://github.com/box/box-content-preview/commit/b8c6080))
+- Docs: Update README to point to new CodePen demo ([5e20db3](https://github.com/box/box-content-preview/commit/5e20db3))
+- Mojito: Update translations (#123) ([86c8475](https://github.com/box/box-content-preview/commit/86c8475))
 
 <a name="0.124.0"></a>
+
 # 0.124.0 (2017-05-17)
 
-* 0.124.0 ([e7fd504](https://github.com/box/box-content-preview/commit/e7fd504))
-
-
+- 0.124.0 ([e7fd504](https://github.com/box/box-content-preview/commit/e7fd504))
 
 <a name="0.123.0"></a>
+
 # 0.123.0 (2017-05-17)
 
-* 0.123.0 ([cdd3799](https://github.com/box/box-content-preview/commit/cdd3799))
-* Update: Adding iso639 code translations (#122) ([b4de2a6](https://github.com/box/box-content-preview/commit/b4de2a6))
-* New: Multi image annotations post bundling refactor ([93a5ba2](https://github.com/box/box-content-preview/commit/93a5ba2))
-* New: platform excel online fork (#101) ([a247b9d](https://github.com/box/box-content-preview/commit/a247b9d))
-* New: Support closed-captions/subtitles (#117) ([4c56532](https://github.com/box/box-content-preview/commit/4c56532))
-* Chore: Bundling annotations.css separately from preview.css (#106) ([699ed56](https://github.com/box/box-content-preview/commit/699ed56))
-* Chore: Document viewer tweaks (#114) ([5d0f884](https://github.com/box/box-content-preview/commit/5d0f884))
-* Chore: Moving common annotation methods into Base classes (#111) ([27a908a](https://github.com/box/box-content-preview/commit/27a908a))
-* Chore: Remove unnecessary mobile check (#120) ([7268548](https://github.com/box/box-content-preview/commit/7268548))
-* Chore: Tweak readme on self-hosted vs Box-hosted ([104d03e](https://github.com/box/box-content-preview/commit/104d03e))
-* Chore: Update readme section on Promise polyfills ([7c90078](https://github.com/box/box-content-preview/commit/7c90078))
-* Fix: Dont rely on preview's script tag being present after execution (#105) ([3ae639a](https://github.com/box/box-content-preview/commit/3ae639a))
-* Fix: Issue when 'load' event is fired before BoxAnnotations is loaded (#108) ([b4c8d32](https://github.com/box/box-content-preview/commit/b4c8d32))
-* Fix: Older versions of webkit iOS incorrectly cache range requests (#118) ([0424e16](https://github.com/box/box-content-preview/commit/0424e16))
-* Fix: Set media viewers' settings menu dimensions with javascript (#116) ([3c36f0a](https://github.com/box/box-content-preview/commit/3c36f0a))
-* Docs: Remove unneeded file types from image360 docs (#119) ([0b7d8de](https://github.com/box/box-content-preview/commit/0b7d8de))
-* Mojito: Update translations (#113) ([7c12442](https://github.com/box/box-content-preview/commit/7c12442))
-* Upgrade: Upgrade Shaka-player to 2.1.1 (#110) ([4387245](https://github.com/box/box-content-preview/commit/4387245))
-
-
+- 0.123.0 ([cdd3799](https://github.com/box/box-content-preview/commit/cdd3799))
+- Update: Adding iso639 code translations (#122) ([b4de2a6](https://github.com/box/box-content-preview/commit/b4de2a6))
+- New: Multi image annotations post bundling refactor ([93a5ba2](https://github.com/box/box-content-preview/commit/93a5ba2))
+- New: platform excel online fork (#101) ([a247b9d](https://github.com/box/box-content-preview/commit/a247b9d))
+- New: Support closed-captions/subtitles (#117) ([4c56532](https://github.com/box/box-content-preview/commit/4c56532))
+- Chore: Bundling annotations.css separately from preview.css (#106) ([699ed56](https://github.com/box/box-content-preview/commit/699ed56))
+- Chore: Document viewer tweaks (#114) ([5d0f884](https://github.com/box/box-content-preview/commit/5d0f884))
+- Chore: Moving common annotation methods into Base classes (#111) ([27a908a](https://github.com/box/box-content-preview/commit/27a908a))
+- Chore: Remove unnecessary mobile check (#120) ([7268548](https://github.com/box/box-content-preview/commit/7268548))
+- Chore: Tweak readme on self-hosted vs Box-hosted ([104d03e](https://github.com/box/box-content-preview/commit/104d03e))
+- Chore: Update readme section on Promise polyfills ([7c90078](https://github.com/box/box-content-preview/commit/7c90078))
+- Fix: Dont rely on preview's script tag being present after execution (#105) ([3ae639a](https://github.com/box/box-content-preview/commit/3ae639a))
+- Fix: Issue when 'load' event is fired before BoxAnnotations is loaded (#108) ([b4c8d32](https://github.com/box/box-content-preview/commit/b4c8d32))
+- Fix: Older versions of webkit iOS incorrectly cache range requests (#118) ([0424e16](https://github.com/box/box-content-preview/commit/0424e16))
+- Fix: Set media viewers' settings menu dimensions with javascript (#116) ([3c36f0a](https://github.com/box/box-content-preview/commit/3c36f0a))
+- Docs: Remove unneeded file types from image360 docs (#119) ([0b7d8de](https://github.com/box/box-content-preview/commit/0b7d8de))
+- Mojito: Update translations (#113) ([7c12442](https://github.com/box/box-content-preview/commit/7c12442))
+- Upgrade: Upgrade Shaka-player to 2.1.1 (#110) ([4387245](https://github.com/box/box-content-preview/commit/4387245))
 
 <a name="0.122.0"></a>
+
 # 0.122.0 (2017-05-09)
 
-* 0.122.0 ([c735f38](https://github.com/box/box-content-preview/commit/c735f38))
-* Mojito: Update translations (#107) ([197945d](https://github.com/box/box-content-preview/commit/197945d))
-* Chore: Allow console logging to show in tests (#100) ([b0e15b1](https://github.com/box/box-content-preview/commit/b0e15b1))
-* Chore: cleaning up DocBaseViewer (#103) ([9d444b3](https://github.com/box/box-content-preview/commit/9d444b3))
-* Chore: Remove font-smoothing and update progress bar color (#104) ([2581b88](https://github.com/box/box-content-preview/commit/2581b88))
-* Chore: Remove unused 'parent' field from Box File object (#91) ([1f9a94b](https://github.com/box/box-content-preview/commit/1f9a94b))
-* Update: Make media player web-accessible according to WCAG2.0 spec (#97) ([687dba4](https://github.com/box/box-content-preview/commit/687dba4))
-* Update: Re-enable font loading API support check (#99) ([eca9e6d](https://github.com/box/box-content-preview/commit/eca9e6d))
-* Fix: Add Annotations bundling changes back  (#95) ([bbc6ea3](https://github.com/box/box-content-preview/commit/bbc6ea3))
-* Fix: Make all svgs not focusable (#98) ([edcf0e1](https://github.com/box/box-content-preview/commit/edcf0e1))
-
-
+- 0.122.0 ([c735f38](https://github.com/box/box-content-preview/commit/c735f38))
+- Mojito: Update translations (#107) ([197945d](https://github.com/box/box-content-preview/commit/197945d))
+- Chore: Allow console logging to show in tests (#100) ([b0e15b1](https://github.com/box/box-content-preview/commit/b0e15b1))
+- Chore: cleaning up DocBaseViewer (#103) ([9d444b3](https://github.com/box/box-content-preview/commit/9d444b3))
+- Chore: Remove font-smoothing and update progress bar color (#104) ([2581b88](https://github.com/box/box-content-preview/commit/2581b88))
+- Chore: Remove unused 'parent' field from Box File object (#91) ([1f9a94b](https://github.com/box/box-content-preview/commit/1f9a94b))
+- Update: Make media player web-accessible according to WCAG2.0 spec (#97) ([687dba4](https://github.com/box/box-content-preview/commit/687dba4))
+- Update: Re-enable font loading API support check (#99) ([eca9e6d](https://github.com/box/box-content-preview/commit/eca9e6d))
+- Fix: Add Annotations bundling changes back (#95) ([bbc6ea3](https://github.com/box/box-content-preview/commit/bbc6ea3))
+- Fix: Make all svgs not focusable (#98) ([edcf0e1](https://github.com/box/box-content-preview/commit/edcf0e1))
 
 <a name="0.121.1"></a>
+
 ## 0.121.1 (2017-04-29)
 
-* 0.121.1 ([948fbf8](https://github.com/box/box-content-preview/commit/948fbf8))
-* Revert annotations bundling (#94) ([176ad13](https://github.com/box/box-content-preview/commit/176ad13))
-
-
+- 0.121.1 ([948fbf8](https://github.com/box/box-content-preview/commit/948fbf8))
+- Revert annotations bundling (#94) ([176ad13](https://github.com/box/box-content-preview/commit/176ad13))
 
 <a name="0.121.0"></a>
+
 # 0.121.0 (2017-04-25)
 
-* 0.121.0 ([3e1e045](https://github.com/box/box-content-preview/commit/3e1e045))
-* Chore: Add console logging to better debug hanging preview (#93) ([3e6299b](https://github.com/box/box-content-preview/commit/3e6299b))
-* Chore: Bundling Annotators separately in annotations.js (#75) ([efa8b2a](https://github.com/box/box-content-preview/commit/efa8b2a))
-* Chore: Do not load annotations on shared links (#88) ([8b959cd](https://github.com/box/box-content-preview/commit/8b959cd))
-* Chore: Removed underscored variables and getters from all annotation files (#83) ([ac838d2](https://github.com/box/box-content-preview/commit/ac838d2))
-* Chore: User agent refactor and Browser tests (#87) ([059f6ac](https://github.com/box/box-content-preview/commit/059f6ac))
-* Fix: Don't load preload if the rep has an error (#92) ([ab5c65a](https://github.com/box/box-content-preview/commit/ab5c65a))
-* Fix: Ensuring annotations are loaded when viewer has permissions (#90) ([b90cdde](https://github.com/box/box-content-preview/commit/b90cdde))
-* Update: Document viewer optimizations (#89) ([41560d6](https://github.com/box/box-content-preview/commit/41560d6))
-* Upgrade: Shaka Player 2.0.8 (#85) ([461070d](https://github.com/box/box-content-preview/commit/461070d))
-
-
+- 0.121.0 ([3e1e045](https://github.com/box/box-content-preview/commit/3e1e045))
+- Chore: Add console logging to better debug hanging preview (#93) ([3e6299b](https://github.com/box/box-content-preview/commit/3e6299b))
+- Chore: Bundling Annotators separately in annotations.js (#75) ([efa8b2a](https://github.com/box/box-content-preview/commit/efa8b2a))
+- Chore: Do not load annotations on shared links (#88) ([8b959cd](https://github.com/box/box-content-preview/commit/8b959cd))
+- Chore: Removed underscored variables and getters from all annotation files (#83) ([ac838d2](https://github.com/box/box-content-preview/commit/ac838d2))
+- Chore: User agent refactor and Browser tests (#87) ([059f6ac](https://github.com/box/box-content-preview/commit/059f6ac))
+- Fix: Don't load preload if the rep has an error (#92) ([ab5c65a](https://github.com/box/box-content-preview/commit/ab5c65a))
+- Fix: Ensuring annotations are loaded when viewer has permissions (#90) ([b90cdde](https://github.com/box/box-content-preview/commit/b90cdde))
+- Update: Document viewer optimizations (#89) ([41560d6](https://github.com/box/box-content-preview/commit/41560d6))
+- Upgrade: Shaka Player 2.0.8 (#85) ([461070d](https://github.com/box/box-content-preview/commit/461070d))
 
 <a name="0.120.1"></a>
+
 ## 0.120.1 (2017-04-19)
 
-* 0.120.1 ([35be0a5](https://github.com/box/box-content-preview/commit/35be0a5))
-* Update: Tweak pdf.js range requests for improved performance (#84) ([0e7f358](https://github.com/box/box-content-preview/commit/0e7f358))
-
-
+- 0.120.1 ([35be0a5](https://github.com/box/box-content-preview/commit/35be0a5))
+- Update: Tweak pdf.js range requests for improved performance (#84) ([0e7f358](https://github.com/box/box-content-preview/commit/0e7f358))
 
 <a name="0.120.0"></a>
+
 # 0.120.0 (2017-04-18)
 
-* 0.120.0 ([85337bc](https://github.com/box/box-content-preview/commit/85337bc))
-* Fix: Handle text representation error (#72) ([81fc4e4](https://github.com/box/box-content-preview/commit/81fc4e4))
-* Fix: Only bind custom listeners when annotation threads exist (#74) ([1e2e9f7](https://github.com/box/box-content-preview/commit/1e2e9f7))
-* Fix: Prevent webGL error when prefetching Preview.js (#82) ([e0a420a](https://github.com/box/box-content-preview/commit/e0a420a))
-* Update: Add client information to performance logging (#80) ([f7bea68](https://github.com/box/box-content-preview/commit/f7bea68))
-* Update: Add disableTextLayer option for doc and text viewers (#71) ([a36f735](https://github.com/box/box-content-preview/commit/a36f735))
-* Update: Changing analytics client name to 'box-content-preview' (#79) ([983dda9](https://github.com/box/box-content-preview/commit/983dda9))
-* Update: Disabling font loading API for pdf.js to prevent glitches (#68) ([5b5807b](https://github.com/box/box-content-preview/commit/5b5807b))
-* Chore: Mock super.setup() in all Viewer unit tests (#81) ([fec384c](https://github.com/box/box-content-preview/commit/fec384c))
-* Chore: Rename test-html files and update fixture loading (#78) ([8285e39](https://github.com/box/box-content-preview/commit/8285e39))
-* Chore: Triggering point annotation mode by emitting a message (#77) ([cc3e283](https://github.com/box/box-content-preview/commit/cc3e283))
-* Chore: Updating annotations icons to the new Box blue (#76) ([979e129](https://github.com/box/box-content-preview/commit/979e129))
-* Mojito: Update translations (#70) ([5daa11e](https://github.com/box/box-content-preview/commit/5daa11e))
-
-
+- 0.120.0 ([85337bc](https://github.com/box/box-content-preview/commit/85337bc))
+- Fix: Handle text representation error (#72) ([81fc4e4](https://github.com/box/box-content-preview/commit/81fc4e4))
+- Fix: Only bind custom listeners when annotation threads exist (#74) ([1e2e9f7](https://github.com/box/box-content-preview/commit/1e2e9f7))
+- Fix: Prevent webGL error when prefetching Preview.js (#82) ([e0a420a](https://github.com/box/box-content-preview/commit/e0a420a))
+- Update: Add client information to performance logging (#80) ([f7bea68](https://github.com/box/box-content-preview/commit/f7bea68))
+- Update: Add disableTextLayer option for doc and text viewers (#71) ([a36f735](https://github.com/box/box-content-preview/commit/a36f735))
+- Update: Changing analytics client name to 'box-content-preview' (#79) ([983dda9](https://github.com/box/box-content-preview/commit/983dda9))
+- Update: Disabling font loading API for pdf.js to prevent glitches (#68) ([5b5807b](https://github.com/box/box-content-preview/commit/5b5807b))
+- Chore: Mock super.setup() in all Viewer unit tests (#81) ([fec384c](https://github.com/box/box-content-preview/commit/fec384c))
+- Chore: Rename test-html files and update fixture loading (#78) ([8285e39](https://github.com/box/box-content-preview/commit/8285e39))
+- Chore: Triggering point annotation mode by emitting a message (#77) ([cc3e283](https://github.com/box/box-content-preview/commit/cc3e283))
+- Chore: Updating annotations icons to the new Box blue (#76) ([979e129](https://github.com/box/box-content-preview/commit/979e129))
+- Mojito: Update translations (#70) ([5daa11e](https://github.com/box/box-content-preview/commit/5daa11e))
 
 <a name="0.119.1"></a>
+
 ## 0.119.1 (2017-04-12)
 
-* 0.119.1 ([bc9b581](https://github.com/box/box-content-preview/commit/bc9b581))
-* Fix: adding patch to options check in release script (#69) ([86c3fef](https://github.com/box/box-content-preview/commit/86c3fef))
-* Fix: updating metadata from repStatus (#60) ([51143b0](https://github.com/box/box-content-preview/commit/51143b0))
-
-
+- 0.119.1 ([bc9b581](https://github.com/box/box-content-preview/commit/bc9b581))
+- Fix: adding patch to options check in release script (#69) ([86c3fef](https://github.com/box/box-content-preview/commit/86c3fef))
+- Fix: updating metadata from repStatus (#60) ([51143b0](https://github.com/box/box-content-preview/commit/51143b0))
 
 <a name="0.119.0"></a>
+
 # 0.119.0 (2017-04-11)
 
-* 0.119.0 ([762fad8](https://github.com/box/box-content-preview/commit/762fad8))
-* Fix: Hiding download button in all cases if browser cannot download (#61) ([3a5bb41](https://github.com/box/box-content-preview/commit/3a5bb41))
-* Fix: Temporary disableFontFaces on IOS 10.3 ([67de2d7](https://github.com/box/box-content-preview/commit/67de2d7))
-* Update: Decrease mobile web max pdf.js canvas size to 3MP (#66) ([88304c9](https://github.com/box/box-content-preview/commit/88304c9))
-* Update: Increase default doc chunk size to 384KB (#64) ([ebbaccd](https://github.com/box/box-content-preview/commit/ebbaccd))
-* Update: Upgrade pdf.js to v1.8.175 (#63) ([14ac6f9](https://github.com/box/box-content-preview/commit/14ac6f9))
-* Chore: Removing unneeded compatibility.js from pdf.js (#65) ([82d582e](https://github.com/box/box-content-preview/commit/82d582e))
-* Chore: Update changelog generator to ignore old pull requests (#59) ([7ad5088](https://github.com/box/box-content-preview/commit/7ad5088))
-
-
+- 0.119.0 ([762fad8](https://github.com/box/box-content-preview/commit/762fad8))
+- Fix: Hiding download button in all cases if browser cannot download (#61) ([3a5bb41](https://github.com/box/box-content-preview/commit/3a5bb41))
+- Fix: Temporary disableFontFaces on IOS 10.3 ([67de2d7](https://github.com/box/box-content-preview/commit/67de2d7))
+- Update: Decrease mobile web max pdf.js canvas size to 3MP (#66) ([88304c9](https://github.com/box/box-content-preview/commit/88304c9))
+- Update: Increase default doc chunk size to 384KB (#64) ([ebbaccd](https://github.com/box/box-content-preview/commit/ebbaccd))
+- Update: Upgrade pdf.js to v1.8.175 (#63) ([14ac6f9](https://github.com/box/box-content-preview/commit/14ac6f9))
+- Chore: Removing unneeded compatibility.js from pdf.js (#65) ([82d582e](https://github.com/box/box-content-preview/commit/82d582e))
+- Chore: Update changelog generator to ignore old pull requests (#59) ([7ad5088](https://github.com/box/box-content-preview/commit/7ad5088))
 
 <a name="0.118.0"></a>
+
 # 0.118.0 (2017-04-06)
 
-* 0.118.0 ([930c432](https://github.com/box/box-content-preview/commit/930c432))
-* Chore: Moving existing CHANGELOG.md to HISTORY.md ([126f78d](https://github.com/box/box-content-preview/commit/126f78d))
-* Chore: Updating README describing .conventional-changelog-lintrc (#57) ([897b858](https://github.com/box/box-content-preview/commit/897b858))
-* Update: New Box-branding for Oculus Touch models (#58) ([59880de](https://github.com/box/box-content-preview/commit/59880de))
-
-
+- 0.118.0 ([930c432](https://github.com/box/box-content-preview/commit/930c432))
+- Chore: Moving existing CHANGELOG.md to HISTORY.md ([126f78d](https://github.com/box/box-content-preview/commit/126f78d))
+- Chore: Updating README describing .conventional-changelog-lintrc (#57) ([897b858](https://github.com/box/box-content-preview/commit/897b858))
+- Update: New Box-branding for Oculus Touch models (#58) ([59880de](https://github.com/box/box-content-preview/commit/59880de))
 
 <a name="0.117.0"></a>
+
 # 0.117.0 (2017-04-06)
 
-* New: Initial push to GitHub ([448c477](https://github.com/box/box-content-preview/commit/448c477))
-
-
-
+- New: Initial push to GitHub ([448c477](https://github.com/box/box-content-preview/commit/448c477))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ This project adheres to the [Box Open Code of Conduct](http://opensource.box.com
 
 ## How to contribute
 
-* **File an issue** - if you found a bug, want to request an enhancement, or want to implement something (bug fix or feature).
-* **Send a pull request** - if you want to contribute code. Please be sure to file an issue first.
+- **File an issue** - if you found a bug, want to request an enhancement, or want to implement something (bug fix or feature).
+- **Send a pull request** - if you want to contribute code. Please be sure to file an issue first.
 
 ## Pull request best practices
 
@@ -39,35 +39,21 @@ The upstream source is the project under the Box organization on GitHub. To add 
 git remote add upstream git@github.com:box/box-content-preview.git
 ```
 
-### Step 4: Create a feature branch
+### Step 4: Push your feature branch to your fork
 
-Create a branch with a descriptive name, such as `add-search`.
-
-### Step 5: Push your feature branch to your fork
-
-As you develop code, continue to push code to your remote feature branch. Please make sure to include the issue number you're addressing in your commit message, such as:
+Keep a separate feature branch for each issue you want to address. As you develop code, continue to push code to your remote feature branch. If applicable, please make sure to include the issue number you're addressing in your commit message, such as:
 
 ```
-Tag: Short description (fixes #1234)
+tag(scope): short description
 
-Longer description here if necessary
+fixes #1234
+longer description here if necessary.
+include BREAKING CHANGE keyword for breaking changes.
 ```
-The Tag is one of the following:
 
-* `Fix` - for a bug fix.
-* `Update` - for a backwards-compatible enhancement or a change to a rule that increases the number of reported problems.
-* `New` - implemented a new feature.
-* `Breaking` - for a backwards-incompatible enhancement or feature.
-* `Docs` - changes to documentation only.
-* `Build` - changes to build process only.
-* `Upgrade` - for a dependency upgrade.
-* `Chore` - for refactoring, adding tests, etc. (anything that isn’t user-facing).
+The message summary should be a one-sentence description of the change, and it must be 72 characters in length or shorter. For a list of tags, please see the conventional changelog [documentation](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum). 
 
-The message summary should be a one-sentence description of the change, and it must be 72 characters in length or shorter. If the pull request addresses an issue, then the issue number should be mentioned at the end.
-
-Keep a separate feature branch for each issue you want to address.
-
-### Step 6: Rebase
+### Step 5: Rebase
 
 Before sending a pull request, rebase against upstream, such as:
 
@@ -78,11 +64,11 @@ git rebase upstream/master
 
 This will add your changes on top of what's already in upstream, minimizing merge issues.
 
-### Step 7: Run the tests
+### Step 6: Run the tests
 
 Make sure that all tests are passing before submitting a pull request.
 
-### Step 8: Send the pull request
+### Step 7: Send the pull request
 
 Send the pull request from your feature branch to us. Be sure to include a description (as mentioned above in step 5) that lets us know what work you did.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Historical Change Log
 
 ## [v0.117.0](https://github.com/box/box-content-preview/tree/v0.117.0) (2017-04-06)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.116.0...v0.117.0)
 
 **Merged pull requests:**
@@ -8,6 +9,7 @@
 - Chore: Fixing changelog generator again [\#56](https://github.com/box/box-content-preview/pull/56) ([tonyjin](https://github.com/tonyjin))
 
 ## [v0.116.0](https://github.com/box/box-content-preview/tree/v0.116.0) (2017-04-06)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.115.0...v0.116.0)
 
 **Merged pull requests:**
@@ -22,6 +24,7 @@
 - Chore: Rename viewers [\#29](https://github.com/box/box-content-preview/pull/29) ([JustinHoldstock](https://github.com/JustinHoldstock))
 
 ## [v0.115.0](https://github.com/box/box-content-preview/tree/v0.115.0) (2017-04-05)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.114.0...v0.115.0)
 
 **Merged pull requests:**
@@ -30,7 +33,7 @@
 - Update: Don't time out during conversion [\#46](https://github.com/box/box-content-preview/pull/46) ([tonyjin](https://github.com/tonyjin))
 - Chore: Minify third party CSS with cssnano [\#45](https://github.com/box/box-content-preview/pull/45) ([tonyjin](https://github.com/tonyjin))
 - Chore: Upgrading PDF.js to 1.7.401 [\#44](https://github.com/box/box-content-preview/pull/44) ([jeremypress](https://github.com/jeremypress))
-- Build: Updating upgrade\_pdfjs script [\#43](https://github.com/box/box-content-preview/pull/43) ([jeremypress](https://github.com/jeremypress))
+- Build: Updating upgrade_pdfjs script [\#43](https://github.com/box/box-content-preview/pull/43) ([jeremypress](https://github.com/jeremypress))
 - Update Translations [\#40](https://github.com/box/box-content-preview/pull/40) ([boxmoji](https://github.com/boxmoji))
 - Chore: Fixing link in README [\#38](https://github.com/box/box-content-preview/pull/38) ([pramodsum](https://github.com/pramodsum))
 - Build: Adding commit linting [\#37](https://github.com/box/box-content-preview/pull/37) ([jeremypress](https://github.com/jeremypress))
@@ -43,6 +46,7 @@
 - Update: Updating box ui colors [\#14](https://github.com/box/box-content-preview/pull/14) ([priyajeet](https://github.com/priyajeet))
 
 ## [v0.114.0](https://github.com/box/box-content-preview/tree/v0.114.0) (2017-03-29)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.113.0...v0.114.0)
 
 **Merged pull requests:**
@@ -50,6 +54,7 @@
 - Chore: Update release script [\#31](https://github.com/box/box-content-preview/pull/31) ([tonyjin](https://github.com/tonyjin))
 
 ## [v0.113.0](https://github.com/box/box-content-preview/tree/v0.113.0) (2017-03-28)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.112.0...v0.113.0)
 
 **Merged pull requests:**
@@ -60,8 +65,8 @@
 - Fix: Don't show error download btn if option is not set [\#25](https://github.com/box/box-content-preview/pull/25) ([tonyjin](https://github.com/tonyjin))
 - Chore: Preview.js cleanup and slight refactor [\#24](https://github.com/box/box-content-preview/pull/24) ([tonyjin](https://github.com/tonyjin))
 - Filmstrip interval should be determined from rep metadata field [\#23](https://github.com/box/box-content-preview/pull/23) ([bhh1988](https://github.com/bhh1988))
-- Breaking: Support {+asset\_path} to follow RFC6570 [\#22](https://github.com/box/box-content-preview/pull/22) ([tonyjin](https://github.com/tonyjin))
-- Fix: Guard against unsupported lose\_context extension on IE11 and Edge [\#21](https://github.com/box/box-content-preview/pull/21) ([MiiBond](https://github.com/MiiBond))
+- Breaking: Support {+asset_path} to follow RFC6570 [\#22](https://github.com/box/box-content-preview/pull/22) ([tonyjin](https://github.com/tonyjin))
+- Fix: Guard against unsupported lose_context extension on IE11 and Edge [\#21](https://github.com/box/box-content-preview/pull/21) ([MiiBond](https://github.com/MiiBond))
 - New: centering image prints [\#18](https://github.com/box/box-content-preview/pull/18) ([jeremypress](https://github.com/jeremypress))
 - Chore: Remove dist folder from repo [\#16](https://github.com/box/box-content-preview/pull/16) ([tonyjin](https://github.com/tonyjin))
 - Chore: Separately version third-party assets [\#15](https://github.com/box/box-content-preview/pull/15) ([tonyjin](https://github.com/tonyjin))
@@ -72,6 +77,7 @@
 - Breaking: Switching to Preview class instead of Preview singleton [\#7](https://github.com/box/box-content-preview/pull/7) ([priyajeet](https://github.com/priyajeet))
 
 ## [v0.112.0](https://github.com/box/box-content-preview/tree/v0.112.0) (2017-03-22)
+
 [Full Changelog](https://github.com/box/box-content-preview/compare/v0.111.0...v0.112.0)
 
 **Merged pull requests:**

--- a/README.md
+++ b/README.md
@@ -5,46 +5,47 @@
 [![version](https://img.shields.io/badge/version-v2.14.0-blue.svg?style=flat-square)](https://github.com/box/box-content-preview)
 [![npm version](https://img.shields.io/npm/v/box-ui-elements.svg?style=flat-square)](https://www.npmjs.com/package/box-ui-elements)
 
-[Box Content Preview](https://developer.box.com/docs/box-content-preview)
-====================================================================
-The Box Content Preview library allows developers to easily embed high quality and interactive previews of Box files in  desktop and mobile web applications. The JavaScript library fetches information about the file and its converted representations through the Box API, chooses the appropriate viewer for the file type, dynamically loads the necessary static assets and file representations, and finally renders the file. Box Content Preview also allows previews of multiple files to be loaded in the same container and exposes arrows to navigate between those files.
+# [Box Content Preview](https://developer.box.com/docs/box-content-preview)
+
+The Box Content Preview library allows developers to easily embed high quality and interactive previews of Box files in desktop and mobile web applications. The JavaScript library fetches information about the file and its converted representations through the Box API, chooses the appropriate viewer for the file type, dynamically loads the necessary static assets and file representations, and finally renders the file. Box Content Preview also allows previews of multiple files to be loaded in the same container and exposes arrows to navigate between those files.
 
 This library powers Preview in the main Box web application as well as the 'Get Embed Link' Box API endpoint.
 
-Browser Support
----------------
-* Desktop Chrome, Firefox, Safari, Edge, and Internet Explorer 11
-* Limited support for mobile web - previews will render but some controls may not work
+## Browser Support
+
+- Desktop Chrome, Firefox, Safari, Edge, and Internet Explorer 11
+- Limited support for mobile web - previews will render but some controls may not work
 
 If you are using Internet Explorer 11, which doesn't natively support promises, include a polyfill.io script (see sample code below) or a Promise library like Bluebird.
 
-Current Version
----------------
-* Version: v2.14.0
-* Locale: en-US
+## Current Version
+
+- Version: v2.14.0
+- Locale: en-US
 
 https://cdn01.boxcdn.net/platform/preview/2.14.0/en-US/preview.js
 https://cdn01.boxcdn.net/platform/preview/2.14.0/en-US/preview.css
 
-Supported Locales
------------------
+## Supported Locales
+
 To use a different locale, replace `en-US` in the URLs above with any of the following supported locales.
 
 `en-AU`, `en-CA`, `en-GB`, `en-US`, `bn-IN`, `da-DK`, `de-DE`, `es-419`, `es-ES`, `fi-FI`, `fr-CA`, `fr-FR`, `hi-IN`,`it-IT`, `ja-JP`, `ko-KR`, `nb-NO`, `nl-NL`, `pl-PL`, `pt-BR`, `ru-RU`, `sv-SE`, `tr-TR`, `zh-CN`, `zh-TW`
 
-Supported File Types
---------------------
+## Supported File Types
+
 Box Content Preview supports 100+ file types, including most document and image formats, HD video, 3D models, 360-degress images, and 360-degree videos. You can find the full list of supported file types at https://community.box.com/t5/Managing-Your-Content/What-file-types-and-fonts-are-supported-by-Box-s-Content-Preview/ta-p/327#FileTypesSupported.
 
-Usage
------
+## Usage
+
 ### Including Preview as a library
+
 You can self-host the Box Content Preview library or reference the versions available on Box's CDN.
 
 ```html
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
+  <head>
     <meta charset="utf-8" />
     <title>Box Content Preview Demo</title>
 
@@ -53,55 +54,64 @@ You can self-host the Box Content Preview library or reference the versions avai
 
     <!-- Latest version of Preview SDK for your locale -->
     <script src="https://cdn01.boxcdn.net/platform/preview/2.14.0/en-US/preview.js"></script>
-    <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/preview/2.14.0/en-US/preview.css" />
-</head>
-<body>
+    <link
+      rel="stylesheet"
+      href="https://cdn01.boxcdn.net/platform/preview/2.14.0/en-US/preview.css"
+    />
+  </head>
+  <body>
     <div class="preview-container" style="height:400px;width:575px"></div>
     <script>
-        var preview = new Box.Preview();
-        preview.show('93392244621', 'EqFyi1Yq1tD9mxY8F38sxDfp73pFd7FP', {
-    	    container: '.preview-container'
-        });
+      var preview = new Box.Preview();
+      preview.show('93392244621', 'EqFyi1Yq1tD9mxY8F38sxDfp73pFd7FP', {
+        container: '.preview-container',
+      });
     </script>
-</body>
+  </body>
 </html>
 ```
 
 ### Self-hosting
+
 To self-host the Box Content Preview library, follow these steps:
+
 1. Either fork the repo and check out the version you want to host or download the specific version as a zip:
-  * Check out a specific version with `git checkout v2.14.0`
-  * Download a specific version as a zip from https://github.com/box/box-content-preview/releases
+
+- Check out a specific version with `git checkout v2.14.0`
+- Download a specific version as a zip from https://github.com/box/box-content-preview/releases
+
 2. Install dependencies and build the library with `yarn install && yarn build:i18n && yarn:build:prod`
 3. Self-host everything except for the `dev` folder from the `/dist` folder. You must not alter the folder structure and `third-party` needs to be in the same folder as `2.4.0`. For example, if you self-host using a `box-assets` directory, these URLs must be accessible:
-  * https://cdn.YOUR_SITE.com/box-assets/2.4.0/en-US/preview.js
-  * https://cdn.YOUR_SITE.com/box-assets/third-party/text/0.114.0/papaparse.min.js
-  * https://cdn.YOUR_SITE.com/box-assets/third-party/model3d/1.12.0/three.min.js
+
+- https://cdn.YOUR_SITE.com/box-assets/2.4.0/en-US/preview.js
+- https://cdn.YOUR_SITE.com/box-assets/third-party/text/0.114.0/papaparse.min.js
+- https://cdn.YOUR_SITE.com/box-assets/third-party/model3d/1.12.0/three.min.js
 
 ### Importing Preview as a React Component
+
 Preview can also be used as a React Component with the Box Element framework. The source code for the Content Preview Element wrapper is located at https://github.com/box/box-ui-elements/tree/master/src/components/ContentPreview. Please reference https://github.com/box/box-content-preview-demo for a minimal React application using this wrapper.
 
-CORS (Cross-Origin Resource Sharing)
-------------------------------------
+## CORS (Cross-Origin Resource Sharing)
+
 For security purposes, you must whitelist your application's HTTP origin, omitting any trailing slash, in the configuration section of the Developer Console. For example, CodePen's domain is whitelisted for the demo application below.
 
 ![Screenshot of CORS whitelist](images/cors.png)
 
-Demo
-----
+## Demo
+
 View a demo and sample code on CodePen - http://codepen.io/box-platform/pen/rmZdjm.
 
-Initialization
---------------
+## Initialization
+
 ```javascript
 var preview = new Box.Preview();
 preview.show(fileId, accessToken, { options });
 ```
+
 Where `fileId` is a string `Box_File` id and `accessToken` is a Box API access token.
 
+## Parameters & Options
 
-Parameters & Options
--------
 ```javascript
 var preview = new Box.Preview();
 preview.show(fileId, accessToken, {
@@ -115,37 +125,39 @@ preview.show(fileId, accessToken, {
     showDownload: true
 });
 ```
-| Parameter | Description |
-| --- | --- |
-| fileId | Box file ID |
+
+| Parameter   | Description                                                                     |
+| ----------- | ------------------------------------------------------------------------------- |
+| fileId      | Box file ID                                                                     |
 | accessToken | Either a string auth token or a token generator function, see below for details |
 
-| Option | Default | Description |
-| --- | --- | --- |
-| container | document.body | DOM node or selector where Preview should be placed |
-| sharedLink |  | Shared link URL |
-| sharedLinkPassword |  | Shared link password |
-| collection |  | List of file IDs to iterate over for previewing |
-| header | `light` | String value of `none` or `dark` or `light` that controls header visibility and theme |
-| logoUrl |  | URL of logo to show in header |
-| showAnnotations | false | Whether annotations and annotation controls are shown. This option will be overridden by viewer-specific annotation options if they are set. See [Box Annotations](https://github.com/box/box-annotations) for more details |
-| showDownload | false | Whether download button is shown |
-| autoFocus | true | Whether preview should focus itself when a file loads |
-| useHotkeys | true | Whether hotkeys (keyboard shortcuts) are enabled |
-| fixDependencies | false | Temporarily patches AMD to properly load Preview's dependencies. You may need to enable this if your project uses RequireJS |
-| disableEventLog | false | Disables client-side `preview` event log. Previewing with this option enabled will not increment access stats (content access is still logged server-side) |
-| fileOptions | {} | Mapping of file ID to file-level options. See the file option table below for details |
-| previewWMPref | `any` | String value of `all`, `any`, or `none` that sets how previews of watermarked files behave. See https://community.box.com/t5/Sharing-Content-with-Box/Watermarking-Files/ta-p/30766 for more information about watermarking and https://community.box.com/t5/Collaborate-By-Inviting-Others/Understanding-Collaborator-Permission-Levels/ta-p/144 for more information about permissions and collaboration roles.<br><br>`all` forces watermarked previews. If the file type supports watermarking, users with `can_preview` permissions will see a watermarked preview. If the file type cannot be watermarked, no preview is shown.<br><br>`any` is the default watermarking behavior in the Box Web Application. If the file type supports watermarking, users with `can_preview` permissions will see a watermarked preview. If the file type cannot be watermarked, users that have both `can_preview` and `can_upload` permissions will see a non-watermarked preview and no preview otherwise.<br><br>`none` forces non-watermarked previews. Users that have both `can_preview` and `can_upload` permissions will see a non-watermarked preview and no preview otherwise. |
-| downloadWM | false | Whether the download of a watermarked file should be watermarked. This option does not affect non-watermarked files. If true, users will be able to download watermarked versions of supported file types as long as they have `can_preview` permissions (any collaboration role except for `Uploader`). |
+| Option             | Default       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| container          | document.body | DOM node or selector where Preview should be placed                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| sharedLink         |               | Shared link URL                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| sharedLinkPassword |               | Shared link password                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| collection         |               | List of file IDs to iterate over for previewing                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| header             | `light`       | String value of `none` or `dark` or `light` that controls header visibility and theme                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| logoUrl            |               | URL of logo to show in header                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| showAnnotations    | false         | Whether annotations and annotation controls are shown. This option will be overridden by viewer-specific annotation options if they are set. See [Box Annotations](https://github.com/box/box-annotations) for more details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| showDownload       | false         | Whether download button is shown                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| autoFocus          | true          | Whether preview should focus itself when a file loads                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| useHotkeys         | true          | Whether hotkeys (keyboard shortcuts) are enabled                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| fixDependencies    | false         | Temporarily patches AMD to properly load Preview's dependencies. You may need to enable this if your project uses RequireJS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| disableEventLog    | false         | Disables client-side `preview` event log. Previewing with this option enabled will not increment access stats (content access is still logged server-side)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| fileOptions        | {}            | Mapping of file ID to file-level options. See the file option table below for details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| previewWMPref      | `any`         | String value of `all`, `any`, or `none` that sets how previews of watermarked files behave. See https://community.box.com/t5/Sharing-Content-with-Box/Watermarking-Files/ta-p/30766 for more information about watermarking and https://community.box.com/t5/Collaborate-By-Inviting-Others/Understanding-Collaborator-Permission-Levels/ta-p/144 for more information about permissions and collaboration roles.<br><br>`all` forces watermarked previews. If the file type supports watermarking, users with `can_preview` permissions will see a watermarked preview. If the file type cannot be watermarked, no preview is shown.<br><br>`any` is the default watermarking behavior in the Box Web Application. If the file type supports watermarking, users with `can_preview` permissions will see a watermarked preview. If the file type cannot be watermarked, users that have both `can_preview` and `can_upload` permissions will see a non-watermarked preview and no preview otherwise.<br><br>`none` forces non-watermarked previews. Users that have both `can_preview` and `can_upload` permissions will see a non-watermarked preview and no preview otherwise. |
+| downloadWM         | false         | Whether the download of a watermarked file should be watermarked. This option does not affect non-watermarked files. If true, users will be able to download watermarked versions of supported file types as long as they have `can_preview` permissions (any collaboration role except for `Uploader`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-| File Option | Description |
-| --- | --- |
+| File Option   | Description                                                                                                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | fileVersionId | File version ID to preview. This must be a valid non-current file version ID. Use [Get Versions](https://developer.box.com/reference#view-versions-of-a-file) to fetch a list of file versions |
-| startAt | Object with unit and value properties indicating where to start the preview at. Current supported units are 'seconds' for media and 'pages' for documents. |
+| startAt       | Object with unit and value properties indicating where to start the preview at. Current supported units are 'seconds' for media and 'pages' for documents.                                     |
 
 **Example**
 
 This configuration sets version `54321` as the preview version for a file with the ID `12345`:
+
 ```
 const FILE_ID = '12345';
 const TOKEN = 'abcdefg';
@@ -158,8 +170,8 @@ preview.show(FILE_ID, TOKEN, {
 });
 ```
 
-Access Token
-------------
+## Access Token
+
 Box Content Preview needs an access token to make Box API calls. You can either get an access token from the token endpoint (https://developer.box.com/reference#token) or generate a developer token on your application management page (https://blog.box.com/blog/introducing-developer-tokens/).
 
 If your application requires the end user to only be able to access a subset of the Content Preview functionality, you can use [Token Exchange](https://developer.box.com/reference#token-exchange) to appropriately downscope your App/Managed or Service Account token to a resulting token that has the desired set of permissions, and can thus, be securely passed to the end user client initializing the Content Preview.
@@ -170,53 +182,54 @@ Wish to learn more about when, why and how you can use Token Exchange with the C
 
 ### Base Scope
 
-| Scope Name | What permissions does it grant? |
-| --- | --- |
+| Scope Name   | What permissions does it grant?                                                           |
+| ------------ | ----------------------------------------------------------------------------------------- |
 | base_preview | Allows preview access to a file or files in a folder based on user/file/token permissions |
 
 ### Feature Scopes
-| Scope Name | What permissions does it grant? |
-| --- | --- |
-| item_download | Allows files/folders contents to be downloaded |
-| annotation_view_self | Allows user to view their own annotations |
-| annotation_view_all | Allows user to view all annotations on the file |
-| annotation_edit | Allows user to edit their own annotations (includes annotation_view_self) |
+
+| Scope Name           | What permissions does it grant?                                           |
+| -------------------- | ------------------------------------------------------------------------- |
+| item_download        | Allows files/folders contents to be downloaded                            |
+| annotation_view_self | Allows user to view their own annotations                                 |
+| annotation_view_all  | Allows user to view all annotations on the file                           |
+| annotation_edit      | Allows user to edit their own annotations (includes annotation_view_self) |
 
 ### Sample Scenarios
 
-| Scenario| Scope Combinations |
-| --- | --- |
-| User wants basic preview functionality + download | base_preview + item_download |
-| User wants basic preview functionality + ability to edit own annotations| base_preview + annotation_edit |
-| User wants basic preview functionality + ability to view all annotations + ability to edit own annotations| base_preview + annotation_view_all + annotation_edit|
+| Scenario                                                                                                   | Scope Combinations                                   |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| User wants basic preview functionality + download                                                          | base_preview + item_download                         |
+| User wants basic preview functionality + ability to edit own annotations                                   | base_preview + annotation_edit                       |
+| User wants basic preview functionality + ability to view all annotations + ability to edit own annotations | base_preview + annotation_view_all + annotation_edit |
 
-Token Generator Function
-------------------------
+## Token Generator Function
+
 The Preview library optionally takes a token generator function instead of a string token. Using a token generator function allows you to dynamically determine what tokens Preview should use. For example, you can pass in different access tokens for each file or make sure your token is refreshed and valid before showing a preview. The token generator function should return a promise that resolves in either a single string token that applies to all of the files being previewed or a map of typed file IDs to access token for those files.
 
 ```javascript
 // Example token generator function that resolves to a single access token
 var singleTokenGenerator = function() {
-    return someApi.getToken().then(function(data) {
-        return data.token;
-    });
+  return someApi.getToken().then(function(data) {
+    return data.token;
+  });
 };
 
 // Example token generator function that resolves to a map of tokens
 var mapTokenGenerator = function() {
-    return Promise.resolve({
-        file_1234: 'some_token_abcd',
-        file_2345: 'some_token_bcde'
-    });
+  return Promise.resolve({
+    file_1234: 'some_token_abcd',
+    file_2345: 'some_token_bcde',
+  });
 };
 ```
 
-Viewers
--------
+## Viewers
+
 The name of a viewer can be one of the following `Document`, `Presentation`, `MP3`, `MP4`, `Dash`, `Image`, `Text`, `SWF`, `Image360`, `Video360`, `Model3d`, `CSV`, `Markdown`. Call `preview.getViewers()` to get the list of possible viewers.
 
-Additional Methods
-------------------
+## Additional Methods
+
 `preview.hide()` hides the preview.
 
 `preview.updateCollection(/* Array[file ids] */ collection)` updates the collection to navigate through. Assumes the currently visible file is part of this new collection.
@@ -251,8 +264,8 @@ Additional Methods
 
 `preview.prefetchViewers(/* Array[String] */)` prefetches static assets for the specified viewers that the browser can cache for performance benefits.
 
-Events
-------
+## Events
+
 The preview object exposes `addListener` and `removeListener` for binding to events. Event listeners should be bound before `show()` is called, otherwise events can be missed.
 
 ```javascript
@@ -273,9 +286,10 @@ preview.removeListener(EVENTNAME, listener);
 
 EVENTNAME can be one of the following
 
-* `viewer` event will be fired when we have the viewer instance first available. This will be the same object that is also a property included in the `load` event. Preview fires this event before `load` so that clients can attach their listeners before the `load` event is fired.
+- `viewer` event will be fired when we have the viewer instance first available. This will be the same object that is also a property included in the `load` event. Preview fires this event before `load` so that clients can attach their listeners before the `load` event is fired.
 
-* `load` event will be fired on every preview load when `show()` is called or if inter-preview navigation occurs. The event data will contain:
+- `load` event will be fired on every preview load when `show()` is called or if inter-preview navigation occurs. The event data will contain:
+
 ```javascript
   {
       error: 'message', // Error message if any error occurred while loading
@@ -284,9 +298,11 @@ EVENTNAME can be one of the following
       file: {...}       // Box file object with properties defined in file.js
   }
 ```
-* `navigate` event will be fired when navigation happens. The event includes the file ID of the file being navigated to, and this event will fire before `load`.
 
-* `notification` event will be fired when either the preview wrapper or one of the viewers wants to notify something like a warning or non-fatal error. The event data will contain:
+- `navigate` event will be fired when navigation happens. The event includes the file ID of the file being navigated to, and this event will fire before `load`.
+
+- `notification` event will be fired when either the preview wrapper or one of the viewers wants to notify something like a warning or non-fatal error. The event data will contain:
+
 ```javascript
   {
       message: 'message', // Message to show
@@ -294,7 +310,8 @@ EVENTNAME can be one of the following
   }
 ```
 
-* `viewerevent` Each viewer will fire its own sets of events. For example, the Image viewer will fire `rotate` or `resize`, etc. while other viewers may fire another set of events. The preview wrapper will also re-emit events at the preview level, with event data containing:
+- `viewerevent` Each viewer will fire its own sets of events. For example, the Image viewer will fire `rotate` or `resize`, etc. while other viewers may fire another set of events. The preview wrapper will also re-emit events at the preview level, with event data containing:
+
 ```javascript
   {
       event: EVENTNAME,         // Event name
@@ -305,43 +322,46 @@ EVENTNAME can be one of the following
 ```
 
 ### Example event usage
+
 ```javascript
-preview.addListener('viewer', (viewer) => {
-    viewer.addListener('rotate', () => {
-        // Do something when a viewer rotates a preview
-    });
+preview.addListener('viewer', viewer => {
+  viewer.addListener('rotate', () => {
+    // Do something when a viewer rotates a preview
+  });
 });
 
-preview.addListener('load', (data) => {
-    var viewer = data.viewer;
-    viewer.addListener('rotate', () => {
-        // Do something when a viewer rotates a preview
-    });
+preview.addListener('load', data => {
+  var viewer = data.viewer;
+  viewer.addListener('rotate', () => {
+    // Do something when a viewer rotates a preview
+  });
 });
 
-preview.addListener('viewerevent', (data) => {
-    if (data.viewerName === 'Image') {
-        if (data.event === 'rotate') {
-            // Do something when an image preview is rotated
-        }
-    } else if (data.viewerName === 'Image360') {
-        if (data.event === 'rotate') {
-            // Do something different when a 360-degree image is rotated
-        }
-    } else {}
+preview.addListener('viewerevent', data => {
+  if (data.viewerName === 'Image') {
+    if (data.event === 'rotate') {
+      // Do something when an image preview is rotated
+    }
+  } else if (data.viewerName === 'Image360') {
+    if (data.event === 'rotate') {
+      // Do something different when a 360-degree image is rotated
+    }
+  } else {
+  }
 });
 
-preview.addListener('rotate', (data) => {
-    if (data.viewerName === 'Image') {
-        // Do something when an image preview is rotated
-    } else if (data.viewerName === 'Image360') {
-        // Do something different when a 360-degree image is rotated
-    } else {}
+preview.addListener('rotate', data => {
+  if (data.viewerName === 'Image') {
+    // Do something when an image preview is rotated
+  } else if (data.viewerName === 'Image360') {
+    // Do something different when a 360-degree image is rotated
+  } else {
+  }
 });
 ```
 
-Development Setup
------------------
+## Development Setup
+
 1. Install latest LTS version of Node v8.9.4 or higher.
 2. Install yarn package manager `https://yarnpkg.com/en/docs/install`. Alternatively, you can replace any `yarn` command with `npm`.
 3. Fork the upstream repo `https://github.com/box/box-content-preview`.
@@ -352,61 +372,49 @@ Development Setup
 8. Install dependencies `yarn install`
 9. Test your first build! `yarn build`
 10. To automatically rsync files after a Webpack build, add a build/rsync.json file with a `location` field. This file should look like:
+
 ```
 {
     "location": "YOUR_DESIRED_RSYNC_LOCATION_HERE"
 }
 ```
 
-While Developing
-----------------
+## While Developing
+
 Install the following plugins in your preferred editor
 
-* Editor Config (standardizes basic editor configuration)
-* ESLint (Javascript linting)
-* Prettier & Prettier - ESLint (Automatic Javascript formatting following ESLint config)
-* Stylelint (CSS linting)
+- Editor Config (standardizes basic editor configuration)
+- ESLint (Javascript linting)
+- Prettier & Prettier - ESLint (Automatic Javascript formatting following ESLint config)
+- Stylelint (CSS linting)
 
 ### Yarn commands
 
-* `yarn build` to generate resource bundles and JS webpack bundles.
-* `yarn start` to only generate JS webpack bundles on file changes.
-* `yarn start:dev` to launch a webpack-dev-server instance for local development.
-* `yarn test` launches karma tests with PhantomJS.
-* `yarn test -- --src=PATH/TO/SRC/FILENAME` launches test only for `src/lib/PATH/TO/SRC/__tests__/FILENAME-test.js` instead of all tests. For example, `yarn test -- --src=viewers/media/MediaBase` launches tests for `src/lib/viewers/media/__tests__/MediaBase-test.js`. This also works for directories, e.g. `yarn test -- --src=viewers/doc/`.
-* `yarn test:watch` launches karma tests with PhantomJS for debugging. Open the URL mentioned in the console.
-* `yarn test:watch -- --src=path/to/src/FILENAME` launches debugging for `src/lib/path/to/src/__tests__/FILENAME-test.js` instead of all tests. Open the URL mentioned in the console.
+- `yarn build` to generate resource bundles and JS webpack bundles.
+- `yarn start` to only generate JS webpack bundles on file changes.
+- `yarn start:dev` to launch a webpack-dev-server instance for local development.
+- `yarn test` launches karma tests with PhantomJS.
+- `yarn test -- --src=PATH/TO/SRC/FILENAME` launches test only for `src/lib/PATH/TO/SRC/__tests__/FILENAME-test.js` instead of all tests. For example, `yarn test -- --src=viewers/media/MediaBase` launches tests for `src/lib/viewers/media/__tests__/MediaBase-test.js`. This also works for directories, e.g. `yarn test -- --src=viewers/doc/`.
+- `yarn test:watch` launches karma tests with PhantomJS for debugging. Open the URL mentioned in the console.
+- `yarn test:watch -- --src=path/to/src/FILENAME` launches debugging for `src/lib/path/to/src/__tests__/FILENAME-test.js` instead of all tests. Open the URL mentioned in the console.
 
 For more script commands see `package.json`. Test coverage reports are available under reports/coverage.
 
-### Config files
+## Support
 
-* .babelrc - https://babeljs.io/docs/usage/babelrc/
-* .editorconfig - http://editorconfig.org/
-* .eslintignore - http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories
-* .eslintrc - http://eslint.org/docs/user-guide/configuring
-* .gitignore - https://git-scm.com/docs/gitignore
-* .stylelintrc - https://stylelint.io/user-guide/configuration/
-* .travis.yml - https://docs.travis-ci.com/user/customizing-the-build
-* browserslist - https://github.com/ai/browserslist
-* commitlint.config.js - https://github.com/marionebl/commitlint
-* postcss.config.js - https://github.com/postcss/postcss-loader
-
-Support
--------
 If you have any questions, please search our [issues list](https://github.com/box/box-content-preview/issues) to see if they have been previously answered. Report new issues [here](https://github.com/box/box-content-preview/issues/new).
 
 For general Box Platform, API, and Box Element questions, please visit our [developer forum](https://community.box.com/t5/Developer-Forum/bd-p/DeveloperForum) or contact us via one of our [available support channels](https://community.box.com/t5/Community/ct-p/English).
 
-Copyright and License
----------------------
+## Copyright and License
+
 Copyright 2016-present Box, Inc. All Rights Reserved.
 
 Licensed under the Box Software License Agreement v.20170516.
 You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   https://developer.box.com/docs/box-sdk-license
+https://developer.box.com/docs/box-sdk-license
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,11 +1,11 @@
-Upgrading Guide
-=========================
+# Upgrading Guide
 
-Upgrading from 1.x to 2.x
--------------------------
+## Upgrading from 1.x to 2.x
+
 Version 2 includes a breaking change to the DOM structure of the Preview element.
 
 In version 1, the `.bp-navigate` buttons were siblings with the `.bp` container div
+
 ```
 <div class="bp" tabindex="0">
     ...
@@ -17,7 +17,9 @@ In version 1, the `.bp-navigate` buttons were siblings with the `.bp` container 
     ...
 </button>
 ```
+
 But in version 2, the buttons are now inside a new container div `.bp-content`.
+
 ```
 <div class="bp" tabindex="0">
     <div class="bp-content">

--- a/build/release.sh
+++ b/build/release.sh
@@ -143,7 +143,7 @@ update_readme() {
 
 push_to_github() {
     # Add new files
-    git commit -am "Release: $VERSION"
+    git commit -am "chore(release): $VERSION"
 
     # Force update tag after updating files
     git tag -a v$VERSION -m $VERSION

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "chai": "^4.2.0",
         "chai-dom": "^1.8.1",
         "conventional-changelog-cli": "^2.0.5",
-        "conventional-github-releaser": "^2.0.0",
+        "conventional-github-releaser": "^3.1.3",
         "create-react-class": "^15.6.2",
         "css-loader": "^0.28.7",
         "cssnano-cli": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,6 +523,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+  integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
+
 "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
@@ -2204,6 +2209,19 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  integrity sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 cachedir@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.3.0.tgz#5e01928bf2d95b5edd94b0942188246740e0dbc4"
@@ -2606,6 +2624,13 @@ clone-regexp@^1.0.0:
     is-regexp "^1.0.0"
     is-supported-regexp-flag "^1.0.0"
 
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  dependencies:
+    mimic-response "^1.0.0"
+
 clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
@@ -2882,14 +2907,7 @@ conventional-changelog-angular@^5.0.3:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-atom@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz#4917759947f4db86073f9d3838a2d54302d5843d"
-  integrity sha512-4+hmbBwcAwx1XzDZ4aEOxk/ONU0iay10G0u/sld16ksgnRUHN7CxmZollm3FFaptr6VADMq1qxomA+JlpblBlg==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-atom@^2.0.1:
+conventional-changelog-atom@^2.0.0, conventional-changelog-atom@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-2.0.1.tgz#dc88ce650ffa9ceace805cbe70f88bfd0cb2c13a"
   integrity sha512-9BniJa4gLwL20Sm7HWSNXd0gd9c5qo49gCi8nylLFpqAHhkFTj7NQfROq3f1VpffRtzfTQp4VKU5nxbe2v+eZQ==
@@ -2907,14 +2925,7 @@ conventional-changelog-cli@^2.0.5:
     meow "^4.0.0"
     tempfile "^1.1.1"
 
-conventional-changelog-codemirror@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz#debc43991d487d7964e65087fbbe034044bd51fb"
-  integrity sha512-8M7pGgQVzRU//vG3rFlLYqqBywOLxu9XM0/lc1/1Ll7RuKA79PgK9TDpuPmQDHFnqGS7D1YiZpC3Z0D9AIYExg==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-codemirror@^2.0.1:
+conventional-changelog-codemirror@^2.0.0, conventional-changelog-codemirror@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.1.tgz#acc046bc0971460939a0cc2d390e5eafc5eb30da"
   integrity sha512-23kT5IZWa+oNoUaDUzVXMYn60MCdOygTA2I+UjnOMiYVhZgmVwNd6ri/yDlmQGXHqbKhNR5NoXdBzSOSGxsgIQ==
@@ -2929,26 +2940,7 @@ conventional-changelog-conventionalcommits@^3.0.2:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-core@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz#45b6347c4c6512e1f163f7ff55c9f5bcb88fd990"
-  integrity sha512-lP1s7Z3NyEFcG78bWy7GG7nXsq9OpAJgo2xbyAlVBDweLSL5ghvyEZlkEamnAQpIUVK0CAVhs8nPvCiQuXT/VA==
-  dependencies:
-    conventional-changelog-writer "^3.0.4"
-    conventional-commits-parser "^2.1.5"
-    dateformat "^3.0.0"
-    get-pkg-repo "^1.0.0"
-    git-raw-commits "^1.3.4"
-    git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.3.4"
-    lodash "^4.2.1"
-    normalize-package-data "^2.3.5"
-    q "^1.5.1"
-    read-pkg "^1.1.0"
-    read-pkg-up "^1.0.1"
-    through2 "^2.0.0"
-
-conventional-changelog-core@^3.2.2:
+conventional-changelog-core@^3.1.0, conventional-changelog-core@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz#de41e6b4a71011a18bcee58e744f6f8f0e7c29c0"
   integrity sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==
@@ -2967,24 +2959,17 @@ conventional-changelog-core@^3.2.2:
     read-pkg-up "^3.0.0"
     through2 "^3.0.0"
 
-conventional-changelog-ember@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz#f3825d7434168f3d9211b5532dc1d5769532b668"
-  integrity sha512-hBM1xb5IrjNtsjXaGryPF/Wn36cwyjkNeqX/CIDbJv/1kRFBHsWoSPYBiNVEpg8xE5fcK4DbPhGTDN2sVoPeiA==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-ember@^2.0.2:
+conventional-changelog-ember@^2.0.1, conventional-changelog-ember@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-2.0.2.tgz#284ffdea8c83ea8c210b65c5b4eb3e5cc0f4f51a"
   integrity sha512-qtZbA3XefO/n6DDmkYywDYi6wDKNNc98MMl2F9PKSaheJ25Trpi3336W8fDlBhq0X+EJRuseceAdKLEMmuX2tg==
   dependencies:
     q "^1.5.1"
 
-conventional-changelog-eslint@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.5.tgz#8bae05ebbf574e6506caf7b37dc51ca21b74d220"
-  integrity sha512-7NUv+gMOS8Y49uPFRgF7kuLZqpnrKa2bQMZZsc62NzvaJmjUktnV03PYHuXhTDEHt5guvV9gyEFtUpgHCDkojg==
+conventional-changelog-eslint@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.1.tgz#f65e0e7f63dc09c044244b8785313a602e628002"
+  integrity sha512-yH3+bYrtvgKxSFChUBQnKNh9/U9kN2JElYBm253VpYs5wXhPHVc9ENcuVGWijh24nnOkei7wEJmnmUzgZ4ok+A==
   dependencies:
     q "^1.5.1"
 
@@ -2995,14 +2980,7 @@ conventional-changelog-eslint@^3.0.2:
   dependencies:
     q "^1.5.1"
 
-conventional-changelog-express@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz#812a9cf778677e12f978ac9c40d85297c0bfcca9"
-  integrity sha512-M+UUb715TXT6l9vyMf4HYvAepnQn0AYTcPi6KHrFsd80E0HErjQnqStBg8i3+Qm7EV9+RyATQEnIhSzHbdQ7+A==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-express@^2.0.1:
+conventional-changelog-express@^2.0.0, conventional-changelog-express@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-2.0.1.tgz#fea2231d99a5381b4e6badb0c1c40a41fcacb755"
   integrity sha512-G6uCuCaQhLxdb4eEfAIHpcfcJ2+ao3hJkbLrw/jSK/eROeNfnxCJasaWdDAfFkxsbpzvQT4W01iSynU3OoPLIw==
@@ -3030,15 +3008,7 @@ conventional-changelog-jscs@^0.1.0:
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-jshint@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz#b2de33cd0870d9af804ac6a4fded0ee25b69c9bb"
-  integrity sha512-CdrqwDgL56b176FVxHmhuOvnO1dRDQvrMaHyuIVjcFlOXukATz2wVT17g8jQU3LvybVbyXvJRbdD5pboo7/1KQ==
-  dependencies:
-    compare-func "^1.3.1"
-    q "^1.5.1"
-
-conventional-changelog-jshint@^2.0.1:
+conventional-changelog-jshint@^2.0.0, conventional-changelog-jshint@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.1.tgz#11c0e8283abf156a4ff78e89be6fdedf9bd72202"
   integrity sha512-kRFJsCOZzPFm2tzRHULWP4tauGMvccOlXYf3zGeuSW4U0mZhk5NsjnRZ7xFWrTFPlCLV+PNmHMuXp5atdoZmEg==
@@ -3046,31 +3016,15 @@ conventional-changelog-jshint@^2.0.1:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-preset-loader@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz#b29af6332f9313857be36427623c9016bfeeaf33"
-  integrity sha512-yWPIP9wwsCKeUSPYApnApWhKIDjWRIX/uHejGS1tYfEsQR/bwpDFET7LYiHT+ujNbrlf6h1s3NlPGheOd4yJRQ==
+conventional-changelog-preset-loader@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz#81d1a07523913f3d17da3a49f0091f967ad345b0"
+  integrity sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==
 
 conventional-changelog-preset-loader@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz#65bb600547c56d5627d23135154bcd9a907668c4"
   integrity sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==
-
-conventional-changelog-writer@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz#705b46a8b8277bd7fd79cad8032095b5d803864c"
-  integrity sha512-EUf/hWiEj3IOa5Jk8XDzM6oS0WgijlYGkUfLc+mDnLH9RwpZqhYIBwgJHWHzEB4My013wx2FhmUu45P6tQrucw==
-  dependencies:
-    compare-func "^1.3.1"
-    conventional-commits-filter "^1.1.5"
-    dateformat "^3.0.0"
-    handlebars "^4.0.2"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    semver "^5.5.0"
-    split "^1.0.0"
-    through2 "^2.0.0"
 
 conventional-changelog-writer@^4.0.5:
   version "4.0.6"
@@ -3088,22 +3042,22 @@ conventional-changelog-writer@^4.0.5:
     split "^1.0.0"
     through2 "^3.0.0"
 
-conventional-changelog@^1.1.0:
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.18.tgz#ffe28798e4ddef5f6e2f74398e8248bcb233360b"
-  integrity sha512-swf5bqhm7PsY2cw6zxuPy6+rZiiGwEpQnrWki+L+z2oZI53QSYwU4brpljmmWss821AsiwmVL+7V6hP+ER+TBA==
+conventional-changelog@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-2.0.3.tgz#779cff582c0091d2b24574003eaa82ef5ddf653d"
+  integrity sha512-4bcII9cJHSKb2qi9e8qGF6aJHLf/AB0dokhyR+X6QILTMl77s4l163vK+reXhajvfOYbbHQvsrWybr5+PKZwNA==
   dependencies:
     conventional-changelog-angular "^1.6.6"
-    conventional-changelog-atom "^0.2.4"
-    conventional-changelog-codemirror "^0.3.4"
-    conventional-changelog-core "^2.0.5"
-    conventional-changelog-ember "^0.3.6"
-    conventional-changelog-eslint "^1.0.5"
-    conventional-changelog-express "^0.3.4"
+    conventional-changelog-atom "^2.0.0"
+    conventional-changelog-codemirror "^2.0.0"
+    conventional-changelog-core "^3.1.0"
+    conventional-changelog-ember "^2.0.1"
+    conventional-changelog-eslint "^3.0.0"
+    conventional-changelog-express "^2.0.0"
     conventional-changelog-jquery "^0.1.0"
     conventional-changelog-jscs "^0.1.0"
-    conventional-changelog-jshint "^0.3.4"
-    conventional-changelog-preset-loader "^1.1.6"
+    conventional-changelog-jshint "^2.0.0"
+    conventional-changelog-preset-loader "^2.0.1"
 
 conventional-changelog@^3.1.8:
   version "3.1.8"
@@ -3122,14 +3076,6 @@ conventional-changelog@^3.1.8:
     conventional-changelog-jshint "^2.0.1"
     conventional-changelog-preset-loader "^2.1.1"
 
-conventional-commits-filter@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz#77aac065e3de9c1a74b801e8e25c9affb3184f65"
-  integrity sha512-mj3+WLj8UZE72zO9jocZjx8+W4Bwnx/KHoIz1vb4F8XUXj0XSjp8Y3MFkpRyIpsRiCBX+DkDjxGKF/nfeu7BGw==
-  dependencies:
-    is-subset "^0.1.1"
-    modify-values "^1.0.0"
-
 conventional-commits-filter@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz#f122f89fbcd5bb81e2af2fcac0254d062d1039c1"
@@ -3138,7 +3084,7 @@ conventional-commits-filter@^2.0.2:
     lodash.ismatch "^4.4.0"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^2.1.0, conventional-commits-parser@^2.1.5:
+conventional-commits-parser@^2.1.0:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz#9ac3a4ab221c0c3c9e9dd2c09ae01e6d1e1dabe0"
   integrity sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==
@@ -3164,21 +3110,22 @@ conventional-commits-parser@^3.0.2:
     through2 "^3.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-github-releaser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/conventional-github-releaser/-/conventional-github-releaser-2.0.0.tgz#eed95c3f5c37b93ecbf2a2ed2fefb9fc26e1d31b"
-  integrity sha1-7tlcP1w3uT7L8qLtL++5/Cbh0xs=
+conventional-github-releaser@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/conventional-github-releaser/-/conventional-github-releaser-3.1.3.tgz#0074165abd0da675e56cfd08b3601de8faa4dcba"
+  integrity sha512-Yt2h9FrpMZV9geO38aXqCvd5N3YGnXZ07Du2kWjSWnBE+QIqcp+dAat/svvWfQyyKMiB1otcZidetPJoKRauqA==
   dependencies:
-    conventional-changelog "^1.1.0"
+    conventional-changelog "^2.0.0"
     dateformat "^3.0.0"
-    gh-got "^6.0.0"
-    git-semver-tags "^1.0.0"
+    debug "^3.1.0"
+    gh-got "^7.0.0"
+    git-semver-tags "^2.0.0"
     lodash.merge "^4.0.2"
-    meow "^3.3.0"
+    meow "^5.0.0"
     object-assign "^4.0.1"
     q "^1.4.1"
     semver "^5.0.1"
-    semver-regex "^1.0.0"
+    semver-regex "^2.0.0"
     through2 "^2.0.0"
 
 convert-source-map@^1.1.0:
@@ -3610,7 +3557,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^3.2.0:
+decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
@@ -5128,6 +5075,14 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-access@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
@@ -5279,7 +5234,7 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
-get-stream@^3.0.0:
+get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
@@ -5310,12 +5265,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-got@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/gh-got/-/gh-got-6.0.0.tgz#d74353004c6ec466647520a10bd46f7299d268d0"
-  integrity sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==
+gh-got@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/gh-got/-/gh-got-7.1.0.tgz#f2b14eef375ce49b66d5f034a1c124f56dc5bcf0"
+  integrity sha512-KeWkkhresa7sbpzQLYzITMgez5rMigUsijhmSAHcLDORIMUbdlkdoZyaN1wQvIjmUZnyb/wkAPaXb4MQKX0mdQ==
   dependencies:
-    got "^7.0.0"
+    got "^8.0.0"
     is-plain-obj "^1.1.0"
 
 git-raw-commits@2.0.0:
@@ -5329,7 +5284,7 @@ git-raw-commits@2.0.0:
     split2 "^2.0.0"
     through2 "^2.0.0"
 
-git-raw-commits@^1.3.0, git-raw-commits@^1.3.4:
+git-raw-commits@^1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.4.tgz#442c3df5985b4f5689e9e43597f5194736aac001"
   integrity sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==
@@ -5348,15 +5303,7 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^1.0.0, git-semver-tags@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.4.tgz#2ceb2a355c6d7514c123c35e297067d08caf3a92"
-  integrity sha512-Xe2Z74MwXZfAezuaO6e6cA4nsgeCiARPzaBp23gma325c/OXdt//PhrknptIaynNeUp2yWtmikV7k5RIicgGIQ==
-  dependencies:
-    meow "^4.0.0"
-    semver "^5.5.0"
-
-git-semver-tags@^2.0.2:
+git-semver-tags@^2.0.0, git-semver-tags@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.2.tgz#f506ec07caade191ac0c8d5a21bdb8131b4934e3"
   integrity sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==
@@ -5561,24 +5508,27 @@ gonzales-pe@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
-got@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
-  integrity sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==
+got@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.2.tgz#1d23f64390e97f776cac52e5b936e5f514d2e937"
+  integrity sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==
   dependencies:
-    decompress-response "^3.2.0"
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
     duplexer3 "^0.1.4"
     get-stream "^3.0.0"
-    is-plain-obj "^1.1.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
     isurl "^1.0.0-alpha5"
     lowercase-keys "^1.0.0"
-    p-cancelable "^0.3.0"
-    p-timeout "^1.1.1"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    url-parse-lax "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
@@ -5609,7 +5559,7 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
-handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.1.0:
+handlebars@^4.0.1, handlebars@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -5862,6 +5812,11 @@ htmlparser2@^3.10.0:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -6110,6 +6065,14 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
+
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  integrity sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.3"
@@ -6483,20 +6446,15 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-retry-allowed@^1.0.0:
+is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
-  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
 is-supported-regexp-flag@^1.0.0:
   version "1.0.0"
@@ -6754,6 +6712,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
@@ -6998,6 +6961,13 @@ kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
   integrity sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
+  dependencies:
+    json-buffer "3.0.0"
 
 killable@^1.0.0:
   version "1.0.1"
@@ -7501,7 +7471,7 @@ loud-rejection@^1.0.0, loud-rejection@^1.6.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lowercase-keys@^1.0.0:
+lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
   integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
@@ -8212,6 +8182,15 @@ normalize-selector@^0.2.0:
   resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
   integrity sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  integrity sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 normalize-url@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
@@ -8531,15 +8510,20 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-cancelable@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
-  integrity sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
+p-cancelable@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
+  integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
 
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
 p-limit@^1.1.0:
   version "1.2.0"
@@ -8586,10 +8570,10 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
-p-timeout@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
-  integrity sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  integrity sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==
   dependencies:
     p-finally "^1.0.0"
 
@@ -9340,10 +9324,15 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.0, prepend-http@^1.0.1:
+prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -9575,6 +9564,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -9720,7 +9718,7 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
-read-pkg@^1.0.0, read-pkg@^1.1.0:
+read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
   integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
@@ -9765,6 +9763,19 @@ read-pkg@^4.0.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^2.0.0, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.0:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.3.3:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
@@ -9776,19 +9787,6 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.0:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -10184,6 +10182,13 @@ resolve@^1.2.0, resolve@^1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -10385,10 +10390,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-semver-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
-  integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0:
   version "5.5.0"
@@ -10724,6 +10729,13 @@ sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
   integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
+  dependencies:
+    is-plain-obj "^1.0.0"
+
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
   dependencies:
     is-plain-obj "^1.0.0"
 
@@ -11430,7 +11442,7 @@ time-stamp@^2.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.2.0.tgz#917e0a66905688790ec7bbbde04046259af83f57"
   integrity sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==
 
-timed-out@^4.0.0:
+timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
@@ -11814,12 +11826,12 @@ url-join@^2.0.2:
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
   integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
 
-url-parse-lax@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
-    prepend-http "^1.0.1"
+    prepend-http "^2.0.0"
 
 url-parse@^1.1.8, url-parse@^1.4.3:
   version "1.4.4"


### PR DESCRIPTION
We should consider moving to semantic-release in the future, but that will require additional effort. I also ran all the MD files through prettier since they're modified during release.