### PR TITLE
fix(drawing): show sub-shadow in color picker control button

### DIFF
--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -7,7 +7,7 @@
     justify-content: center;
 }
 
-.bp-ColorPickerControl-button {
+.bp-ColorPickerControl-toggle {
     @include bp-ControlButton;
 
     &.bp-is-active,
@@ -48,7 +48,7 @@
     }
 }
 
-.bp-ColorPickerControl-swatch {
+.bp-ColorPickerControl-toggle-swatch {
     width: 18px;
     height: 18px;
     border: 2px solid #fff;

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -1,11 +1,5 @@
 @import '../styles';
 
-@mixin bp-highlight-style {
-    padding: 8px;
-    background-color: $fours;
-    border-radius: 4px;
-}
-
 .bp-ColorPickerControl {
     position: relative;
     display: flex;
@@ -16,10 +10,13 @@
 .bp-ColorPickerControl-button {
     @include bp-ControlButton;
 
-    &:hover,
-    &:focus {
-        .bp-ColorPickerControl-highlight {
-            @include bp-highlight-style;
+    &.bp-is-toggled,
+    &:focus,
+    &:hover {
+        .bp-ColorPickerControl-toggle-background {
+            padding: 8px;
+            background-color: $fours;
+            border-radius: 4px;
         }
     }
 }
@@ -48,12 +45,6 @@
 
     &.bp-is-open {
         display: block;
-    }
-}
-
-.bp-ColorPickerControl-highlight {
-    &.bp-has-attention {
-        @include bp-highlight-style;
     }
 }
 

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -9,6 +9,15 @@
 
 .bp-ColorPickerControl-button {
     @include bp-ControlButton;
+
+    &:hover,
+    &:focus {
+        .bp-ColorPickerControl-highlight {
+            padding: 8px;
+            background-color: $fours;
+            border-radius: 4px;
+        }
+    }
 }
 
 .bp-ColorPickerControl-palette {
@@ -36,12 +45,6 @@
     &.bp-is-open {
         display: block;
     }
-}
-
-.bp-ColorPickerControl-highlight {
-    padding: 8px;
-    background-color: $fours;
-    border-radius: 4px;
 }
 
 .bp-ColorPickerControl-swatch {

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -10,7 +10,7 @@
 .bp-ColorPickerControl-button {
     @include bp-ControlButton;
 
-    &.bp-is-toggled,
+    &.bp-is-active,
     &:focus,
     &:hover {
         .bp-ColorPickerControl-toggle-background {

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -1,6 +1,6 @@
 @import '../styles';
 
-@mixin highlight-style {
+@mixin bp-highlight-style {
     padding: 8px;
     background-color: $fours;
     border-radius: 4px;
@@ -19,7 +19,7 @@
     &:hover,
     &:focus {
         .bp-ColorPickerControl-highlight {
-            @include highlight-style();
+            @include bp-highlight-style;
         }
     }
 }
@@ -52,8 +52,8 @@
 }
 
 .bp-ColorPickerControl-highlight {
-    &.bp-is-open {
-        @include highlight-style();
+    &.bp-has-attention {
+        @include bp-highlight-style;
     }
 }
 

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -1,5 +1,11 @@
 @import '../styles';
 
+@mixin highlight-style {
+    padding: 8px;
+    background-color: $fours;
+    border-radius: 4px;
+}
+
 .bp-ColorPickerControl {
     position: relative;
     display: flex;
@@ -13,9 +19,7 @@
     &:hover,
     &:focus {
         .bp-ColorPickerControl-highlight {
-            padding: 8px;
-            background-color: $fours;
-            border-radius: 4px;
+            @include highlight-style();
         }
     }
 }
@@ -44,6 +48,12 @@
 
     &.bp-is-open {
         display: block;
+    }
+}
+
+.bp-ColorPickerControl-highlight {
+    &.bp-is-open {
+        @include highlight-style();
     }
 }
 

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.scss
@@ -38,6 +38,12 @@
     }
 }
 
+.bp-ColorPickerControl-highlight {
+    padding: 8px;
+    background-color: $fours;
+    border-radius: 4px;
+}
+
 .bp-ColorPickerControl-swatch {
     width: 18px;
     height: 18px;

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -44,7 +44,11 @@ export default function ColorPickerControl({
                 type="button"
                 {...rest}
             >
-                <div className={classNames('bp-ColorPickerControl-highlight', { 'bp-is-open': isColorPickerToggled })}>
+                <div
+                    className={classNames('bp-ColorPickerControl-highlight', {
+                        'bp-has-attention': isColorPickerToggled,
+                    })}
+                >
                     <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
                 </div>
             </button>

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -37,18 +37,14 @@ export default function ColorPickerControl({
     return (
         <div className="bp-ColorPickerControl">
             <button
-                className="bp-ColorPickerControl-button"
+                className={classNames('bp-ColorPickerControl-button', { 'bp-is-toggled': isColorPickerToggled })}
                 data-testid="bp-ColorPickerControl-button"
                 onBlur={handleBlur}
                 onClick={handleClick}
                 type="button"
                 {...rest}
             >
-                <div
-                    className={classNames('bp-ColorPickerControl-highlight', {
-                        'bp-has-attention': isColorPickerToggled,
-                    })}
-                >
+                <div className="bp-ColorPickerControl-toggle-background">
                     <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
                 </div>
             </button>

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -44,7 +44,9 @@ export default function ColorPickerControl({
                 type="button"
                 {...rest}
             >
-                <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
+                <div className="bp-ColorPickerControl-highlight">
+                    <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
+                </div>
             </button>
             <div
                 className={classNames('bp-ColorPickerControl-palette', { 'bp-is-open': isColorPickerToggled })}

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -37,7 +37,7 @@ export default function ColorPickerControl({
     return (
         <div className="bp-ColorPickerControl">
             <button
-                className={classNames('bp-ColorPickerControl-button', { 'bp-is-toggled': isColorPickerToggled })}
+                className={classNames('bp-ColorPickerControl-button', { 'bp-is-active': isColorPickerToggled })}
                 data-testid="bp-ColorPickerControl-button"
                 onBlur={handleBlur}
                 onClick={handleClick}

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -37,15 +37,15 @@ export default function ColorPickerControl({
     return (
         <div className="bp-ColorPickerControl">
             <button
-                className={classNames('bp-ColorPickerControl-button', { 'bp-is-active': isColorPickerToggled })}
-                data-testid="bp-ColorPickerControl-button"
+                className={classNames('bp-ColorPickerControl-toggle', { 'bp-is-active': isColorPickerToggled })}
+                data-testid="bp-ColorPickerControl-toggle"
                 onBlur={handleBlur}
                 onClick={handleClick}
                 type="button"
                 {...rest}
             >
                 <div className="bp-ColorPickerControl-toggle-background">
-                    <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
+                    <div className="bp-ColorPickerControl-toggle-swatch" style={{ backgroundColor: activeColor }} />
                 </div>
             </button>
             <div

--- a/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
+++ b/src/lib/viewers/controls/color-picker/ColorPickerControl.tsx
@@ -44,7 +44,7 @@ export default function ColorPickerControl({
                 type="button"
                 {...rest}
             >
-                <div className="bp-ColorPickerControl-highlight">
+                <div className={classNames('bp-ColorPickerControl-highlight', { 'bp-is-open': isColorPickerToggled })}>
                     <div className="bp-ColorPickerControl-swatch" style={{ backgroundColor: activeColor }} />
                 </div>
             </button>

--- a/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
+++ b/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
@@ -34,10 +34,10 @@ describe('ColorPickerControl', () => {
             const toggleButton = getToggleButton(wrapper);
 
             toggleButton.simulate('click');
-            expect(getToggleButton(wrapper).hasClass('bp-is-toggled')).toBe(true);
+            expect(getToggleButton(wrapper).hasClass('bp-is-active')).toBe(true);
 
             toggleButton.simulate('blur');
-            expect(getToggleButton(wrapper).hasClass('bp-is-toggled')).toBe(false);
+            expect(getToggleButton(wrapper).hasClass('bp-is-active')).toBe(false);
         });
 
         test('should close the palette when button is blurred', () => {

--- a/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
+++ b/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
@@ -29,6 +29,17 @@ describe('ColorPickerControl', () => {
             expect(getColorPickerPalette(wrapper).hasClass('bp-is-open')).toBe(true);
         });
 
+        test('should apply toggle background when the toggle button is clicked and remove the background when the button is blurred', () => {
+            const wrapper = getWrapper();
+            const toggleButton = getToggleButton(wrapper);
+
+            toggleButton.simulate('click');
+            expect(getToggleButton(wrapper).hasClass('bp-is-toggled')).toBe(true);
+
+            toggleButton.simulate('blur');
+            expect(getToggleButton(wrapper).hasClass('bp-is-toggled')).toBe(false);
+        });
+
         test('should close the palette when button is blurred', () => {
             const wrapper = getWrapper();
             const toggleButton = getToggleButton(wrapper);

--- a/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
+++ b/src/lib/viewers/controls/color-picker/__tests__/ColorPickerControl-test.tsx
@@ -12,7 +12,7 @@ describe('ColorPickerControl', () => {
         wrapper.find('[data-testid="bp-ColorPickerControl-palette"]');
 
     const getToggleButton = (wrapper: ShallowWrapper): ShallowWrapper =>
-        wrapper.find('[data-testid="bp-ColorPickerControl-button"]');
+        wrapper.find('[data-testid="bp-ColorPickerControl-toggle"]');
 
     describe('render', () => {
         test('should not render ColorPickerPalette when the component is first mounted', () => {


### PR DESCRIPTION
**Changes in this PR:**
- [x] add sub shadow in color picker control button
- [x] cross browser testing

**Demo:**
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/7213887/104671830-6d5e2600-5693-11eb-97a6-a622659a2dc9.gif)

**Chrome**
<img width="213" alt="chrome" src="https://user-images.githubusercontent.com/7213887/104662721-49ddb000-5680-11eb-8da7-f6e60071b0a2.png">

**Safari**
<img width="267" alt="safari" src="https://user-images.githubusercontent.com/7213887/104662730-4cd8a080-5680-11eb-8567-11d9e3add53a.png">

**FF**
<img width="390" alt="firefox" src="https://user-images.githubusercontent.com/7213887/104662742-4fd39100-5680-11eb-89f6-446821e927be.png">

**Edge**
<img width="238" alt="edge" src="https://user-images.githubusercontent.com/7213887/104662749-52ce8180-5680-11eb-9091-ee191d0e62ac.png">

**IE**
<img width="184" alt="ie" src="https://user-images.githubusercontent.com/7213887/104662753-5530db80-5680-11eb-8c07-fec070db2e77.png">