### PR TITLE
fix(annotations): Fix text blocked by old highlight selection background

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -271,6 +271,11 @@ $thumbnail-sidebar-width: 226px;
             }
         }
 
+        // For legacy Annotations highlight selection
+        .rangy-highlight {
+            opacity: .2;
+        }
+
         ::selection {
             background-color: fade-out($box-blue, .9);
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/17711683/96492074-eca89e80-11f7-11eb-97a6-c9f375e2a001.png)

After:
![image](https://user-images.githubusercontent.com/17711683/96492100-f7633380-11f7-11eb-951a-3e7018f87587.png)
