### PR TITLE
fix(fullscreen): fix fullscreen mode for ios/iphone combo

### DIFF
--- a/src/lib/_common.scss
+++ b/src/lib/_common.scss
@@ -1,3 +1,4 @@
+@import '~box-ui-elements/es/styles/variables';
 @import 'boxui';
 
 $header-height: 48px;
@@ -125,15 +126,6 @@ $header-height: 48px;
     outline: none;
     -webkit-overflow-scrolling: touch;
 
-    // Pseudo fullscreen for iOS Safari which doesn't support the fullscreen API
-    &.bp-fullscreen-unsupported {
-        position: fixed;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-    }
-
     &.bp-dark {
         background-color: $black;
     }
@@ -148,6 +140,12 @@ $header-height: 48px;
         flex: 1 1 auto;
         align-items: center;
         outline: none;
+
+        // Pseudo fullscreen for iOS Safari which doesn't support the fullscreen API
+        &.bp-fullscreen-unsupported {
+            position: fixed;
+            z-index: $overlay-z-index;
+        }
     }
 
     .bp-content.bp-is-fullscreen {


### PR DESCRIPTION
Fixed an issue with the pseudo-fullscreen mode on ios iphone. Fullscreen APIs are not supported on that os+device combo. The pseudo-fullscreen mode broke some time ago and was no longer usable

The Fullscreen class adds "bp-fullscreen-unsupported" class and the corresponding CSS that applied the fullscreen styling did not select the correct element. Additionally, it would also appear under elements such as the header and sidebar elements, so I had to bump the z-index up

iOS iPhone psuedo-fullscreen mode bug
![annotations-fullscreen-bug-safari-ios](https://user-images.githubusercontent.com/1041516/174170030-b1a850e0-ac44-4207-9f1c-0fd9505a47df.gif)

Fixed
![preview-fullscreen-ios-fix](https://user-images.githubusercontent.com/1041516/174170105-847e9522-8cf2-4750-a541-9e68e7073d82.gif)

This supercedes https://github.com/box/box-content-preview/pull/1452 which hides the Fullscreen node toggle for unsupported devices