### PR TITLE
feat(dashviewer): Video performance instrumentation

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -90,3 +90,17 @@ export const USER_DOCUMENT_THUMBNAIL_EVENTS = {
 };
 
 export const MISSING_EXTERNAL_REFS = 'missing_x_refs';
+
+export const MEDIA_METRIC = {
+    bufferFill: 'bufferFill',
+    duration: 'duration',
+    lagRatio: 'lagRatio',
+    seeked: 'seeked',
+    totalBufferLag: 'totalBufferLag',
+    watchLength: 'watchLength',
+};
+
+export const MEDIA_METRIC_EVENTS = {
+    bufferFill: 'media_metric_buffer_fill',
+    endPlayback: 'media_metric_end_playback',
+};

--- a/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
+++ b/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
@@ -44,6 +44,7 @@ describe('lib/viewers/box3d/video360/Video360Viewer', () => {
         options.container = containerEl;
         options.location = {};
         viewer = new Video360Viewer(options);
+        sandbox.stub(viewer, 'processMetrics');
     });
 
     afterEach(() => {

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -107,8 +107,7 @@ class DashViewer extends VideoBaseViewer {
      * @return {void}
      */
     load() {
-        // Add event listeners for the media element
-        this.addEventListenersForMediaElement();
+        this.loadUI();
 
         this.mediaUrl = this.options.representation.content.url_template;
         this.watermarkCacheBust = Date.now();
@@ -661,7 +660,6 @@ class DashViewer extends VideoBaseViewer {
         }
 
         this.calculateVideoDimensions();
-        this.loadUI();
 
         if (this.isAutoplayEnabled()) {
             this.autoplay();

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -648,9 +648,8 @@ class DashViewer extends VideoBaseViewer {
             return;
         }
 
-        this.loadUI();
-
         this.calculateVideoDimensions();
+        this.loadUI();
 
         if (this.isAutoplayEnabled()) {
             this.autoplay();

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -200,7 +200,7 @@ class DashViewer extends VideoBaseViewer {
             Timer.start(tag);
         } else {
             Timer.stop(tag);
-            this.metrics[MEDIA_METRIC.totalBufferLag] = this.metrics[MEDIA_METRIC.totalBufferLag] || 0;
+            this.metrics[MEDIA_METRIC.totalBufferLag] = this.metrics[MEDIA_METRIC.totalBufferLag];
             this.metrics[MEDIA_METRIC.totalBufferLag] += Timer.get(tag).elapsed;
             Timer.reset(tag);
         }

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -194,7 +194,7 @@ class DashViewer extends VideoBaseViewer {
      * @param {boolean} object.buffering - Indicates whether the player is buffering or not
      */
     handleBuffering({ buffering }) {
-        const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.totalBufferLag);
+        const tag = this.createTimerTag(MEDIA_METRIC.totalBufferLag);
 
         if (buffering) {
             Timer.start(tag);
@@ -212,7 +212,7 @@ class DashViewer extends VideoBaseViewer {
      * @return {void}
      */
     processBufferFillMetric() {
-        const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.bufferFill);
+        const tag = this.createTimerTag(MEDIA_METRIC.bufferFill);
         const bufferFill = Timer.get(tag).elapsed;
         this.metrics[MEDIA_METRIC.bufferFill] = bufferFill;
 
@@ -230,22 +230,22 @@ class DashViewer extends VideoBaseViewer {
             return;
         }
 
-        const lagLength = this.metrics[MEDIA_METRIC.totalBufferLag];
-        const playLength = this.determinePlayLength();
+        const totalBufferLag = this.metrics[MEDIA_METRIC.totalBufferLag];
+        const watchLength = this.determineWatchLength();
 
-        this.metrics[MEDIA_METRIC.totalBufferLag] = lagLength;
-        this.metrics[MEDIA_METRIC.lagRatio] = lagLength / playLength;
+        this.metrics[MEDIA_METRIC.totalBufferLag] = totalBufferLag;
+        this.metrics[MEDIA_METRIC.lagRatio] = totalBufferLag / watchLength;
         this.metrics[MEDIA_METRIC.duration] = this.mediaEl ? this.mediaEl.duration * 1000 : 0;
-        this.metrics[MEDIA_METRIC.watchLength] = playLength;
+        this.metrics[MEDIA_METRIC.watchLength] = watchLength;
 
         this.emitMetric(MEDIA_METRIC_EVENTS.endPlayback, { ...this.metrics });
     }
 
     /**
-     * Determines the play length, or how much of the media was consumed
-     * @return {number} - The play length in milliseconds
+     * Determines the watch length, or how much of the media was consumed
+     * @return {number} - The watch length in milliseconds
      */
-    determinePlayLength() {
+    determineWatchLength() {
         if (!this.mediaEl || !this.mediaEl.played) {
             return -1;
         }

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -241,7 +241,7 @@ class DashViewer extends VideoBaseViewer {
         this.metrics[MEDIA_METRIC.duration] = this.mediaEl.duration * 1000;
         this.metrics[MEDIA_METRIC.watchLength] = playLength;
 
-        this.emitMetric(MEDIA_METRIC_EVENTS.endPlayback, this.metrics);
+        this.emitMetric(MEDIA_METRIC_EVENTS.endPlayback, { ...this.metrics });
     }
 
     /**

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -232,7 +232,7 @@ class DashViewer extends VideoBaseViewer {
 
         this.metrics[MEDIA_METRIC.totalBufferLag] = lagLength;
         this.metrics[MEDIA_METRIC.lagRatio] = lagLength / playLength;
-        this.metrics[MEDIA_METRIC.duration] = this.mediaEl.duration * 1000;
+        this.metrics[MEDIA_METRIC.duration] = this.mediaEl ? this.mediaEl.duration * 1000 : 0;
         this.metrics[MEDIA_METRIC.watchLength] = playLength;
 
         this.emitMetric(MEDIA_METRIC_EVENTS.endPlayback, { ...this.metrics });

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -171,8 +171,7 @@ class MediaBaseViewer extends BaseViewer {
     load() {
         super.load();
 
-        // Add event listeners for the media element
-        this.addEventListenersForMediaElement();
+        this.loadUI();
 
         const template = this.options.representation.content.url_template;
         this.mediaUrl = this.createContentUrlWithAuthParams(template);
@@ -217,8 +216,6 @@ class MediaBaseViewer extends BaseViewer {
         if (this.destroyed) {
             return;
         }
-
-        this.loadUI();
 
         if (this.isAutoplayEnabled()) {
             this.autoplay();
@@ -382,6 +379,9 @@ class MediaBaseViewer extends BaseViewer {
 
         // Add event listeners for the media controls
         this.addEventListenersForMediaControls();
+
+        // Add event listeners for the media element
+        this.addEventListenersForMediaElement();
     }
 
     /**
@@ -419,10 +419,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     setTimeCode() {
-        if (!this.mediaControls) {
-            return;
-        }
-
         this.mediaControls.setTimeCode(this.mediaEl.currentTime);
     }
 
@@ -458,10 +454,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     updateVolumeIcon() {
-        if (!this.mediaControls) {
-            return;
-        }
-
         this.mediaControls.updateVolumeIcon(this.mediaEl.volume);
     }
 
@@ -475,10 +467,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     playingHandler() {
-        if (this.mediaControls) {
-            this.mediaControls.showPauseIcon();
-        }
-
+        this.mediaControls.showPauseIcon();
         this.hideLoadingIcon();
         this.handleRate();
         this.handleVolume();
@@ -492,10 +481,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     progressHandler() {
-        if (!this.mediaControls) {
-            return;
-        }
-
         this.mediaControls.updateProgress();
     }
 
@@ -506,10 +491,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     pauseHandler() {
-        if (!this.mediaControls) {
-            return;
-        }
-
         this.mediaControls.showPlayIcon();
     }
 

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -795,7 +795,6 @@ class MediaBaseViewer extends BaseViewer {
         // Make sure it's within bounds
         newTime = Math.max(0, Math.min(newTime, this.mediaEl.duration));
         this.setMediaTime(newTime);
-        this.metrics[MEDIA_METRIC.seeked] = true;
     }
 
     /**

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -753,11 +753,22 @@ class MediaBaseViewer extends BaseViewer {
         this.mediaEl.removeEventListener('volumechange', this.updateVolumeIcon);
     }
 
+    /**
+     * Callback from the 'loadstart' event from the media element. Triggers a timer to measure the initial buffer fill.
+     * @return {void}
+     */
     startBufferFillTimer() {
         const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.bufferFill);
         Timer.start(tag);
     }
 
+    /**
+     * Callback from the 'canplay' event from the media element. The first time this event is triggered we
+     * calculate the initial buffer fill time.
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplay_event}
+     * @emits MEDIA_METRIC_EVENTS.bufferFill
+     * @return {void}
+     */
     stopBufferFillTimer() {
         const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.bufferFill);
         Timer.stop(tag);

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -55,6 +55,8 @@ class MediaBaseViewer extends BaseViewer {
         this.toggleMute = this.toggleMute.bind(this);
         this.togglePlay = this.togglePlay.bind(this);
         this.updateVolumeIcon = this.updateVolumeIcon.bind(this);
+
+        window.addEventListener('beforeunload', this.processMetrics);
     }
 
     /**
@@ -124,6 +126,9 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     destroy() {
+        // Best effort to emit current media metrics as page unloads
+        window.removeEventListener('beforeunload', this.processMetrics);
+
         if (this.mediaControls) {
             this.mediaControls.removeAllListeners();
             this.mediaControls.destroy();
@@ -414,6 +419,10 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     setTimeCode() {
+        if (!this.mediaControls) {
+            return;
+        }
+
         this.mediaControls.setTimeCode(this.mediaEl.currentTime);
     }
 
@@ -449,6 +458,10 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     updateVolumeIcon() {
+        if (!this.mediaControls) {
+            return;
+        }
+
         this.mediaControls.updateVolumeIcon(this.mediaEl.volume);
     }
 
@@ -462,7 +475,10 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     playingHandler() {
-        this.mediaControls.showPauseIcon();
+        if (this.mediaControls) {
+            this.mediaControls.showPauseIcon();
+        }
+
         this.hideLoadingIcon();
         this.handleRate();
         this.handleVolume();
@@ -490,6 +506,10 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     pauseHandler() {
+        if (!this.mediaControls) {
+            return;
+        }
+
         this.mediaControls.showPlayIcon();
     }
 

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -147,10 +147,6 @@ class MediaBaseViewer extends BaseViewer {
         try {
             if (this.mediaEl) {
                 this.removeEventListenersForMediaElement();
-
-                this.mediaEl.removeEventListener('loadeddata', this.loadeddataHandler);
-                this.mediaEl.removeEventListener('error', this.errorHandler);
-
                 this.removePauseEventListener();
                 this.mediaEl.removeAttribute('src');
                 this.mediaEl.load();
@@ -740,6 +736,8 @@ class MediaBaseViewer extends BaseViewer {
     removeEventListenersForMediaElement() {
         this.mediaEl.removeEventListener('canplay', this.handleCanPlay);
         this.mediaEl.removeEventListener('ended', this.mediaendHandler);
+        this.mediaEl.removeEventListener('error', this.errorHandler);
+        this.mediaEl.removeEventListener('loadeddata', this.loadeddataHandler);
         this.mediaEl.removeEventListener('loadstart', this.handleLoadStart);
         this.mediaEl.removeEventListener('pause', this.pauseHandler);
         this.mediaEl.removeEventListener('playing', this.playingHandler);
@@ -754,7 +752,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     handleLoadStart() {
-        const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.bufferFill);
+        const tag = this.createTimerTag(MEDIA_METRIC.bufferFill);
         Timer.start(tag);
     }
 
@@ -766,7 +764,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     handleCanPlay() {
-        const tag = Timer.createTag(this.options.file.id, MEDIA_METRIC.bufferFill);
+        const tag = this.createTimerTag(MEDIA_METRIC.bufferFill);
         Timer.stop(tag);
 
         // Only interested in the first event after 'loadstart' to determine the buffer fill
@@ -966,6 +964,14 @@ class MediaBaseViewer extends BaseViewer {
      */
     getMetricsWhitelist() {
         return [MEDIA_METRIC_EVENTS.bufferFill, MEDIA_METRIC_EVENTS.endPlayback];
+    }
+
+    /**
+     * Utility to create a Timer tag name
+     * @param {string} tagName - tag name
+     */
+    createTimerTag(tagName) {
+        return Timer.createTag(this.options.file.id, tagName);
     }
 }
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -642,6 +642,7 @@ describe('lib/viewers/media/DashViewer', () => {
             sandbox.stub(dash, 'calculateVideoDimensions');
             sandbox.stub(dash, 'loadSubtitles');
             sandbox.stub(dash, 'loadAlternateAudio');
+            sandbox.stub(dash, 'loadUI');
 
             dash.options.autoFocus = true;
             dash.loadeddataHandler();
@@ -655,6 +656,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(dash.loaded).to.be.true;
             expect(document.activeElement).to.equal(dash.mediaContainerEl);
             expect(dash.mediaControls.show).to.be.called;
+            expect(dash.loadUI).to.be.called;
         });
     });
 
@@ -1290,5 +1292,11 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.showGearHdIcon(sdTrack);
             expect(dash.wrapperEl).to.not.have.class(CSS_CLASS_HD);
         });
+    });
+
+    describe('bufferingHandler()', () => {
+        it('should start a timer if buffering is true', () => {});
+
+        it('should start a timer if buffering is true', () => {});
     });
 });

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -148,6 +148,7 @@ describe('lib/viewers/media/DashViewer', () => {
             sandbox.stub(dash, 'loadAssets');
             sandbox.stub(dash, 'isAutoplayEnabled').returns(true);
             sandbox.stub(dash, 'autoplay');
+            sandbox.stub(dash, 'loadUI');
 
             sandbox.stub(dash, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             sandbox.stub(Promise, 'all').returns(stubs.promise);
@@ -159,6 +160,7 @@ describe('lib/viewers/media/DashViewer', () => {
                     expect(dash.loadDashPlayer).to.be.called;
                     expect(dash.resetLoadTimeout).to.be.called;
                     expect(dash.autoplay).to.be.called;
+                    expect(dash.loadUI).to.be.called;
                 })
                 .catch(() => {});
         });
@@ -224,6 +226,7 @@ describe('lib/viewers/media/DashViewer', () => {
             sandbox.stub(shaka, 'Player').returns(dash.player);
             stubs.mockPlayer.expects('addEventListener').withArgs('adaptation', sinon.match.func);
             stubs.mockPlayer.expects('addEventListener').withArgs('error', sinon.match.func);
+            stubs.mockPlayer.expects('addEventListener').withArgs('buffering', sinon.match.func);
             stubs.mockPlayer.expects('configure');
             stubs.mockPlayer
                 .expects('load')
@@ -631,7 +634,6 @@ describe('lib/viewers/media/DashViewer', () => {
             sandbox.stub(dash, 'isAutoplayEnabled').returns(true);
             sandbox.stub(dash, 'autoplay');
             sandbox.stub(dash, 'loadFilmStrip');
-            sandbox.stub(dash, 'loadUI');
             sandbox.stub(dash, 'resize');
             sandbox.stub(dash, 'handleVolume');
             sandbox.stub(dash, 'startBandwidthTracking');
@@ -644,7 +646,6 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.options.autoFocus = true;
             dash.loadeddataHandler();
             expect(dash.autoplay).to.be.called;
-            expect(dash.loadUI).to.be.called;
             expect(dash.showMedia).to.be.called;
             expect(dash.showPlayButton).to.be.called;
             expect(dash.calculateVideoDimensions).to.be.called;

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1295,7 +1295,7 @@ describe('lib/viewers/media/DashViewer', () => {
         });
     });
 
-    describe('bufferingHandler()', () => {
+    describe('handleBuffering()', () => {
         beforeEach(() => {
             sandbox.stub(Timer, 'createTag').returns('foo');
             sandbox.stub(Timer, 'get').returns({ elapsed: 5 });
@@ -1305,7 +1305,7 @@ describe('lib/viewers/media/DashViewer', () => {
         });
 
         it('should start a timer if buffering is true', () => {
-            dash.bufferingHandler({ buffering: true });
+            dash.handleBuffering({ buffering: true });
             expect(Timer.start).to.have.been.called;
             expect(Timer.stop).not.to.have.been.called;
             expect(Timer.reset).not.to.have.been.called;
@@ -1313,7 +1313,7 @@ describe('lib/viewers/media/DashViewer', () => {
         });
 
         it('should stop the timer if buffering is false', () => {
-            dash.bufferingHandler({ buffering: false });
+            dash.handleBuffering({ buffering: false });
             expect(Timer.start).not.to.have.been.called;
             expect(Timer.stop).to.have.been.called;
             expect(Timer.reset).to.have.been.called;
@@ -1339,10 +1339,31 @@ describe('lib/viewers/media/DashViewer', () => {
     });
 
     describe('processMetrics()', () => {
-        it('should process the current playback metrics', () => {
+        beforeEach(() => {
             sandbox.stub(dash, 'determinePlayLength').returns(10);
             sandbox.stub(dash, 'emitMetric');
             dash.mediaEl.duration = 5;
+        });
+
+        it('should not emit an event if loaded is false', () => {
+            dash.loaded = false;
+            const expMetrics = {
+                bufferFill: 0,
+                duration: 0,
+                lagRatio: 0,
+                seeked: false,
+                totalBufferLag: 0,
+                watchLength: 0,
+            };
+
+            dash.processMetrics();
+
+            expect(dash.emitMetric).not.to.have.been.called;
+            expect(dash.metrics).to.be.eql(expMetrics);
+        });
+
+        it('should process the current playback metrics if loaded', () => {
+            dash.loaded = true;
             dash.metrics.totalBufferLag = 1000;
 
             const expMetrics = {

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -10,7 +10,6 @@ import { VIEWER_EVENT } from '../../../events';
 
 let dash;
 let stubs = {};
-let mediaElRef;
 
 const CSS_CLASS_MEDIA = 'bp-media';
 const CSS_CLASS_HD = 'bp-media-controls-is-hd';
@@ -100,7 +99,6 @@ describe('lib/viewers/media/DashViewer', () => {
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
         dash.containerEl = containerEl;
         dash.setup();
-        mediaElRef = dash.mediaEl;
     });
 
     afterEach(() => {
@@ -109,7 +107,6 @@ describe('lib/viewers/media/DashViewer', () => {
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (dash && typeof dash.destroy === 'function' && !dash.destroyed) {
-            dash.mediaEl = mediaElRef;
             dash.destroy();
         }
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1340,7 +1340,7 @@ describe('lib/viewers/media/DashViewer', () => {
 
     describe('processMetrics()', () => {
         beforeEach(() => {
-            sandbox.stub(dash, 'determinePlayLength').returns(10);
+            sandbox.stub(dash, 'determineWatchLength').returns(10);
             sandbox.stub(dash, 'emitMetric');
             dash.mediaEl.duration = 5;
         });
@@ -1382,23 +1382,23 @@ describe('lib/viewers/media/DashViewer', () => {
         });
     });
 
-    describe('determinePlayLength()', () => {
+    describe('determineWatchLength()', () => {
         it('should return -1 if mediaEl does not exist', () => {
             dash.mediaEl = null;
 
-            expect(dash.determinePlayLength()).to.be.equal(-1);
+            expect(dash.determineWatchLength()).to.be.equal(-1);
         });
 
         it('should return -1 if mediaEl.played is falsy', () => {
             dash.mediaEl.played = false;
 
-            expect(dash.determinePlayLength()).to.be.equal(-1);
+            expect(dash.determineWatchLength()).to.be.equal(-1);
         });
 
         it('should return 0 if there are no played parts', () => {
             dash.mediaEl.played = [];
 
-            expect(dash.determinePlayLength()).to.be.equal(0);
+            expect(dash.determineWatchLength()).to.be.equal(0);
         });
 
         it('should return the sum of all the played parts', () => {
@@ -1408,7 +1408,7 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.mediaEl.played.start.withArgs(1).returns(10);
             dash.mediaEl.played.end.withArgs(1).returns(15);
 
-            expect(dash.determinePlayLength()).to.be.equal(10000);
+            expect(dash.determineWatchLength()).to.be.equal(10000);
         });
     });
 });

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1362,6 +1362,16 @@ describe('lib/viewers/media/DashViewer', () => {
     });
 
     describe('determinePlayLength()', () => {
+        let originalMediaEl;
+
+        beforeEach(() => {
+            originalMediaEl = dash.mediaEl;
+        });
+
+        afterEach(() => {
+            dash.mediaEl = originalMediaEl;
+        });
+
         it('should return -1 if mediaEl does not exist', () => {
             dash.mediaEl = null;
 

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -10,6 +10,7 @@ import { VIEWER_EVENT } from '../../../events';
 
 let dash;
 let stubs = {};
+let mediaElRef;
 
 const CSS_CLASS_MEDIA = 'bp-media';
 const CSS_CLASS_HD = 'bp-media-controls-is-hd';
@@ -99,6 +100,7 @@ describe('lib/viewers/media/DashViewer', () => {
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: sandbox.mock() });
         dash.containerEl = containerEl;
         dash.setup();
+        mediaElRef = dash.mediaEl;
     });
 
     afterEach(() => {
@@ -107,6 +109,7 @@ describe('lib/viewers/media/DashViewer', () => {
         Object.defineProperty(BaseViewer.prototype, 'setup', { value: setupFunc });
 
         if (dash && typeof dash.destroy === 'function' && !dash.destroyed) {
+            dash.mediaEl = mediaElRef;
             dash.destroy();
         }
 
@@ -1362,16 +1365,6 @@ describe('lib/viewers/media/DashViewer', () => {
     });
 
     describe('determinePlayLength()', () => {
-        let originalMediaEl;
-
-        beforeEach(() => {
-            originalMediaEl = dash.mediaEl;
-        });
-
-        afterEach(() => {
-            dash.mediaEl = originalMediaEl;
-        });
-
         it('should return -1 if mediaEl does not exist', () => {
             dash.mediaEl = null;
 

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -104,7 +104,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
             media.destroy();
 
-            expect(media.mediaEl.removeEventListener.callCount).to.equal(9);
+            expect(media.mediaEl.removeEventListener.callCount).to.equal(11);
             expect(media.mediaEl.removeAttribute).to.be.calledWith('src');
             expect(media.mediaEl.load).to.be.called;
             expect(media.removePauseEventListener.callCount).to.equal(1);
@@ -115,11 +115,13 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         beforeEach(() => {
             media.mediaEl = document.createElement('video');
             media.mediaEl.addEventListener = sandbox.stub();
+            sandbox.stub(media, 'loadUI');
         });
 
         it('should load mediaUrl in the media element', () => {
             sandbox.stub(media, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             return media.load().then(() => {
+                expect(media.loadUI).to.be.called;
                 expect(media.mediaEl.addEventListener).to.be.calledWith('loadeddata', media.loadeddataHandler);
                 expect(media.mediaEl.addEventListener).to.be.calledWith('error', media.errorHandler);
                 expect(media.mediaEl.src).to.equal('www.netflix.com');
@@ -150,7 +152,6 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         it('should finish loading, resize the media viewer, and focus on mediaContainerEl', () => {
             sandbox.stub(media, 'handleVolume');
             sandbox.stub(media, 'emit');
-            sandbox.stub(media, 'loadUI');
             sandbox.stub(media, 'resize');
             sandbox.stub(media, 'showMedia');
 
@@ -160,7 +161,6 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             expect(media.handleVolume).to.be.called;
             expect(media.loaded).to.be.true;
             expect(media.emit).to.be.calledWith(VIEWER_EVENT.load);
-            expect(media.loadUI).to.be.called;
             expect(media.resize).to.be.called;
             expect(media.showMedia).to.be.called;
             expect(document.activeElement).to.equal(media.mediaContainerEl);
@@ -313,7 +313,6 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             media.loadUI();
 
             expect(media.addEventListenersForMediaControls).to.be.called;
-            expect(media.addEventListenersForMediaElement).to.be.called;
         });
     });
 
@@ -723,7 +722,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
             media.addEventListenersForMediaElement();
 
-            expect(media.mediaEl.addEventListener.callCount).to.equal(8);
+            expect(media.mediaEl.addEventListener.callCount).to.equal(9);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -1140,19 +1140,19 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         });
     });
 
-    describe('startBufferFillTime()', () => {
+    describe('handleLoadStart()', () => {
         it('should start the timer', () => {
             sandbox.stub(Timer, 'createTag').returns('foo');
             sandbox.stub(Timer, 'start');
 
-            media.startBufferFillTimer();
+            media.handleLoadStart();
 
             expect(Timer.createTag).to.be.calledWith(1, 'bufferFill');
             expect(Timer.start).to.be.calledWith('foo');
         });
     });
 
-    describe('stopBufferFillTimer()', () => {
+    describe('handleCanPlay()', () => {
         it('should stop the timer and process the metrics', () => {
             sandbox.stub(Timer, 'createTag').returns('foo');
             sandbox.stub(Timer, 'stop');
@@ -1160,10 +1160,10 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
 
             media.mediaEl = { removeEventListener: sandbox.stub() };
 
-            media.stopBufferFillTimer();
+            media.handleCanPlay();
 
             expect(Timer.stop).to.be.calledWith('foo');
-            expect(media.mediaEl.removeEventListener).to.be.calledWith('canplay', media.stopBufferFillTimer);
+            expect(media.mediaEl.removeEventListener).to.be.calledWith('canplay', media.handleCanPlay);
             expect(media.processBufferFillMetric).to.be.called;
         });
     });

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -149,7 +149,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
     describe('playingHandler()', () => {
         it('should hide the play button', () => {
             sandbox.stub(videoBase, 'hidePlayButton');
-            videoBase.loadeddataHandler(); // load media controls UI
+            videoBase.loadUI(); // load media controls UI
 
             videoBase.playingHandler();
 
@@ -160,7 +160,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
     describe('pauseHandler()', () => {
         it('should show the play button', () => {
             sandbox.stub(videoBase, 'showPlayButton');
-            videoBase.loadeddataHandler(); // load media controls UI
+            videoBase.loadUI(); // load media controls UI
 
             videoBase.pauseHandler();
 
@@ -169,7 +169,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
         it('should hide the loading icon', () => {
             sandbox.stub(videoBase, 'hideLoadingIcon');
-            videoBase.loadeddataHandler(); // load media controls UI
+            videoBase.loadUI(); // load media controls UI
 
             videoBase.pauseHandler();
 


### PR DESCRIPTION
Introduces two new metric events:
-  `media_metric_buffer_fill` which represents the initial buffering before playback can begin
- `media_metric_end_playback` which contains metrics around total buffering time, lag/watch ratio, etc...

`media_metric_buffer_fill` will be emitted as soon as it is measured.

`media_metric_end_playback` will be emitted in 3 scenarios:
1. when playback is finished (`ended` event is fired)
2. when the viewer is destroyed (when preview is closed)
3. when the page unloads

As part of this PR, only the `DashViewer` will emit these metrics.

TODO:

- [x] fix unit tests
- [x] add new unit tests
