### PR TITLE
fix(a11y): fix keyboard navigation in video viewer

### DIFF
--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -925,7 +925,7 @@ class MediaBaseViewer extends BaseViewer {
             case 'tab':
             case 'shift+tab':
                 this.mediaContainerEl.classList.add(CLASS_ELEM_KEYBOARD_FOCUS);
-                this.mediaControls.show();
+                this.mediaControls.disableHideAndShow();
                 return false; // So that tab can proceed to do its default behavior of going to the next element
             case 'space':
             case 'k':

--- a/src/lib/viewers/media/MediaControls.js
+++ b/src/lib/viewers/media/MediaControls.js
@@ -672,6 +672,16 @@ class MediaControls extends EventEmitter {
     }
 
     /**
+     * Prevents hiding of the controls and show media controls.
+     *
+     * @return {void}
+     */
+    disableHideAndShow() {
+        this.preventHiding = true;
+        this.show();
+    }
+
+    /**
      * Toggles the media controls
      *
      * @return {void}

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -44,6 +44,10 @@ class VideoBaseViewer extends MediaBaseViewer {
         this.playButtonEl.classList.add(CLASS_PLAY_BUTTON);
         this.playButtonEl.classList.add(CLASS_HIDDEN);
         this.playButtonEl.innerHTML = ICON_PLAY_LARGE;
+        this.playButtonEl.setAttribute('role', 'button');
+        this.playButtonEl.setAttribute('tabindex', '0');
+        this.playButtonEl.setAttribute('aria-label', __('media_play'));
+        this.playButtonEl.setAttribute('title', __('media_play'));
 
         this.lowerLights();
     }

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -62,6 +62,7 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             decreaseSpeed: sandbox.stub(),
             isVolumeScrubberFocused: sandbox.stub(),
             isTimeScrubberFocused: sandbox.stub(),
+            disableHideAndShow: sandbox.stub(),
         };
     });
 
@@ -858,13 +859,13 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         it('should add keyboard-focus class on tab and return false', () => {
             expect(media.onKeydown('Tab')).to.be.false;
             expect(media.mediaContainerEl).to.have.class(CLASS_ELEM_KEYBOARD_FOCUS);
-            expect(media.mediaControls.show).to.be.called;
+            expect(media.mediaControls.disableHideAndShow).to.be.called;
         });
 
         it('should add keyboard-focus class on shift+tab and return false', () => {
             expect(media.onKeydown('Shift+Tab')).to.be.false;
             expect(media.mediaContainerEl).to.have.class(CLASS_ELEM_KEYBOARD_FOCUS);
-            expect(media.mediaControls.show).to.be.called;
+            expect(media.mediaControls.disableHideAndShow).to.be.called;
         });
 
         it('should toggle play and return true on Space', () => {

--- a/src/lib/viewers/media/__tests__/MediaControls-test.js
+++ b/src/lib/viewers/media/__tests__/MediaControls-test.js
@@ -680,6 +680,16 @@ describe('lib/viewers/media/MediaControls', () => {
         });
     });
 
+    describe('disableHideAndShow()', () => {
+        it('should set preventHiding to true and show the controls', () => {
+            stubs.show = sandbox.stub(mediaControls, 'show');
+
+            mediaControls.disableHideAndShow();
+            expect(mediaControls.preventHiding).to.equal(true);
+            expect(stubs.show).to.be.called;
+        });
+    });
+
     describe('toggle()', () => {
         beforeEach(() => {
             stubs.isVisible = sandbox.stub(mediaControls, 'isVisible');

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -83,6 +83,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.mediaEl.getAttribute('playsinline')).to.equal('');
             expect(videoBase.playButtonEl.className).to.equal('bp-media-play-button bp-is-hidden');
             expect(videoBase.playButtonEl.innerHTML).contains('<path d="M0 0h24v24H0z" fill="none"');
+            expect(videoBase.playButtonEl.getAttribute('role')).to.equal('button');
+            expect(videoBase.playButtonEl.getAttribute('tabindex')).to.equal('0');
+            expect(videoBase.playButtonEl.getAttribute('aria-label')).to.equal(__('media_play'));
+            expect(videoBase.playButtonEl.getAttribute('title')).to.equal(__('media_play'));
             expect(VideoBaseViewer.prototype.lowerLights).to.be.called;
 
             Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {


### PR DESCRIPTION
- Made the play button in the middle focusable
- Disabled hiding of the control when user starts to navigate via keyboard (tab or shift+tab) so that buttons in the controls can be focused
