### PR TITLE
fix(download): show appropriate download error

### DIFF
--- a/src/i18n/en-AU.properties
+++ b/src/i18n/en-AU.properties
@@ -63,7 +63,7 @@ error_password_protected=We’re sorry, but the preview didn't load. This docume
 # Preview error message shown when conversion was unable to process the file at the given time.
 error_try_again_later=We’re sorry, but the preview didn't load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn’t load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks as if something is wrong with this file. We apologise for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser

--- a/src/i18n/en-AU.properties
+++ b/src/i18n/en-AU.properties
@@ -41,11 +41,11 @@ has_x_refs=This preview has references you cannot view. Open the file in its nat
 
 # Error messages
 # Default preview error message
-error_generic=We're sorry, the preview didn't load.
+error_generic=We’re sorry, the preview didn't load.
 # Default preview error message
-error_unsupported=We're sorry, we can't preview this file type in your web browser. To view this content, please download and open it on your device.
+error_unsupported=We’re sorry, we can't preview this file type in your web browser. To view this content, please download and open it on your device.
 # Account doesn't have a sufficient tariff to preview the requested file type
-error_account=We're sorry, your account is unable to preview this file type.
+error_account=We’re sorry, your account is unable to preview this file type.
 # No permissions preview error message
 error_permissions=Sorry! You don't have permission to preview this file.
 # Preview refresh error message suggesting refreshing the page as a possible fix
@@ -59,15 +59,15 @@ error_browser_unsupported=Sorry! Your browser doesn't support preview for {1}.
 # Preview error message shown when document loading fails (most likely due to password or watermark)
 error_document=Sorry! The preview hasn't loaded. This document may be protected.
 # Preview error message shown when the document is password protected
-error_password_protected=We're sorry, but the preview didn't load. This document is protected.
+error_password_protected=We’re sorry, but the preview didn't load. This document is protected.
 # Preview error message shown when conversion was unable to process the file at the given time.
-error_try_again_later=We're sorry, but the preview didn't load. Please try again later.
+error_try_again_later=We’re sorry, but the preview didn't load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We're sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks as if something is wrong with this file. We apologise for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser
-error_flash_not_enabled=We're sorry, the preview did not load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
+error_flash_not_enabled=We’re sorry, the preview did not load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
 
 # Media Preview
 # Label for autoplay in media player

--- a/src/i18n/en-CA.properties
+++ b/src/i18n/en-CA.properties
@@ -59,11 +59,11 @@ error_browser_unsupported=We’re sorry, your browser doesn't support preview fo
 # Preview error message shown when document loading fails (most likely due to password or watermark)
 error_document=We’re sorry, the preview didn't load. This document may be protected.
 # Preview error message shown when the document is password protected
-error_password_protected=We’re sorry the preview didn't load. This document is protected.
+error_password_protected=We’re sorry the preview didn’t load. This document is protected.
 # Preview error message shown when conversion was unable to process the file at the given time.
-error_try_again_later=We’re sorry the preview didn't load. Please try again later.
+error_try_again_later=We’re sorry the preview didn’t load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn’t load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks like something is wrong with this file. We apologize for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser

--- a/src/i18n/en-CA.properties
+++ b/src/i18n/en-CA.properties
@@ -41,33 +41,33 @@ has_x_refs=This preview has references you cannot view. Open the file in its nat
 
 # Error messages
 # Default preview error message
-error_generic=We're sorry, the preview didn't load.
+error_generic=We’re sorry, the preview didn't load.
 # Default preview error message
-error_unsupported=We're sorry, we can't preview this file type in your web browser. To view this content please download and open it on your device.
+error_unsupported=We’re sorry, we can't preview this file type in your web browser. To view this content please download and open it on your device.
 # Account doesn't have a sufficient tariff to preview the requested file type
-error_account=We're sorry, your account is unable to preview this file type.
+error_account=We’re sorry, your account is unable to preview this file type.
 # No permissions preview error message
-error_permissions=We're sorry, you don't have permission to preview this file.
+error_permissions=We’re sorry, you don't have permission to preview this file.
 # Preview refresh error message suggesting refreshing the page as a possible fix
-error_refresh=We're sorry, the preview didn't load. Please refresh the page.
+error_refresh=We’re sorry, the preview didn't load. Please refresh the page.
 # Preview rate limit error suggesting waiting a few minutes to avoid rate limit
