### PR TITLE
fix(preview): Fix highlighting text when performing click and drag

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -322,10 +322,11 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 
     .textLayer {
-        caret-color: black; // Required for caret navigation on transparent text
         top: $pdfjs-page-padding;
         bottom: auto;
+        z-index: 2;
         opacity: 1;
+        caret-color: black; // Required for caret navigation on transparent text
 
         // Only allow text divs to be selected
         > div {

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -324,7 +324,7 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     .textLayer {
         top: $pdfjs-page-padding;
         bottom: auto;
-        z-index: 2;
+        z-index: 1;
         opacity: 1;
         caret-color: black; // Required for caret navigation on transparent text
 


### PR DESCRIPTION
Fix highlighting text in Preview. This bug was introduced as a regression during PDF.js upgrade.

### Root cause description
Inside this [commit](https://github.com/mozilla/pdf.js/commit/1b00511301840d413f3369f834999ee44d3dfa8d#diff-90b9c7e02c41b4051095250577f8dd385455429d67abe6bf360e13ef17d7fe19L26) PDF.js team removed `z-index:2` from `.textLayer` class which is causing a bug that user cannot highlight text when annotations are enabled.

### Screenshots
2.108.0 version (current):
<img width="238" alt="image" src="https://github.com/box/box-content-preview/assets/141409011/0f96e110-15d1-43c3-97f1-31cb24ed4fd3">

2.107.0 version:
<img width="240" alt="image" src="https://github.com/box/box-content-preview/assets/141409011/0b05d529-6215-4f65-9f17-99c2ffbeb097">


