### PR TITLE
feat(viewer): use unsupported file type error message for .boxdicom

### DIFF
--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -34,10 +34,9 @@ class IFrameLoader extends AssetLoader {
      * @inheritdoc
      */
     determineViewer(file, disabledViewers = [], viewerOptions = {}) {
-        const isDicomFile = file.extension === 'boxdicom';
         const disableDicom = getProp(viewerOptions, 'IFrame.disableDicom');
         // Removes boxdicom as a supported extension when the file is a Boxdicom file and the disableDicom viewer option is enabled
-        if (disableDicom && isDicomFile) {
+        if (disableDicom) {
             this.viewers = this.viewers.filter(viewer => !viewer.EXT.includes('boxdicom'));
         }
 

--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -35,7 +35,7 @@ class IFrameLoader extends AssetLoader {
      */
     determineViewer(file, disabledViewers = [], viewerOptions = {}) {
         const disableDicom = getProp(viewerOptions, 'IFrame.disableDicom');
-        // Removes boxdicom as a supported extension when the file is a Boxdicom file and the disableDicom viewer option is enabled
+        // Removes boxdicom as a supported extension when the disableDicom viewer option is enabled
         if (disableDicom) {
             this.viewers = this.viewers.filter(viewer => !viewer.EXT.includes('boxdicom'));
         }

--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -9,7 +9,13 @@ const VIEWERS = [
         NAME: 'IFrame',
         CONSTRUCTOR: IFrameViewer,
         REP: ORIGINAL_REP_NAME,
-        EXT: ['boxnote', 'boxdicom'],
+        EXT: ['boxdicom'],
+    },
+    {
+        NAME: 'IFrame',
+        CONSTRUCTOR: IFrameViewer,
+        REP: ORIGINAL_REP_NAME,
+        EXT: ['boxnote'],
     },
 ];
 
@@ -30,15 +36,9 @@ class IFrameLoader extends AssetLoader {
     determineViewer(file, disabledViewers = [], viewerOptions = {}) {
         const isDicomFile = file.extension === 'boxdicom';
         const disableDicom = getProp(viewerOptions, 'IFrame.disableDicom');
-        // The IFrame viewer is disabled when the file is a Boxdicom file and the disableDicom viewer option is enabled
+        // Removes boxdicom as a supported extension when the file is a Boxdicom file and the disableDicom viewer option is enabled
         if (disableDicom && isDicomFile) {
-            disabledViewers.push('IFrame');
-
-            // Removes boxdicom as a supported extension
-            const iframeViewer = this.viewers[0].EXT;
-            if (iframeViewer) {
-                this.viewers[0].EXT = iframeViewer.filter(extension => extension !== 'boxdicom');
-            }
+            this.viewers = this.viewers.filter(viewer => !viewer.EXT.includes('boxdicom'));
         }
 
         return super.determineViewer(file, disabledViewers);

--- a/src/lib/viewers/iframe/IFrameLoader.js
+++ b/src/lib/viewers/iframe/IFrameLoader.js
@@ -33,6 +33,12 @@ class IFrameLoader extends AssetLoader {
         // The IFrame viewer is disabled when the file is a Boxdicom file and the disableDicom viewer option is enabled
         if (disableDicom && isDicomFile) {
             disabledViewers.push('IFrame');
+
+            // Removes boxdicom as a supported extension
+            const iframeViewer = this.viewers[0].EXT;
+            if (iframeViewer) {
+                this.viewers[0].EXT = iframeViewer.filter(extension => extension !== 'boxdicom');
+            }
         }
 
         return super.determineViewer(file, disabledViewers);

--- a/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
@@ -27,13 +27,13 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
     });
 
     test.each`
-        disableDicom | fileType      | viewerInstance
-        ${true}      | ${'boxdicom'} | ${undefined}
-        ${true}      | ${'boxnote'}  | ${IFrameLoader.viewers[0]}
-        ${false}     | ${'boxdicom'} | ${IFrameLoader.viewers[0]}
+        disableDicom | fileType      | viewerInstance             | viewerExtensions
+        ${false}     | ${'boxdicom'} | ${IFrameLoader.viewers[0]} | ${['boxnote', 'boxdicom']}
+        ${true}      | ${'boxdicom'} | ${undefined}               | ${['boxnote']}
+        ${true}      | ${'boxnote'}  | ${IFrameLoader.viewers[0]} | ${['boxnote']}
     `(
         'should return correct result depending on the disableDicom viewer option and file type',
-        ({ disableDicom, fileType, viewerInstance }) => {
+        ({ disableDicom, fileType, viewerInstance, viewerExtensions }) => {
             iframe.options.file.extension = fileType;
 
             const viewerOptions = {
@@ -43,6 +43,7 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
             };
             const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
             expect(viewer).toEqual(viewerInstance);
+            expect(IFrameLoader.getViewers()[0].EXT).toMatchObject(viewerExtensions);
         },
     );
 });

--- a/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
+++ b/src/lib/viewers/iframe/__tests__/IFrameLoader-test.js
@@ -16,24 +16,32 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
         },
     });
 
-    test('should have the correct viewer', () => {
-        const iframeViewer = IFrameLoader.viewers[0];
-        expect(iframeViewer).toEqual({
-            NAME: 'IFrame',
-            CONSTRUCTOR: IFrameViewer,
-            REP: 'ORIGINAL',
-            EXT: ['boxnote', 'boxdicom'],
-        });
+    test('should have the correct viewers', () => {
+        const iframeViewers = IFrameLoader.viewers;
+        expect(iframeViewers).toEqual([
+            {
+                NAME: 'IFrame',
+                CONSTRUCTOR: IFrameViewer,
+                REP: 'ORIGINAL',
+                EXT: ['boxdicom'],
+            },
+            {
+                NAME: 'IFrame',
+                CONSTRUCTOR: IFrameViewer,
+                REP: 'ORIGINAL',
+                EXT: ['boxnote'],
+            },
+        ]);
     });
 
     test.each`
-        disableDicom | fileType      | viewerInstance             | viewerExtensions
-        ${false}     | ${'boxdicom'} | ${IFrameLoader.viewers[0]} | ${['boxnote', 'boxdicom']}
-        ${true}      | ${'boxdicom'} | ${undefined}               | ${['boxnote']}
-        ${true}      | ${'boxnote'}  | ${IFrameLoader.viewers[0]} | ${['boxnote']}
+        disableDicom | fileType      | viewerInstance
+        ${false}     | ${'boxdicom'} | ${IFrameLoader.viewers.find(v => v.EXT.includes('boxdicom'))}
+        ${true}      | ${'boxdicom'} | ${undefined}
+        ${true}      | ${'boxnote'}  | ${IFrameLoader.viewers.find(v => v.EXT.includes('boxnote'))}
     `(
         'should return correct result depending on the disableDicom viewer option and file type',
-        ({ disableDicom, fileType, viewerInstance, viewerExtensions }) => {
+        ({ disableDicom, fileType, viewerInstance }) => {
             iframe.options.file.extension = fileType;
 
             const viewerOptions = {
@@ -43,7 +51,7 @@ describe('lib/viewers/iframe/IFrameLoader', () => {
             };
             const viewer = IFrameLoader.determineViewer(iframe.options.file, [], viewerOptions);
             expect(viewer).toEqual(viewerInstance);
-            expect(IFrameLoader.getViewers()[0].EXT).toMatchObject(viewerExtensions);
+            expect(IFrameLoader.getViewers().some(v => v.EXT.includes('boxdicom'))).toEqual(!disableDicom);
         },
     );
 });


### PR DESCRIPTION
Uses the unsupported file type error message instead of the account error message for Box Dicom files.