### PR TITLE
feat(annotations): hide fullscreen toggle if browser API not supported

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -14,6 +14,7 @@ export const CLASS_BOX_PREVIEW_BUTTON = 'bp-btn';
 export const CLASS_BOX_PREVIEW_CONTAINER = 'bp-container';
 export const CLASS_BOX_PREVIEW_CONTENT = 'bp-content';
 export const CLASS_BOX_PREVIEW_FIND_BAR = 'bp-find-bar';
+export const CLASS_BOX_PREVIEW_FULLSCREEN = 'bp-has-fullscreen';
 export const CLASS_BOX_PREVIEW_HAS_HEADER = 'bp-has-header';
 export const CLASS_BOX_PREVIEW_HAS_NAVIGATION = 'bp-has-navigation';
 export const CLASS_BOX_PREVIEW_HEADER = 'bp-header';

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -25,6 +25,7 @@ import {
     CLASS_ANNOTATIONS_CREATE_REGION,
     CLASS_ANNOTATIONS_DISCOVERABLE,
     CLASS_ANNOTATIONS_ONLY_CONTROLS,
+    CLASS_BOX_PREVIEW_FULLSCREEN,
     CLASS_BOX_PREVIEW_MOBILE,
     FILE_OPTION_START,
     SELECTOR_BOX_PREVIEW_BTN_ANNOTATE_DRAW,
@@ -145,6 +146,7 @@ class BaseViewer extends EventEmitter {
         this.cache = options.cache;
         this.previewUI = options.ui;
         this.repStatuses = [];
+        this.isFullScreenSupported = fullscreen.isSupported();
         this.isMobile = Browser.isMobile();
         this.hasTouch = Browser.hasTouch();
 
@@ -210,6 +212,11 @@ class BaseViewer extends EventEmitter {
 
         // Timeout for loading the preview
         this.loadTimeout = LOAD_TIMEOUT_MS;
+
+        // Add class for devices that do not support fullscreen API
+        if (this.isFullScreenSupported) {
+            this.rootEl.classList.add(CLASS_BOX_PREVIEW_FULLSCREEN);
+        }
 
         // For mobile browsers add mobile class just in case viewers need it
         if (this.isMobile) {

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -89,6 +89,17 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.annotatorPromiseResolver).toBeDefined();
         });
 
+        test('should add class to container if fullscreen API on browser supported', () => {
+            base.isFullScreenSupported = true;
+            jest.spyOn(base, 'loadBoxAnnotations').mockResolvedValue(undefined);
+            jest.spyOn(base, 'areAnnotationsEnabled').mockReturnValue(true);
+
+            base.setup();
+
+            const container = document.querySelector(constants.SELECTOR_BOX_PREVIEW);
+            expect(container).toHaveClass('bp-has-fullscreen');
+        });
+
         test('should add a mobile class to the container if on mobile', () => {
             base.isMobile = true;
             jest.spyOn(base, 'loadBoxAnnotations').mockResolvedValue(undefined);

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -11,6 +11,12 @@ $thumbnail-border-radius: 6px;
 $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
 
 .bp {
+    &:not(.bp-has-fullscreen) {
+        .bp-FullscreenToggle {
+            display: none;
+        }
+    }
+
     .bp-ThumbnailsToggle {
         display: none;
     }


### PR DESCRIPTION
[Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) is not supported on all browsers, most notably iOS browsers (e.g. chrome, firefox, safari, etc) on iPhone. The API's are supported on iPad however.

https://zpl.io/dxDDLEp

<img width="470" alt="image" src="https://user-images.githubusercontent.com/1041516/173689027-a4ed5b27-2327-404e-8bf2-6333077e4c16.png">

**Desktop**

<img width="1209" alt="Screen Shot 2022-06-14 at 1 59 45 PM" src="https://user-images.githubusercontent.com/1041516/173689500-6c3445f4-6ed6-439a-9ddc-a35963c28401.png">

**iPhone**

<img width="561" alt="Screen Shot 2022-06-14 at 2 00 19 PM" src="https://user-images.githubusercontent.com/1041516/173689520-8dbd3255-3980-4c72-aa8e-aee96bc6653f.png">

**iPad**
Fullscreen API are supported on iOS iPad

<img width="888" alt="Screen Shot 2022-06-14 at 2 09 29 PM" src="https://user-images.githubusercontent.com/1041516/173689553-8c129806-8cfc-4ff3-9aba-1719a269c0b8.png">
<img width="888" alt="Screen Shot 2022-06-14 at 2 09 34 PM" src="https://user-images.githubusercontent.com/1041516/173689573-f985815b-d519-4c6a-ae2a-aac5fd8bf2e6.png">