### PR TITLE
feat(doc-first): adding doc first behavior to presentations

### DIFF
--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -209,7 +209,7 @@ class ThumbnailsSidebar {
         if (nextThumbnailEl) {
             const parsedPageNum = parseInt(nextThumbnailEl.dataset.bpPageNum, 10);
             // max doc first pages is 8 and this prevents the 9th page from being blank if the pdfDocument is not loaded yet
-            if (parsedPageNum > this.preloader?.retrievedPages && !this.pdfViewer.pdfDocument) {
+            if (parsedPageNum > this.preloader?.retrievedPagesCount && !this.pdfViewer.pdfDocument) {
                 return;
             }
             this.requestThumbnailImage(parsedPageNum - 1, nextThumbnailEl);

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -86,7 +86,7 @@ describe('ThumbnailsSidebar', () => {
         test('should clean up the instance properties', () => {
             thumbnailsSidebar.destroy();
             expect(thumbnailsSidebar.pdfViewer).toBeNull();
-            const preloader = { retrievedPages: 3 };
+            const preloader = { retrievedPagesCount: 3 };
             thumbnailsSidebar = new ThumbnailsSidebar(anchorEl, pdfViewer, preloader);
             thumbnailsSidebar.destroy();
             expect(thumbnailsSidebar.preloader).toBeNull();
@@ -181,7 +181,7 @@ describe('ThumbnailsSidebar', () => {
             const items = [createThumbnailEl(9, false)];
             thumbnailsSidebar.currentThumbnails = items;
             thumbnailsSidebar.pdfViewer.pdfDocument = null;
-            thumbnailsSidebar.preloader = { retrievedPages: 8 };
+            thumbnailsSidebar.preloader = { retrievedPagesCount: 8 };
             thumbnailsSidebar.renderNextThumbnailImage();
 
             expect(stubs.requestThumbnailImage).not.toHaveBeenCalled();

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1329,12 +1329,7 @@ class DocBaseViewer extends BaseViewer {
 
         // Preloader will only be used if we're not using a cached page number.
         // This is why we need to emit the event here and not in the block below
-        if (
-            !this.startPageRendered &&
-            pageNumber === 1 &&
-            this.preloader?.loadTime &&
-            this.preloader?.retrievedPagesCount > 1
-        ) {
+        if (!this.startPageRendered && pageNumber === 1 && this.preloader?.loadTime && this.preloader?.isWebp) {
             const timeDiff = Date.now() - this.preloader.loadTime;
             this.emitMetric({
                 name: LOAD_METRIC.preloadContentLoadTimeDiff,

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -425,7 +425,7 @@ class DocBaseViewer extends BaseViewer {
         if (this.docFirstPagesEnabled) {
             // If there is an error and we are in a retry don't
             // re-render the preloader. Use the existing one.
-            if (!this.preloader?.retrievedPages) {
+            if (!this.preloader?.retrievedPagesCount) {
                 this.loadAssets(EXIF_READER).then(() => {
                     this.showPreload();
                 });
@@ -1329,7 +1329,12 @@ class DocBaseViewer extends BaseViewer {
 
         // Preloader will only be used if we're not using a cached page number.
         // This is why we need to emit the event here and not in the block below
-        if (!this.startPageRendered && pageNumber === 1 && this.preloader?.loadTime) {
+        if (
+            !this.startPageRendered &&
+            pageNumber === 1 &&
+            this.preloader?.loadTime &&
+            this.preloader?.retrievedPagesCount > 1
+        ) {
             const timeDiff = Date.now() - this.preloader.loadTime;
             this.emitMetric({
                 name: LOAD_METRIC.preloadContentLoadTimeDiff,

--- a/src/lib/viewers/doc/DocFirstPreloader.js
+++ b/src/lib/viewers/doc/DocFirstPreloader.js
@@ -15,6 +15,7 @@ import {
     CLASS_BOX_PRELOAD_COMPLETE,
     CLASS_DOC_FIRST_IMAGE,
     CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE,
+    CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION,
 } from '../../constants';
 
 import { PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER } from './DocBaseViewer';
@@ -75,7 +76,7 @@ class DocFirstPreloader extends EventEmitter {
     thumbnailsOpen = false;
 
     /** @property {number} - Preloader number of pages retrieved from representation api */
-    retrievedPages = 0;
+    retrievedPagesCount = 0;
 
     /** @property {HTMLElement} - Preload loading spinner element */
     spinnner;
@@ -88,11 +89,13 @@ class DocFirstPreloader extends EventEmitter {
      * @param {Api} options.api - API Instance
      * @return {DocPreloader} DocPreloader instance
      */
-    constructor(previewUI, { api } = {}) {
+    constructor(previewUI, { api } = {}, isPresentation = false) {
         super();
         this.api = api;
         this.previewUI = previewUI;
-        this.wrapperClassName = CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_DOCUMENT;
+        this.wrapperClassName = isPresentation
+            ? CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION
+            : CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_DOCUMENT;
     }
 
     buildPreloaderImagePlaceHolder(image) {
@@ -164,7 +167,7 @@ class DocFirstPreloader extends EventEmitter {
                         }
                     });
 
-                    this.retrievedPages = Object.keys(this.preloadedImages).length;
+                    this.retrievedPagesCount = Object.keys(this.preloadedImages).length;
                     const previewMask = document.getElementsByClassName('bcpr-PreviewMask')[0];
                     previewMask.style.display = 'none';
                     if (docBaseViewer.shouldThumbnailsBeToggled()) {
@@ -174,7 +177,7 @@ class DocFirstPreloader extends EventEmitter {
                         docBaseViewer.initThumbnails();
                         this.thumbnailsOpen = true;
                     }
-                    if (this.retrievedPages) {
+                    if (this.retrievedPagesCount) {
                         this.emit('preload');
                         this.loadTime = Date.now();
                         this.wrapperEl.classList.add('loaded');
@@ -273,7 +276,7 @@ class DocFirstPreloader extends EventEmitter {
 
         this.preloadEl = undefined;
         this.imageEl = undefined;
-        this.retrievedPages = undefined;
+        this.retrievedPagesCount = undefined;
         Object.values(this.preloadedImages).forEach(image => {
             URL.revokeObjectURL(image);
         });

--- a/src/lib/viewers/doc/DocFirstPreloader.js
+++ b/src/lib/viewers/doc/DocFirstPreloader.js
@@ -81,6 +81,9 @@ class DocFirstPreloader extends EventEmitter {
     /** @property {HTMLElement} - Preload loading spinner element */
     spinnner;
 
+    /** @property {boolean} - Preloader used webp */
+    isWebp = false;
+
     /**
      * [constructor]
      *
@@ -129,7 +132,7 @@ class DocFirstPreloader extends EventEmitter {
         }
 
         this.numPages = pages;
-
+        this.isWebp = !!pagedPreLoadUrlWithAuth;
         this.initializePreloadContainerComponents(containerEl);
         const promises = this.getPreloadImageRequestPromises(preloadUrlWithAuth, pages, pagedPreLoadUrlWithAuth);
         // eslint-disable-next-line consistent-return

--- a/src/lib/viewers/doc/Document.scss
+++ b/src/lib/viewers/doc/Document.scss
@@ -6,40 +6,6 @@
     overflow-y: scroll;
 }
 
-.bp-document-preload-spinner {
-    position: fixed;
-    top: 50%;
-    left: 43%;
-    z-index: 1000;
-    display: none;
-    width: 160px;
-    height: 160px;
-    background-color: transparent;
-    border: 2px solid red;
-    border-top: 5px solid transparent;
-    border-radius: 50%;
-    transform: translate(-50%, -50%);
-    animation: spin 1s linear infinite;
-
-    @keyframes spin {
-        from {
-            transform: translate(-50%, -50%) rotate(0deg);
-        }
-
-        to {
-            transform: translate(-50%, -50%) rotate(360deg);
-        }
-    }
-
-    &.bp-sidebar-closed {
-        left: 50%;
-    }
-
-    &.bp-thumbnails-close {
-        left: 37%;
-    }
-}
-
 // Used for showing preload, aka Instant Preview
 .bp-document-preload-wrapper {
     position: absolute;

--- a/src/lib/viewers/doc/Presentation.scss
+++ b/src/lib/viewers/doc/Presentation.scss
@@ -38,6 +38,7 @@
     right: 0;
     bottom: 0;
     left: 0;
+    align-content: center;
     margin: 0;
     background-color: $ffive;
     transition: opacity .5s;
@@ -62,7 +63,7 @@
 
     .bp-preload-content,
     .bp-preload-overlay,
-    .bp-preload-placeholder {
+    .bp-preload-placeholder::before {
         position: absolute;
         top: 0;
         right: 0;
@@ -82,6 +83,18 @@
         @include bp-DocGhost;
         @include bp-DocShadow;
 
+        position: relative;
         margin: auto;
+        padding-top: 5px;
+        //margin: 15px auto 30px;
+
+        img.doc-first-image {
+            width: 100%;
+            height: 100%;
+        }
+
+        img.loaded {
+            visibility: visible;
+        }
     }
 }

--- a/src/lib/viewers/doc/Presentation.scss
+++ b/src/lib/viewers/doc/Presentation.scss
@@ -54,6 +54,12 @@
         background-color: $sunset-grey;
     }
 
+    &.loaded {
+        .bp-document-preload-spinner {
+            display: block;
+        }
+    }
+
     .bp-preload-content,
     .bp-preload-overlay,
     .bp-preload-placeholder {

--- a/src/lib/viewers/doc/Presentation.scss
+++ b/src/lib/viewers/doc/Presentation.scss
@@ -86,7 +86,6 @@
         position: relative;
         margin: auto;
         padding-top: 5px;
-        //margin: 15px auto 30px;
 
         img.doc-first-image {
             width: 100%;

--- a/src/lib/viewers/doc/PresentationPreloader.js
+++ b/src/lib/viewers/doc/PresentationPreloader.js
@@ -1,8 +1,8 @@
-import DocFirstPreloader from './DocFirstPreloader';
-import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION, CLASS_PREVIEW_LOADED } from '../../constants';
+import DocPreloader from './DocPreloader';
+import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION } from '../../constants';
 import { setDimensions } from '../../util';
 
-class PresentationPreloader extends DocFirstPreloader {
+class PresentationPreloader extends DocPreloader {
     /** @inheritdoc */
     maxZoomScale = 0;
 

--- a/src/lib/viewers/doc/PresentationPreloader.js
+++ b/src/lib/viewers/doc/PresentationPreloader.js
@@ -1,5 +1,5 @@
 import DocFirstPreloader from './DocFirstPreloader';
-import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION,CLASS_PREVIEW_LOADED } from '../../constants';
+import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION, CLASS_PREVIEW_LOADED } from '../../constants';
 import { setDimensions } from '../../util';
 
 class PresentationPreloader extends DocFirstPreloader {

--- a/src/lib/viewers/doc/PresentationPreloader.js
+++ b/src/lib/viewers/doc/PresentationPreloader.js
@@ -1,8 +1,8 @@
-import DocPreloader from './DocPreloader';
-import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION } from '../../constants';
+import DocFirstPreloader from './DocFirstPreloader';
+import { CLASS_INVISIBLE, CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_PRESENTATION,CLASS_PREVIEW_LOADED } from '../../constants';
 import { setDimensions } from '../../util';
 
-class PresentationPreloader extends DocPreloader {
+class PresentationPreloader extends DocFirstPreloader {
     /** @inheritdoc */
     maxZoomScale = 0;
 

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -25,7 +25,7 @@ class PresentationViewer extends DocBaseViewer {
         this.pagesinitHandler = this.pagesinitHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
         this.throttledWheelHandler = this.getWheelHandler().bind(this);
-        this.docFirstPagesEnabled = false;
+        //this.docFirstPagesEnabled = false;
     }
 
     /**

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -25,7 +25,7 @@ class PresentationViewer extends DocBaseViewer {
         this.pagesinitHandler = this.pagesinitHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
         this.throttledWheelHandler = this.getWheelHandler().bind(this);
-        //this.docFirstPagesEnabled = false;
+        // this.docFirstPagesEnabled = false;
     }
 
     /**

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -1,5 +1,7 @@
 import throttle from 'lodash/throttle';
 import DocBaseViewer from './DocBaseViewer';
+
+import DocFirstPreloader from './DocFirstPreloader';
 import PresentationPreloader from './PresentationPreloader';
 import { CLASS_INVISIBLE } from '../../constants';
 import { getProp } from '../../util';
@@ -17,6 +19,9 @@ class PresentationViewer extends DocBaseViewer {
     /**
      * @inheritdoc
      */
+
+    docFirstPagesEnabled;
+
     constructor(options) {
         super(options);
 
@@ -25,7 +30,6 @@ class PresentationViewer extends DocBaseViewer {
         this.pagesinitHandler = this.pagesinitHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
         this.throttledWheelHandler = this.getWheelHandler().bind(this);
-        // this.docFirstPagesEnabled = false;
     }
 
     /**
@@ -41,13 +45,17 @@ class PresentationViewer extends DocBaseViewer {
         this.docEl.classList.add('bp-doc-presentation');
 
         // Set up preloader
-        this.preloader = new PresentationPreloader(this.previewUI, { api: this.api });
+        this.preloader = this.docFirstPagesEnabled
+            ? new DocFirstPreloader(this.previwewUI, { api: this.api }, true)
+            : new PresentationPreloader(this.previewUI, { api: this.api });
+
         this.preloader.addListener('preload', this.onPreload.bind(this));
     }
 
     /**
      * @inheritdoc
      */
+
     destroy() {
         super.destroy();
         this.preloader.removeAllListeners('preload');

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2317,6 +2317,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.preloader = new DocFirstPreloader();
                 docBase.preloader.loadTime = 20;
                 docBase.preloader.retrievedPagesCount = 4;
+                docBase.preloader.isWebp = true;
                 docBase.pagerenderedHandler({ pageNumber: 1 });
 
                 expect(stubs.emitMetric).toHaveBeenCalledWith({
@@ -2332,6 +2333,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.preloader = new DocFirstPreloader();
                 docBase.preloader.loadTime = 20;
                 docBase.preloader.retrievedPagesCount = 1;
+                docBase.preloader.isWebp = false;
                 docBase.pagerenderedHandler({ pageNumber: 1 });
 
                 expect(stubs.emitMetric).not.toHaveBeenCalledWith({

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2310,7 +2310,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.renderUI).toBeCalled();
             });
 
-            test('should emit doc first pages metric', () => {
+            test('should emit doc first pages metric if webp representation is available', () => {
                 jest.spyOn(Date, 'now').mockReturnValue(100);
                 docBase.startPageRendered = false;
                 docBase.docFirstPagesEnabled = true;
@@ -2326,7 +2326,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should notemit doc first pages metric if retrieved pages count is 1', () => {
+            test('should not emit doc first pages metric if no webp representation is available', () => {
                 jest.spyOn(Date, 'now').mockReturnValue(100);
                 docBase.startPageRendered = false;
                 docBase.docFirstPagesEnabled = true;

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2316,10 +2316,25 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.docFirstPagesEnabled = true;
                 docBase.preloader = new DocFirstPreloader();
                 docBase.preloader.loadTime = 20;
-                docBase.preloader.retrievedPages = 4;
+                docBase.preloader.retrievedPagesCount = 4;
                 docBase.pagerenderedHandler({ pageNumber: 1 });
 
                 expect(stubs.emitMetric).toHaveBeenCalledWith({
+                    data: 80,
+                    name: 'preload_content_load_time_diff',
+                });
+            });
+
+            test('should notemit doc first pages metric if retrieved pages count is 1', () => {
+                jest.spyOn(Date, 'now').mockReturnValue(100);
+                docBase.startPageRendered = false;
+                docBase.docFirstPagesEnabled = true;
+                docBase.preloader = new DocFirstPreloader();
+                docBase.preloader.loadTime = 20;
+                docBase.preloader.retrievedPagesCount = 1;
+                docBase.pagerenderedHandler({ pageNumber: 1 });
+
+                expect(stubs.emitMetric).not.toHaveBeenCalledWith({
                     data: 80,
                     name: 'preload_content_load_time_diff',
                 });

--- a/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
@@ -99,12 +99,14 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
     });
 
     describe('showPreload()', () => {
+        let mockContainer;
         beforeEach(() => {
             jest.spyOn(preloader, 'pdfJsDocLoadComplete').mockReturnValue(false);
             jest.spyOn(preloader, 'emit');
             jest.spyOn(preloader, 'showSpinner');
             jest.spyOn(preloader, 'setPreloadImageDimensions').mockResolvedValue();
             jest.spyOn(preloader, 'loadImage').mockReturnValue(mockFirstImage);
+            mockContainer = document.createElement('div');
         });
 
         it('should not proceed if the document is already loaded', async () => {
@@ -115,12 +117,23 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             expect(preloader.initializePreloadContainerComponents).not.toHaveBeenCalled();
         });
 
+        it('should set isWebp to true if pagedPreLoadUrlWithAuth is provided', async () => {
+            jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue([]);
+            await preloader.showPreload(null, mockContainer, 'mock-paged-image-url', 1, mockDocBaseViewer);
+            expect(preloader.isWebp).toBe(true);
+        });
+
+        it('should set isWebp to false if pagedPreLoadUrlWithAuth is not provided', async () => {
+            jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue([]);
+            await preloader.showPreload('mock-url', mockContainer, null, 1, mockDocBaseViewer);
+            expect(preloader.isWebp).toBe(false);
+        });
+
         it('should handle thubmnail sidebar correctly', async () => {
             const mockBlob = new Blob(['mock-content'], { type: 'image/webp' });
             const mockPromises = [Promise.resolve(mockBlob)];
             jest.spyOn(preloader, 'loadImage').mockReturnValue(new Image(100, 200));
             jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue(mockPromises);
-            const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 1, mockDocBaseViewer);
             expect(mockElement.style.display).toBe('none');
@@ -160,7 +173,6 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
                 }
                 return '';
             });
-            const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 4, mockDocBaseViewer);
             expect(preloader.numPages).toBe(4);
@@ -188,7 +200,6 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             const mockBlob = new Blob(['mock-content'], { type: 'image/webp' });
             const mockPromises = [Promise.resolve(new Error('error')), Promise.resolve(mockBlob)];
             jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue(mockPromises);
-            const mockContainer = document.createElement('div');
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 2, mockDocBaseViewer);
             expect(preloader.retrievedPagesCount).toBe(0);
             expect(preloader.setPreloadImageDimensions).not.toHaveBeenCalled();
@@ -209,7 +220,6 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue(mockPromises);
             jest.spyOn(URL, 'createObjectURL').mockReturnValue('mock-object-url');
 
-            const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 3, mockDocBaseViewer);
             expect(preloader.retrievedPagesCount).toBe(1);
@@ -247,7 +257,6 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
                 return '';
             });
 
-            const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 4, mockDocBaseViewer);
             expect(preloader.retrievedPagesCount).toBe(2);
@@ -258,22 +267,6 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             expect(mockDocBaseViewer.initThumbnails).toHaveBeenCalled();
             expect(preloader.emit).toHaveBeenCalled();
             expect(preloader.loadTime).not.toBeUndefined();
-        });
-
-        it('should use the jpeg image as  preloader if webp is not available ', async () => {
-            const mockBlob = new Blob(['mock-content'], { type: 'image/jpg' });
-            const mockPromises = [Promise.resolve(new Error('error')), Promise.resolve(mockBlob)];
-            jest.spyOn(preloader, 'pdfJsDocLoadComplete').mockReturnValue(false);
-            jest.spyOn(preloader, 'emit');
-            jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue(mockPromises);
-            jest.spyOn(preloader, 'setPreloadImageDimensions').mockResolvedValue();
-            const mockContainer = document.createElement('div');
-            await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 2, mockDocBaseViewer);
-            expect(preloader.retrievedPagesCount).toBe(0);
-            expect(preloader.setPreloadImageDimensions).not.toHaveBeenCalled();
-            expect(mockDocBaseViewer.initThumbnails).not.toHaveBeenCalled();
-            expect(preloader.emit).not.toHaveBeenCalled();
-            expect(preloader.loadTime).toBeUndefined();
         });
     });
 

--- a/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
@@ -164,7 +164,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 4, mockDocBaseViewer);
             expect(preloader.numPages).toBe(4);
-            expect(preloader.retrievedPages).toBe(4);
+            expect(preloader.retrievedPagesCount).toBe(4);
             expect(preloader.initializePreloadContainerComponents).toHaveBeenCalledWith(mockContainer);
             expect(preloader.getPreloadImageRequestPromises).toHaveBeenCalledWith(
                 'mock-url',
@@ -190,7 +190,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             jest.spyOn(preloader, 'getPreloadImageRequestPromises').mockReturnValue(mockPromises);
             const mockContainer = document.createElement('div');
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 2, mockDocBaseViewer);
-            expect(preloader.retrievedPages).toBe(0);
+            expect(preloader.retrievedPagesCount).toBe(0);
             expect(preloader.setPreloadImageDimensions).not.toHaveBeenCalled();
             expect(mockDocBaseViewer.initThumbnails).not.toHaveBeenCalled();
             expect(preloader.showSpinner).not.toHaveBeenCalled();
@@ -212,7 +212,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 3, mockDocBaseViewer);
-            expect(preloader.retrievedPages).toBe(1);
+            expect(preloader.retrievedPagesCount).toBe(1);
             expect(preloader.preloadedImages[1]).toBe('mock-object-url');
             expect(preloader.setPreloadImageDimensions).toHaveBeenCalled();
             expect(mockDocBaseViewer.initThumbnails).toHaveBeenCalled();
@@ -250,7 +250,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             const mockContainer = document.createElement('div');
             mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(true);
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 4, mockDocBaseViewer);
-            expect(preloader.retrievedPages).toBe(2);
+            expect(preloader.retrievedPagesCount).toBe(2);
             expect(preloader.preloadedImages[1]).toBe('mock-object-url1');
             expect(preloader.preloadedImages[2]).toBe('mock-object-url2');
             expect(preloader.setPreloadImageDimensions).toHaveBeenCalled();
@@ -269,7 +269,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             jest.spyOn(preloader, 'setPreloadImageDimensions').mockResolvedValue();
             const mockContainer = document.createElement('div');
             await preloader.showPreload('mock-url', mockContainer, 'mock-paged-image-url', 2, mockDocBaseViewer);
-            expect(preloader.retrievedPages).toBe(0);
+            expect(preloader.retrievedPagesCount).toBe(0);
             expect(preloader.setPreloadImageDimensions).not.toHaveBeenCalled();
             expect(mockDocBaseViewer.initThumbnails).not.toHaveBeenCalled();
             expect(preloader.emit).not.toHaveBeenCalled();

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -59,6 +59,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
         test('should add the document class to the doc element and set up preloader', () => {
             expect(doc.docEl).toHaveClass('bp-doc-document');
             expect(doc.preloader).toBeInstanceOf(DocPreloader);
+            expect(doc.preloader.wrapperClassName).toBe('bp-document-preload-wrapper');
         });
 
         test('should add the document class to the doc element and set up doc first preloader if feature is enabled', () => {
@@ -66,6 +67,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
             doc.setup();
             expect(doc.docEl).toHaveClass('bp-doc-document');
             expect(doc.preloader).toBeInstanceOf(DocFirstPreloader);
+            expect(doc.preloader.wrapperClassName).toBe('bp-document-preload-wrapper');
         });
 
         test('should invoke onPreload callback', () => {

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -3,6 +3,7 @@ import PresentationViewer from '../PresentationViewer';
 import BaseViewer from '../../BaseViewer';
 import DocBaseViewer from '../DocBaseViewer';
 import PresentationPreloader from '../PresentationPreloader';
+import DocFirstPreloader from '../DocFirstPreloader';
 import { CLASS_INVISIBLE } from '../../../constants';
 
 let containerEl;
@@ -73,7 +74,17 @@ describe('lib/viewers/doc/PresentationViewer', () => {
         test('should add the presentation class to the presentation element and set up preloader', () => {
             expect(presentation.docEl).toHaveClass('bp-doc-presentation');
             expect(presentation.preloader).toBeInstanceOf(PresentationPreloader);
-            expect(presentation.docFirstPagesEnabled).toBe(false);
+            expect(presentation.preloader.wrapperClassName).toBe('bp-presentation-preload-wrapper');
+        });
+
+        test('should add the presentation class to the presentation element and set up doc first preloader if feature is enabled', () => {
+            jest.spyOn(presentation, 'featureEnabled').mockImplementation(
+                feature => feature === 'docFirstPages.enabled',
+            );
+            presentation.setup();
+            expect(presentation.docEl).toHaveClass('bp-doc-presentation');
+            expect(presentation.preloader).toBeInstanceOf(DocFirstPreloader);
+            expect(presentation.preloader.wrapperClassName).toBe('bp-presentation-preload-wrapper');
         });
 
         test('should invoke onPreload callback', () => {

--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -474,3 +474,37 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         display: none;
     }
 }
+
+.bp-document-preload-spinner {
+    position: fixed;
+    top: 50%;
+    left: 43%;
+    z-index: 1000;
+    display: none;
+    width: 160px;
+    height: 160px;
+    background-color: transparent;
+    border: 2px solid red;
+    border-top: 5px solid transparent;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    animation: spin 1s linear infinite;
+
+    @keyframes spin {
+        from {
+            transform: translate(-50%, -50%) rotate(0deg);
+        }
+
+        to {
+            transform: translate(-50%, -50%) rotate(360deg);
+        }
+    }
+
+    &.bp-sidebar-closed {
+        left: 50%;
+    }
+
+    &.bp-thumbnails-close {
+        left: 37%;
+    }
+}


### PR DESCRIPTION
* Adding doc first preloader to presentations
* renaming retrievedPages to retrievedPagesCount
* updating metrics event logic to only preload time diff data if there are webp representations
* extracting doc first specific css out into the document mixin



![2025-05-08 11 32 46](https://github.com/user-attachments/assets/53e93aba-289a-418d-8b05-c619e90b30f8)

