### PR TITLE
feat(nodejs20): WEBAPP-30462 Node updated to 20

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: 'focal'
 node_js:
-    - '18'
+    - '20'
 addons:
     apt:
         packages:

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "webpack-dev-server": "^3.11.2"
     },
     "engines": {
-        "node": ">=18.x",
+        "node": ">=18.0.0",
         "yarn": ">=1.19.x"
     },
     "scripts": {
@@ -142,8 +142,7 @@
         "last 2 Firefox versions",
         "last 2 Safari versions",
         "last 2 Edge versions",
-        "last 2 iOS versions",
-        "IE 11"
+        "last 2 iOS versions"
     ],
     "husky": {
         "hooks": {
@@ -155,6 +154,7 @@
     "resolutions": {
         "mojito-rb-gen/merge": "1.2.1",
         "**/react-intl/**/@types/react": "18.3.1",
-        "cheerio": "1.0.0-rc.12"
+        "cheerio": "1.0.0-rc.12",
+        "acorn": "8.14.0"
     }
 }

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -534,7 +534,7 @@ describe('lib/Preview', () => {
                 determineRepresentation: () => {},
             };
             viewer = {
-                CONSTRUCTOR: () => {},
+                CONSTRUCTOR: function constr() {},
             };
 
             sandbox
@@ -597,7 +597,7 @@ describe('lib/Preview', () => {
 
         test('should prefetch assets, preload, and content if viewer defines a prefetch function and preload is false, but viewer preload option is true', () => {
             viewer = {
-                CONSTRUCTOR: () => {
+                CONSTRUCTOR: function constr() {
                     return {
                         prefetch: sandbox.mock().withArgs({
                             assets: true,
@@ -618,7 +618,7 @@ describe('lib/Preview', () => {
 
         test('should prefetch assets and content but not preload if viewer defines a prefetch function and preload is false, and viewer preload option is false', () => {
             viewer = {
-                CONSTRUCTOR: () => {
+                CONSTRUCTOR: function constr() {
                     return {
                         prefetch: sandbox.mock().withArgs({
                             assets: true,
@@ -639,7 +639,7 @@ describe('lib/Preview', () => {
 
         test('should prefetch assets and preload, but not content if viewer defines a prefetch function and preload is true', () => {
             viewer = {
-                CONSTRUCTOR: () => {
+                CONSTRUCTOR: function constr() {
                     return {
                         prefetch: sandbox.mock().withArgs({
                             assets: true,
@@ -663,7 +663,7 @@ describe('lib/Preview', () => {
                 prefetchStub = jest.fn();
 
                 /* eslint-disable require-jsdoc */
-                const stubViewer = () => {
+                const stubViewer = function constr() {
                     return { prefetch: prefetchStub };
                 };
                 /* eslint-enable require-jsdoc */
@@ -1774,7 +1774,7 @@ describe('lib/Preview', () => {
 
         test('should instantiate the viewer, set logger, attach viewer events, and load the viewer', () => {
             stubs.loader.determineViewer.mockReturnValue({
-                CONSTRUCTOR: () => {
+                CONSTRUCTOR: function constr() {
                     return stubs.viewer;
                 },
                 NAME: 'someViewerName',

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,9 +1,4 @@
-// TODO @mickryan remove after we upgrade the annotations version
-let annotationMessages = {};
-
-try {
-    annotationMessages = require('box-annotations-messages').default; // eslint-disable-line
-} catch (e) {} // eslint-disable-line
+const annotationMessages = {};
 
 const language = __LANGUAGE__ || 'en-US'; // eslint-disable-line
 

--- a/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
+++ b/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
@@ -192,6 +192,9 @@ describe('lib/viewers/box3d/video360/Video360Viewer', () => {
             stubs.initBox3d = jest.spyOn(Video360Renderer.prototype, 'initBox3d').mockResolvedValue(undefined);
             stubs.initVr = jest.spyOn(Video360Renderer.prototype, 'initVr').mockImplementation();
             stubs.create360Environment = jest.spyOn(viewer, 'create360Environment').mockResolvedValue(undefined);
+            window.BoxSDK = function sdk() {
+                return {};
+            };
         });
 
         afterEach(() => {
@@ -202,6 +205,7 @@ describe('lib/viewers/box3d/video360/Video360Viewer', () => {
                 }
             });
             viewer.renderer = null;
+            window.BoxSDK = undefined;
         });
 
         test('should create a new Video360 renderer instance', done => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,30 +2759,10 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^6.4.1:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
-
-acorn@^7.1.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.2.4:
+acorn@8.14.0, acorn@^6.4.1, acorn@^7.1.1, acorn@^8.2.4, acorn@^8.8.0, acorn@^8.8.2:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
-
-acorn@^8.8.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
-  integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
-
-acorn@^8.8.2:
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
-  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 add-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Updated project to work with Nodejs 20.

Bumped resolution of `acorn` to most recent as with node update it's older version stops working properly with optional chaining operators. The proper solution is to update Webpack to next version which should be handled in another task.

Removed IE 11 compatibility. Due to side effect, constructor mocks with arrow functions stopped working (were transcribed before).