### PR TITLE
fix(typescript): override rootDir from remote tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "@box/frontend/ts/tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src"
+    },
     "include": ["./src/**/*"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This fixes an error from tsc that imports are not residing in the correct root dir.