### PR TITLE
fix(controls): stop event propagation from controls

### DIFF
--- a/src/lib/Controls.js
+++ b/src/lib/Controls.js
@@ -44,10 +44,10 @@ class Controls {
         this.controlsEl.addEventListener('mouseleave', this.mouseleaveHandler);
         this.controlsEl.addEventListener('focusin', this.focusinHandler);
         this.controlsEl.addEventListener('focusout', this.focusoutHandler);
+        this.controlsEl.addEventListener('click', this.clickHandler);
 
         if (this.hasTouch) {
             this.containerEl.addEventListener('touchstart', this.mousemoveHandler);
-            this.controlsEl.addEventListener('click', this.clickHandler);
         }
     }
 
@@ -175,9 +175,15 @@ class Controls {
      * @param {Event} event - A DOM-normalized event object.
      * @return {void}
      */
-    clickHandler = () => {
+    clickHandler = event => {
+        if (event) {
+            event.stopPropagation();
+        }
+
+        if (this.hasTouch) {
+            this.shouldHide = true;
+        }
         // If we are not focused in on the page num input, allow hiding after timeout
-        this.shouldHide = true;
     };
 
     /**

--- a/src/lib/Controls.js
+++ b/src/lib/Controls.js
@@ -183,7 +183,6 @@ class Controls {
         if (this.hasTouch) {
             this.shouldHide = true;
         }
-        // If we are not focused in on the page num input, allow hiding after timeout
     };
 
     /**

--- a/src/lib/Controls.js
+++ b/src/lib/Controls.js
@@ -61,10 +61,10 @@ class Controls {
         this.controlsEl.removeEventListener('mouseleave', this.mouseleaveHandler);
         this.controlsEl.removeEventListener('focusin', this.focusinHandler);
         this.controlsEl.removeEventListener('focusout', this.focusoutHandler);
+        this.controlsEl.removeEventListener('click', this.clickHandler);
 
         if (this.hasTouch) {
             this.containerEl.removeEventListener('touchstart', this.mousemoveHandler);
-            this.controlsEl.removeEventListener('click', this.clickHandler);
         }
 
         this.buttonRefs.forEach(ref => {


### PR DESCRIPTION
* Stop event propagation from preview controls, this is interfering with annotations.
* Add new tests for Controls.js constructor