### PR TITLE
fix(a11y): wrong focus selection on toggleFullscreen method

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -121,6 +121,9 @@ class BaseViewer extends EventEmitter {
     /** @property {HTMLElement} - The .bp-content which is the container for the viewer's content */
     containerEl;
 
+    /** @property {HTMLButtonElement} - The button which will be focus when fullscreen is toggle */
+    fullscreenToggleEl;
+
     /** @property {boolean} - Stores whether the Viewer has been setup yet. */
     isSetup = false;
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -191,9 +191,6 @@ class BaseViewer extends EventEmitter {
         // From the perspective of viewers bp-content holds everything
         this.containerEl = container.querySelector(SELECTOR_BOX_PREVIEW_CONTENT);
 
-        // Element to focus when fullscreen is toggled.
-        this.fullscreenToggleEl = null;
-
         // Set an aria-label for all files
         this.containerEl.setAttribute('aria-label', __('file_preview_label'));
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -281,6 +281,7 @@ class BaseViewer extends EventEmitter {
         this.annotatorPromise = null;
         this.annotatorPromiseResolver = null;
         this.emittedMetrics = null;
+        this.fullscreenToggleEl = null;
         this.emit('destroy');
     }
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -553,7 +553,8 @@ class BaseViewer extends EventEmitter {
      * @protected
      * @return {void}
      */
-    toggleFullscreen() {
+    toggleFullscreen(isFullscreen, fullscreenToggleEl) {
+        this.fullscreenToggleEl = fullscreenToggleEl;
         fullscreen.toggle(this.containerEl);
     }
 
@@ -568,6 +569,9 @@ class BaseViewer extends EventEmitter {
         if (this.annotator && this.areNewAnnotationsEnabled()) {
             this.annotator.emit(ANNOTATOR_EVENT.setVisibility, false);
             this.disableAnnotationControls();
+        }
+        if (this.fullscreenToggleEl && this.fullscreenToggleEl.focus) {
+            this.fullscreenToggleEl.focus();
         }
     }
 

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -191,6 +191,9 @@ class BaseViewer extends EventEmitter {
         // From the perspective of viewers bp-content holds everything
         this.containerEl = container.querySelector(SELECTOR_BOX_PREVIEW_CONTENT);
 
+        // Element to focus when fullscreen is toggled.
+        this.fullscreenToggleEl = null;
+
         // Set an aria-label for all files
         this.containerEl.setAttribute('aria-label', __('file_preview_label'));
 
@@ -551,6 +554,8 @@ class BaseViewer extends EventEmitter {
      * Enters or exits fullscreen
      *
      * @protected
+     * @param {boolean} [isFullscreen] - flag to allow fullscreen
+     * @param {HTMLElement} element - Element to be focused after fullscreen toggle
      * @return {void}
      */
     toggleFullscreen(isFullscreen, fullscreenToggleEl) {

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -5,7 +5,7 @@ import useFullscreen from '../hooks/useFullscreen';
 import './FullscreenToggle.scss';
 
 export type Props = {
-    onFullscreenToggle: (isFullscreen: boolean) => void;
+    onFullscreenToggle: (isFullscreen: boolean, toggleFullscreen: EventTarget | null) => void;
     onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 };
 
@@ -14,12 +14,14 @@ export default function FullscreenToggle({ onFullscreenToggle, ...rest }: Props)
     const Icon = isFullscreen ? IconFullscreenOut24 : IconFullscreenIn24;
     const title = isFullscreen ? __('exit_fullscreen') : __('enter_fullscreen');
 
-    const handleClick = (): void => {
-        onFullscreenToggle(!isFullscreen);
-    };
-
     return (
-        <button className="bp-FullscreenToggle" onClick={handleClick} title={title} type="button" {...rest}>
+        <button
+            className="bp-FullscreenToggle"
+            onClick={({ target }) => onFullscreenToggle(!isFullscreen, target)}
+            title={title}
+            type="button"
+            {...rest}
+        >
             <Icon />
         </button>
     );

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -14,14 +14,12 @@ export default function FullscreenToggle({ onFullscreenToggle, ...rest }: Props)
     const Icon = isFullscreen ? IconFullscreenOut24 : IconFullscreenIn24;
     const title = isFullscreen ? __('exit_fullscreen') : __('enter_fullscreen');
 
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+        onFullscreenToggle(!isFullscreen, event.target);
+    };
+
     return (
-        <button
-            className="bp-FullscreenToggle"
-            onClick={({ target }): void => onFullscreenToggle(!isFullscreen, target)}
-            title={title}
-            type="button"
-            {...rest}
-        >
+        <button className="bp-FullscreenToggle" onClick={handleClick} title={title} type="button" {...rest}>
             <Icon />
         </button>
     );

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -14,8 +14,8 @@ export default function FullscreenToggle({ onFullscreenToggle, ...rest }: Props)
     const Icon = isFullscreen ? IconFullscreenOut24 : IconFullscreenIn24;
     const title = isFullscreen ? __('exit_fullscreen') : __('enter_fullscreen');
 
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        onFullscreenToggle(!isFullscreen, event.target);
+    const handleClick = ({ target }: React.MouseEvent): void => {
+        onFullscreenToggle(!isFullscreen, target);
     };
 
     return (

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -17,7 +17,7 @@ export default function FullscreenToggle({ onFullscreenToggle, ...rest }: Props)
     return (
         <button
             className="bp-FullscreenToggle"
-            onClick={({ target }) => onFullscreenToggle(!isFullscreen, target)}
+            onClick={({ target }): void => onFullscreenToggle(!isFullscreen, target)}
             title={title}
             type="button"
             {...rest}

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -5,7 +5,7 @@ import useFullscreen from '../hooks/useFullscreen';
 import './FullscreenToggle.scss';
 
 export type Props = {
-    onFullscreenToggle: (isFullscreen: boolean, toggleFullscreen: EventTarget | null) => void;
+    onFullscreenToggle: (isFullscreen: boolean, toggleFullscreenEl: EventTarget | null) => void;
     onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 };
 

--- a/src/lib/viewers/controls/fullscreen/__tests__/FullscreenToggle-test.tsx
+++ b/src/lib/viewers/controls/fullscreen/__tests__/FullscreenToggle-test.tsx
@@ -34,10 +34,11 @@ describe('FullscreenToggle', () => {
 
         test('should invoke onFullscreenToggle prop on click', () => {
             const onToggle = jest.fn();
+            const mockedEvent = { target: document.createElement('button') };
             const wrapper = getWrapper({ onFullscreenToggle: onToggle });
 
-            wrapper.simulate('click');
-            expect(onToggle).toBeCalledWith(true);
+            wrapper.simulate('click', mockedEvent);
+            expect(onToggle).toBeCalledWith(true, mockedEvent.target);
         });
     });
 


### PR DESCRIPTION
When the fullscreen is toggled the focus should go back to the fullscreen toggle button located on toolbar.

![image](https://user-images.githubusercontent.com/19536369/134389952-2c351786-95d0-4252-a8a2-ebffb75bb628.png)
