### PR TITLE
fix(thumbnails): Fix position of ContentPreview navigate button

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -410,3 +410,9 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         display: none;
     }
 }
+
+/* stylelint-disable declaration-no-important */
+.bcpr.bcpr-thumbnails-open .bcpr-navigate-left {
+    left: $thumbnail-sidebar-width !important; // TODO: Move to BUIE once this release is in production
+}
+/* stylelint-enable declaration-no-important */


### PR DESCRIPTION
I'm adding this override here to simplify the release coordination between Preview SDK and BUIE. We can move it to BUIE proper and remove the `!important` once this release is being used in production. I'm open to other suggestions, as well.