-error_rate_limit=We're sorry, the preview didn't load because your request was rate limited. Please wait a few minutes and try again.
+error_rate_limit=We’re sorry, the preview didn't load because your request was rate limited. Please wait a few minutes and try again.
 # Preview re-upload error message suggesting re-uploading the file or contacting support as a possible fix
-error_reupload=We're sorry, the preview didn't load. Please re-upload the file or contact Box support.
+error_reupload=We’re sorry, the preview didn't load. Please re-upload the file or contact Box support.
 # Preview error message shown when the user's browser doesn't support previews of this file type
-error_browser_unsupported=We're sorry, your browser doesn't support preview for {1}.
+error_browser_unsupported=We’re sorry, your browser doesn't support preview for {1}.
 # Preview error message shown when document loading fails (most likely due to password or watermark)
-error_document=We're sorry, the preview didn't load. This document may be protected.
+error_document=We’re sorry, the preview didn't load. This document may be protected.
 # Preview error message shown when the document is password protected
-error_password_protected=We're sorry the preview didn't load. This document is protected.
+error_password_protected=We’re sorry the preview didn't load. This document is protected.
 # Preview error message shown when conversion was unable to process the file at the given time.
-error_try_again_later=We're sorry the preview didn't load. Please try again later.
+error_try_again_later=We’re sorry the preview didn't load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We're sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks like something is wrong with this file. We apologize for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser
-error_flash_not_enabled=We're sorry, the preview didn't load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
+error_flash_not_enabled=We’re sorry, the preview didn't load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
 
 # Media Preview
 # Label for autoplay in media player
@@ -171,11 +171,11 @@ annotation_draw_save=Save drawing
 # Accessibilty text for button that soft deletes drawing
 annotation_draw_delete=Delete drawing
 # Text for when annotations fail to load
-annotations_load_error=We're sorry, annotations failed to load for this file.
+annotations_load_error=We’re sorry, annotations failed to load for this file.
 # Text for when the annotation can't be created
-annotations_create_error=We're sorry, the annotation could not be created.
+annotations_create_error=We’re sorry, the annotation could not be created.
 # Text for when the annotation can't be deleted
-annotations_delete_error=We're sorry, the annotation could not be deleted.
+annotations_delete_error=We’re sorry, the annotation could not be deleted.
 # Text for when the authorization token is invalid
 annotations_authorization_error=Your session has expired. Please refresh the page.
 

--- a/src/i18n/en-GB.properties
+++ b/src/i18n/en-GB.properties
@@ -63,7 +63,7 @@ error_password_protected=We’re sorry, but the preview didn't load. This docume
 # Preview error message shown when conversion was unable to process the file at the given time.
 error_try_again_later=We’re sorry, but the preview didn't load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn’t load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks as if something is wrong with this file. We apologise for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser

--- a/src/i18n/en-GB.properties
+++ b/src/i18n/en-GB.properties
@@ -41,11 +41,11 @@ has_x_refs=This preview has references you cannot view. Open the file in its nat
 
 # Error messages
 # Default preview error message
-error_generic=We're sorry, the preview didn't load.
+error_generic=We’re sorry, the preview didn't load.
 # Default preview error message
-error_unsupported=We're sorry, we can't preview this file type in your web browser. To view this content, please download and open it on your device.
+error_unsupported=We’re sorry, we can't preview this file type in your web browser. To view this content, please download and open it on your device.
 # Account doesn't have a sufficient tariff to preview the requested file type
-error_account=We're sorry, your account is unable to preview this file type.
+error_account=We’re sorry, your account is unable to preview this file type.
 # No permissions preview error message
 error_permissions=Sorry! You don't have permission to preview this file.
 # Preview refresh error message suggesting refreshing the page as a possible fix
@@ -59,15 +59,15 @@ error_browser_unsupported=Sorry! Your browser doesn't support preview for {1}.
 # Preview error message shown when document loading fails (most likely due to password or watermark)
 error_document=Sorry! The preview hasn't loaded. This document may be protected.
 # Preview error message shown when the document is password protected
-error_password_protected=We're sorry, but the preview didn't load. This document is protected.
+error_password_protected=We’re sorry, but the preview didn't load. This document is protected.
 # Preview error message shown when conversion was unable to process the file at the given time.
