### PR TITLE
fix(pdfjs-preload): adding null check to emmitter function

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -666,7 +666,7 @@ class BaseViewer extends EventEmitter {
             event,
             data,
             viewerName: viewer ? viewer.NAME : '',
-            fileId: file.id,
+            fileId: file ? file.id : '',
         });
     }
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -741,6 +741,27 @@ describe('lib/viewers/BaseViewer', () => {
                 }),
             );
         });
+
+        test('should not fail if file or viewer is not defined', () => {
+            const event = 'someEvent';
+            const data = {};
+            base = new BaseViewer({
+                container: containerEl,
+            });
+            const emitStub = jest.fn();
+            Object.defineProperty(EventEmitter.prototype, 'emit', { value: emitStub });
+            base.emit(event, data);
+            expect(emitStub).toBeCalledWith(event, data);
+            expect(emitStub).toBeCalledWith(
+                VIEWER_EVENT.default,
+                expect.objectContaining({
+                    event,
+                    data,
+                    viewerName: '',
+                    fileId: '',
+                }),
+            );
+        });
     });
 
     describe('Pinch to Zoom Handlers', () => {


### PR DESCRIPTION
Noticed that there were multiple errors being logged in the console because the emit function in BaseViewer was not protecting against cases where the file could potentially be undefined when the assets loaded event is emitted which will always be the case with the pdf.js asset pre-loading optimization we implemented.