### PR TITLE
fix(drawing): emit color event when color picker is opened

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1123,9 +1123,7 @@ class BaseViewer extends EventEmitter {
             }
         }
 
-        if (mode === AnnotationMode.DRAWING) {
-            this.annotator.emit(ANNOTATOR_EVENT.setColor, this.annotationModule.getColor());
-        }
+        this.annotator.emit(ANNOTATOR_EVENT.setColor, this.annotationModule.getColor());
     };
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1124,8 +1124,7 @@ class BaseViewer extends EventEmitter {
         }
 
         if (mode === AnnotationMode.DRAWING) {
-            const color = this.annotationModule.getColor();
-            this.annotator.emit(ANNOTATOR_EVENT.setColor, color);
+            this.annotator.emit(ANNOTATOR_EVENT.setColor, this.annotationModule.getColor());
         }
     };
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1122,6 +1122,11 @@ class BaseViewer extends EventEmitter {
                 this.containerEl.classList.add(className);
             }
         }
+
+        if (mode === AnnotationMode.DRAWING) {
+            const color = this.annotationModule.getColor();
+            this.annotator.emit(ANNOTATOR_EVENT.setColor, color);
+        }
     };
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1779,6 +1779,12 @@ describe('lib/viewers/BaseViewer', () => {
                 destroy: jest.fn(),
                 setMode: jest.fn(),
             };
+            base.annotationModule.cache = {
+                get: jest.fn().mockReturnValue('#000'),
+            };
+            base.annotator = {
+                emit: jest.fn(),
+            };
             base.containerEl = document.createElement('div');
             base.areNewAnnotationsEnabled = jest.fn().mockReturnValue(true);
         });
@@ -1819,6 +1825,14 @@ describe('lib/viewers/BaseViewer', () => {
 
                 expect(base.containerEl).not.toHaveClass(constants.CLASS_ANNOTATIONS_CREATE_REGION);
             });
+        });
+
+        test('should call emit if mode is AnnotationMode.DRAWING', () => {
+            jest.spyOn(base, 'areNewAnnotationsEnabled').mockReturnValue(true);
+
+            base.processAnnotationModeChange(AnnotationMode.DRAWING);
+
+            expect(base.annotator.emit).toBeCalledWith(ANNOTATOR_EVENT.setColor, '#000');
         });
     });
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -529,15 +529,18 @@ describe('lib/viewers/BaseViewer', () => {
             jest.spyOn(base, 'disableAnnotationControls');
             jest.spyOn(base, 'processAnnotationModeChange');
 
-            base.annotator = {
-                emit: jest.fn(),
-                toggleAnnotationMode: jest.fn(),
-            };
             base.annotationControls = {
                 destroy: jest.fn(),
                 resetControls: jest.fn(),
                 setMode: jest.fn(),
                 toggle: jest.fn(),
+            };
+            base.annotationModule.cache = {
+                get: jest.fn().mockReturnValue('#000'),
+            };
+            base.annotator = {
+                emit: jest.fn(),
+                toggleAnnotationMode: jest.fn(),
             };
 
             base.handleFullscreenEnter();
@@ -1047,14 +1050,18 @@ describe('lib/viewers/BaseViewer', () => {
             jest.spyOn(base, 'areNewAnnotationsEnabled').mockReturnValue(true);
             jest.spyOn(base, 'processAnnotationModeChange');
 
-            base.annotator = {
-                toggleAnnotationMode: jest.fn(),
-            };
             base.annotationControls = {
                 destroy: jest.fn(),
                 resetControls: jest.fn(),
                 setMode: jest.fn(),
                 toggle: jest.fn(),
+            };
+            base.annotationModule.cache = {
+                get: jest.fn().mockReturnValue('#000'),
+            };
+            base.annotator = {
+                emit: jest.fn(),
+                toggleAnnotationMode: jest.fn(),
             };
 
             base.disableAnnotationControls();
@@ -1827,7 +1834,7 @@ describe('lib/viewers/BaseViewer', () => {
             });
         });
 
-        test('should call emit if mode is AnnotationMode.DRAWING', () => {
+        test('should call emit', () => {
             jest.spyOn(base, 'areNewAnnotationsEnabled').mockReturnValue(true);
 
             base.processAnnotationModeChange(AnnotationMode.DRAWING);


### PR DESCRIPTION
**Issue:**
If the user updates the drawing color in the first browser tab (when there are two tabs open), the cursor color will be stale in the second tab. The proposed fix is to emit the color change event every time the Color Picker is opened - this will ensure that the cursor color matches the color in the Preview Toolbar.

**Changes in this PR:**
- [x] emit color change event whenever the Color Picker button is clicked that results in mode becoming `AnnotatonMode.DRAWING`
- [x] update unit tests

**Demo:**
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/7213887/104242069-73de6a80-5413-11eb-9ba1-61cf24ef008a.gif)