### PR TITLE
feat(remote-sync): Enable remote syncing based on an API response

### DIFF
--- a/build/ApiRsyncPlugin.js
+++ b/build/ApiRsyncPlugin.js
@@ -1,0 +1,19 @@
+const { execSync } = require('child_process');
+
+function ApiRsyncPlugin(source, destination) {
+    this.source = source;
+    this.destination = destination;
+}
+
+/* eslint-disable no-console */
+ApiRsyncPlugin.prototype.apply = function rsync(compiler) {
+    compiler.plugin('done', () => {
+        console.log('');
+        console.log(`🔄 🔄 🔄  Rsync starting for ${this.source} 🔄 🔄 🔄`);
+        execSync(`rsync -avz -e "ssh -p 8022 -o ConnectTimeout=3" ${this.source} ${this.destination}`, {
+            stdio: [0, 1, 2],
+        });
+    });
+};
+
+module.exports = ApiRsyncPlugin;


### PR DESCRIPTION
### Why?

The current rsync.json file only supports a statically defined location. This works find for statically defined host/IP addresses but doesn't work well if the remote source goes through another proxy layer (ie K8 ingress, reverse proxy, etc)

### How?

To resolve this, I added the ability to define a host/IP address from the result of an API call. This expands on the current `rsync.json` file while preserving backwards compatablity.

### Example

```json
{
    "apiLocation": {
        "url": "https://example-website/api/info",
        "user": "root",
        "ip": "serverIpAddress",
        "path": "/var/www/assets/example-website"
    }
}

```