### PR TITLE
feat(viewer): Add focus trap for fullscreen

### DIFF
--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -1,0 +1,137 @@
+import { decodeKeydown } from './util';
+
+const FOCUSABLE_ELEMENTS = [
+    'a[href]:not([disabled])',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input[type="text"]:not([disabled])',
+    'input[type="radio"]:not([disabled])',
+    'input[type="checkbox"]:not([disabled])',
+    'select:not([disabled])',
+];
+
+function isButton(element: HTMLElement): boolean {
+    return element.tagName.toLowerCase() === 'button';
+}
+function isVisible(element: HTMLElement): boolean {
+    return element.offsetHeight > 0 && element.offsetWidth > 0;
+}
+function createFocusAnchor(): HTMLElement {
+    const element = document.createElement('i');
+    element.setAttribute('aria-hidden', 'true');
+    element.tabIndex = 0;
+
+    return element;
+}
+
+class FocusTrap {
+    element: HTMLElement;
+
+    firstFocusableElement: HTMLElement | null = null;
+
+    lastFocusableElement: HTMLElement | null = null;
+
+    trapFocusableElement: HTMLElement | null = null;
+
+    constructor(element: HTMLElement) {
+        this.element = element;
+    }
+
+    destroy(): void {
+        this.disable();
+    }
+
+    focusFirstElement = (): void => {
+        if (!this.element) {
+            return;
+        }
+
+        const focusableElements = this.getFocusableElements();
+        if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+        } else if (this.trapFocusableElement) {
+            this.trapFocusableElement.focus();
+        }
+    };
+
+    focusLastElement = (): void => {
+        if (!this.element) {
+            return;
+        }
+
+        const focusableElements = this.getFocusableElements();
+        if (focusableElements.length > 0) {
+            focusableElements[focusableElements.length - 1].focus();
+        } else if (this.trapFocusableElement) {
+            this.trapFocusableElement.focus();
+        }
+    };
+
+    getFocusableElements = (): Array<HTMLElement> => {
+        // Look for focusable elements
+        const foundElements = this.element.querySelectorAll(FOCUSABLE_ELEMENTS.join(', '));
+        // Filter out the elements that are preview control buttons and not visible
+        return Array.prototype.slice.call(foundElements).filter(el => (isButton(el) && isVisible(el)) || !isButton(el));
+    };
+
+    handleTrapKeydown = (event: KeyboardEvent): void => {
+        const key = decodeKeydown(event);
+        const isTabPressed = key === 'Tab' || key === 'Shift+Tab';
+
+        if (!isTabPressed) {
+            return;
+        }
+        event.stopPropagation();
+        event.preventDefault();
+    };
+
+    handleKeydown = (event: KeyboardEvent): void => {
+        const key = decodeKeydown(event);
+        const isTabPressed = key === 'Tab' || key === 'Shift+Tab';
+
+        if (this.element === document.activeElement && isTabPressed) {
+            this.focusFirstElement();
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    };
+
+    enable(): void {
+        this.element.addEventListener('keydown', this.handleKeydown);
+
+        // Create focus anchors (beginning, end and trap)
+        this.firstFocusableElement = createFocusAnchor();
+        this.lastFocusableElement = createFocusAnchor();
+        this.trapFocusableElement = createFocusAnchor();
+
+        this.firstFocusableElement.addEventListener('focus', this.focusLastElement);
+        this.lastFocusableElement.addEventListener('focus', this.focusFirstElement);
+        this.trapFocusableElement.addEventListener('keydown', this.handleTrapKeydown);
+
+        this.element.prepend(this.firstFocusableElement);
+        this.element.append(this.lastFocusableElement);
+        this.element.append(this.trapFocusableElement);
+    }
+
+    disable(): void {
+        this.element.removeEventListener('keydown', this.handleKeydown);
+
+        if (this.firstFocusableElement) {
+            this.element.removeChild(this.firstFocusableElement);
+        }
+
+        if (this.lastFocusableElement) {
+            this.element.removeChild(this.lastFocusableElement);
+        }
+
+        if (this.trapFocusableElement) {
+            this.element.removeChild(this.trapFocusableElement);
+        }
+
+        this.firstFocusableElement = null;
+        this.lastFocusableElement = null;
+        this.trapFocusableElement = null;
+    }
+}
+
+export default FocusTrap;

