### PR TITLE
fix(annotations): Scroll to presentation page only when necessary

### DIFF
--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -129,7 +129,11 @@ class PresentationViewer extends DocBaseViewer {
      * @override
      */
     handleScrollToAnnotation(data) {
-        this.setPage(getProp(data, 'target.location.value', 1));
+        const targetPage = getProp(data, 'target.location.value', 1);
+
+        if (this.pdfViewer.currentPageNumber !== targetPage) {
+            this.setPage(targetPage);
+        }
 
         super.handleScrollToAnnotation(data);
     }

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -518,11 +518,25 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             presentation.annotator = {
                 scrollToAnnotation: scrollToAnnotationStub,
             };
+            presentation.pdfViewer.currentPageNumber = 2;
 
             presentation.handleScrollToAnnotation(mockPartialAnnotation);
 
             expect(setPageStub).to.be.calledWith(1);
             expect(scrollToAnnotationStub).to.be.calledWith('123');
+        });
+
+        it('should defer to the base viewer if the location value provided matches the current page', () => {
+            const mockPartialAnnotation = { id: '123', target: { location: { value: 1 } } };
+
+            presentation.annotator = {
+                scrollToAnnotation: scrollToAnnotationStub,
+            };
+
+            presentation.handleScrollToAnnotation(mockPartialAnnotation);
+
+            expect(setPageStub).not.to.be.called;
+            expect(scrollToAnnotationStub).to.be.calledWith(mockPartialAnnotation.id);
         });
     });
 });


### PR DESCRIPTION
This change prevents the scroll position from being reset if the user has zoomed in and selects multiple annotations on the same page.