### PR TITLE
fix(pdf): Move controls layer above popup layer

### DIFF
--- a/src/lib/viewers/controls/controls-root/ControlsRoot.scss
+++ b/src/lib/viewers/controls/controls-root/ControlsRoot.scss
@@ -4,7 +4,7 @@
     position: absolute;
     bottom: 25px;
     left: 50%;
-    z-index: 3;
+    z-index: 4;
     transform: translate3d(-50%, 0, 0);
     backface-visibility: hidden;
 


### PR DESCRIPTION
The popup annotation layer, which comes before this controls layer in the HTML hierarchy, now has a z-index of 4 due to changes needed for the PDFjs upgrade - because of this, the popup annotation layer was covering this controls layer. This causes the E2E tests in box-annotations to fail. So to resolve this, we need to also bring the controls layer up to a z-index of 4. 

Ran this change with the E2E tests for box-annotations locally and it was passing.