### PR TITLE
feat(annotations): Disable target pointer-events when explicit creation

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,4 +1,5 @@
 export const CLASS_ACTIVE = 'bp-is-active';
+export const CLASS_ANNOTATIONS_CREATE_HIGHLIGHT = 'bp-annotations-create--highlight';
 export const CLASS_ANNOTATIONS_CREATE_REGION = 'bp-annotations-create--region';
 export const CLASS_ANNOTATIONS_DISCOVERABLE = 'bp-annotations-discoverable';
 export const CLASS_NAVIGATION_VISIBILITY = 'bp-is-navigation-visible';

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -19,6 +19,7 @@ import {
 } from '../util';
 import {
     ANNOTATOR_EVENT,
+    CLASS_ANNOTATIONS_CREATE_HIGHLIGHT,
     CLASS_ANNOTATIONS_CREATE_REGION,
     CLASS_ANNOTATIONS_DISCOVERABLE,
     CLASS_BOX_PREVIEW_MOBILE,
@@ -45,6 +46,11 @@ const VIEWER_STATUSES = {
     error: 'error',
     loaded: 'loaded',
     loading: 'loading',
+};
+
+const ANNOTATION_CLASSES = {
+    [AnnotationMode.HIGHLIGHT]: CLASS_ANNOTATIONS_CREATE_HIGHLIGHT,
+    [AnnotationMode.REGION]: CLASS_ANNOTATIONS_CREATE_REGION,
 };
 
 const ANNOTATIONS_JS = 'annotations.js';
@@ -1098,14 +1104,14 @@ class BaseViewer extends EventEmitter {
 
         this.annotationControls.setMode(mode);
 
-        if (this.options.enableAnnotationsDiscoverability && this.containerEl) {
-            switch (mode) {
-                case AnnotationMode.REGION:
-                    this.containerEl.classList.add(CLASS_ANNOTATIONS_CREATE_REGION);
-                    break;
-                default:
-                    this.containerEl.classList.remove(CLASS_ANNOTATIONS_CREATE_REGION);
-                    break;
+        if (this.containerEl) {
+            // Remove all annotations create related classes
+            Object.values(ANNOTATION_CLASSES).forEach(createClass => this.containerEl.classList.remove(createClass));
+
+            // Apply the mode's related created class
+            const className = ANNOTATION_CLASSES[mode];
+            if (className) {
+                this.containerEl.classList.add(className);
             }
         }
     };

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -20,7 +20,12 @@ let base;
 let containerEl;
 let stubs = {};
 const sandbox = sinon.sandbox.create();
-const { ANNOTATOR_EVENT, CLASS_ANNOTATIONS_CREATE_REGION, CLASS_ANNOTATIONS_DISCOVERABLE } = constants;
+const {
+    ANNOTATOR_EVENT,
+    CLASS_ANNOTATIONS_CREATE_HIGHLIGHT,
+    CLASS_ANNOTATIONS_CREATE_REGION,
+    CLASS_ANNOTATIONS_DISCOVERABLE,
+} = constants;
 
 describe('lib/viewers/BaseViewer', () => {
     before(() => {
@@ -1932,16 +1937,15 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.annotationControls.setMode).to.be.calledWith(AnnotationMode.REGION);
         });
 
-        it('should add create region class and mode is REGION', () => {
-            base.processAnnotationModeChange(AnnotationMode.REGION);
+        [
+            [AnnotationMode.REGION, CLASS_ANNOTATIONS_CREATE_REGION],
+            [AnnotationMode.HIGHLIGHT, CLASS_ANNOTATIONS_CREATE_HIGHLIGHT],
+        ].forEach(([mode, className]) => {
+            it(`should add the appropriate create class when mode is ${mode}`, () => {
+                base.processAnnotationModeChange(mode);
 
-            expect(base.containerEl).to.have.class(CLASS_ANNOTATIONS_CREATE_REGION);
-        });
-
-        it('should add create highlight class and mode is HIGHLIGHT', () => {
-            base.processAnnotationModeChange(AnnotationMode.HIGHLIGHT);
-
-            expect(base.containerEl).to.have.class(constants.CLASS_ANNOTATIONS_CREATE_HIGHLIGHT);
+                expect(base.containerEl).to.have.class(className);
+            });
         });
 
         [AnnotationMode.NONE, AnnotationMode.HIGHLIGHT].forEach(mode => {

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1932,11 +1932,16 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.annotationControls.setMode).to.be.calledWith(AnnotationMode.REGION);
         });
 
-        it('should add create region class if discoverability is enabled and mode is REGION', () => {
-            base.options.enableAnnotationsDiscoverability = true;
+        it('should add create region class and mode is REGION', () => {
             base.processAnnotationModeChange(AnnotationMode.REGION);
 
             expect(base.containerEl).to.have.class(CLASS_ANNOTATIONS_CREATE_REGION);
+        });
+
+        it('should add create highlight class and mode is HIGHLIGHT', () => {
+            base.processAnnotationModeChange(AnnotationMode.HIGHLIGHT);
+
+            expect(base.containerEl).to.have.class(constants.CLASS_ANNOTATIONS_CREATE_HIGHLIGHT);
         });
 
         [AnnotationMode.NONE, AnnotationMode.HIGHLIGHT].forEach(mode => {

--- a/src/lib/viewers/doc/_annotations.scss
+++ b/src/lib/viewers/doc/_annotations.scss
@@ -1,0 +1,22 @@
+@mixin bp-annotations-create-base {
+    // Reset cursor popup in explicit region mode
+    .ba-PopupCursor {
+        display: block;
+    }
+
+    .annotationLayer {
+        pointer-events: none;
+    }
+}
+
+@mixin bp-annotations-disable-highlight-targets {
+    .ba-HighlightList .ba-HighlightSvg.is-listening .ba-HighlightTarget-rect {
+        pointer-events: none;
+    }
+}
+
+@mixin bp-annotations-disable-region-targets {
+    .ba-RegionAnnotations-list.is-listening .ba-RegionAnnotation {
+        pointer-events: none;
+    }
+}

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -1,4 +1,5 @@
 @import '../../boxuiVariables';
+@import './annotations';
 
 $pdfjs-highlight: #b400aa !default;
 $pdfjs-highlight-selected: #006400 !default;
@@ -346,19 +347,21 @@ $thumbnail-sidebar-width: 226px;
                 pointer-events: auto;
             }
         }
+    }
 
-        &.bp-annotations-create--region {
-            // Reset cursor popup in explicit region mode
-            .ba-PopupCursor {
-                display: block;
-            }
+    &.bp-annotations-create--highlight {
+        @include bp-annotations-create-base;
+        @include bp-annotations-disable-highlight-targets;
+        @include bp-annotations-disable-region-targets;
+    }
 
-            .annotationLayer,
-            .ba-HighlightList .ba-HighlightSvg.is-listening .ba-HighlightTarget-rect,
-            .ba-RegionAnnotation,
-            .textLayer span {
-                pointer-events: none;
-            }
+    &.bp-annotations-create--region {
+        @include bp-annotations-create-base;
+        @include bp-annotations-disable-highlight-targets;
+        @include bp-annotations-disable-region-targets;
+
+        .textLayer span {
+            pointer-events: none;
         }
     }
 

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -353,13 +353,10 @@ $thumbnail-sidebar-width: 226px;
                 display: block;
             }
 
-            .textLayer {
-                span {
-                    pointer-events: none;
-                }
-            }
-
-            .annotationLayer {
+            .annotationLayer,
+            .ba-HighlightList .ba-HighlightSvg.is-listening .ba-HighlightTarget-rect,
+            .ba-RegionAnnotation,
+            .textLayer span {
                 pointer-events: none;
             }
         }


### PR DESCRIPTION
When in explicit annotation creation mode (highlight or region), all existing annotation targets should not be interact-able. 