### PR TITLE
fix(ThumbnailsSidebar): A11Y - add aria-current to ThumbnailsSidebar

### DIFF
--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -440,8 +440,10 @@ class ThumbnailsSidebar {
             const parsedPageNum = parseInt(thumbnailEl.dataset.bpPageNum, 10);
             if (parsedPageNum === this.currentPage) {
                 thumbnailEl.classList.add(CLASS_BOX_PREVIEW_THUMBNAIL_IS_SELECTED);
+                thumbnailEl.setAttribute('aria-current', true);
             } else {
                 thumbnailEl.classList.remove(CLASS_BOX_PREVIEW_THUMBNAIL_IS_SELECTED);
+                thumbnailEl.removeAttribute('aria-current');
             }
         });
     }

--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -254,6 +254,7 @@ class ThumbnailsSidebar {
 
         if (pageNum === this.currentPage) {
             thumbnailEl.classList.add(CLASS_BOX_PREVIEW_THUMBNAIL_IS_SELECTED);
+            thumbnailEl.setAttribute('aria-current', true);
         }
 
         // If image is already in cache, then use it instead of waiting for

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -435,10 +435,16 @@ describe('ThumbnailsSidebar', () => {
 
     describe('applyCurrentPageSelection()', () => {
         let thumbnails;
+        let parentEl;
 
         beforeEach(() => {
             stubs.addClass = jest.fn();
             stubs.removeClass = jest.fn();
+            stubs.addAriaAttribute = jest.fn();
+            stubs.removeAriaAttribute = jest.fn();
+
+            parentEl = document.createElement('div');
+            parentEl.dataset.bpPageNum = '3';
 
             // eslint-disable-next-line
             const createTestThumbnail = pageNum => {
@@ -446,6 +452,8 @@ describe('ThumbnailsSidebar', () => {
                 thumbnail.dataset.bpPageNum = pageNum;
                 thumbnail.classList.add = stubs.addClass;
                 thumbnail.classList.remove = stubs.removeClass;
+                thumbnail.setAttribute = stubs.addAriaAttribute;
+                thumbnail.removeAttribute = stubs.removeAriaAttribute;
                 return thumbnail;
             };
 
@@ -474,6 +482,14 @@ describe('ThumbnailsSidebar', () => {
 
             expect(stubs.removeClass).toBeCalledTimes(2);
             expect(stubs.addClass).toBeCalledTimes(1);
+        });
+
+        test('should add the aria-current attribute when thumbnail is selected', () => {
+            thumbnailsSidebar.currentPage = 2;
+
+            thumbnailsSidebar.applyCurrentPageSelection();
+
+            expect(stubs.addAriaAttribute).toBeCalledTimes(1);
         });
     });
 

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -435,16 +435,11 @@ describe('ThumbnailsSidebar', () => {
 
     describe('applyCurrentPageSelection()', () => {
         let thumbnails;
-        let parentEl;
 
         beforeEach(() => {
             stubs.addClass = jest.fn();
             stubs.removeClass = jest.fn();
             stubs.addAriaAttribute = jest.fn();
-            stubs.removeAriaAttribute = jest.fn();
-
-            parentEl = document.createElement('div');
-            parentEl.dataset.bpPageNum = '3';
 
             // eslint-disable-next-line
             const createTestThumbnail = pageNum => {
@@ -453,7 +448,6 @@ describe('ThumbnailsSidebar', () => {
                 thumbnail.classList.add = stubs.addClass;
                 thumbnail.classList.remove = stubs.removeClass;
                 thumbnail.setAttribute = stubs.addAriaAttribute;
-                thumbnail.removeAttribute = stubs.removeAriaAttribute;
                 return thumbnail;
             };
 

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -440,6 +440,7 @@ describe('ThumbnailsSidebar', () => {
             stubs.addClass = jest.fn();
             stubs.removeClass = jest.fn();
             stubs.addAriaAttribute = jest.fn();
+            stubs.removeAriaAttribute = jest.fn();
 
             // eslint-disable-next-line
             const createTestThumbnail = pageNum => {
@@ -448,6 +449,7 @@ describe('ThumbnailsSidebar', () => {
                 thumbnail.classList.add = stubs.addClass;
                 thumbnail.classList.remove = stubs.removeClass;
                 thumbnail.setAttribute = stubs.addAriaAttribute;
+                thumbnail.removeAttribute = stubs.removeAriaAttribute;
                 return thumbnail;
             };
 
@@ -484,6 +486,14 @@ describe('ThumbnailsSidebar', () => {
             thumbnailsSidebar.applyCurrentPageSelection();
 
             expect(stubs.addAriaAttribute).toBeCalledTimes(1);
+        });
+
+        test('should remove the aria-current attribute when thumbnail is not selected', () => {
+            thumbnailsSidebar.currentPage = 2;
+
+            thumbnailsSidebar.applyCurrentPageSelection();
+
+            expect(stubs.removeAriaAttribute).toBeCalledTimes(2);
         });
     });
 


### PR DESCRIPTION
There is a visual indication of the current thumbnail that also presents the current page You should convey this information to screen reader with aria-current="true". For example:

<div class="bp-thumbnail bp-thumbnail-is-selected bp-thumbnail-image-loaded" data-bp-page-num="7" role="button" aria-current="true">


![Screen Shot 2021-08-05 at 2 56 06 PM](https://user-images.githubusercontent.com/79931431/128412923-2371af75-29b5-4948-a207-59890866d551.png)
