### PR TITLE
fix(a11y): remove instructions

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -197,6 +197,9 @@ box3d_settings_projection_label=Camera Projection
 # Settings rotate model label
 box3d_settings_rotate_label=Rotate Model
 
+# Document Preview
+document_label=Document Viewer
+
 # Annotations
 # Placeholder text for create textarea in annotation dialog
 annotation_add_comment_placeholder=Add a comment here...

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -197,9 +197,6 @@ box3d_settings_projection_label=Camera Projection
 # Settings rotate model label
 box3d_settings_rotate_label=Rotate Model
 
-# Document Preview
-document_label=Press Alt+Arrow key combinations for caret navigation and text selection within the document's contents
-
 # Annotations
 # Placeholder text for create textarea in annotation dialog
 annotation_add_comment_placeholder=Add a comment here...

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -158,7 +158,9 @@ class DocBaseViewer extends BaseViewer {
         super.setup();
 
         this.docEl = this.createViewer(document.createElement('div'));
+        this.docEl.setAttribute('aria-label', __('document_label'));
         this.docEl.classList.add('bp-doc');
+        this.docEl.tabIndex = '0';
 
         if (Browser.getName() === 'Safari') {
             this.docEl.classList.add(IS_SAFARI_CLASS);

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -158,9 +158,7 @@ class DocBaseViewer extends BaseViewer {
         super.setup();
 
         this.docEl = this.createViewer(document.createElement('div'));
-        this.docEl.setAttribute('aria-label', __('document_label'));
         this.docEl.classList.add('bp-doc');
-        this.docEl.tabIndex = '0';
 
         if (Browser.getName() === 'Safari') {
             this.docEl.classList.add(IS_SAFARI_CLASS);


### PR DESCRIPTION
### Description of Changes
Recommendation was to remove tabindex and aria label 'Press alt + arrow keys...' text since it is not accurate for Windows computers, and it will not help keyboard users who are not using a screen reader. 

