### PR TITLE
fix(pdf): Revert pdf.js to v2.2.228 due to font rendering issue

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -107,7 +107,7 @@ export const PDFJS_MAX_AUTO_SCALE = 1.25; // Should match MAX_AUTO_SCALE in pdf_
 export const PDFJS_WIDTH_PADDING_PX = 40; // Should match SCROLLBAR_PADDING in pdf_viewer.js
 export const PDFJS_HEIGHT_PADDING_PX = 5; // Should match VERTICAL_PADDING in pdf_viewer.js
 
-export const DOC_STATIC_ASSETS_VERSION = '2.53.0';
+export const DOC_STATIC_ASSETS_VERSION = '2.16.0'; // v2.53.0 has font rendering issues in large documents in MS Edge
 export const MEDIA_STATIC_ASSETS_VERSION = '2.14.0';
 export const MODEL3D_STATIC_ASSETS_VERSION = '1.12.0';
 export const SWF_STATIC_ASSETS_VERSION = '0.112.0';


### PR DESCRIPTION
We found a font rendering regression when previewing large documents in Microsoft Edge via VM. There appears to be an emerging rendering issue with the latest version of pdf.js in resource-constrained environments. We'll need to revert to the prior working version until it's resolved.