### PR TITLE
fix(doc-first): webp rep is not marked as success bug

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -387,14 +387,24 @@ class DocBaseViewer extends BaseViewer {
             this.startPreloadTimer();
             this.preloader.showPreload(preloadUrlWithAuth, this.containerEl);
         } else {
-            const preloadRepPaged = getRepresentation(file, 'webp');
-            const { pages: pageCount = 1 } = preloadRepPaged?.metadata || {};
-            const { url_template: pagedUrlTemplate = '' } = preloadRepPaged?.content || {};
-            const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
-            const pagedPreLoadUrlWithAuth =
-                newPagedUrlTemplate && this.createContentUrlWithAuthParams(newPagedUrlTemplate);
             this.startPreloadTimer();
-            this.preloader.showPreload(preloadUrlWithAuth, this.containerEl, pagedPreLoadUrlWithAuth, pageCount, this);
+            const preloadRepPaged = getRepresentation(file, 'webp');
+            if (!preloadRepPaged || RepStatus.getStatus(preloadRepPaged) !== STATUS_SUCCESS) {
+                this.preloader.showPreload(preloadUrlWithAuth, this.containerEl, null, 1, this);
+            } else {
+                const { pages: pageCount = 1 } = preloadRepPaged?.metadata || {};
+                const { url_template: pagedUrlTemplate = '' } = preloadRepPaged?.content || {};
+                const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
+                const pagedPreLoadUrlWithAuth =
+                    newPagedUrlTemplate && this.createContentUrlWithAuthParams(newPagedUrlTemplate);
+                this.preloader.showPreload(
+                    preloadUrlWithAuth,
+                    this.containerEl,
+                    pagedPreLoadUrlWithAuth,
+                    pageCount,
+                    this,
+                );
+            }
         }
     }
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -397,13 +397,7 @@ class DocBaseViewer extends BaseViewer {
                 const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
                 const pagedPreLoadUrlWithAuth =
                     newPagedUrlTemplate && this.createContentUrlWithAuthParams(newPagedUrlTemplate);
-                this.preloader.showPreload(
-                    preloadUrlWithAuth,
-                    this.containerEl,
-                    pagedPreLoadUrlWithAuth,
-                    pageCount,
-                    this,
-                );
+                this.preloader.showPreload(null, this.containerEl, pagedPreLoadUrlWithAuth, pageCount, this);
             }
         }
     }

--- a/src/lib/viewers/doc/DocFirstPreloader.js
+++ b/src/lib/viewers/doc/DocFirstPreloader.js
@@ -14,6 +14,7 @@ import {
     CLASS_BOX_PREVIEW_THUMBNAILS_OPEN,
     CLASS_BOX_PRELOAD_COMPLETE,
     CLASS_DOC_FIRST_IMAGE,
+    CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE,
 } from '../../constants';
 
 import { PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER } from './DocBaseViewer';
