### PR TITLE
fix(preview): fix auto scroll issue with embed preview

### DIFF
--- a/src/lib/VirtualScroller.js
+++ b/src/lib/VirtualScroller.js
@@ -418,7 +418,7 @@ class VirtualScroller {
             // If it is already present and visible, do nothing, but if not visible
             // then scroll it into view
             if (!this.isVisible(foundItem)) {
-                foundItem.scrollIntoView();
+                foundItem.scrollIntoView({ block: 'nearest' });
             }
         } else {
             // If it is not present, then adjust the scrollTop so that the list item

--- a/src/lib/__tests__/VirtualScroller-test.js
+++ b/src/lib/__tests__/VirtualScroller-test.js
@@ -535,7 +535,7 @@ describe('VirtualScroller', () => {
             virtualScroller.scrollIntoView(1);
 
             expect(stubs.isVisible).toBeCalled();
-            expect(stubs.scrollIntoView).toBeCalled();
+            expect(stubs.scrollIntoView).toBeCalledWith({ block: 'nearest' });
             expect(scrollingEl.scrollTop).toBeUndefined();
             expect(stubs.dispatchEvent).not.toBeCalled();
         });

--- a/src/lib/featureChecking.ts
+++ b/src/lib/featureChecking.ts
@@ -12,6 +12,6 @@ export const isFeatureEnabled = (features: FeatureConfig, featureName: string): 
     return !!get(features, featureName, false);
 };
 
-export const getFeatureConfig = (features: FeatureConfig, featureName: string): FeatureConfig => {
+export const getFeatureConfig = (features: FeatureConfig, featureName: string): FeatureOptions => {
     return get(features, featureName, {});
 };


### PR DESCRIPTION
## Issue
Scrolling jumps to bottom of page on embedded multi-page previews


## Summary of changes
- Add `{ block: 'nearest' }` as param to [`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) to prevent the parent scrollbar from jumping around
- Fix a type to pass lint check


## Demo
### Before
![auto_scroll_before](https://github.com/box/box-content-preview/assets/17888863/c298d691-045f-4991-959f-b164488fa6bc)

### After
![auto_scroll_after](https://github.com/box/box-content-preview/assets/17888863/511d00b7-7051-4ed4-9807-179dcc45c4d0)
