### PR TITLE
fix(a11y): screen reader support for view only file preview

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -177,6 +177,12 @@ class DocBaseViewer extends BaseViewer {
 
         this.viewerEl = this.docEl.appendChild(document.createElement('div'));
         this.viewerEl.classList.add('pdfViewer');
+        // Text layer should be rendered for a11y reasons thats why we will block user from selecting content when no download permissions was granted
+        const isViewOnly = !checkPermission(this.options.file, PERMISSION_DOWNLOAD);
+        if (isViewOnly) {
+            this.viewerEl.classList.add('viewOnly');
+        }
+
         this.loadTimeout = LOAD_TIMEOUT_MS;
 
         this.startPageNum = this.getStartPage(this.startAt);
@@ -795,7 +801,9 @@ class DocBaseViewer extends BaseViewer {
         const { AnnotationMode: PDFAnnotationMode = {} } = this.pdfjsLib;
         const assetUrlCreator = createAssetUrlCreator(location);
         const hasDownload = checkPermission(file, PERMISSION_DOWNLOAD);
-        const hasTextLayer = hasDownload && !this.getViewerOption('disableTextLayer');
+        const enabledTextLayerMode = hasDownload
+            ? PDFJS_TEXT_LAYER_MODE.ENABLE
+            : PDFJS_TEXT_LAYER_MODE.ENABLE_PERMISSIONS; // This mode will prevent default behavior for copy events in the TextLayerBuilder
 
         return new PdfViewerClass({
             annotationMode: PDFAnnotationMode.ENABLE, // Show annotations, but not forms
@@ -806,7 +814,9 @@ class DocBaseViewer extends BaseViewer {
             linkService: this.pdfLinkService,
             maxCanvasPixels: this.isMobile ? MOBILE_MAX_CANVAS_SIZE : -1,
             renderInteractiveForms: false, // Enabling prevents unverified signatures from being displayed
-            textLayerMode: hasTextLayer ? PDFJS_TEXT_LAYER_MODE.ENABLE : PDFJS_TEXT_LAYER_MODE.DISABLE,
+            textLayerMode: this.getViewerOption('disableTextLayer')
+                ? PDFJS_TEXT_LAYER_MODE.DISABLE
+                : enabledTextLayerMode,
         });
     }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -276,35 +276,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             docBase.setup();
             expect(docBase.pageTracker).toBeInstanceOf(PageTracker);
         });
-        test('should add view only class if user does not have download permissions', () => {
-            docBase = new DocBaseViewer({
-                file: {
-                    id: '0',
-                },
-            });
-            docBase.containerEl = containerEl;
-
-            jest.spyOn(file, 'checkPermission').mockReturnValue(false);
-            docBase.setup();
-
-            expect(file.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-            expect(docBase.viewerEl).toHaveClass('viewOnly');
-        });
-
-        test('should not add view only class if user has download permissions', () => {
-            docBase = new DocBaseViewer({
-                file: {
-                    id: '0',
-                },
-            });
-            docBase.containerEl = containerEl;
-
-            jest.spyOn(file, 'checkPermission').mockReturnValue(true);
-            docBase.setup();
-
-            expect(file.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
-            expect(docBase.viewerEl).not.toHaveClass('viewOnly');
-        });
     });
 
     describe('Non setup methods', () => {
@@ -1177,6 +1148,26 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect(stubs.getViewerOption).toBeCalledWith('disableTextLayer');
                     // Text Layer mode 1 = enabled
                     expect(stubs.pdfViewerClass).toBeCalledWith(expect.objectContaining({ textLayerMode: 1 }));
+                });
+            });
+
+            test('should add view only class if user does not have download permissions', () => {
+                docBase.containerEl = containerEl;
+                stubs.checkPermission.mockReturnValueOnce(false);
+
+                return docBase.initViewer('').then(() => {
+                    expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
+                    expect(docBase.viewerEl).toHaveClass('pdfViewer--viewOnly');
+                });
+            });
+
+            test('should not add view only class if user has download permissions', () => {
+                docBase.containerEl = containerEl;
+                stubs.checkPermission.mockReturnValueOnce(true);
+
+                return docBase.initViewer('').then(() => {
+                    expect(stubs.checkPermission).toBeCalledWith(docBase.options.file, PERMISSION_DOWNLOAD);
+                    expect(docBase.viewerEl).not.toHaveClass('pdfViewer--viewOnly');
                 });
             });
 

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -305,7 +305,7 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 
     .pdfViewer {
-        &--viewOnly {
+        &.pdfViewer--viewOnly {
             .textLayer {
                 span {
                     cursor: unset;

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -305,10 +305,10 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 
     .pdfViewer {
-        &.viewOnly {
+        &--viewOnly {
             .textLayer {
                 span {
-                    cursor: not-allowed;
+                    cursor: unset;
                     user-select: none;
                 }
             }

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -304,6 +304,17 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         }
     }
 
+    .pdfViewer {
+        &.viewOnly {
+            .textLayer {
+                span {
+                    cursor: not-allowed;
+                    user-select: none;
+                }
+            }
+        }
+    }
+
     .textLayer {
         caret-color: black; // Required for caret navigation on transparent text
         top: $pdfjs-page-padding;


### PR DESCRIPTION
This change adds support for screen readers and allow to disable copying content for view only PDF documents.

In order to simplify things the "view only" permission was implemented using CSS and JS , which should hopefully suffice.
The advantage of this approach, as opposed to e.g. disabling the textLayer completely, is first of all that it ensures that document is accessible through a screen reader. Secondly this also ensures that searching still works correctly even in copy-protected documents.

This kind of copy-protection is not very strong and is also relatively easy to create some workarounds. Hence a simple solution, targeting "normal"-users rather than "advanced"-users is hopefully deemed acceptable here.

Demo - https://cloud.box.com/s/h9dg4g7bwxorp60qvfvqgu5trjx9v5q6