### PR TITLE
fix(video): Change event type for setting up video element

### DIFF
--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -210,7 +210,7 @@ class MediaBaseViewer extends BaseViewer {
      */
     addEventListenersForMediaLoad() {
         this.mediaEl.addEventListener('canplay', this.handleCanPlay);
-        this.mediaEl.addEventListener('loadeddata', this.loadeddataHandler);
+        this.mediaEl.addEventListener('loadedmetadata', this.loadeddataHandler);
         this.mediaEl.addEventListener('loadstart', this.handleLoadStart);
     }
 

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -124,7 +124,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         it('should load mediaUrl in the media element', () => {
             sandbox.stub(media, 'getRepStatus').returns({ getPromise: () => Promise.resolve() });
             return media.load().then(() => {
-                expect(media.mediaEl.addEventListener).to.be.calledWith('loadeddata', media.loadeddataHandler);
+                expect(media.mediaEl.addEventListener).to.be.calledWith('loadedmetadata', media.loadeddataHandler);
                 expect(media.mediaEl.addEventListener).to.be.calledWith('error', media.errorHandler);
                 expect(media.mediaEl.src).to.equal('www.netflix.com');
             });


### PR DESCRIPTION
Fixes an issue with Safari not showing videos on MacOS Catalina