### PR TITLE
fix(pdfs-preload): adding new exifreader to preload and fixing issue causing console errors

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -666,7 +666,7 @@ class BaseViewer extends EventEmitter {
             event,
             data,
             viewerName: viewer ? viewer.NAME : '',
-            fileId: file.id,
+            fileId: file ? file.id : '',
         });
     }
 
@@ -1011,6 +1011,10 @@ class BaseViewer extends EventEmitter {
         const boxAnnotations = this.options.boxAnnotations || new global.BoxAnnotations(viewerOptions);
         this.annotatorConf = boxAnnotations.determineAnnotator(this.options, this.viewerConfig);
 
+        if (this.annotatorConf.CONSTRUCTOR === global.BoxAnnotations) {
+            return;
+        }
+
         if (!this.annotatorConf) {
             return;
         }
@@ -1238,6 +1242,9 @@ class BaseViewer extends EventEmitter {
         const { showAnnotationsControls, file } = this.options;
         const { permissions, extension } = file || {};
 
+        if (file) {
+            return true;
+        }
         if (!this.hasAnnotationCreatePermission(permissions) && !this.hasAnnotationViewPermission(permissions)) {
             return false;
         }

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1011,10 +1011,6 @@ class BaseViewer extends EventEmitter {
         const boxAnnotations = this.options.boxAnnotations || new global.BoxAnnotations(viewerOptions);
         this.annotatorConf = boxAnnotations.determineAnnotator(this.options, this.viewerConfig);
 
-        if (this.annotatorConf.CONSTRUCTOR === global.BoxAnnotations) {
-            return;
-        }
-
         if (!this.annotatorConf) {
             return;
         }
@@ -1242,9 +1238,6 @@ class BaseViewer extends EventEmitter {
         const { showAnnotationsControls, file } = this.options;
         const { permissions, extension } = file || {};
 
-        if (file) {
-            return true;
-        }
         if (!this.hasAnnotationCreatePermission(permissions) && !this.hasAnnotationViewPermission(permissions)) {
             return false;
         }

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -741,6 +741,27 @@ describe('lib/viewers/BaseViewer', () => {
                 }),
             );
         });
+
+        test('should not fail if file or viewer is not defined', () => {
+            const event = 'someEvent';
+            const data = {};
+            base = new BaseViewer({
+                container: containerEl,
+            });
+            const emitStub = jest.fn();
+            Object.defineProperty(EventEmitter.prototype, 'emit', { value: emitStub });
+            base.emit(event, data);
+            expect(emitStub).toBeCalledWith(event, data);
+            expect(emitStub).toBeCalledWith(
+                VIEWER_EVENT.default,
+                expect.objectContaining({
+                    event,
+                    data,
+                    viewerName: '',
+                    fileId: '',
+                }),
+            );
+        });
     });
 
     describe('Pinch to Zoom Handlers', () => {

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -403,7 +403,7 @@ class DocBaseViewer extends BaseViewer {
         const isWatermarked = file && file.watermark_info && file.watermark_info.is_watermarked;
 
         if (assets) {
-            const ASSETS = this.docFirstPagesEnabled ? [...JS_NO_EXIF, ...EXIF_READER] : JS;
+            const ASSETS = getFeatureConfig('docFirstPages.enabled') ? [...JS_NO_EXIF, ...EXIF_READER] : JS;
             this.prefetchAssets(ASSETS, CSS);
             this.prefetchAssets(PRELOAD_JS, [], true);
         }
@@ -435,7 +435,7 @@ class DocBaseViewer extends BaseViewer {
      * @return {void}
      */
     loadViewerAssets() {
-        const ASSETS = this.docFirstPagesEnabled ? [...JS_NO_EXIF, ...EXIF_READER] : JS;
+        const ASSETS = getFeatureConfig('docFirstPages.enabled') ? [...JS_NO_EXIF, ...EXIF_READER] : JS;
         this.loadAssets(ASSETS, CSS);
         this.loadAssets(PRELOAD_JS, []);
     }

--- a/src/lib/viewers/doc/docAssets.js
+++ b/src/lib/viewers/doc/docAssets.js
@@ -3,10 +3,10 @@ import { DOC_STATIC_ASSETS_VERSION } from '../../constants';
 const STATIC_URI = `third-party/doc/${DOC_STATIC_ASSETS_VERSION}`;
 export const CMAP = `${STATIC_URI}/cmaps/`;
 export const IMAGES = `${STATIC_URI}/images/`;
-export const WORKER = `${STATIC_URI}/pdf.worker.min.js`;
+export const WORKER = `${STATIC_URI}/pdf.worker.min.mjs`;
 
-export const JS = [`${STATIC_URI}/pdf.min.js`, `${STATIC_URI}/pdf_viewer.min.js`, `${STATIC_URI}/exif.min.js`];
-export const JS_NO_EXIF = [`${STATIC_URI}/pdf.min.js`, `${STATIC_URI}/pdf_viewer.min.js`];
+export const JS = [`${STATIC_URI}/pdf.min.mjs`, `${STATIC_URI}/pdf_viewer.min.mjs`, `${STATIC_URI}/exif.min.js`];
+export const JS_NO_EXIF = [`${STATIC_URI}/pdf.min.mjs`, `${STATIC_URI}/pdf_viewer.min.mjs`];
 export const EXIF_READER = [`${STATIC_URI}/exif-reader.min.js`];
 export const CSS = [`${STATIC_URI}/pdf_viewer.min.css`];
 export const PRELOAD_JS = [WORKER];

--- a/src/lib/viewers/doc/docAssets.js
+++ b/src/lib/viewers/doc/docAssets.js
@@ -3,10 +3,10 @@ import { DOC_STATIC_ASSETS_VERSION } from '../../constants';
 const STATIC_URI = `third-party/doc/${DOC_STATIC_ASSETS_VERSION}`;
 export const CMAP = `${STATIC_URI}/cmaps/`;
 export const IMAGES = `${STATIC_URI}/images/`;
-export const WORKER = `${STATIC_URI}/pdf.worker.min.mjs`;
+export const WORKER = `${STATIC_URI}/pdf.worker.min.js`;
 
-export const JS = [`${STATIC_URI}/pdf.min.mjs`, `${STATIC_URI}/pdf_viewer.min.mjs`, `${STATIC_URI}/exif.min.js`];
-export const JS_NO_EXIF = [`${STATIC_URI}/pdf.min.mjs`, `${STATIC_URI}/pdf_viewer.min.mjs`];
+export const JS = [`${STATIC_URI}/pdf.min.js`, `${STATIC_URI}/pdf_viewer.min.js`, `${STATIC_URI}/exif.min.js`];
+export const JS_NO_EXIF = [`${STATIC_URI}/pdf.min.js`, `${STATIC_URI}/pdf_viewer.min.js`];
 export const EXIF_READER = [`${STATIC_URI}/exif-reader.min.js`];
 export const CSS = [`${STATIC_URI}/pdf_viewer.min.css`];
 export const PRELOAD_JS = [WORKER];


### PR DESCRIPTION
The new pdfjs preload logic worked for all of the pdfjs related files but it did not add the proper exifReader library because the value this.docFirstPagesEnabled was not yet initialized when the loadViewer assets call was made. This didn't cause an error but correctly including this library should improve performance for that first preview. Additionally, noticed that there were multiple errors being logged in the console because the emit function in BaseViewer was not protecting against cases where the file could potentially be undefined when the assets loaded event is emitted which will always be the case with the pdfjs asset pre-loading optimization we implemented.