-error_try_again_later=We're sorry, but the preview didn't load. Please try again later.
+error_try_again_later=We’re sorry, but the preview didn't load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We're sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn't load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks as if something is wrong with this file. We apologise for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser
-error_flash_not_enabled=We're sorry, the preview did not load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
+error_flash_not_enabled=We’re sorry, the preview did not load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
 
 # Media Preview
 # Label for autoplay in media player

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -41,33 +41,33 @@ has_x_refs=This preview has references you cannot view. Open the file in its nat
 
 # Error messages
 # Default preview error message
-error_generic=We're sorry, the preview didn't load.
+error_generic=We’re sorry, the preview didn’t load.
 # Default preview error message
-error_unsupported=We're sorry, we can't preview this file type in your web browser. To view this content please download and open it on your device.
-# Account doesn't have a sufficient tariff to preview the requested file type
-error_account=We're sorry, your account is unable to preview this file type.
+error_unsupported=We’re sorry, we can’t preview this file type in your web browser. To view this content please download and open it on your device.
+# Account doesn’t have a sufficient tariff to preview the requested file type
+error_account=We’re sorry, your account is unable to preview this file type.
 # No permissions preview error message
-error_permissions=We're sorry, you don't have permission to preview this file.
+error_permissions=We’re sorry, you don’t have permission to preview this file.
 # Preview refresh error message suggesting refreshing the page as a possible fix
-error_refresh=We're sorry, the preview didn't load. Please refresh the page.
+error_refresh=We’re sorry, the preview didn’t load. Please refresh the page.
 # Preview rate limit error suggesting waiting a few minutes to avoid rate limit
-error_rate_limit=We're sorry, the preview didn't load because your request was rate limited. Please wait a few minutes and try again.
+error_rate_limit=We’re sorry, the preview didn’t load because your request was rate limited. Please wait a few minutes and try again.
 # Preview re-upload error message suggesting re-uploading the file or contacting support as a possible fix
-error_reupload=We're sorry, the preview didn't load. Please re-upload the file or contact Box support.
-# Preview error message shown when the user's browser doesn't support previews of this file type
-error_browser_unsupported=We're sorry, your browser doesn't support preview for {1}.
+error_reupload=We’re sorry, the preview didn’t load. Please re-upload the file or contact Box support.
+# Preview error message shown when the user’s browser doesn’t support previews of this file type
+error_browser_unsupported=We’re sorry, your browser doesn’t support preview for {1}.
 # Preview error message shown when document loading fails (most likely due to password or watermark)
-error_document=We're sorry, the preview didn't load. This document may be protected.
+error_document=We’re sorry, the preview didn’t load. This document may be protected.
 # Preview error message shown when the document is password protected
-error_password_protected=We're sorry the preview didn't load. This document is protected.
+error_password_protected=We’re sorry the preview didn’t load. This document is protected.
 # Preview error message shown when conversion was unable to process the file at the given time.
-error_try_again_later=We're sorry the preview didn't load. Please try again later.
+error_try_again_later=We’re sorry the preview didn’t load. Please try again later.
 # Preview error message shown when conversion failed due to file contents
-error_bad_file=We're sorry the preview didn't load. This file could not be converted.
+error_bad_file=We’re sorry the preview didn’t load. This file could not be converted.
 # Preview error message shown when the file cannot be downloaded
 error_not_downloadable=Oops! It looks like something is wrong with this file. We apologize for the inconvenience and recommend that you upload a new version of this file or roll back to a previous version. Please contact us for more details.
 # Preview error message shown when flash is not enabled on their browser
-error_flash_not_enabled=We're sorry, the preview didn't load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
+error_flash_not_enabled=We’re sorry, the preview didn’t load because Flash is not enabled on your browser. If possible, please enable Flash and refresh the page.
 
 # Media Preview
 # Label for autoplay in media player
@@ -171,11 +171,11 @@ annotation_draw_save=Save drawing
 # Accessibilty text for button that soft deletes drawing
 annotation_draw_delete=Delete drawing
 # Text for when annotations fail to load
-annotations_load_error=We're sorry, annotations failed to load for this file.
-# Text for when the annotation can't be created
-annotations_create_error=We're sorry, the annotation could not be created.
-# Text for when the annotation can't be deleted
-annotations_delete_error=We're sorry, the annotation could not be deleted.
+annotations_load_error=We’re sorry, annotations failed to load for this file.
+# Text for when the annotation can’t be created
+annotations_create_error=We’re sorry, the annotation could not be created.
+# Text for when the annotation can’t be deleted
+annotations_delete_error=We’re sorry, the annotation could not be deleted.
 # Text for when the authorization token is invalid
 annotations_authorization_error=Your session has expired. Please refresh the page.
 
