### PR TITLE
feat(printing): Move print() to imageBase

### DIFF
--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -1,8 +1,6 @@
-import Browser from '../../Browser';
 import ImageBaseViewer from './ImageBaseViewer';
 import { ICON_FULLSCREEN_IN, ICON_FULLSCREEN_OUT, ICON_ROTATE_LEFT } from '../../icons/icons';
 import { CLASS_INVISIBLE } from '../../constants';
-import * as util from '../../util';
 import './Image.scss';
 
 const CSS_CLASS_IMAGE = 'bp-image';
@@ -50,7 +48,7 @@ class ImageViewer extends ImageBaseViewer {
     /**
      * Loads an Image.
      *
-     * @return {void}
+     * @return {Promise}
      */
     load() {
         super.load();
@@ -283,40 +281,6 @@ class ImageViewer extends ImageBaseViewer {
             ICON_FULLSCREEN_IN,
         );
         this.controls.add(__('exit_fullscreen'), this.toggleFullscreen, 'bp-exit-fullscreen-icon', ICON_FULLSCREEN_OUT);
-    }
-
-    /**
-     * Prints image using an an iframe.
-     *
-     * @return {void}
-     */
-    print() {
-        const browserName = Browser.getName();
-
-        /**
-         * Called async to ensure resource is loaded for print preview. Then removes listener to prevent
-         * multiple handlers.
-         *
-         * @return {void}
-         */
-        const defaultPrintHandler = () => {
-            if (browserName === 'Explorer' || browserName === 'Edge') {
-                this.printframe.contentWindow.document.execCommand('print', false, null);
-            } else {
-                this.printframe.contentWindow.print();
-            }
-
-            this.printframe.removeEventListener('load', defaultPrintHandler);
-            this.emit('printsuccess');
-        };
-
-        this.printframe = util.openContentInsideIframe(this.imageEl.outerHTML);
-        this.printframe.addEventListener('load', defaultPrintHandler);
-        this.printframe.contentWindow.focus();
-
-        this.printImage = this.printframe.contentDocument.querySelector('img');
-        this.printImage.style.display = 'block';
-        this.printImage.style.margin = '0 auto';
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.html
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.html
@@ -1,13 +1,18 @@
 <style>
-    html, body {
+    html,
+    body {
         width: 100%;
         height: 100%;
     }
     .container {
         width: 500px;
         height: 500px;
-        margin: 200px; 
+        margin: 200px;
         background-color: #eee;
     }
 </style>
-<div class="container"><div class="bp-container"><div class="bp"></div></div></div>
+<div class="container">
+    <div class="bp-container">
+        <div class="bp"><img /></div>
+    </div>
+</div>

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -677,7 +677,6 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
         it('should open the content inside an iframe, center, and focus', () => {
             imageBase.print();
             expect(stubs.openContentInsideIframe).to.be.called;
-            console.log(imageBase.printImages[0]);
             expect(imageBase.printImages[0].style.display).to.equal('block');
             expect(imageBase.printImages[0].style.margin).to.equal('0px auto');
             expect(imageBase.printImages[0].style.width).to.equal('100%');

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -2,7 +2,6 @@
 import ImageViewer from '../ImageViewer';
 import BaseViewer from '../../BaseViewer';
 import Browser from '../../../Browser';
-import * as util from '../../../util';
 
 const sandbox = sinon.sandbox.create();
 const imageUrl =
@@ -344,75 +343,6 @@ describe('lib/viewers/image/ImageViewer', () => {
 
             expect(image.controls).to.not.be.undefined;
             expect(image.controls.buttonRefs.length).to.equal(5);
-        });
-    });
-
-    describe('print()', () => {
-        beforeEach(() => {
-            stubs.execCommand = sandbox.stub();
-            stubs.focus = sandbox.stub();
-            stubs.print = sandbox.stub();
-            stubs.mockIframe = {
-                addEventListener() {},
-                contentWindow: {
-                    document: {
-                        execCommand: stubs.execCommand,
-                    },
-                    focus: stubs.focus,
-                    print: stubs.print,
-                },
-                contentDocument: {
-                    querySelector: sandbox.stub().returns(containerEl.querySelector('img')),
-                },
-                removeEventListener() {},
-            };
-
-            stubs.openContentInsideIframe = sandbox.stub(util, 'openContentInsideIframe').returns(stubs.mockIframe);
-            stubs.getName = sandbox.stub(Browser, 'getName');
-        });
-
-        it('should open the content inside an iframe, center, and focus', () => {
-            image.print();
-            expect(stubs.openContentInsideIframe).to.be.called;
-            expect(image.printImage.style.display).to.equal('block');
-            expect(image.printImage.style.margin).to.equal('0px auto');
-            expect(stubs.focus).to.be.called;
-        });
-
-        it('should execute the print command if the browser is Explorer', done => {
-            stubs.getName.returns('Explorer');
-            stubs.mockIframe.addEventListener = (type, callback) => {
-                callback();
-                expect(stubs.execCommand).to.be.calledWith('print', false, null);
-
-                done();
-            };
-
-            image.print();
-        });
-
-        it('should execute the print command if the browser is Edge', done => {
-            stubs.getName.returns('Edge');
-            stubs.mockIframe.addEventListener = (type, callback) => {
-                callback();
-                expect(stubs.execCommand).to.be.calledWith('print', false, null);
-
-                done();
-            };
-
-            image.print();
-        });
-
-        it('should call the contentWindow print for other browsers', done => {
-            stubs.getName.returns('Chrome');
-            stubs.mockIframe.addEventListener = (type, callback) => {
-                callback();
-                expect(stubs.print).to.be.called;
-
-                done();
-            };
-
-            image.print();
         });
     });
 


### PR DESCRIPTION
Moving the print function to imageBase will allow
MultiImageViewer to inherit the functionality.