### PR TITLE
fix(copy-paste-issue): PDFJS copy paste fix

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -80,7 +80,7 @@ const PAGES_UNIT_NAME = 'pages';
 const PDFJS_TEXT_LAYER_MODE = {
     DISABLE: 0, // Should match TextLayerMode enum in pdf_viewer.js
     ENABLE: 1,
-    ENABLE_ENHANCE: 2,
+    ENABLE_PERMISSIONS: 2,
 };
 const PINCH_PAGE_CLASS = 'pinch-page';
 const PINCHING_CLASS = 'pinching';
@@ -796,7 +796,6 @@ class DocBaseViewer extends BaseViewer {
         const assetUrlCreator = createAssetUrlCreator(location);
         const hasDownload = checkPermission(file, PERMISSION_DOWNLOAD);
         const hasTextLayer = hasDownload && !this.getViewerOption('disableTextLayer');
-        const textLayerMode = this.isMobile ? PDFJS_TEXT_LAYER_MODE.ENABLE : PDFJS_TEXT_LAYER_MODE.ENABLE_ENHANCE;
 
         return new PdfViewerClass({
             annotationMode: PDFAnnotationMode.ENABLE, // Show annotations, but not forms
@@ -807,7 +806,7 @@ class DocBaseViewer extends BaseViewer {
             linkService: this.pdfLinkService,
             maxCanvasPixels: this.isMobile ? MOBILE_MAX_CANVAS_SIZE : -1,
             renderInteractiveForms: false, // Enabling prevents unverified signatures from being displayed
-            textLayerMode: hasTextLayer ? textLayerMode : PDFJS_TEXT_LAYER_MODE.DISABLE,
+            textLayerMode: hasTextLayer ? PDFJS_TEXT_LAYER_MODE.ENABLE : PDFJS_TEXT_LAYER_MODE.DISABLE,
         });
     }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1145,7 +1145,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-                    // Text Layer mode 1 = Enabled
+                    // Text Layer mode 1 = enabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
                 });
             });
@@ -1156,7 +1156,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-                    // Text Layer mode 1 = Enabled
+                    // Text Layer mode 1 = enabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
                 });
             });
@@ -1166,7 +1166,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-                    // Text Layer mode 0 = Disabled
+                    // Text Layer mode 0 = disabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 0 }));
                 });
             });
@@ -1178,7 +1178,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
                     expect(stubs.getViewerOption).toBeCalledWith('disableTextLayer');
-                    // Text Layer mode 0 = Disabled
+                    // Text Layer mode 0 = disabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 0 }));
                 });
             });

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1145,11 +1145,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-                    expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 2 }));
+                    expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
                 });
             });
 
-            test('should simplify the text layer if the user is on mobile', () => {
+            test('should enable the text layer if the user is on mobile', () => {
                 docBase.isMobile = true;
                 stubs.checkPermission.mockReturnValueOnce(true);
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1145,6 +1145,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
+                    // Text Layer mode 1 = Enabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
                 });
             });
@@ -1155,6 +1156,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
+                    // Text Layer mode 1 = Enabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
                 });
             });
@@ -1164,6 +1166,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
+                    // Text Layer mode 0 = Disabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 0 }));
                 });
             });
@@ -1175,6 +1178,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.initViewer('').then(() => {
                     expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
                     expect(stubs.getViewerOption).toBeCalledWith('disableTextLayer');
+                    // Text Layer mode 0 = Disabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 0 }));
                 });
             });


### PR DESCRIPTION
We noticed when upgrading to PDFJS v3.6.172, copy/paste did not work for text on pdfs. This is because in this new PDFJS version, the enum we were using to pass into the `textLayerMode`, had changed from `ENABLE_ENHANCE` to `ENABLE_PERMISSION`. In previous PDFJS versions, `ENABLE_ENHANCE` would be an option to enable textLayerMode and enhance the text selection (improve text selection across multiple lines). However they have deprecated this option as of `v3.0.279` as noted here: 
- https://github.com/mozilla/pdf.js/pull/15259
- https://github.com/mozilla/pdf.js/issues/15138
- https://github.com/mozilla/pdf.js/pull/15145

They have replaced this enum with a new option called `ENABLE_PERMISSION` which if passed in for `textLayerMode`, checks the permission flags set for the PDF document. So if the PDF document doesn't have the `COPY` flag set, and `ENABLE_PERMISSION` is passed in, the user will not be able to copy the document. This is discussed here:
- https://github.com/mozilla/pdf.js/pull/16333
- https://github.com/mozilla/pdf.js/pull/16320

Because `ENABLE_PERMISSION` uses the same enum as the deprecated `ENABLE_ENHANCE`, we were using `ENABLE_PERMISSION` mistakenly when upgrading versions. To solve this, we can just use the `ENABLE` enum instead, which doesn't check for the documents permissions. We use this enum for mobile and it is also what PDFJS uses as the default `textLayerMode` as well, so I don't believe there's much risk.

The Enhanced Text Selection seems to be the drawback to this change, i'm not sure if the pdfjs team has plans to bring it back, but this comment mentioned that "in general it's often too slow to be usable in practice". 
- https://github.com/mozilla/pdf.js/issues/15138#issuecomment-1177206433


![2023-07-10 16 50 02](https://github.com/box/box-content-preview/assets/11734293/edc764bd-8db9-41dd-9059-2ca962f06ddf)