### PR TITLE
fix(annotations): remove bp prefix from region cursor keys

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -157,5 +157,5 @@ export const METADATA = {
 export const ERROR_CODE_403_FORBIDDEN_BY_POLICY = 'forbidden_by_policy';
 
 // LocalStorage Keys
-export const DOCUMENT_FTUX_CURSOR_SEEN_KEY = 'bp-ftux-cursor-seen-document';
-export const IMAGE_FTUX_CURSOR_SEEN_KEY = 'bp-ftux-cursor-seen-image';
+export const DOCUMENT_FTUX_CURSOR_SEEN_KEY = 'ftux-cursor-seen-document';
+export const IMAGE_FTUX_CURSOR_SEEN_KEY = 'ftux-cursor-seen-image';


### PR DESCRIPTION
Changes in this PR:
- [x] remove `bp-` from the local storage key constants for region cursor FTUX