@@ -191,7 +191,9 @@ notification_annotation_draw_mode=Press down and drag the pointer to draw on the
 # Notification message shown when the user has a degraded preview experience due to blocked download hosts
 notification_degraded_preview=It looks like your connection to {1} is being blocked. We think we can make file previews faster for you. To do that, please ask your network admin to configure firewall settings so that {1} is reachable.
 # Notification message shown when a file cannot be downloaded
-notification_cannot_download=Sorry! You can't download this file.
+notification_cannot_download=Sorry! You can’t download this file.
+# Notification message shown when a file cannot be downloaded due to an access policy
+notification_cannot_download_due_to_policy=Downloading of this content has been disabled based on an access policy.
 
 # Link Text
 link_contact_us=Contact Us

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1670,7 +1670,7 @@ describe('lib/Preview', () => {
             stubs.checkPermission.withArgs(sinon.match.any, PERMISSION_PREVIEW).returns(false);
             expect(() => preview.loadViewer()).to.throw(
                 PreviewError,
-                /We're sorry, you don't have permission to preview this file./,
+                /We’re sorry, you don’t have permission to preview this file./,
             );
         });
 

--- a/src/lib/__tests__/PreviewError-test.js
+++ b/src/lib/__tests__/PreviewError-test.js
@@ -26,12 +26,12 @@ describe('lib/PreviewError', () => {
 
         it('should default display message to generic error message if not provided', () => {
             const previewError = new PreviewError('some_code');
-            expect(previewError.displayMessage).to.equal("We're sorry, the preview didn't load.");
+            expect(previewError.displayMessage).to.equal('We’re sorry, the preview didn’t load.');
         });
 
         it('should default message to display message if message is not provided', () => {
             const previewError = new PreviewError('some_code');
-            expect(previewError.message).to.equal("We're sorry, the preview didn't load.");
+            expect(previewError.message).to.equal('We’re sorry, the preview didn’t load.');
         });
     });
 });

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -136,3 +136,6 @@ export const METADATA = {
     SCOPE_GLOBAL: 'global',
     TEMPLATE_AUTOCAD: 'autocad',
 };
+
+// Error Codes
+export const ERROR_CODE_403_FORBIDDEN_BY_POLICY = 'forbidden_by_policy';

--- a/src/lib/viewers/box3d/model3d/__tests__/Model3DLoader-test.js
+++ b/src/lib/viewers/box3d/model3d/__tests__/Model3DLoader-test.js
@@ -30,7 +30,7 @@ describe('lib/viewers/box3d/model3d/Model3DLoader', () => {
             sandbox.stub(Browser, 'supportsModel3D').returns(false);
             expect(() => Model3DLoader.determineViewer(file)).to.throw(
                 PreviewError,
-                /browser doesn't support preview for 3D models/,
+                /browser doesn’t support preview for 3D models/,
             );
         });
 

