### PR TITLE
feat(thumbnails): remove thumbnail toggle on small modalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "babel-loader": "^8.0.6",
         "babel-plugin-transform-require-ignore": "^0.1.1",
         "box-annotations": "^2.3.0",
-        "box-ui-elements": "15.0.0-beta.50",
+        "box-ui-elements": "15.1.0-beta.21",
         "chai": "^4.2.0",
         "classnames": "^2.2.6",
         "conventional-changelog-cli": "^2.0.28",

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -139,7 +139,7 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         }
     }
 
-    @media (min-width: 600px) {
+    @media (min-width: $size-large-min) {
         $bp-thumbnails-animation: 300ms cubic-bezier(.4, 0, .2, 1);
 
         &.bp-loaded.bp-thumbnails-open-active,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,10 +3286,10 @@ box-annotations@^2.3.0:
   resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-2.3.0.tgz#5cac38171f7f8d9283659e2b243310f19d5ab7d3"
   integrity sha512-Ea7tPgyJjX7vcnmZIfCorbzHd6oYx/OHVMPnZVQL/dUHR5vRKhLM0610xqwmVlUpk627sqHw5x/APaa+kt4SXg==
 
-box-ui-elements@15.0.0-beta.50:
-  version "15.0.0-beta.50"
-  resolved "https://registry.yarnpkg.com/box-ui-elements/-/box-ui-elements-15.0.0-beta.50.tgz#e92772dca56b7ca18f75b10be1af07f131c8f4c0"
-  integrity sha512-DD1Mi4+xR6RxsK/4H5rwjp2dAbMozngcLEmN3sGrJDsKxRVQ7ghT92dUhXtDRcwuQTWoDkPxdRyVN9ilJQ5jLQ==
+box-ui-elements@15.1.0-beta.21:
+  version "15.1.0-beta.21"
+  resolved "https://registry.yarnpkg.com/box-ui-elements/-/box-ui-elements-15.1.0-beta.21.tgz#4fa34bf6bf3b10d79f95b0e56349c057926573e3"
+  integrity sha512-ey7lwuv+ds9rq3nVfVcneedWaptw3nYdlF32antUxw0IkkuAYft3LX4XxRHDqNQSv5LzUBqxd5wd1caxVpiuWQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Note: Please approve https://github.com/box/box-content-preview/pull/1448 first

This is hidden on smaller modalities in order to prioritize other functions

https://zpl.io/dxDDLEp

![preview-controls-hide-thumbnail-toggle](https://user-images.githubusercontent.com/1041516/173171780-1fc7eba2-16bc-4b7e-b1e9-27036b5ccd50.gif)

