### PR TITLE
feat(viewer): Add support for disabling .boxdicom file type

### DIFF
--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -28,10 +28,10 @@ class IFrameLoader extends AssetLoader {
      * @inheritdoc
      */
     determineViewer(file, disabledViewers = [], viewerOptions = {}) {
-        const isDicomFile = file.name === 'Dicom.boxdicom' || file.extension === 'boxdicom';
-        const openWithAmbraEnabled = getProp(viewerOptions, 'IFrame.openWithAmbra');
-        // The IFrame viewer is disabled when the file is a Boxdicom file and Open_with_Ambra FF is enabled
-        if (openWithAmbraEnabled && isDicomFile) {
+        const isDicomFile = file.extension === 'boxdicom';
+        const disableDicom = getProp(viewerOptions, 'IFrame.disableDicom');
+        // The IFrame viewer is disabled when the file is a Boxdicom file and the disableDicom viewer option is enabled
+        if (disableDicom && isDicomFile) {
             disabledViewers.push('IFrame');
         }
 

--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -1,3 +1,4 @@
+import getProp from 'lodash/get';
 import AssetLoader from '../AssetLoader';
 import IFrameViewer from './IFrameViewer';
 import { ORIGINAL_REP_NAME } from '../../constants';
@@ -21,6 +22,20 @@ class IFrameLoader extends AssetLoader {
     constructor() {
         super();
         this.viewers = VIEWERS;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    determineViewer(file, disabledViewers = [], viewerOptions = {}) {
+        const isDicomFile = file.name === 'Dicom.boxdicom' || file.extension === 'boxdicom';
+        const openWithAmbraEnabled = getProp(viewerOptions, 'IFrame.openWithAmbra');
+        // The IFrame viewer is disabled when the file is a Boxdicom file and Open_with_Ambra FF is enabled
+        if (openWithAmbraEnabled && isDicomFile) {
+            disabledViewers.push('IFrame');
+        }
+
+        return super.determineViewer(file, disabledViewers);
     }
 }
 

--- a/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
@@ -1,8 +1,6 @@
 import IFrameLoader from '../IFrameLoader';
 import IFrameViewer from '../IFrameViewer';
 
-const sandbox = sinon.createSandbox();
-
 describe('lib/viewers/iframe/IFrameLoader', () => {
     const iframe = new IFrameViewer({
         file: {
@@ -18,10 +16,6 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
         },
     });
 
-    afterEach(() => {
-        sandbox.verifyAndRestore();
-    });
-
     test('should have the correct viewer', () => {
         const iframeViewer = IFrameLoader.viewers[0];
         expect(iframeViewer).toEqual({
@@ -32,14 +26,14 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
         });
     });
 
-    test.each([
-        // disableDicom, fileType, viewerInstance
-        [true, 'boxdicom', undefined],
-        [true, 'boxnote', IFrameLoader.viewers[0]],
-        [false, 'boxdicom', IFrameLoader.viewers[0]],
-    ])(
+    test.each`
+        disableDicom | fileType      | viewerInstance
+        ${true}      | ${'boxdicom'} | ${undefined}
+        ${true}      | ${'boxnote'}  | ${IFrameLoader.viewers[0]}
+        ${false}     | ${'boxdicom'} | ${IFrameLoader.viewers[0]}
+    `(
         'should return correct result depending on the disableDicom viewer option and file type',
-        (disableDicom, fileType, viewerInstance) => {
+        ({ disableDicom, fileType, viewerInstance }) => {
             iframe.options.file.extension = fileType;
 
             const viewerOptions = {

--- a/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
@@ -1,10 +1,23 @@
-/* eslint-disable no-unused-expressions */
 import IFrameLoader from '../IFrameLoader';
 import IFrameViewer from '../IFrameViewer';
 
 const sandbox = sinon.createSandbox();
 
 describe('lib/viewers/iframe/IFrameLoader', () => {
+    const iframe = new IFrameViewer({
+        file: {
+            id: '123',
+            extension: 'boxnote',
+            representations: {
+                entries: [
+                    {
+                        representation: 'ORIGINAL',
+                    },
+                ],
+            },
+        },
+    });
+
     afterEach(() => {
         sandbox.verifyAndRestore();
     });
@@ -18,4 +31,24 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
             EXT: ['boxnote', 'boxdicom'],
         });
     });
+
+    test.each([
+        // disableDicom, fileType, viewerInstance
+        [true, 'boxdicom', undefined],
+        [true, 'boxnote', IFrameLoader.viewers[0]],
+        [false, 'boxdicom', IFrameLoader.viewers[0]],
+    ])(
+        'should return correct result depending on the disableDicom viewer option and file type',
+        (disableDicom, fileType, viewerInstance) => {
+            iframe.options.file.extension = fileType;
+
+            const viewerOptions = {
+                IFrame: {
+                    disableDicom,
+                },
+            };
+            const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
+            expect(viewer).toEqual(viewerInstance);
+        },
+    );
 });

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -1,5 +1,6 @@
 import IFrameViewer from '../IFrameViewer';
 import BaseViewer from '../../BaseViewer';
+import IFrameLoader from '../IFrameLoader';
 
 let containerEl;
 let iframe;
@@ -15,6 +16,13 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
             file: {
                 id: '123',
                 extension: 'boxnote',
+                representations: {
+                    entries: [
+                        {
+                            representation: 'ORIGINAL',
+                        },
+                    ],
+                },
             },
         });
 
@@ -80,6 +88,42 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
             });
 
             iframe.load();
+        });
+
+        test('should not return a viewer if file is a boxdicom and the open_with_ambra FF is enabled', () => {
+            iframe.options.file.extension = 'boxdicom';
+
+            const viewerOptions = {
+                IFrame: {
+                    openWithAmbra: true,
+                },
+            };
+            const viewer = IFrameLoader.determineViewer(iframe, [], viewerOptions);
+            expect(viewer).toBeUndefined();
+        });
+
+        test('should return a viewer if file is a boxnote and open_with_ambra FF is enabled', () => {
+            iframe.options.file.extension = 'boxnote';
+
+            const viewerOptions = {
+                IFrame: {
+                    openWithAmbra: true,
+                },
+            };
+            const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
+            expect(viewer).toBeDefined();
+        });
+
+        test('should return a viewer if open_with_ambra FF is disabled', () => {
+            iframe.options.file.extension = 'boxdicom';
+
+            const viewerOptions = {
+                IFrame: {
+                    openWithAmbra: false,
+                },
+            };
+            const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
+            expect(viewer).toBeDefined();
         });
 
         test('should invoke startLoadTimer()', () => {

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -1,6 +1,6 @@
+import IFrameLoader from '../IFrameLoader';
 import IFrameViewer from '../IFrameViewer';
 import BaseViewer from '../../BaseViewer';
-import IFrameLoader from '../IFrameLoader';
 
 let containerEl;
 let iframe;
@@ -95,7 +95,7 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
             const viewerOptions = {
                 IFrame: {
-                    openWithAmbra: true,
+                    disableDicom: true,
                 },
             };
             const viewer = IFrameLoader.determineViewer(iframe, [], viewerOptions);
@@ -107,7 +107,7 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
             const viewerOptions = {
                 IFrame: {
-                    openWithAmbra: true,
+                    disableDicom: true,
                 },
             };
             const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
@@ -119,12 +119,36 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
             const viewerOptions = {
                 IFrame: {
-                    openWithAmbra: false,
+                    disableDicom: false,
                 },
             };
             const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
             expect(viewer).toBeDefined();
         });
+
+        test.each([
+            // disableDicom, fileType, viewerDefined
+            [true, 'boxdicom', false],
+            [true, 'boxnote', true],
+            [false, 'boxdicom', true],
+        ])(
+            'should return correct result depending on the disableDicom viewer option and file type',
+            (disableDicom, fileType, viewerDefined) => {
+                iframe.options.file.extension = fileType;
+
+                const viewerOptions = {
+                    IFrame: {
+                        disableDicom,
+                    },
+                };
+                const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
+                if (viewerDefined) {
+                    expect(viewer).toBeDefined();
+                } else {
+                    expect(viewer).toBeUndefined();
+                }
+            },
+        );
 
         test('should invoke startLoadTimer()', () => {
             const stub = jest.spyOn(iframe, 'startLoadTimer');

--- a/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameViewer-test.js
@@ -1,4 +1,3 @@
-import IFrameLoader from '../IFrameLoader';
 import IFrameViewer from '../IFrameViewer';
 import BaseViewer from '../../BaseViewer';
 
@@ -16,13 +15,6 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
             file: {
                 id: '123',
                 extension: 'boxnote',
-                representations: {
-                    entries: [
-                        {
-                            representation: 'ORIGINAL',
-                        },
-                    ],
-                },
             },
         });
 
@@ -89,66 +81,6 @@ describe('lib/viewers/iframe/IFrameViewer', () => {
 
             iframe.load();
         });
-
-        test('should not return a viewer if file is a boxdicom and the open_with_ambra FF is enabled', () => {
-            iframe.options.file.extension = 'boxdicom';
-
-            const viewerOptions = {
-                IFrame: {
-                    disableDicom: true,
-                },
-            };
-            const viewer = IFrameLoader.determineViewer(iframe, [], viewerOptions);
-            expect(viewer).toBeUndefined();
-        });
-
-        test('should return a viewer if file is a boxnote and open_with_ambra FF is enabled', () => {
-            iframe.options.file.extension = 'boxnote';
-
-            const viewerOptions = {
-                IFrame: {
-                    disableDicom: true,
-                },
-            };
-            const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
-            expect(viewer).toBeDefined();
-        });
-
-        test('should return a viewer if open_with_ambra FF is disabled', () => {
-            iframe.options.file.extension = 'boxdicom';
-
-            const viewerOptions = {
-                IFrame: {
-                    disableDicom: false,
-                },
-            };
-            const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
-            expect(viewer).toBeDefined();
-        });
-
-        test.each([
-            // disableDicom, fileType, viewerDefined
-            [true, 'boxdicom', false],
-            [true, 'boxnote', true],
-            [false, 'boxdicom', true],
-        ])(
-            'should return correct result depending on the disableDicom viewer option and file type',
-            (disableDicom, fileType, viewerDefined) => {
-                iframe.options.file.extension = fileType;
-
-                const viewerOptions = {
-                    IFrame: {
-                        disableDicom,
-                    },
-                };
-                const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
-                if (viewerDefined) {
-                    expect(viewer).toBeDefined();
-                } else {
-                    expect(viewer).toBeUndefined();
-                }
-            },
-        );
 
         test('should invoke startLoadTimer()', () => {
             const stub = jest.spyOn(iframe, 'startLoadTimer');


### PR DESCRIPTION
Removes preview support for boxdicom files. This is a prerequisite for modifying the default behavior to opening boxdicom files with Ambra.