--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -136,6 +136,7 @@ class PreviewErrorViewer extends BaseViewer {
     addDownloadButton() {
         this.downloadBtnEl = this.infoEl.appendChild(document.createElement('button'));
         this.downloadBtnEl.className = 'bp-btn bp-btn-primary';
+        this.downloadBtnEl.dataset.testid = 'preview-error-download-btn';
         this.downloadBtnEl.textContent = __('download');
         this.downloadBtnEl.addEventListener('click', this.download);
     }

--- a/src/lib/viewers/media/__tests__/MediaLoader-test.js
+++ b/src/lib/viewers/media/__tests__/MediaLoader-test.js
@@ -27,7 +27,7 @@ describe('lib/viewers/media/MediaLoader', () => {
             sandbox.stub(util, 'requires360Viewer').returns(true);
             expect(() => MediaLoader.determineViewer(file)).to.throw(
                 PreviewError,
-                /browser doesn't support preview for 360-degree videos/,
+                /browser doesn’t support preview for 360-degree videos/,
             );
         });
 

--- a/test/integration/document/Thumbnails.e2e.test.js
+++ b/test/integration/document/Thumbnails.e2e.test.js
@@ -10,17 +10,18 @@ describe('Preview Document Thumbnails', () => {
      * @param {number} pageNum - Page number
      * @return {Element} Thumbnail subject
      */
-    const getThumbnail = (pageNum) => cy.get(`.bp-thumbnail[data-bp-page-num=${pageNum}]`);
+    const getThumbnail = pageNum => cy.get(`.bp-thumbnail[data-bp-page-num=${pageNum}]`);
 
     /**
      * Gets the thumbnail and ensures the thumbnail image has rendered
      * @param {number} pageNum - Page number
      * @return {Element} Thumbnail subject
      */
-    const getThumbnailWithRenderedImage = (pageNum) => getThumbnail(pageNum).should(($thumbnail) => {
-        expect($thumbnail.find('.bp-thumbnail-image')).to.exist;
-        return $thumbnail;
-    });
+    const getThumbnailWithRenderedImage = pageNum =>
+        getThumbnail(pageNum).should($thumbnail => {
+            expect($thumbnail.find('.bp-thumbnail-image')).to.exist;
+            return $thumbnail;
+        });
 
     /**
      * Shows the document preview
@@ -40,8 +41,7 @@ describe('Preview Document Thumbnails', () => {
     const toggleThumbnails = () => {
         cy.showDocumentControls();
 
-        cy
-            .getByTitle('Toggle thumbnails')
+        cy.getByTitle('Toggle thumbnails')
             .should('be.visible')
             .click();
 
@@ -86,8 +86,7 @@ describe('Preview Document Thumbnails', () => {
         showDocumentPreview({ enableThumbnailsSidebar: true });
 
         // Verify we're on page 1
-        cy
-            .getByTestId('current-page')
+        cy.getByTestId('current-page')
             .as('currentPage')
             .invoke('text')
             .should('equal', '1');
@@ -100,16 +99,14 @@ describe('Preview Document Thumbnails', () => {
             .click()
             .should('have.class', THUMBNAIL_SELECTED_CLASS);
         getThumbnailWithRenderedImage(1).should('not.have.class', THUMBNAIL_SELECTED_CLASS);
-        cy
-            .get('@currentPage')
+        cy.get('@currentPage')
             .invoke('text')
             .should('equal', '2');
     });
 
     it('Should reflect the selected page when page is changed', () => {
         showDocumentPreview({ enableThumbnailsSidebar: true });
-        cy
-            .getByTestId('current-page')
+        cy.getByTestId('current-page')
             .as('currentPage')
             .invoke('text')
             .should('equal', '1');
@@ -122,16 +119,14 @@ describe('Preview Document Thumbnails', () => {
 
         getThumbnailWithRenderedImage(2).should('have.class', THUMBNAIL_SELECTED_CLASS);
         getThumbnailWithRenderedImage(1).should('not.have.class', THUMBNAIL_SELECTED_CLASS);
-        cy
-            .get('@currentPage')
+        cy.get('@currentPage')
             .invoke('text')
             .should('equal', '2');
     });
 
     it('Should reflect the selected page even when thumbnail was not previously in rendered window', () => {
         showDocumentPreview({ enableThumbnailsSidebar: true });
-        cy
-            .getByTestId('current-page')
+        cy.getByTestId('current-page')
             .as('currentPage')
             .invoke('text')
             .should('equal', '1');
@@ -142,8 +137,7 @@ describe('Preview Document Thumbnails', () => {
 
         cy.showDocumentControls();
         cy.getByTitle('Click to enter page number').click();
-        cy
-            .getByTestId('page-num-input')
+        cy.getByTestId('page-num-input')
             .should('be.visible')
             .type('200')
             .blur();
@@ -151,16 +145,14 @@ describe('Preview Document Thumbnails', () => {
         getThumbnailWithRenderedImage(200).should('have.class', THUMBNAIL_SELECTED_CLASS);
 
         getThumbnail(1).should('not.exist');
-        cy
-            .get('@currentPage')
+        cy.get('@currentPage')
             .invoke('text')
             .should('equal', '200');
     });
 
     it('Should still reflect the current viewed page when thumbnails sidebar is toggled open', () => {
         showDocumentPreview({ enableThumbnailsSidebar: true });
-        cy
-            .getByTestId('current-page')
+        cy.getByTestId('current-page')
             .as('currentPage')
             .invoke('text')
             .should('equal', '1');
@@ -171,8 +163,7 @@ describe('Preview Document Thumbnails', () => {
 
         cy.showDocumentControls();
         cy.getByTitle('Click to enter page number').click();
-        cy
-            .getByTestId('page-num-input')
+        cy.getByTestId('page-num-input')
             .should('be.visible')
             .type('200')
             .blur();
@@ -184,8 +175,7 @@ describe('Preview Document Thumbnails', () => {
         cy.getByTestId('thumbnails-sidebar').should('not.be.visible');
 
         cy.getByTitle('Click to enter page number').click();
-        cy
-            .getByTestId('page-num-input')
+        cy.getByTestId('page-num-input')
             .should('be.visible')
             .type('1')
             .blur();
@@ -249,8 +239,7 @@ describe('Preview Document Thumbnails', () => {
         cy.getByTestId('thumbnails-sidebar').should('be.visible');
 
         cy.getByTitle('Click to enter page number').click();
-        cy
-            .getByTestId('page-num-input')
+        cy.getByTestId('page-num-input')
             .should('be.visible')
             .type('50')
             .blur();
@@ -261,15 +250,17 @@ describe('Preview Document Thumbnails', () => {
 
         cy.getByTestId('thumbnails-sidebar').should('be.visible');
         getThumbnailWithRenderedImage(50).should('have.class', THUMBNAIL_SELECTED_CLASS);
-        cy.getByTestId('thumbnails-sidebar').find('.bp-vs').then(($virtualScrollerEl) => {
-            expect($virtualScrollerEl[0].scrollTop).to.not.equal(0);
-        });
+        cy.getByTestId('thumbnails-sidebar')
+            .find('.bp-vs')
+            .then($virtualScrollerEl => {
+                expect($virtualScrollerEl[0].scrollTop).to.not.equal(0);
+            });
     });
 
     it('Should not show the thumbnails sidebar when a document preview errors', () => {
         cy.showPreview(token, badFileId, { enableThumbnailsSidebar: true });
 
-        cy.contains('We\'re sorry the preview didn\'t load. This file could not be converted.');
+        cy.contains('We’re sorry the preview didn’t load. This file could not be converted.');
         cy.getByTestId('thumbnails-sidebar').should('not.exist');
     });
 
@@ -287,8 +278,7 @@ describe('Preview Document Thumbnails', () => {
         getThumbnailWithRenderedImage(2).click();
         cy.focused().type('{downarrow}');
         getThumbnailWithRenderedImage(3).should('have.class', THUMBNAIL_SELECTED_CLASS);
-        cy
-            .getByTestId('current-page')
+        cy.getByTestId('current-page')
             .as('currentPage')
             .invoke('text')
             .should('equal', '3');
@@ -297,8 +287,7 @@ describe('Preview Document Thumbnails', () => {
         cy.focused().type('{uparrow}');
 
         getThumbnailWithRenderedImage(2).should('have.class', THUMBNAIL_SELECTED_CLASS);
-        cy
-            .get('@currentPage')
+        cy.get('@currentPage')
             .invoke('text')
             .should('equal', '2');
     });

--- a/test/integration/sanity/Download.e2e.test.js
+++ b/test/integration/sanity/Download.e2e.test.js
@@ -1,0 +1,39 @@
+// <reference types='Cypress' />
+describe('Download disabled while preview is already open', () => {
+    const token = Cypress.env('ACCESS_TOKEN');
+    const fileIdBad = Cypress.env('FILE_ID_BAD');
+
+    beforeEach(() => {
+        cy.visit('/');
+    });
+
+    it('should give generic download error when trying to download and its forbidden', () => {
+        cy.showPreview(token, fileIdBad, { showDownload: true });
+        cy.route({
+            method: 'GET',
+            url: `**/files/${fileIdBad}?fields=download_url`,
+            status: 403,
+            response: {},
+        });
+
+        cy.getByTestId('preview-error-download-btn').should('be.visible');
+        cy.getByTestId('preview-error-download-btn').click();
+        cy.contains('Sorry! You can’t download this file.');
+    });
+
+    it('should give shield error when trying to download and access policy prevents download', () => {
+        cy.showPreview(token, fileIdBad, { showDownload: true });
+        cy.route({
+            method: 'GET',
+            url: `**/files/${fileIdBad}?fields=download_url`,
+            status: 403,
+            response: {
+                code: 'forbidden_by_policy',
+            },
+        });
+
+        cy.getByTestId('preview-error-download-btn').should('be.visible');
+        cy.getByTestId('preview-error-download-btn').click();
+        cy.contains('Downloading of this content has been disabled based on an access policy.');
+    });
+});


### PR DESCRIPTION
for when download might get disabled due to an access policy while the user is already previewing the file without browser refresh.

Also fixes the apostrophes