### PR TITLE
fix(archive): Fix truncated breadcrumb when file name is too long

### DIFF
--- a/src/lib/viewers/archive/Breadcrumbs.scss
+++ b/src/lib/viewers/archive/Breadcrumbs.scss
@@ -8,4 +8,8 @@
     padding: 0 20px;
     border-bottom: 1px solid $bdl-gray-10;
     box-shadow: 0 4px 6px -2px $transparent-black;
+
+    .breadcrumb-item {
+        max-width: 200px;
+    }
 }


### PR DESCRIPTION
<img width="1033" alt="long-breadcrumb" src="https://user-images.githubusercontent.com/17711683/73396158-ab511700-4295-11ea-891d-17cd3271fab5.png">
->
<img width="1302" alt="correct-breadcrumb" src="https://user-images.githubusercontent.com/17711683/73396162-ac824400-4295-11ea-95ee-4712fc4eafd1.png">
