### PR TITLE
feat(archive): Add archive loader to prepare for conversion feature flip

### DIFF
--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -2420,7 +2420,7 @@ describe('lib/Preview', () => {
             stubs.getHeaders = sandbox.stub(util, 'getHeaders');
             stubs.headers = {
                 'X-Rep-Hints':
-                    '[3d][pdf][text][mp3][jpg?dimensions=1024x1024&paged=false][jpg?dimensions=2048x2048,png?dimensions=2048x2048]',
+                    '[3d][pdf][text][mp3][json][jpg?dimensions=1024x1024&paged=false][jpg?dimensions=2048x2048,png?dimensions=2048x2048]',
             };
 
             preview.options.sharedLink = 'link';

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -93,8 +93,7 @@ export const STATUS_SUCCESS = 'success';
 export const STATUS_VIEWABLE = 'viewable';
 
 // X-Rep-Hints for Representations API
-export const X_REP_HINT_ARCHIVE = '[json]';
-export const X_REP_HINT_BASE = '[3d][pdf][text][mp3]';
+export const X_REP_HINT_BASE = '[3d][pdf][text][mp3][json]';
 export const X_REP_HINT_DOC_THUMBNAIL = '[jpg?dimensions=1024x1024&paged=false]';
 export const X_REP_HINT_IMAGE = '[jpg?dimensions=2048x2048,png?dimensions=2048x2048]';
 export const X_REP_HINT_VIDEO_DASH = '[dash,mp4][filmstrip]';

--- a/src/lib/loaders.js
+++ b/src/lib/loaders.js
@@ -1,3 +1,4 @@
+import ArchiveLoader from './viewers/archive/ArchiveLoader';
 import ImageLoader from './viewers/image/ImageLoader';
 import Image360Loader from './viewers/box3d/image360/Image360Loader';
 import SWFLoader from './viewers/swf/SWFLoader';
@@ -11,6 +12,7 @@ import OfficeLoader from './viewers/office/OfficeLoader';
 
 // Order in this list matters
 export default [
+    ArchiveLoader,
     TextLoader, // should come before document
     OfficeLoader, // should come before document
     DocLoader, // should come after text


### PR DESCRIPTION
If conversion feature flip is not enabled for a user, the user will see the error message "We're sorry, your account is unable to preview this file type."