### PR TITLE
fix(pdf): override css missing asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "box-content-preview",
-    "version": "2.101.0",
+    "version": "2.100.0",
     "description": "Box Content Preview UI Element",
     "author": "Box (https://www.box.com/)",
     "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "box-content-preview",
-    "version": "2.100.0",
+    "version": "2.101.0",
     "description": "Box Content Preview UI Element",
     "author": "Box (https://www.box.com/)",
     "license": "SEE LICENSE IN LICENSE",

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -290,6 +290,8 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         }
 
         &.loadingIcon::after {
+            top: $pdfjs-page-padding;
+            bottom: $pdfjs-page-padding;
             background: none;
         }
 

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -295,6 +295,17 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         }
     }
 
+    //overwriting background image in pdf_viewer.css. Was causing 404's
+    /* stylelint-disable declaration-no-important */
+    .pdfViewer .page.loadingIcon {
+        background-image: none !important;
+    }
+
+    .pdfViewer .page.loadingIcon::after {
+        background-image: none !important;
+    }
+    /* stylelint-enable declaration-no-important */
+
     .pdfViewer .page.pinch-page {
         padding: 0;
         visibility: visible;

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -289,22 +289,15 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
             background: none;
         }
 
+        &.loadingIcon::after {
+            background: none;
+        }
+
         // Fixes annotation icon broken src
         .textAnnotation > img {
             opacity: 0;
         }
     }
-
-    //overwriting background image in pdf_viewer.css. Was causing 404's
-    /* stylelint-disable declaration-no-important */
-    .pdfViewer .page.loadingIcon {
-        background-image: none !important;
-    }
-
-    .pdfViewer .page.loadingIcon::after {
-        background-image: none !important;
-    }
-    /* stylelint-enable declaration-no-important */
 
     .pdfViewer .page.pinch-page {
         padding: 0;


### PR DESCRIPTION
Because of a change in a css rule in the latest version of [pdf_viewer.css ](https://github.com/mozilla/pdf.js/blob/v3.6.172/web/pdf_viewer.css#L162)we were not overriding the loadingIcon style's background image which caused the CDN to record a large number of 404's as a result. 