### PR TITLE
Wrong focus on close findbar

### DIFF
--- a/src/lib/viewers/controls/findbar/FindBarToggle.tsx
+++ b/src/lib/viewers/controls/findbar/FindBarToggle.tsx
@@ -12,15 +12,12 @@ export default function FindBarToggle({ onFindBarToggle }: Props): JSX.Element |
     if (!onFindBarToggle) {
         return null;
     }
-    const onClickHandler = () => {
-        onFindBarToggle(buttonReference.current);
-    };
 
     return (
         <button
             ref={buttonReference}
             className="bp-FindBarToggle"
-            onClick={onClickHandler}
+            onClick={(): void => onFindBarToggle(buttonReference.current)}
             title={__('toggle_findbar')}
             type="button"
         >

--- a/src/lib/viewers/controls/findbar/FindBarToggle.tsx
+++ b/src/lib/viewers/controls/findbar/FindBarToggle.tsx
@@ -3,16 +3,27 @@ import IconSearch24 from '../icons/IconSearch24';
 import './FindBarToggle.scss';
 
 export type Props = {
-    onFindBarToggle?: () => void;
+    onFindBarToggle: (buttonElement: HTMLDivElement | null) => void;
 };
 
 export default function FindBarToggle({ onFindBarToggle }: Props): JSX.Element | null {
+    const buttonReference = React.useRef(null);
+
     if (!onFindBarToggle) {
         return null;
     }
+    const onClickHandler = () => {
+        onFindBarToggle(buttonReference.current);
+    };
 
     return (
-        <button className="bp-FindBarToggle" onClick={onFindBarToggle} title={__('toggle_findbar')} type="button">
+        <button
+            ref={buttonReference}
+            className="bp-FindBarToggle"
+            onClick={onClickHandler}
+            title={__('toggle_findbar')}
+            type="button"
+        >
             <IconSearch24 />
         </button>
     );

--- a/src/lib/viewers/controls/findbar/FindBarToggle.tsx
+++ b/src/lib/viewers/controls/findbar/FindBarToggle.tsx
@@ -3,21 +3,18 @@ import IconSearch24 from '../icons/IconSearch24';
 import './FindBarToggle.scss';
 
 export type Props = {
-    onFindBarToggle?: (buttonElement: HTMLDivElement | null) => void;
+    onFindBarToggle?: (buttonElement: EventTarget | null) => void;
 };
 
 export default function FindBarToggle({ onFindBarToggle }: Props): JSX.Element | null {
-    const buttonReference = React.useRef(null);
-
     if (!onFindBarToggle) {
         return null;
     }
 
     return (
         <button
-            ref={buttonReference}
             className="bp-FindBarToggle"
-            onClick={(): void => onFindBarToggle(buttonReference.current)}
+            onClick={(event): void => onFindBarToggle(event.target)}
             title={__('toggle_findbar')}
             type="button"
         >

--- a/src/lib/viewers/controls/findbar/FindBarToggle.tsx
+++ b/src/lib/viewers/controls/findbar/FindBarToggle.tsx
@@ -3,7 +3,7 @@ import IconSearch24 from '../icons/IconSearch24';
 import './FindBarToggle.scss';
 
 export type Props = {
-    onFindBarToggle: (buttonElement: HTMLDivElement | null) => void;
+    onFindBarToggle?: (buttonElement: HTMLDivElement | null) => void;
 };
 
 export default function FindBarToggle({ onFindBarToggle }: Props): JSX.Element | null {

--- a/src/lib/viewers/controls/findbar/FindBarToggle.tsx
+++ b/src/lib/viewers/controls/findbar/FindBarToggle.tsx
@@ -14,7 +14,7 @@ export default function FindBarToggle({ onFindBarToggle }: Props): JSX.Element |
     return (
         <button
             className="bp-FindBarToggle"
-            onClick={(event): void => onFindBarToggle(event.target)}
+            onClick={({ target }): void => onFindBarToggle(target)}
             title={__('toggle_findbar')}
             type="button"
         >

--- a/src/lib/viewers/controls/findbar/__tests__/FindBarToggle-test.tsx
+++ b/src/lib/viewers/controls/findbar/__tests__/FindBarToggle-test.tsx
@@ -9,12 +9,12 @@ describe('FindBarToggle', () => {
     describe('event handlers', () => {
         test('should forward the click from the button', () => {
             const onToggle = jest.fn();
-            const mockedEvent = { target: {} };
+            const mockedEvent = { target: document.createElement('button') };
             const wrapper = getWrapper({ onFindBarToggle: onToggle });
 
             wrapper.simulate('click', mockedEvent);
 
-            expect(onToggle).toBeCalled();
+            expect(onToggle).toBeCalledWith(mockedEvent.target);
         });
     });
 

--- a/src/lib/viewers/controls/findbar/__tests__/FindBarToggle-test.tsx
+++ b/src/lib/viewers/controls/findbar/__tests__/FindBarToggle-test.tsx
@@ -9,9 +9,10 @@ describe('FindBarToggle', () => {
     describe('event handlers', () => {
         test('should forward the click from the button', () => {
             const onToggle = jest.fn();
+            const mockedEvent = { target: {} };
             const wrapper = getWrapper({ onFindBarToggle: onToggle });
 
-            wrapper.simulate('click');
+            wrapper.simulate('click', mockedEvent);
 
             expect(onToggle).toBeCalled();
         });

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -410,8 +410,8 @@ class DocBaseViewer extends BaseViewer {
     }
 
     handleFindBarClose() {
-        if (this.docEl) {
-            this.docEl.focus(); // Prevent focus from transferring to the root document element
+        if (this.findBarToggleElement) {
+            this.findBarToggleElement.focus();
         }
     }
 
@@ -1483,7 +1483,8 @@ class DocBaseViewer extends BaseViewer {
         this.pinchPage = null;
     }
 
-    toggleFindBar() {
+    toggleFindBar(elementToFocus) {
+        this.findBarToggleElement = elementToFocus;
         this.findBar.toggle();
     }
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -410,7 +410,7 @@ class DocBaseViewer extends BaseViewer {
     }
 
     handleFindBarClose() {
-        if (this.findBarToggleElement) {
+        if (this.findBarToggleElement && this.findBarToggleElement.focus) {
             this.findBarToggleElement.focus();
         }
     }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -410,8 +410,8 @@ class DocBaseViewer extends BaseViewer {
     }
 
     handleFindBarClose() {
-        if (this.findBarToggleElement && this.findBarToggleElement.focus) {
-            this.findBarToggleElement.focus();
+        if (this.findBarToggleEl && this.findBarToggleEl.focus) {
+            this.findBarToggleEl.focus();
         }
     }
 
@@ -1483,8 +1483,8 @@ class DocBaseViewer extends BaseViewer {
         this.pinchPage = null;
     }
 
-    toggleFindBar(elementToFocus) {
-        this.findBarToggleElement = elementToFocus;
+    toggleFindBar(findBarToggleEl) {
+        this.findBarToggleEl = findBarToggleEl;
         this.findBar.toggle();
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19536369/134058886-259261da-7b3c-49de-b216-5ab036f06a0a.png)

When the findBar is closed the focus should go back to the find toggle button located on toolbar.

![image](https://user-images.githubusercontent.com/19536369/134058927-147bc27d-a81b-4028-b9f4-210c01f3d714.png)
