### PR TITLE
fix(discoverability): add AnnotationInput.INIT in AnnotationControlsFSM

### DIFF
--- a/src/lib/AnnotationControlsFSM.ts
+++ b/src/lib/AnnotationControlsFSM.ts
@@ -12,6 +12,7 @@ export enum AnnotationInput {
     CANCEL = 'cancel',
     CLICK = 'click',
     CREATE = 'create',
+    INIT = 'init',
     RESET = 'reset',
     STARTED = 'started',
     SUCCESS = 'success',
@@ -53,7 +54,7 @@ export default class AnnotationControlsFSM {
             return stateModeMap[this.currentState];
         }
 
-        if (input === AnnotationInput.RESET) {
+        if (input === AnnotationInput.RESET || input === AnnotationInput.INIT) {
             this.currentState = AnnotationState.NONE;
             return stateModeMap[this.currentState];
         }

--- a/src/lib/AnnotationControlsFSM.ts
+++ b/src/lib/AnnotationControlsFSM.ts
@@ -54,7 +54,7 @@ export default class AnnotationControlsFSM {
             return stateModeMap[this.currentState];
         }
 
-        if (input === AnnotationInput.RESET || input === AnnotationInput.INIT) {
+        if (input === AnnotationInput.RESET) {
             this.currentState = AnnotationState.NONE;
             return stateModeMap[this.currentState];
         }
@@ -67,7 +67,11 @@ export default class AnnotationControlsFSM {
                 break;
             case AnnotationState.HIGHLIGHT_TEMP:
             case AnnotationState.REGION_TEMP:
-                if (input === AnnotationInput.CANCEL || input === AnnotationInput.SUCCESS) {
+                if (
+                    input === AnnotationInput.CANCEL ||
+                    input === AnnotationInput.SUCCESS ||
+                    input === AnnotationInput.INIT
+                ) {
                     this.currentState = AnnotationState.NONE;
                 }
                 break;

--- a/src/lib/AnnotationControlsFSM.ts
+++ b/src/lib/AnnotationControlsFSM.ts
@@ -12,7 +12,6 @@ export enum AnnotationInput {
     CANCEL = 'cancel',
     CLICK = 'click',
     CREATE = 'create',
-    INIT = 'init',
     RESET = 'reset',
     STARTED = 'started',
     SUCCESS = 'success',

--- a/src/lib/AnnotationControlsFSM.ts
+++ b/src/lib/AnnotationControlsFSM.ts
@@ -67,11 +67,7 @@ export default class AnnotationControlsFSM {
                 break;
             case AnnotationState.HIGHLIGHT_TEMP:
             case AnnotationState.REGION_TEMP:
-                if (
-                    input === AnnotationInput.CANCEL ||
-                    input === AnnotationInput.SUCCESS ||
-                    input === AnnotationInput.INIT
-                ) {
+                if (input === AnnotationInput.CANCEL || input === AnnotationInput.SUCCESS) {
                     this.currentState = AnnotationState.NONE;
                 }
                 break;

--- a/src/lib/__tests__/AnnotationControlsFSM-test.js
+++ b/src/lib/__tests__/AnnotationControlsFSM-test.js
@@ -67,25 +67,13 @@ describe('lib/AnnotationControlsFSM', () => {
             expect(annotationControlsFSM.transition(AnnotationInput.RESET)).toEqual(AnnotationMode.NONE);
             expect(annotationControlsFSM.getState()).toEqual(AnnotationState.NONE);
         });
-
-        it('should reset state if input is AnnotationInput.INIT', () => {
-            const annotationControlsFSM = new AnnotationControlsFSM();
-
-            expect(annotationControlsFSM.transition(AnnotationInput.INIT)).toEqual(AnnotationMode.NONE);
-            expect(annotationControlsFSM.getState()).toEqual(AnnotationState.NONE);
-        });
     });
 
     describe('AnnotationState.HIGHLIGHT/REGION', () => {
         // Stay in the same state
         [AnnotationState.HIGHLIGHT, AnnotationState.REGION].forEach(state => {
             Object.values(AnnotationInput)
-                .filter(
-                    input =>
-                        input !== AnnotationInput.CLICK &&
-                        input !== AnnotationInput.RESET &&
-                        input !== AnnotationInput.INIT,
-                )
+                .filter(input => input !== AnnotationInput.CLICK && input !== AnnotationInput.RESET)
                 .forEach(input => {
                     it(`should stay in state ${state} if input is ${input}`, () => {
                         const annotationControlsFSM = new AnnotationControlsFSM(state);
@@ -118,16 +106,6 @@ describe('lib/AnnotationControlsFSM', () => {
                     input: AnnotationInput.RESET,
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.NONE,
-                },
-                {
-                    input: AnnotationInput.INIT,
-                    mode: AnnotationMode.HIGHLIGHT,
-                    output: AnnotationMode.HIGHLIGHT,
-                },
-                {
-                    input: AnnotationInput.INIT,
-                    mode: AnnotationMode.REGION,
-                    output: AnnotationMode.HIGHLIGHT,
                 },
             ].forEach(({ input, mode, output }) => {
                 test(`should output ${output} if input is ${input} and mode is ${mode}`, () => {
@@ -163,12 +141,12 @@ describe('lib/AnnotationControlsFSM', () => {
                     output: AnnotationMode.NONE,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.REGION,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.HIGHLIGHT,
                     output: AnnotationMode.REGION,
                 },
@@ -208,11 +186,6 @@ describe('lib/AnnotationControlsFSM', () => {
                 },
                 {
                     input: AnnotationInput.RESET,
-                    nextState: AnnotationState.NONE,
-                    output: AnnotationMode.NONE,
-                },
-                {
-                    input: AnnotationInput.INIT,
                     nextState: AnnotationState.NONE,
                     output: AnnotationMode.NONE,
                 },
@@ -260,12 +233,12 @@ describe('lib/AnnotationControlsFSM', () => {
                     output: AnnotationMode.NONE,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.HIGHLIGHT,
                     output: AnnotationMode.NONE,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.NONE,
                 },
@@ -303,12 +276,12 @@ describe('lib/AnnotationControlsFSM', () => {
                     output: AnnotationMode.NONE,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.NONE,
                 },
                 {
-                    input: AnnotationInput.INIT,
+                    input: AnnotationInput.CANCEL,
                     mode: AnnotationMode.HIGHLIGHT,
                     output: AnnotationMode.NONE,
                 },

--- a/src/lib/__tests__/AnnotationControlsFSM-test.js
+++ b/src/lib/__tests__/AnnotationControlsFSM-test.js
@@ -122,12 +122,12 @@ describe('lib/AnnotationControlsFSM', () => {
                 {
                     input: AnnotationInput.INIT,
                     mode: AnnotationMode.HIGHLIGHT,
-                    output: AnnotationMode.NONE,
+                    output: AnnotationMode.HIGHLIGHT,
                 },
                 {
                     input: AnnotationInput.INIT,
                     mode: AnnotationMode.REGION,
-                    output: AnnotationMode.NONE,
+                    output: AnnotationMode.HIGHLIGHT,
                 },
             ].forEach(({ input, mode, output }) => {
                 test(`should output ${output} if input is ${input} and mode is ${mode}`, () => {
@@ -165,12 +165,12 @@ describe('lib/AnnotationControlsFSM', () => {
                 {
                     input: AnnotationInput.INIT,
                     mode: AnnotationMode.REGION,
-                    output: AnnotationMode.NONE,
+                    output: AnnotationMode.REGION,
                 },
                 {
                     input: AnnotationInput.INIT,
                     mode: AnnotationMode.HIGHLIGHT,
-                    output: AnnotationMode.NONE,
+                    output: AnnotationMode.REGION,
                 },
             ].forEach(({ input, mode, output }) => {
                 test(`should output ${output} if input is ${input} and mode is ${mode}`, () => {

--- a/src/lib/__tests__/AnnotationControlsFSM-test.js
+++ b/src/lib/__tests__/AnnotationControlsFSM-test.js
@@ -67,13 +67,25 @@ describe('lib/AnnotationControlsFSM', () => {
             expect(annotationControlsFSM.transition(AnnotationInput.RESET)).toEqual(AnnotationMode.NONE);
             expect(annotationControlsFSM.getState()).toEqual(AnnotationState.NONE);
         });
+
+        it('should reset state if input is AnnotationInput.INIT', () => {
+            const annotationControlsFSM = new AnnotationControlsFSM();
+
+            expect(annotationControlsFSM.transition(AnnotationInput.INIT)).toEqual(AnnotationMode.NONE);
+            expect(annotationControlsFSM.getState()).toEqual(AnnotationState.NONE);
+        });
     });
 
     describe('AnnotationState.HIGHLIGHT/REGION', () => {
         // Stay in the same state
         [AnnotationState.HIGHLIGHT, AnnotationState.REGION].forEach(state => {
             Object.values(AnnotationInput)
-                .filter(input => input !== AnnotationInput.CLICK && input !== AnnotationInput.RESET)
+                .filter(
+                    input =>
+                        input !== AnnotationInput.CLICK &&
+                        input !== AnnotationInput.RESET &&
+                        input !== AnnotationInput.INIT,
+                )
                 .forEach(input => {
                     it(`should stay in state ${state} if input is ${input}`, () => {
                         const annotationControlsFSM = new AnnotationControlsFSM(state);
@@ -107,6 +119,16 @@ describe('lib/AnnotationControlsFSM', () => {
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.NONE,
                 },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.HIGHLIGHT,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.REGION,
+                    output: AnnotationMode.NONE,
+                },
             ].forEach(({ input, mode, output }) => {
                 test(`should output ${output} if input is ${input} and mode is ${mode}`, () => {
                     const annotationControlsFSM = new AnnotationControlsFSM(AnnotationState.HIGHLIGHT);
@@ -137,6 +159,16 @@ describe('lib/AnnotationControlsFSM', () => {
                 },
                 {
                     input: AnnotationInput.RESET,
+                    mode: AnnotationMode.HIGHLIGHT,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.REGION,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
                     mode: AnnotationMode.HIGHLIGHT,
                     output: AnnotationMode.NONE,
                 },
@@ -176,6 +208,11 @@ describe('lib/AnnotationControlsFSM', () => {
                 },
                 {
                     input: AnnotationInput.RESET,
+                    nextState: AnnotationState.NONE,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
                     nextState: AnnotationState.NONE,
                     output: AnnotationMode.NONE,
                 },
@@ -222,6 +259,16 @@ describe('lib/AnnotationControlsFSM', () => {
                     mode: AnnotationMode.REGION,
                     output: AnnotationMode.NONE,
                 },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.HIGHLIGHT,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.REGION,
+                    output: AnnotationMode.NONE,
+                },
             ].forEach(({ input, mode, output }) => {
                 test(`should output ${output} if input is ${input} and mode is ${mode}`, () => {
                     const annotationControlsFSM = new AnnotationControlsFSM(AnnotationState.HIGHLIGHT_TEMP);
@@ -252,6 +299,16 @@ describe('lib/AnnotationControlsFSM', () => {
                 },
                 {
                     input: AnnotationInput.RESET,
+                    mode: AnnotationMode.HIGHLIGHT,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
+                    mode: AnnotationMode.REGION,
+                    output: AnnotationMode.NONE,
+                },
+                {
+                    input: AnnotationInput.INIT,
                     mode: AnnotationMode.HIGHLIGHT,
                     output: AnnotationMode.NONE,
                 },


### PR DESCRIPTION
This change is needed due to a change in box-annotations where we always call `handleStop` which would trigger 
```
handleAnnotationCreatorChangeEvent({ status, type }) {
    this.processAnnotationModeChange(this.annotationControlsFSM.transition(status, type));
}
```

Status in this case would be AnnotationInput.INIT which is `cancel`.

When the input is `cancel`, this means that we want to reset AnnotationControlsFSM state to be `AnnotationState.NONE` only if our current state is `HIGHLIGHT_TEMP` or `REGION_TEMP`.