### PR TITLE
feat(annotations): scroll to annotation on load

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -989,6 +989,7 @@ class BaseViewer extends EventEmitter {
 
         if (this.areNewAnnotationsEnabled() && this.annotationControls) {
             this.annotator.addListener('annotations_create', this.handleAnnotationCreateEvent);
+            this.handleAnnotationsOnLoad();
         }
     }
 
@@ -1036,6 +1037,19 @@ class BaseViewer extends EventEmitter {
 
         this.annotator.scrollToAnnotation(data);
     }
+
+    handleAnnotationsOnLoad = () => {
+        const {
+            file: { id },
+        } = this.options;
+
+        const loadedAnnotationId = getProp(this.options, `fileOptions.${id}.annotations.activeId`, null);
+        const annotation = loadedAnnotationId ? this.annotator.getAnnotationById(loadedAnnotationId) : null;
+
+        if (annotation) {
+            this.handleScrollToAnnotation(annotation);
+        }
+    };
 
     /**
      * Returns whether or not annotations are enabled for this viewer.

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1296,6 +1296,49 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
+    describe('handleAnnotationsOnLoad()', () => {
+        let getAnnotationStub;
+        let scrollToAnnotationStub;
+
+        beforeEach(() => {
+            getAnnotationStub = sandbox.stub().returns({ id: 'ABC' });
+            scrollToAnnotationStub = sandbox.stub();
+
+            base.annotator = {
+                init: sandbox.stub(),
+                scrollToAnnotation: scrollToAnnotationStub,
+                getAnnotationById: getAnnotationStub,
+            };
+        });
+
+        it('should not call handleScrollToAnnotation if there is not an active annotation', () => {
+            base.options.fileOptions = {
+                '0': {
+                    annotations: {},
+                },
+            };
+
+            base.handleAnnotationsOnLoad();
+
+            expect(scrollToAnnotationStub).not.to.be.called;
+            expect(getAnnotationStub).not.to.be.called;
+        });
+        it('should call scroll to annotation if active annotation is set', () => {
+            base.options.fileOptions = {
+                '0': {
+                    annotations: {
+                        activeId: 'ABC',
+                    },
+                },
+            };
+
+            base.handleAnnotationsOnLoad();
+
+            expect(scrollToAnnotationStub).to.be.calledWith('ABC');
+            expect(getAnnotationStub).to.be.called;
+        });
+    });
+
     describe('areAnnotationsEnabled()', () => {
         beforeEach(() => {
             stubs.getViewerOption = sandbox


### PR DESCRIPTION
* Add handler that will look for a set annotations activeId in the file options and if present, scroll to annotation.