@@ -119,7 +120,7 @@ class DocFirstPreloader extends EventEmitter {
      * @param {string} preloadUrlWithAuth - URL for preload content with authorization query params
      * @return {Promise} Promise to show preload
      */
-    async showPreload(preloadUrlWithAuth, containerEl, pagedPreLoadUrlWithAuth = '', pages, docBaseViewer) {
+    async showPreload(preloadUrlWithAuth, containerEl, pagedPreLoadUrlWithAuth, pages, docBaseViewer) {
         if (this.pdfJsDocLoadComplete()) {
             return;
         }
@@ -187,8 +188,10 @@ class DocFirstPreloader extends EventEmitter {
         if (!this.spinner) {
             this.spinner = document.createElement('div');
             this.spinner.classList.add(CLASS_BOX_PREVIEW_PRELOAD_SPINNER);
-            if (!document.getElementsByClassName('bcs-is-open')[0]) {
+            if (!document.getElementsByClassName('bcs-is-open')[0] && this.thumbnailsOpen) {
                 this.spinner.classList.add('bp-sidebar-closed');
+            } else if (!this.thumbnailsOpen) {
+                this.spinner.classList.add(CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE);
             }
             this.wrapperEl.appendChild(this.spinner);
         }
@@ -216,6 +219,9 @@ class DocFirstPreloader extends EventEmitter {
     }
 
     getPreloadImageRequestPromises(preloadUrlWithAuth, pages, pagedPreLoadUrlWithAuth) {
+        if (!preloadUrlWithAuth && !pagedPreLoadUrlWithAuth) {
+            return [];
+        }
         const firstPageUrl = !pagedPreLoadUrlWithAuth
             ? preloadUrlWithAuth
             : pagedPreLoadUrlWithAuth.replace(PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER, '1.webp');

--- a/src/lib/viewers/doc/DocFirstPreloader.js
+++ b/src/lib/viewers/doc/DocFirstPreloader.js
@@ -190,7 +190,7 @@ class DocFirstPreloader extends EventEmitter {
             this.spinner.classList.add(CLASS_BOX_PREVIEW_PRELOAD_SPINNER);
             if (!document.getElementsByClassName('bcs-is-open')[0] && this.thumbnailsOpen) {
                 this.spinner.classList.add('bp-sidebar-closed');
-            } else if (!this.thumbnailsOpen) {
+            } else if (!this.thumbnailsOpen && document.getElementsByClassName('bcs-is-open')[0]) {
                 this.spinner.classList.add(CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE);
             }
             this.wrapperEl.appendChild(this.spinner);

--- a/src/lib/viewers/doc/Document.scss
+++ b/src/lib/viewers/doc/Document.scss
@@ -34,6 +34,10 @@
     &.bp-sidebar-closed {
         left: 50%;
     }
+
+    &.bp-thumbnails-close {
+        left: 37%;
+    }
 }
 
 // Used for showing preload, aka Instant Preview

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -690,7 +690,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(startPreloadTimerStub).toBeCalled();
             });
 
-            test('should load doc first preloader properly for doc first pages', () => {
+            test('should load doc first preloader properly for doc first pages when webp rep available', () => {
                 jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
                     // pagedUrlTemplate gets turned into this url in the code as {+asset_path} is replaced with PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER
                     if (url === `https://url/${PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER}`) {
@@ -707,13 +707,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.docFirstPagesEnabled = true;
                 docBase.showPreload();
                 expect(startPreloadTimerStub).toHaveBeenCalled();
-                expect(docBase.preloader.showPreload).toHaveBeenCalledWith(
-                    'preload-url',
-                    containerEl,
-                    'paged-url',
-                    4,
-                    docBase,
-                );
+                expect(docBase.preloader.showPreload).toHaveBeenCalledWith(null, containerEl, 'paged-url', 4, docBase);
             });
 
             test('should not throw an error in doc first preloader and use jpeg rep if no webp rep available', () => {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -744,7 +744,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 };
 
                 jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
-                    // pagedUrlTemplate gets turned into this url in the code as {+asset_path} is replaced with PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER
+                    // the webpRep template gets turned into this url in the code as {+asset_path} is replaced with PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER
                     if (url === `https://url/${PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER}`) {
                         return 'paged-url';
                     }

--- a/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
@@ -384,9 +384,22 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             const mockWrapperEl = document.createElement('div');
             jest.spyOn(mockWrapperEl, 'appendChild');
             preloader.wrapperEl = mockWrapperEl;
+            preloader.thumbnailsOpen = true;
             preloader.showSpinner();
             expect(preloader.spinner).toBeInstanceOf(HTMLDivElement);
             expect(preloader.spinner.classList.contains('bp-sidebar-closed')).toBe(true);
+            expect(preloader.spinner.classList.contains('bp-thumbnails-close')).not.toBe(true);
+        });
+
+        it('should create the spinner and position it properly if thumbnails are closed', () => {
+            const mockWrapperEl = document.createElement('div');
+            jest.spyOn(mockWrapperEl, 'appendChild');
+            preloader.wrapperEl = mockWrapperEl;
+            preloader.thumbnailsOpen = false;
+            preloader.showSpinner();
+            expect(preloader.spinner).toBeInstanceOf(HTMLDivElement);
+            expect(preloader.spinner.classList.contains('bp-thumbnails-close')).toBe(true);
+            expect(preloader.spinner.classList.contains('bp-sidebar-closed')).not.toBe(true);
         });
     });
 

--- a/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
@@ -393,6 +393,14 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
 
         it('should create the spinner and position it properly if thumbnails are closed', () => {
             const mockWrapperEl = document.createElement('div');
+            jest.spyOn(document, 'getElementsByClassName').mockImplementation(klass => {
+                if (klass === 'bcs-is-open') {
+                    return ['div'];
+                }
+
+                return null;
+            });
+
             jest.spyOn(mockWrapperEl, 'appendChild');
             preloader.wrapperEl = mockWrapperEl;
             preloader.thumbnailsOpen = false;


### PR DESCRIPTION
When the webp rep comes back with a a non success status such as the response below, the preloader still constructed a webp image url from the template and tried to request it. This returned a 404 which stopped the preloader. The end result was that preloading was essentially disabled in cases such as this when in actuality the jpeg url should be used instead.

```
 {
                 "representation": "webp",
                 "properties": { ......},
                 "info": {
                    "url": "........."
                  },
                  "status": {
                    "state": "error",
                    "code": "error_large_size_file"
                 },
                 "content": {
                    "url_template": "..........."
                }
  },
```

Additionally, I updating the positioning of the spinner based on whether or not thumbnail sidebar is open or not.