### PR TITLE
feat(preview-error): Display file icon based on extension for errors

### DIFF
--- a/src/lib/viewers/error/PreviewErrorViewer.js
+++ b/src/lib/viewers/error/PreviewErrorViewer.js
@@ -80,8 +80,7 @@ class PreviewErrorViewer extends BaseViewer {
 
         const { displayMessage, details, message } = error;
         const { file } = this.options;
-        const { extension } = file || {};
-        const iconExtension = extension === 'flv' || extension === 'tgz' || extension === 'zip' ? extension : undefined;
+        const { extension: iconExtension } = file || {};
 
         // Display the default or file-specific error icon
         this.errorIcon = new ErrorIcon({ containerEl: this.iconEl });

--- a/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
+++ b/src/lib/viewers/error/__tests__/PreviewErrorViewer-test.js
@@ -55,7 +55,8 @@ describe('lib/viewers/error/PreviewErrorViewer', () => {
             ['zip', 'zip'],
             ['tgz', 'tgz'],
             ['flv', 'flv'],
-            ['blah', undefined],
+            ['pdf', 'pdf'],
+            ['pptx', 'pptx'],
         ])('should set appropriate icon', (fileExtension, iconExtension) => {
             const err = new PreviewError('some_code');
             error.options.file.extension = fileExtension;


### PR DESCRIPTION
**Description**
Remove restriction such that preview will fetch the icon based on the extension from box-ui-elements when there is a preview error. Will rely on the logic there to return a default icon when one does not exist for the extension.

See: https://github.com/box/box-ui-elements/blob/1850977829e4888139462a6f65794b1cffc52a08/src/components/preview/previewIcons.ts#L183

**Screenshots**
![image](https://github.com/user-attachments/assets/bbcb118b-6755-44a6-82ad-373ff002e628)
<img width="1795" alt="image-1" src="https://github.com/user-attachments/assets/007640c7-4950-48d0-86bf-155b3ed5f1c8">
