### PR TITLE
fix: prevent printing via browser

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1270,6 +1270,8 @@ class Preview extends EventEmitter {
             if (checkFeature(this.viewer, 'print')) {
                 this.ui.showPrintButton(this.print);
             }
+        } else {
+            this.ui.preventBrowserPrinting();
         }
 
         const { error } = data;

--- a/src/lib/PreviewUI.js
+++ b/src/lib/PreviewUI.js
@@ -426,6 +426,30 @@ class PreviewUI {
         const loadingDownloadButtonEl = loadingWrapperEl.querySelector(SELECTOR_BOX_PREVIEW_BTN_LOADING_DOWNLOAD);
         loadingDownloadButtonEl.textContent = __('download_file');
     }
+
+    /**
+     * Attempts to prevent printing using the browser.
+     *
+     * @private
+     * @return {void}
+     */
+    preventBrowserPrinting() {
+        const sheet = document.styleSheets[0];
+        // Doesn't matter which stylesheet is picked up.
+        // Under most circumstances there should be a stylesheet.
+        // However a user may remove all of them manually.
+        if (sheet) {
+            sheet.insertRule(`
+                @media print {
+                    ${SELECTOR_BOX_PREVIEW},
+                    ${SELECTOR_BOX_PREVIEW_CONTAINER},
+                    ${SELECTOR_BOX_PREVIEW_CONTENT} {
+                        display: none !important;
+                    }
+                }
+            `);
+        }
+    }
 }
 
 export default PreviewUI;

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1814,6 +1814,7 @@ describe('lib/Preview', () => {
             stubs.showDownloadButton = sandbox.stub(preview.ui, 'showDownloadButton');
             stubs.showPrintButton = sandbox.stub(preview.ui, 'showPrintButton');
             stubs.hideLoadingIndicator = sandbox.stub(preview.ui, 'hideLoadingIndicator');
+            stubs.preventBrowserPrinting = sandbox.stub(preview.ui, 'preventBrowserPrinting');
             stubs.emit = sandbox.stub(preview, 'emit');
             stubs.logPreviewEvent = sandbox.stub(preview, 'logPreviewEvent');
             stubs.prefetchNextFiles = sandbox.stub(preview, 'prefetchNextFiles');
@@ -1839,12 +1840,14 @@ describe('lib/Preview', () => {
             stubs.canDownload.returns(true);
             preview.finishLoading();
             expect(stubs.showDownloadButton).to.be.called;
+            expect(stubs.preventBrowserPrinting).to.not.be.called;
         });
 
         it("should not show download button if file can't be downloaded", () => {
             stubs.canDownload.returns(false);
             preview.finishLoading();
             expect(stubs.showDownloadButton).to.not.be.called;
+            expect(stubs.preventBrowserPrinting).to.be.called;
         });
 
         it('should show print button if print is supported', () => {
@@ -1852,6 +1855,7 @@ describe('lib/Preview', () => {
             stubs.canDownload.returns(true);
             preview.finishLoading();
             expect(stubs.showPrintButton).to.be.called;
+            expect(stubs.preventBrowserPrinting).to.not.be.called;
         });
 
         it('should not show print button if print is not supported', () => {
@@ -1859,6 +1863,7 @@ describe('lib/Preview', () => {
             stubs.canDownload.returns(true);
             preview.finishLoading();
             expect(stubs.showPrintButton).to.not.be.called;
+            expect(stubs.preventBrowserPrinting).to.be.called;
         });
 
         it("should not show print button if file can't be downloaded", () => {

--- a/src/lib/__tests__/PreviewUI-test.js
+++ b/src/lib/__tests__/PreviewUI-test.js
@@ -395,4 +395,13 @@ describe('lib/PreviewUI', () => {
             expect(ui.isSetup()).to.be.true;
         });
     });
+
+    describe('preventBrowserPrinting()', () => {
+        it('should insert media print rules', () => {
+            ui.preventBrowserPrinting();
+            const sheet = document.styleSheets[0];
+
+            console.error(sheet);
+        });
+    });
 });


### PR DESCRIPTION
when there is no download permission. This still does not prevent other ways to print/get data.