### PR TITLE
fix(content-insights): events recurrent request issue

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1444,6 +1444,7 @@ class Preview extends EventEmitter {
                 if (this.logRetryCount > LOG_RETRY_COUNT) {
                     this.pageTrackerReporter(false);
                     this.logRetryCount = 0;
+                    clearTimeout(this.logRetryTimeout);
                     return;
                 }
 

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1423,14 +1423,18 @@ class Preview extends EventEmitter {
             .then(() => {
                 // Reset retry count after successfully logging
                 this.logRetryCount = 0;
-                this.viewer.emit('preview_event_report', true);
+                if (this.viewer) {
+                    this.viewer.emit('preview_event_report', true);
+                }
             })
             .catch(() => {
                 // Don't retry more than the retry limit
                 this.logRetryCount += 1;
                 if (this.logRetryCount > LOG_RETRY_COUNT) {
                     this.logRetryCount = 0;
-                    this.viewer.emit('preview_event_report', false);
+                    if (this.viewer) {
+                        this.viewer.emit('preview_event_report', false);
+                    }
                     return;
                 }
 

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -2115,6 +2115,21 @@ describe('lib/Preview', () => {
                 expect(stubs.emit).toBeCalledWith('preview_event_report', false);
             });
         });
+        test('should not call emit viewer event on logPreviewEvent if preview was hidden and viewer was destroyed', () => {
+            preview.viewer = {
+                emit: jest.fn(),
+                destroy: jest.fn(),
+            };
+
+            stubs.emit = jest.spyOn(preview.viewer, 'emit');
+            stubs.destroy = jest.spyOn(preview.viewer, 'destroy');
+
+            preview.hide();
+            preview.pageTrackerReporter(true);
+
+            expect(stubs.destroy).toBeCalled();
+            expect(stubs.emit).not.toBeCalled();
+        });
     });
 
     describe('handleFetchError()', () => {


### PR DESCRIPTION
Issue was introduced with latest 2.91 release

How to reproduce:

1. Open a Preview for any file.
2. Wait until the 2.0/events  request start, but go back before the request is finished
3. The code will enter in a state of sending those events in a loop state

Proposed change should fix this behaviour.