### PR TITLE
perf(presentation): Improve presentation rendering performance in Safari

### DIFF
--- a/src/lib/viewers/doc/Presentation.scss
+++ b/src/lib/viewers/doc/Presentation.scss
@@ -12,6 +12,10 @@
         bottom: 0;
         left: 0;
         margin: auto;
+
+        &.bp-is-invisible {
+            opacity: 0; // Combine with visibility: hidden to improve large file performance in Safari
+        }
     }
 
     &.overflow-x {

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -84,7 +84,6 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         background-color: $d-eight;
         border-radius: $thumbnail-border-radius;
         box-shadow: 0 0 0 1px $off-white, 0 1px 4px 0 rgba(0, 0, 0, .08);
-        transition: box-shadow 50ms ease;
     }
 
     .bp-thumbnail-page-number {
@@ -101,7 +100,6 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         border-radius: $thumbnail-border-radius / 2 0 $thumbnail-border-radius 0;
         box-shadow: 1px 1px 2px 0 rgba(0, 0, 0, .2);
         opacity: 0;
-        transition: background 50ms ease, opacity 50ms ease;
     }
 
     .bp-thumbnail-image {


### PR DESCRIPTION
The Presentation viewer creates all pages of a document as a big stack of elements using absolute positioning. It controls the page elements' visibility via the `visibility` style directive. However, unlike other browsers, Safari 14 on MacOS Big Sur seems to frequently layout/paint every page of the document, even if the page has `visibility: hidden` set. Adding `opacity: 0` seems to resolve the problem.