### PR TITLE
fix(archive): Fix inconsistent search bar style on mobile devices

### DIFF
--- a/src/lib/viewers/archive/SearchBar.scss
+++ b/src/lib/viewers/archive/SearchBar.scss
@@ -13,6 +13,8 @@
         width: 100%;
         height: 36px; // fix IE 11 doesn't respect line-height
         font: inherit;
+        /* stylelint-disable-next-line property-no-vendor-prefix */
+        -webkit-appearance: none; // fix iOS Safari search bar rounded corner
 
         &::-webkit-search-cancel-button,
         &::-webkit-search-results-button {


### PR DESCRIPTION
![Screenshot(iOS)-COXP-7274](https://user-images.githubusercontent.com/17711683/73388086-725d7600-4286-11ea-897c-9b96bdcb4a58.jpg)
Fixed:
<img width="458" alt="WX20200129-105954@2x" src="https://user-images.githubusercontent.com/17711683/73388143-873a0980-4286-11ea-963b-8a9b10549cb6.png">
