### PR TITLE
feat(pdf): Move annotation marker styling back to sdk

### DIFF
--- a/src/lib/viewers/controls/annotations/AnnotationsControls.scss
+++ b/src/lib/viewers/controls/annotations/AnnotationsControls.scss
@@ -9,3 +9,7 @@
 .bp-AnnotationsControls-exitBtn {
     display: none;
 }
+
+.ba-point-annotation-marker {
+    z-index: 3;
+}


### PR DESCRIPTION
Per discussion with @bfoxx1906 , we decided this style should be kept with the SDK