### PR TITLE
feat(pdf): Move annotation styling to box-annotations

### DIFF
--- a/src/lib/viewers/controls/annotations/AnnotationsControls.scss
+++ b/src/lib/viewers/controls/annotations/AnnotationsControls.scss
@@ -9,10 +9,3 @@
 .bp-AnnotationsControls-exitBtn {
     display: none;
 }
-
-.ba-Layer--popup,
-.ba-Layer--highlight,
-.ba-Layer--drawing,
-.ba-point-annotation-marker {
-    z-index: 3;
-}


### PR DESCRIPTION
In v3.6.172 of PDFjs, a z-index styling was explicitly added to pdf_viewer.css: https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.6.172/pdf_viewer.css. This styling was not present in the previous version of PDFjs that we're using: https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf_viewer.css and keeping this new styling causes issues with the other layers in preview (i.e. popup layer, highlighted layer, etc.). Updating styling for our layers resolves the issues that QA has discovered, but moving them to the box-annotations repo is preferable.

Have tested this change in the SDK with the stylings moved to box-annotations/linked with EUA.