### PR TITLE
fix(drawing): fix accessibility for color picker components

### DIFF
--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -24,11 +24,6 @@ export default function ColorPickerControl({
 
     return (
         <div className="bp-ColorPickerControl">
-            {isColorPickerToggled && (
-                <div className="bp-ColorPickerControl-palette">
-                    <ColorPickerPalette colors={colors} data-testid="bp-ColorPickerPalette" onSelect={handleSelect} />
-                </div>
-            )}
             <button
                 className="bp-ColorPickerControl-button"
                 data-testid="bp-ColorPickerControl-button"
@@ -38,6 +33,11 @@ export default function ColorPickerControl({
             >
                 <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
             </button>
+            {isColorPickerToggled && (
+                <div className="bp-ColorPickerControl-palette">
+                    <ColorPickerPalette colors={colors} data-testid="bp-ColorPickerPalette" onSelect={handleSelect} />
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Changes in this PR:
- [x] Move ColorPickerPalette element down below the button element so that when the user tabs from the button they are able to focus on the swatches in the palette
- [x] approved by design
- [x] cross browser testing

Note: We aren't adding any additional key handling (left / right arrows) as I think the current tabbing experience is satisfactory for complete navigation through the color picker elements