### PR TITLE
fix(doc-first): code update

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -85,7 +85,7 @@ export const APP_HOST = 'https://app.box.com';
 
 export const ORIGINAL_REP_NAME = 'ORIGINAL';
 export const PRELOAD_REP_NAME = 'jpg';
-
+export const PRELOAD_PAGED_REP_NAME = 'webp';
 export const STATUS_ERROR = 'error';
 export const STATUS_NONE = 'none';
 export const STATUS_PENDING = 'pending';

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -25,6 +25,7 @@ class PresentationViewer extends DocBaseViewer {
         this.pagesinitHandler = this.pagesinitHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
         this.throttledWheelHandler = this.getWheelHandler().bind(this);
+        this.docFirstPagesEnabled = false;
     }
 
     /**

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -73,6 +73,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
         test('should add the presentation class to the presentation element and set up preloader', () => {
             expect(presentation.docEl).toHaveClass('bp-doc-presentation');
             expect(presentation.preloader).toBeInstanceOf(PresentationPreloader);
+            expect(presentation.docFirstPagesEnabled).toBe(false);
         });
 
         test('should invoke onPreload callback', () => {


### PR DESCRIPTION
Based on issues found when migrated to production the following fixes were made

* updating the preloader time diff event to only return the time diff as it's value
* changing the logic so that webp preloading will happen if there is no available jpeg rep but a webp rep is available
* adding/updating test cases 
* being more explicit about Presentations not using the new preloader. While not causing en error, presentations were going down that doc first codepath when the feature was enabled and should not be.