--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -110,10 +110,9 @@ class FocusTrap {
     enable(): void {
         this.element.addEventListener('keydown', this.handleKeydown);
 
-        // Create focus anchors (beginning, end and trap)
-        this.firstFocusableElement = createFocusAnchor({ className: 'FocusTrap-first' });
-        this.lastFocusableElement = createFocusAnchor({ className: 'FocusTrap-last' });
-        this.trapFocusableElement = createFocusAnchor({ className: 'FocusTrap-trap' });
+        this.firstFocusableElement = createFocusAnchor({ className: 'bp-FocusTrap-first' });
+        this.lastFocusableElement = createFocusAnchor({ className: 'bp-FocusTrap-last' });
+        this.trapFocusableElement = createFocusAnchor({ className: 'bp-FocusTrap-trap' });
 
         this.firstFocusableElement.addEventListener('focus', this.focusLastElement);
         this.lastFocusableElement.addEventListener('focus', this.focusFirstElement);

--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -24,10 +24,11 @@ function isButton(element: HTMLElement): boolean {
 function isVisible(element: HTMLElement): boolean {
     return element.offsetHeight > 0 && element.offsetWidth > 0;
 }
-function createFocusAnchor(): HTMLElement {
+function createFocusAnchor({ className = '' }): HTMLElement {
     const element = document.createElement('i');
     element.setAttribute('aria-hidden', 'true');
     element.tabIndex = 0;
+    element.className = className;
 
     return element;
 }
@@ -94,7 +95,11 @@ class FocusTrap {
         const isTabPressed = key === 'Tab' || key === 'Shift+Tab';
 
         if (this.element === document.activeElement && isTabPressed) {
-            this.focusFirstElement();
+            if (key === 'Tab') {
+                this.focusFirstElement();
+            } else {
+                this.focusLastElement();
+            }
             event.stopPropagation();
             event.preventDefault();
         }
@@ -104,9 +109,9 @@ class FocusTrap {
         this.element.addEventListener('keydown', this.handleKeydown);
 
         // Create focus anchors (beginning, end and trap)
-        this.firstFocusableElement = createFocusAnchor();
-        this.lastFocusableElement = createFocusAnchor();
-        this.trapFocusableElement = createFocusAnchor();
+        this.firstFocusableElement = createFocusAnchor({ className: 'FocusTrap-first' });
+        this.lastFocusableElement = createFocusAnchor({ className: 'FocusTrap-last' });
+        this.trapFocusableElement = createFocusAnchor({ className: 'FocusTrap-trap' });
 
         this.firstFocusableElement.addEventListener('focus', this.focusLastElement);
         this.lastFocusableElement.addEventListener('focus', this.focusFirstElement);

--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -120,8 +120,8 @@ class FocusTrap {
         this.trapFocusableElement.addEventListener('keydown', this.handleTrapKeydown);
 
         this.element.insertBefore(this.firstFocusableElement, this.element.firstElementChild);
-        this.element.append(this.lastFocusableElement);
-        this.element.append(this.trapFocusableElement);
+        this.element.appendChild(this.lastFocusableElement);
+        this.element.appendChild(this.trapFocusableElement);
     }
 
     disable(): void {

--- a/src/lib/__tests__/FocusTrap-test.html
+++ b/src/lib/__tests__/FocusTrap-test.html
@@ -1,0 +1,4 @@
+<div id="test-container" tabindex="0">
+    <input type="text" placeholder="first input" />
+    <input type="text" placeholder="second input" />
+</div>

--- a/src/lib/__tests__/FocusTrap-test.html
+++ b/src/lib/__tests__/FocusTrap-test.html
@@ -1,4 +1,4 @@
 <div id="test-container" tabindex="0">
-    <input type="text" placeholder="first input" />
-    <input type="text" placeholder="second input" />
+    <input class="firstInput" type="text" placeholder="first input" />
+    <input class="secondInput" type="text" placeholder="second input" />
 </div>

--- a/src/lib/__tests__/FocusTrap-test.ts
+++ b/src/lib/__tests__/FocusTrap-test.ts
@@ -6,24 +6,26 @@ describe('lib/FocusTrap', () => {
         fixture.load('__tests__/FocusTrap-test.html');
     });
 
-    const getFocusTrap = (): FocusTrap => new FocusTrap(document.querySelector('#test-container'));
+    const getContainerElement = (): HTMLElement =>
+        document.querySelector<HTMLElement>('#test-container') as HTMLElement;
+    const getFocusTrap = (): FocusTrap => new FocusTrap(getContainerElement());
 
     describe('constructor', () => {
         test('should save reference to element', () => {
             const focusTrap = getFocusTrap();
 
-            expect(focusTrap.element).toBe(document.querySelector('#test-container'));
+            expect(focusTrap.element).toBe(getContainerElement());
         });
     });
 
     describe('enable()', () => {
         test('should add 3 focus anchor elements', () => {
             const focusTrap = getFocusTrap();
-            expect(document.querySelector('#test-container').children.length).toBe(2);
+            expect(getContainerElement().children.length).toBe(2);
 
             focusTrap.enable();
 
-            const children = Array.from(document.querySelector('#test-container').children);
+            const children = Array.from(getContainerElement().children);
             expect(children.length).toBe(5);
             expect(children[0].tagName.toLowerCase()).toBe('i');
             expect(children[1].tagName.toLowerCase()).toBe('input');
@@ -36,18 +38,18 @@ describe('lib/FocusTrap', () => {
     describe('disable()', () => {
         test('should remove the 3 focus anchor elements', () => {
             const focusTrap = getFocusTrap();
-            expect(document.querySelector('#test-container').children.length).toBe(2);
+            expect(getContainerElement().children.length).toBe(2);
 
             focusTrap.enable();
-            expect(document.querySelector('#test-container').children.length).toBe(5);
+            expect(getContainerElement().children.length).toBe(5);
 
             focusTrap.disable();
-            expect(document.querySelector('#test-container').children.length).toBe(2);
+            expect(getContainerElement().children.length).toBe(2);
         });
     });
 
     describe('focus management', () => {
-        let children;
+        let children: Array<HTMLElement>;
         let focusTrap;
 
         beforeEach(() => {
@@ -57,7 +59,7 @@ describe('lib/FocusTrap', () => {
             focusTrap = getFocusTrap();
             focusTrap.enable();
 
-            children = Array.from<HTMLElement>(document.querySelector<HTMLElement>('#test-container').children);
+            children = Array.from(getContainerElement().children) as Array<HTMLElement>;
         });
 
         test('should redirect focus from first anchor to last focusable element', () => {
@@ -107,7 +109,7 @@ describe('lib/FocusTrap', () => {
         });
 
         test('should focus first element if Tab is pressed when container element has focus', () => {
-            const container = document.querySelector<HTMLElement>('#test-container');
+            const container = getContainerElement();
             container.focus();
             expect(document.activeElement).toBe(container);
 
@@ -118,7 +120,7 @@ describe('lib/FocusTrap', () => {
         });
 
         test('should focus first element if Tab is pressed when container element has focus', () => {
-            const container = document.querySelector<HTMLElement>('#test-container');
+            const container = getContainerElement();
             container.focus();
             expect(document.activeElement).toBe(container);
 
@@ -131,7 +133,7 @@ describe('lib/FocusTrap', () => {
         test.each(['Enter', 'Escape', 'ArrowDown'])(
             'should do nothing if %s is pressed when container element has focus',
             key => {
-                const container = document.querySelector<HTMLElement>('#test-container');
+                const container = getContainerElement();
                 container.focus();
                 expect(document.activeElement).toBe(container);
 

--- a/src/lib/__tests__/FocusTrap-test.ts
+++ b/src/lib/__tests__/FocusTrap-test.ts
@@ -1,0 +1,145 @@
+import FocusTrap from '../FocusTrap';
+
+describe('lib/FocusTrap', () => {
+    beforeEach(() => {
+        // Fixture has 2 input elements as children
+        fixture.load('__tests__/FocusTrap-test.html');
+    });
+
+    const getFocusTrap = (): FocusTrap => new FocusTrap(document.querySelector('#test-container'));
+
+    describe('constructor', () => {
+        test('should save reference to element', () => {
+            const focusTrap = getFocusTrap();
+
+            expect(focusTrap.element).toBe(document.querySelector('#test-container'));
+        });
+    });
+
+    describe('enable()', () => {
+        test('should add 3 focus anchor elements', () => {
+            const focusTrap = getFocusTrap();
+            expect(document.querySelector('#test-container').children.length).toBe(2);
+
+            focusTrap.enable();
+
+            const children = Array.from(document.querySelector('#test-container').children);
+            expect(children.length).toBe(5);
+            expect(children[0].tagName.toLowerCase()).toBe('i');
+            expect(children[1].tagName.toLowerCase()).toBe('input');
+            expect(children[2].tagName.toLowerCase()).toBe('input');
+            expect(children[3].tagName.toLowerCase()).toBe('i');
+            expect(children[4].tagName.toLowerCase()).toBe('i');
+        });
+    });
+
+    describe('disable()', () => {
+        test('should remove the 3 focus anchor elements', () => {
+            const focusTrap = getFocusTrap();
+            expect(document.querySelector('#test-container').children.length).toBe(2);
+
+            focusTrap.enable();
+            expect(document.querySelector('#test-container').children.length).toBe(5);
+
+            focusTrap.disable();
+            expect(document.querySelector('#test-container').children.length).toBe(2);
+        });
+    });
+
+    describe('focus management', () => {
+        let children;
+        let focusTrap;
+
+        beforeEach(() => {
+            jest.spyOn(Event.prototype, 'stopPropagation');
+            jest.spyOn(Event.prototype, 'preventDefault');
+
+            focusTrap = getFocusTrap();
+            focusTrap.enable();
+
+            children = Array.from<HTMLElement>(document.querySelector<HTMLElement>('#test-container').children);
+        });
+
+        test('should redirect focus from first anchor to last focusable element', () => {
+            children[1].focus(); // first input
+            expect(document.activeElement).toBe(children[1]);
+
+            children[0].focus(); // first focus anchor element
+            expect(document.activeElement).toBe(children[2]);
+        });
+
+        test('should redirect focus from last anchor to first focusable element', () => {
+            children[2].focus(); // second input
+            expect(document.activeElement).toBe(children[2]);
+
+            children[3].focus(); // last focus anchor element
+            expect(document.activeElement).toBe(children[1]);
+        });
+
+        test('should keep focus trapped on trap anchor when Tab is pressed', () => {
+            children[4].focus(); // trap focus anchor element
+            expect(document.activeElement).toBe(children[4]);
+
+            children[4].dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+            expect(document.activeElement).toBe(children[4]);
+            expect(Event.prototype.stopPropagation).toHaveBeenCalled();
+            expect(Event.prototype.preventDefault).toHaveBeenCalled();
+        });
+
+        test('should keep focus trapped on trap anchor when Shift+Tab is pressed', () => {
+            children[4].focus(); // trap focus anchor element
+            expect(document.activeElement).toBe(children[4]);
+
+            children[4].dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+            expect(document.activeElement).toBe(children[4]);
+            expect(Event.prototype.stopPropagation).toHaveBeenCalled();
+            expect(Event.prototype.preventDefault).toHaveBeenCalled();
+        });
+
+        test.each(['Enter', 'Escape', 'ArrowDown'])('should do nothing if key %s is pressed', key => {
+            children[4].focus(); // trap focus anchor element
+            expect(document.activeElement).toBe(children[4]);
+
+            children[4].dispatchEvent(new KeyboardEvent('keydown', { key }));
+            expect(document.activeElement).toBe(children[4]);
+            expect(Event.prototype.stopPropagation).not.toHaveBeenCalled();
+            expect(Event.prototype.preventDefault).not.toHaveBeenCalled();
+        });
+
+        test('should focus first element if Tab is pressed when container element has focus', () => {
+            const container = document.querySelector<HTMLElement>('#test-container');
+            container.focus();
+            expect(document.activeElement).toBe(container);
+
+            container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+            expect(document.activeElement).toBe(children[1]);
+            expect(Event.prototype.stopPropagation).toHaveBeenCalled();
+            expect(Event.prototype.preventDefault).toHaveBeenCalled();
+        });
+
+        test('should focus first element if Tab is pressed when container element has focus', () => {
+            const container = document.querySelector<HTMLElement>('#test-container');
+            container.focus();
+            expect(document.activeElement).toBe(container);
+
+            container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+            expect(document.activeElement).toBe(children[2]);
+            expect(Event.prototype.stopPropagation).toHaveBeenCalled();
+            expect(Event.prototype.preventDefault).toHaveBeenCalled();
+        });
+
+        test.each(['Enter', 'Escape', 'ArrowDown'])(
+            'should do nothing if %s is pressed when container element has focus',
+            key => {
+                const container = document.querySelector<HTMLElement>('#test-container');
+                container.focus();
+                expect(document.activeElement).toBe(container);
+
+                container.dispatchEvent(new KeyboardEvent('keydown', { key }));
+                expect(document.activeElement).toBe(container);
+                expect(Event.prototype.stopPropagation).not.toHaveBeenCalled();
+                expect(Event.prototype.preventDefault).not.toHaveBeenCalled();
+            },
+        );
+    });
+});

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -1,5 +1,1 @@
 declare const __: Function;
-
-declare const fixture: {
-    load: (path: string) => void;
-};

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -1,1 +1,5 @@
 declare const __: Function;
+
+declare const fixture: {
+    load: (path: string) => void;
+};

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -589,11 +589,16 @@ class BaseViewer extends EventEmitter {
             this.fullscreenToggleEl.focus();
         }
 
-        if (!this.focusTrap) {
-            this.focusTrap = new FocusTrap(this.containerEl);
-        }
+        try {
+            if (!this.focusTrap) {
+                this.focusTrap = new FocusTrap(this.containerEl);
+            }
 
-        this.focusTrap.enable();
+            this.focusTrap.enable();
+        } catch (error) {
+            // eslint-disable-next-line
+            console.error('Unable to enable focus trap around Preview content');
+        }
     }
 
     /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -265,6 +265,10 @@ class BaseViewer extends EventEmitter {
         document.defaultView.removeEventListener('resize', this.debouncedResizeHandler);
         this.removeAllListeners();
 
+        if (this.focusTrap) {
+            this.focusTrap.destroy();
+        }
+
         if (this.containerEl) {
             this.containerEl.removeEventListener('contextmenu', this.preventDefault);
             this.containerEl.innerHTML = '';
@@ -279,10 +283,6 @@ class BaseViewer extends EventEmitter {
             } catch (error) {
                 // No-op, as annotator was likely never initialized in the first place
             }
-        }
-
-        if (this.focusTrap) {
-            this.focusTrap.destroy();
         }
 
         this.destroyed = true;
@@ -589,11 +589,10 @@ class BaseViewer extends EventEmitter {
             this.fullscreenToggleEl.focus();
         }
 
-        if (this.focusTrap) {
-            this.focusTrap.destroy();
+        if (!this.focusTrap) {
+            this.focusTrap = new FocusTrap(this.containerEl);
         }
 
-        this.focusTrap = new FocusTrap(this.containerEl);
         this.focusTrap.enable();
     }
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -547,8 +547,8 @@ describe('lib/viewers/BaseViewer', () => {
 
             base.handleFullscreenEnter();
 
-            expect(FocusTrap.prototype.constructor).toHaveBeenCalledWith(base.containerEl);
-            expect(FocusTrap.prototype.enable).toHaveBeenCalled();
+            expect(FocusTrap.prototype.constructor).toBeCalledWith(base.containerEl);
+            expect(FocusTrap.prototype.enable).toBeCalled();
         });
 
         test('should reuse any existing focus trap', () => {
@@ -559,8 +559,8 @@ describe('lib/viewers/BaseViewer', () => {
 
             base.handleFullscreenEnter();
 
-            expect(FocusTrap.prototype.constructor).not.toHaveBeenCalledWith(base.containerEl);
-            expect(mockFocusTrap.enable).toHaveBeenCalled();
+            expect(FocusTrap.prototype.constructor).not.toBeCalledWith(base.containerEl);
+            expect(mockFocusTrap.enable).toBeCalled();
         });
     });
 
@@ -598,7 +598,7 @@ describe('lib/viewers/BaseViewer', () => {
 
             base.handleFullscreenExit();
 
-            expect(mockFocusTrap.disable).toHaveBeenCalled();
+            expect(mockFocusTrap.disable).toBeCalled();
         });
     });
 
@@ -695,7 +695,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.focusTrap = mockFocusTrap;
             base.destroy();
 
-            expect(mockFocusTrap.destroy).toHaveBeenCalled();
+            expect(mockFocusTrap.destroy).toBeCalled();
         });
     });
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -5,6 +5,7 @@ import * as util from '../../util';
 import Api from '../../api';
 import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
+import FocusTrap from '../../FocusTrap';
 import fullscreen from '../../Fullscreen';
 import intl from '../../i18n';
 import PreviewError from '../../PreviewError';
@@ -18,6 +19,8 @@ let base;
 let containerEl;
 let stubs = {};
 const { ANNOTATOR_EVENT } = constants;
+
+jest.mock('../../FocusTrap');
 
 describe('lib/viewers/BaseViewer', () => {
     beforeEach(() => {
@@ -500,6 +503,9 @@ describe('lib/viewers/BaseViewer', () => {
     });
 
     describe('handleFullscreenEnter()', () => {
+        beforeEach(() => {
+            base.containerEl = document.querySelector('.bp-content');
+        });
         test('should resize the viewer', () => {
             jest.spyOn(base, 'resize');
 
@@ -534,6 +540,28 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.disableAnnotationControls).toBeCalled();
             expect(base.processAnnotationModeChange).toBeCalledWith(AnnotationMode.NONE);
         });
+
+        test('should enable the focus trap', () => {
+            jest.spyOn(FocusTrap.prototype, 'constructor');
+            jest.spyOn(FocusTrap.prototype, 'enable');
+
+            base.handleFullscreenEnter();
+
+            expect(FocusTrap.prototype.constructor).toHaveBeenCalledWith(base.containerEl);
+            expect(FocusTrap.prototype.enable).toHaveBeenCalled();
+        });
+
+        test('should reuse any existing focus trap', () => {
+            jest.spyOn(FocusTrap.prototype, 'constructor');
+
+            const mockFocusTrap = { destroy: jest.fn(), enable: jest.fn() };
+            base.focusTrap = mockFocusTrap;
+
+            base.handleFullscreenEnter();
+
+            expect(FocusTrap.prototype.constructor).not.toHaveBeenCalledWith(base.containerEl);
+            expect(mockFocusTrap.enable).toHaveBeenCalled();
+        });
     });
 
     describe('handleFullscreenExit()', () => {
@@ -562,6 +590,15 @@ describe('lib/viewers/BaseViewer', () => {
 
             expect(base.annotator.emit).toBeCalledWith(ANNOTATOR_EVENT.setVisibility, true);
             expect(base.enableAnnotationControls).toBeCalled();
+        });
+
+        test('should disable any existing focus trap', () => {
+            const mockFocusTrap = { destroy: jest.fn(), disable: jest.fn() };
+            base.focusTrap = mockFocusTrap;
+
+            base.handleFullscreenExit();
+
+            expect(mockFocusTrap.disable).toHaveBeenCalled();
         });
     });
 
@@ -650,6 +687,15 @@ describe('lib/viewers/BaseViewer', () => {
             base.destroy();
 
             expect(base.containerEl.removeEventListener).toBeCalledWith('contextmenu', expect.any(Function));
+        });
+
+        test('should clean up any focus trap', () => {
+            const mockFocusTrap = { destroy: jest.fn() };
+
+            base.focusTrap = mockFocusTrap;
+            base.destroy();
+
+            expect(mockFocusTrap.destroy).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Adds `FocusTrap` class which takes an element and allows you to `enable` or `disable` focus trapping.

This class is used for when Preview enters fullscreen to constrain tab navigation to within the visible previewed content. This can also be applied to the print modal.

TODO:
- [x] add/update unit tests
- [x] cross-browser testing