### PR TITLE
feat(doc): Updated text selection color

### DIFF
--- a/src/lib/viewers/doc/DocFindBar.scss
+++ b/src/lib/viewers/doc/DocFindBar.scss
@@ -1,6 +1,3 @@
-$pdfjs-highlight: #b400aa !default;
-$pdfjs-highlight-selected: #006400 !default;
-
 .bp-find-bar {
     $bdlGray10: #e8e8e8;
 
@@ -118,18 +115,5 @@ $pdfjs-highlight-selected: #006400 !default;
 
     .bp-doc-find-controls {
         display: flex;
-    }
-}
-
-.bp-doc {
-    .textLayer {
-        .highlight {
-            display: inline-block;
-            background-color: fade-out($pdfjs-highlight, .8);
-
-            &.selected {
-                background-color: fade-out($pdfjs-highlight-selected, .8);
-            }
-        }
     }
 }

--- a/src/lib/viewers/doc/DocFindBar.scss
+++ b/src/lib/viewers/doc/DocFindBar.scss
@@ -1,6 +1,5 @@
-$medium-aquamarine: #5aeda8 !default;
-$moon-yellow: #ffba1a !default;
-$blue: #00f !default;
+$pdfjs-highlight: #b400aa !default;
+$pdfjs-highlight-selected: #006400 !default;
 
 .bp-find-bar {
     $bdlGray10: #e8e8e8;
@@ -122,19 +121,15 @@ $blue: #00f !default;
     }
 }
 
-.textLayer {
-    opacity: 1;
+.bp-doc {
+    .textLayer {
+        .highlight {
+            display: inline-block;
+            background-color: fade-out($pdfjs-highlight, .8);
 
-    .highlight {
-        background-color: fade-out($moon-yellow, .5);
-        border-radius: 0;
-
-        &.selected {
-            background-color: fade-out($medium-aquamarine, .5);
+            &.selected {
+                background-color: fade-out($pdfjs-highlight-selected, .8);
+            }
         }
-    }
-
-    ::selection {
-        background-color: fade-out($blue, .8);
     }
 }

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -1,5 +1,7 @@
 @import '../../boxuiVariables';
 
+$pdfjs-highlight: #b400aa !default;
+$pdfjs-highlight-selected: #006400 !default;
 $thumbnail-border-radius: 3px;
 // Accounts for the 1px border on the right so the remaining width is actually 225
 $thumbnail-sidebar-width: 226px;
@@ -261,6 +263,11 @@ $thumbnail-sidebar-width: 226px;
 
         .highlight {
             display: inline-block;
+            background-color: fade-out($pdfjs-highlight, .8);
+
+            &.selected {
+                background-color: fade-out($pdfjs-highlight-selected, .8);
+            }
         }
 
         ::selection {

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -252,14 +252,15 @@ $thumbnail-sidebar-width: 226px;
     .textLayer {
         top: 15px; // Match 15px padding top on page
         bottom: auto;
+        opacity: 1;
 
         // Only allow text divs to be selected
         > div {
             user-select: text;
         }
 
-        .highlight {
-            display: inline-block;
+        ::selection {
+            background-color: fade-out($box-blue, .9);
         }
     }
 

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -259,6 +259,10 @@ $thumbnail-sidebar-width: 226px;
             user-select: text;
         }
 
+        .highlight {
+            display: inline-block;
+        }
+
         ::selection {
             background-color: fade-out($box-blue, .9);
         }


### PR DESCRIPTION
Updated text selection background-color to box blue with 10% opacity

Before:
<img width="880" alt="Screen Shot 2020-08-28 at 10 37 14 AM" src="https://user-images.githubusercontent.com/17791289/91603207-74bda680-e921-11ea-93a0-028a127fc48a.png">

After:
<img width="880" alt="Screen Shot 2020-08-28 at 11 24 14 AM" src="https://user-images.githubusercontent.com/17791289/91603184-67082100-e921-11ea-8a33-7246a15b434a.png">