### PR TITLE
fix: Move Documents load time and emit meaningful content timestamp

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1583,6 +1583,8 @@ class Preview extends EventEmitter {
         const contentLoadTime = Timer.get(contentLoadTag) || {};
         const previewLoadTime = Timer.get(previewLoadTag) || {};
 
+        const { elapsed: contentLoadTimeDuration, end: meaningfulContentTimestamp } = contentLoadTime;
+
         this.emitLogEvent(PREVIEW_METRIC, {
             encoding,
             event_name: LOAD_METRIC.previewLoadEvent,
@@ -1590,7 +1592,8 @@ class Preview extends EventEmitter {
             [LOAD_METRIC.fileInfoTime]: infoTime.elapsed || 0,
             [LOAD_METRIC.convertTime]: convertTime.elapsed || 0,
             [LOAD_METRIC.downloadResponseTime]: downloadTime.elapsed || 0,
-            [LOAD_METRIC.contentLoadTime]: contentLoadTime.elapsed || 0,
+            [LOAD_METRIC.contentLoadTime]: contentLoadTimeDuration || 0,
+            [LOAD_METRIC.meaningfulContentTimestamp]: meaningfulContentTimestamp,
         });
 
         Timer.reset([infoTag, convertTag, downloadTag, contentLoadTag, previewLoadTag]);

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -2350,6 +2350,7 @@ describe('lib/Preview', () => {
             preview.file = {
                 id: fileId,
             };
+            jest.spyOn(Timer, 'get').mockImplementation(() => ({ elapsed: 10, end: 123 }));
         });
 
         afterEach(() => {
@@ -2386,6 +2387,7 @@ describe('lib/Preview', () => {
                 expect(metric[LOAD_METRIC.convertTime]).toBeDefined();
                 expect(metric[LOAD_METRIC.downloadResponseTime]).toBeDefined();
                 expect(metric[LOAD_METRIC.contentLoadTime]).toBeDefined();
+                expect(metric[LOAD_METRIC.meaningfulContentTimestamp]).toBeDefined();
                 expect(metric.value).toBeDefined();
                 done();
             });

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -59,6 +59,7 @@ export const LOAD_METRIC = {
     convertTime: 'convert_time', // Time it took from receiving file info to being able to request the rep.
     downloadResponseTime: 'download_response_time', // Time it took for TTFB when requesting a rep.
     fileInfoTime: 'file_info_time', // Round trip time from file info request to received file info.
+    meaningfulContentTimestamp: 'meaningful_content_timestamp', // Timestamp of when meaningful content was loaded
     preloadTime: 'preload_time', // How long it takes to preload the document.
     previewLoadEvent: 'load', // Event name for preview_metric events related to loading times.
     previewLoadTime: 'preview_loading', // Total preview load time. Maps to "value" of load event

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1162,8 +1162,6 @@ class DocBaseViewer extends BaseViewer {
         this.pdfViewer.currentScaleValue = 'auto';
         this.loadUI();
 
-        const { pagesCount, currentScale } = this.pdfViewer;
-
         // Set page to the user-defined page, previously opened page, or first page
         const startPage = this.startPageNum || this.getCachedPage();
         this.setPage(startPage);
@@ -1174,11 +1172,6 @@ class DocBaseViewer extends BaseViewer {
         // Broadcast that preview has 'loaded' when page structure is available
         if (!this.loaded) {
             this.loaded = true;
-            this.emit(VIEWER_EVENT.load, {
-                encoding: this.encoding,
-                numPages: pagesCount,
-                scale: currentScale,
-            });
 
             // Add page IDs to each page after page structure is available
             this.setupPageIds();
@@ -1237,6 +1230,14 @@ class DocBaseViewer extends BaseViewer {
         if (!this.somePageRendered) {
             this.hidePreload();
             this.somePageRendered = true;
+
+            const { pagesCount, currentScale } = this.pdfViewer;
+
+            this.emit(VIEWER_EVENT.load, {
+                encoding: this.encoding,
+                numPages: pagesCount,
+                scale: currentScale,
+            });
 
             if (this.options.enableThumbnailsSidebar) {
                 this.initThumbnails();

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1884,23 +1884,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.setupPages).toBeCalled();
             });
 
-            test("should broadcast that the preview is loaded if it hasn't already", () => {
-                docBase.pdfViewer = {
-                    currentScale: 'unknown',
-                };
-                docBase.loaded = false;
-                docBase.pdfViewer.pagesCount = 5;
-                docBase.encoding = 'gzip';
-
-                docBase.pagesinitHandler();
-                expect(stubs.emit).toBeCalledWith(VIEWER_EVENT.load, {
-                    encoding: docBase.encoding,
-                    numPages: 5,
-                    scale: 'unknown',
-                });
-                expect(docBase.loaded).toBe(true);
-            });
-
             test('should set the start page based', () => {
                 const START_PAGE_NUM = 2;
                 const PAGES_COUNT = 3;
@@ -1969,6 +1952,23 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.pagerenderedHandler(docBase.event);
                 expect(stubs.initThumbnails).not.toBeCalled();
                 expect(docBase.renderUI).toBeCalled();
+            });
+
+            test("should broadcast that the preview is loaded if it hasn't already", () => {
+                docBase.pdfViewer = {
+                    currentScale: 'unknown',
+                };
+                docBase.loaded = false;
+                docBase.pdfViewer.pagesCount = 5;
+                docBase.encoding = 'gzip';
+
+                docBase.pagerenderedHandler(docBase.event);
+                expect(stubs.emit).toBeCalledWith(VIEWER_EVENT.load, {
+                    encoding: docBase.encoding,
+                    numPages: 5,
+                    scale: 'unknown',
+                });
+                expect(docBase.somePageRendered).toBe(true);
             });
         });
 


### PR DESCRIPTION
Moved the `load` event emitted from `DocBaseViewer` from `pagesinit` to the first `pagerendered` event for PDFJS.

Also modified the `emitLoadMetrics()` method in `Preview.js` to include a `meaningful_content_timestamp` which can be used to calculate Time to Meaningful Content (TTMC)