### PR TITLE
feat(annotations): remove zoom ctrls on mobile

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -201,6 +201,12 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 }
 
+@include breakpoint($medium-screen) {
+    .bp-is-mobile .bp-ZoomControls {
+        display: none;
+    }
+}
+
 .bp-theme-dark {
     .bp {
         .bp-thumbnails-container {


### PR DESCRIPTION
Remove zoom controls on touch devices with small-medium screen widths (<767px). Touch devices in this case refer to mobile. However, mobile seems more like a subset of touch devices to me. Perhaps this is an edge case we can ignore. 

https://zpl.io/dxDDLEp

<img width="536" alt="image" src="https://user-images.githubusercontent.com/1041516/173475700-c2883609-af45-484b-94ef-d2a30c16ec4d.png">

![annotations-remove-zoom-mobile](https://user-images.githubusercontent.com/1041516/173476009-3f2e54de-1edd-41fc-a019-98b23dd5cefe.gif)

