### PR TITLE
fix(pdfjs-preload): removing doc first pages check

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -437,7 +437,7 @@ class DocBaseViewer extends BaseViewer {
      * @return {void}
      */
     loadViewerAssets() {
-        const ASSETS = this.featureEnabled(DOC_FIRST_PAGES_ENABLED) ? [...JS_NO_EXIF, ...EXIF_READER] : JS;
+        const ASSETS = [...JS_NO_EXIF, ...EXIF_READER];
         this.loadAssets(ASSETS, CSS);
         this.loadAssets(PRELOAD_JS, []);
     }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -966,17 +966,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 jest.restoreAllMocks();
             });
 
-            test('should load JS and CSS assets when docFirstPages is disabled', () => {
-                testDocBase.loadViewerAssets();
-                expect(testDocBase.loadAssets).toHaveBeenCalledTimes(2);
-                expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(1, JS, CSS);
-                expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(2, PRELOAD_JS, []);
-            });
-
-            test('should load JS_NO_EXIF and EXIF_READER assets when docFirstPages is enabled', () => {
-                testDocBase.options.features = {
-                    'docFirstPages.enabled': true,
-                };
+            test('should load PDFJS and EXIF_READER', () => {
                 testDocBase.loadViewerAssets();
                 expect(testDocBase.loadAssets).toHaveBeenCalledTimes(2);
                 expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(1, [...JS_NO_EXIF, ...EXIF_READER], CSS);


### PR DESCRIPTION
Removing the doc first pages check. This loadViewerAssets code will only be called from EUA where doc first pages is enabled and including that check here is adding tech debt. The next step will be to consolidate exif reader versions so that only the one for doc first pages is used.