### PR TITLE
fix(doc): Remove unnecessary http header for iOS

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -647,7 +647,6 @@ class DocBaseViewer extends BaseViewer {
         const { file, location } = this.options;
         const { size, watermark_info: watermarkInfo } = file;
         const assetUrlCreator = createAssetUrlCreator(location);
-        const httpHeaders = {};
         const queryParams = {};
 
         // Do not disable create object URL in IE11 or iOS Chrome - pdf.js issues #3977 and #8081 are
@@ -684,7 +683,6 @@ class DocBaseViewer extends BaseViewer {
             disableFontFace,
             disableRange,
             disableStream,
-            httpHeaders,
             rangeChunkSize,
             url: appendQueryParams(pdfUrl, queryParams),
         });

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -669,12 +669,6 @@ class DocBaseViewer extends BaseViewer {
         const rangeChunkSizeDefault = location.locale === 'en-US' ? RANGE_CHUNK_SIZE_US : RANGE_CHUNK_SIZE_NON_US;
         const rangeChunkSize = this.getViewerOption('rangeChunkSize') || rangeChunkSizeDefault;
 
-        // Fix incorrectly cached range requests on older versions of iOS webkit browsers,
-        // see: https://bugs.webkit.org/show_bug.cgi?id=82672
-        if (Browser.isIOS()) {
-            httpHeaders['If-None-Match'] = 'webkit-no-cache';
-        }
-
         // If range requests are disabled, request the gzip compressed version of the representation
         this.encoding = disableRange ? ENCODING_TYPES.GZIP : undefined;
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1223,24 +1223,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            it('should set a cache-busting header if on mobile', () => {
-                docBase.options.location = {
-                    locale: 'en-US',
-                };
-                sandbox.stub(Browser, 'isIOS').returns(true);
-
-                return docBase.initViewer('').then(() => {
-                    expect(stubs.getDocument).to.be.calledWith(
-                        sinon.match({
-                            httpHeaders: {
-                                'If-None-Match': 'webkit-no-cache',
-                            },
-                            rangeChunkSize: 1048576,
-                        }),
-                    );
-                });
-            });
-
             it('should avoid preflight requests by not adding non-standard headers', done => {
                 docBase.options.location = {
                     locale: 'en-US',

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1216,7 +1216,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.initViewer(url).then(() => {
                     expect(stubs.getDocument).to.be.calledWith(
                         sinon.match({
-                            httpHeaders: sinon.match.object,
                             rangeChunkSize: largeChunkSize,
                         }),
                     );
@@ -1227,8 +1226,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.options.location = {
                     locale: 'en-US',
                 };
-                // Excluding IOS for If-None-Match cache busting
-                sandbox.stub(Browser, 'isIOS').returns(false);
                 stubs.getDocument.callsFake(docInitParams => {
                     return new Promise(() => {
                         const { httpHeaders = {} } = docInitParams;
@@ -1262,7 +1259,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.initViewer(url).then(() => {
                     expect(stubs.getDocument).to.be.calledWith(
                         sinon.match({
-                            httpHeaders: sinon.match.object,
                             rangeChunkSize: defaultChunkSize,
                             url: `${url}?${paramsList}`,
                         }),
@@ -1647,7 +1643,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             beforeEach(() => {
                 stubs.addEventListener = sandbox.stub(docBase.docEl, 'addEventListener');
                 stubs.addListener = sandbox.stub(fullscreen, 'addListener');
-                stubs.isIOS = sandbox.stub(Browser, 'isIOS');
             });
 
             it('should add the correct listeners', () => {
@@ -1674,7 +1669,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             beforeEach(() => {
                 stubs.removeEventListener = sandbox.stub(docBase.docEl, 'removeEventListener');
                 stubs.removeFullscreenListener = sandbox.stub(fullscreen, 'removeListener');
-                stubs.isIOS = sandbox.stub(Browser, 'isIOS');
             });
 
             it('should remove the docBase element listeners if the docBase element exists', () => {


### PR DESCRIPTION
The webkit bug was fixed on Jan 2018. I removed the header and tried to preview a pdf file on iOS 12.0 and iOS 13.3 (We only support two latest released versions), and they both work well. So I'm gonna remove the unnecessary http header code for iOS.