### PR TITLE
fix(annotations): scroll to annotation on load

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -988,6 +988,9 @@ class BaseViewer extends EventEmitter {
         if (this.areNewAnnotationsEnabled() && this.annotationControls) {
             this.annotator.addListener('annotations_create', this.handleAnnotationCreateEvent);
         }
+
+        // Signal that the annotator and listeners have been loaded.
+        this.emit('annotations_loaded');
     }
 
     /**

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -2,7 +2,6 @@ import throttle from 'lodash/throttle';
 import DocBaseViewer from './DocBaseViewer';
 import PresentationPreloader from './PresentationPreloader';
 import { CLASS_INVISIBLE } from '../../constants';
-import { getProp } from '../../util';
 import './Presentation.scss';
 
 const WHEEL_THROTTLE = 200;
@@ -42,6 +41,9 @@ class PresentationViewer extends DocBaseViewer {
         // Set up preloader
         this.preloader = new PresentationPreloader(this.previewUI, { api: this.api });
         this.preloader.addListener('preload', this.onPreload.bind(this));
+
+        // listen for set page events
+        this.addListener('setpage', this.setPage);
     }
 
     /**
@@ -50,6 +52,8 @@ class PresentationViewer extends DocBaseViewer {
     destroy() {
         super.destroy();
         this.preloader.removeAllListeners('preload');
+
+        this.removeListener('setpage', this.setPage);
     }
 
     /**
@@ -123,15 +127,6 @@ class PresentationViewer extends DocBaseViewer {
         }
 
         return hasXOverflow || hasYOverflow;
-    }
-
-    /**
-     * @override
-     */
-    handleScrollToAnnotation(data) {
-        this.setPage(getProp(data, 'target.location.value', 1));
-
-        super.handleScrollToAnnotation(data);
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -489,40 +489,4 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             expect(result.last.id).to.equal(1);
         });
     });
-
-    describe('handleScrollToAnnotation', () => {
-        let setPageStub;
-        let scrollToAnnotationStub;
-
-        beforeEach(() => {
-            setPageStub = sandbox.stub(presentation, 'setPage');
-            scrollToAnnotationStub = sandbox.stub();
-        });
-
-        it('should call setPage is location value provided', () => {
-            const mockPartialAnnotation = { id: '123', target: { location: { value: 5 } } };
-
-            presentation.annotator = {
-                scrollToAnnotation: scrollToAnnotationStub,
-            };
-
-            presentation.handleScrollToAnnotation(mockPartialAnnotation);
-
-            expect(setPageStub).to.be.calledWith(5);
-            expect(scrollToAnnotationStub).to.be.calledWith(mockPartialAnnotation.id);
-        });
-
-        it('should call setPage with 1 if location not provided', () => {
-            const mockPartialAnnotation = { id: '123' };
-
-            presentation.annotator = {
-                scrollToAnnotation: scrollToAnnotationStub,
-            };
-
-            presentation.handleScrollToAnnotation(mockPartialAnnotation);
-
-            expect(setPageStub).to.be.calledWith(1);
-            expect(scrollToAnnotationStub).to.be.calledWith('123');
-        });
-    });
 });


### PR DESCRIPTION
* Added `setpage` event that will allow setting the page in PresentationViewer through an event.

* Added `annotatations_loaded` event that will be emitted at the end of the `initAnnotations` method execution. This will enable listeners to know when it is safe to emit the scrolltoannotation event on a hard load.

- [ ] tests