### PR TITLE
Fix yarn build command syntax in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To self-host the Box Content Preview library, follow these steps:
 - Check out a specific version with `git checkout v3.0.0`
 - Download a specific version as a zip from https://github.com/box/box-content-preview/releases
 
-2. Install dependencies and build the library with `yarn install && yarn build:i18n && yarn:build:prod`
+2. Install dependencies and build the library with `yarn install && yarn build:i18n && yarn build:prod`
 3. Self-host everything except for the `dev` folder from the `/dist` folder. You must not alter the folder structure and `third-party` needs to be in the same folder as `2.4.0`. For example, if you self-host using a `box-assets` directory, these URLs must be accessible:
 
 - https://cdn.YOUR_SITE.com/box-assets/2.4.0/en-US/preview.js


### PR DESCRIPTION
This PR fixes a typo in the build instructions where `yarn:build:prod` was incorrectly specified. The correct command syntax is `yarn build:prod`.