### PR TITLE
feat(video-ui-updates): adding vertical media volume controls.

### DIFF
--- a/src/lib/viewers/controls/media/VolumeControls.scss
+++ b/src/lib/viewers/controls/media/VolumeControls.scss
@@ -7,6 +7,9 @@
 }
 
 .bp-VolumeControls-flyout {
+    position: absolute;
+    top: -40px;
+    left: -5px;
     display: none;
     flex: 0 0 auto;
     max-width: 0;
@@ -15,9 +18,6 @@
     transition: max-width 200ms ease-in-out;
 
     &.bp-is-open {
-        position: absolute;
-        top: -40px;
-        left: -5px;
         display: block;
         overflow: visible;
     }

--- a/src/lib/viewers/controls/media/VolumeControls.scss
+++ b/src/lib/viewers/controls/media/VolumeControls.scss
@@ -1,11 +1,13 @@
 @import './styles';
 
 .bp-VolumeControls {
+    position: relative;
     display: flex;
     align-items: center;
 }
 
 .bp-VolumeControls-flyout {
+    display: none;
     flex: 0 0 auto;
     max-width: 0;
     height: $bp-MediaControl-height;
@@ -13,12 +15,16 @@
     transition: max-width 200ms ease-in-out;
 
     &.bp-is-open {
-        max-width: 100px;
+        position: absolute;
+        top: -40px;
+        left: -5px;
+        display: block;
+        overflow: visible;
     }
 }
 
 .bp-VolumeControls-slider {
-    width: 100px - $bp-SliderControl-thumb-size;
+    width: 15px;
     height: 100%;
     margin-right: $bp-SliderControl-thumb-radius;
     margin-left: $bp-SliderControl-thumb-radius;

--- a/src/lib/viewers/controls/media/VolumeControls.tsx
+++ b/src/lib/viewers/controls/media/VolumeControls.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { bdlBoxBlue, white } from 'box-ui-elements/es/styles/variables';
 import IconVolumeMed24 from '../icons/IconVolumeMed24';
 import IconVolumeLow24 from '../icons/IconVolumeLow24';
 import IconVolumeMuted24 from '../icons/IconVolumeMuted24';
@@ -8,7 +7,7 @@ import MediaToggle from './MediaToggle';
 import useAttention from '../hooks/useAttention';
 import './VolumeControls.scss';
 import IconVolumeMax24 from '../icons/IconVolumeMax24';
-import SliderControl from '../slider/SliderControl';
+import VolumeSliderControl from '../slider/VolumeSliderControl';
 
 export type Props = {
     onMuteChange: (isMuted: boolean) => void;
@@ -39,13 +38,24 @@ export default function VolumeControls({ onMuteChange, onVolumeChange, volume = 
 
     const handleVolume = React.useCallback(
         (newValue: number): void => {
-            onVolumeChange(newValue / 100);
+            const newValueToUse = newValue <= 5 ? 0 : newValue;
+            // make sure the value is always between 0 and 1 since the value passed in could be
+            // greater than 100 if the user drags the mouse above the top of the sider when adjusting the volume
+            const volumeToUse = Math.min(1, newValueToUse / 100);
+            onVolumeChange(volumeToUse);
         },
         [onVolumeChange],
     );
 
     return (
-        <div className="bp-VolumeControls" data-testid="bp-volume-controls">
+        <div
+            className="bp-VolumeControls"
+            data-testid="bp-volume-controls"
+            onBlur={handlers.onBlur}
+            onFocus={handlers.onFocus}
+            onMouseOut={handlers.onMouseOut}
+            onMouseOver={handlers.onMouseOver}
+        >
             <MediaToggle
                 className="bp-VolumeControls-toggle"
                 onClick={(): void => onMuteChange(!isMuted)}
@@ -54,15 +64,14 @@ export default function VolumeControls({ onMuteChange, onVolumeChange, volume = 
             >
                 <Icon />
             </MediaToggle>
-
             <div className={classNames('bp-VolumeControls-flyout', { 'bp-is-open': isActive })}>
-                <SliderControl
+                <VolumeSliderControl
                     className="bp-VolumeControls-slider"
                     max={100}
                     onUpdate={handleVolume}
                     step={1}
                     title={__('media_volume_slider')}
-                    track={`linear-gradient(to right, ${bdlBoxBlue} ${value}%, ${white} ${value}%)`}
+                    track={`linear-gradient(to right, #0061d5 ${value}%, #fff ${value}%)`}
                     value={value}
                     {...handlers}
                 />

--- a/src/lib/viewers/controls/media/VolumeControls.tsx
+++ b/src/lib/viewers/controls/media/VolumeControls.tsx
@@ -71,7 +71,6 @@ export default function VolumeControls({ onMuteChange, onVolumeChange, volume = 
                     onUpdate={handleVolume}
                     step={1}
                     title={__('media_volume_slider')}
-                    track={`linear-gradient(to right, #0061d5 ${value}%, #fff ${value}%)`}
                     value={value}
                     {...handlers}
                 />

--- a/src/lib/viewers/controls/media/__tests__/VolumeControls-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/VolumeControls-test.tsx
@@ -54,23 +54,21 @@ describe('VolumeControls', () => {
         });
 
         test.each`
-            volume   | track                                                   | value
-            ${0}     | ${`linear-gradient(to right, #0061d5 0%, #fff 0%)`}     | ${0}
-            ${0.0}   | ${`linear-gradient(to right, #0061d5 0%, #fff 0%)`}     | ${0}
-            ${0.01}  | ${`linear-gradient(to right, #0061d5 1%, #fff 1%)`}     | ${1}
-            ${0.25}  | ${`linear-gradient(to right, #0061d5 25%, #fff 25%)`}   | ${25}
-            ${0.254} | ${`linear-gradient(to right, #0061d5 25%, #fff 25%)`}   | ${25}
-            ${0.255} | ${`linear-gradient(to right, #0061d5 26%, #fff 26%)`}   | ${26}
-            ${1.0}   | ${`linear-gradient(to right, #0061d5 100%, #fff 100%)`} | ${100}
-        `('should render the correct track and value for volume $volume', async ({ track, value, volume }) => {
+            volume   | value
+            ${0}     | ${5}
+            ${0.0}   | ${5}
+            ${0.01}  | ${1}
+            ${0.25}  | ${25}
+            ${0.254} | ${25}
+            ${0.255} | ${26}
+            ${1.0}   | ${100}
+        `('should render the correct track height for volume $volume', async ({ value, volume }) => {
             const max = 100;
             getWrapper({ volume, max });
 
-            const sliderTrack = await screen.findByTestId('bp-slider-control-track');
-            const sliderThumb = await screen.findByTestId('bp-slider-control-thumb');
+            const sliderTrack = await screen.findByTestId('bp-volume-slider-control-track');
 
-            expect(sliderTrack).toHaveStyle({ backgroundImage: track });
-            expect(sliderThumb).toHaveStyle({ left: `${(value / max) * 100}%` });
+            expect(sliderTrack).toHaveStyle({ height: `${value}%` });
         });
     });
 });

--- a/src/lib/viewers/controls/slider/VolumeSliderControl.scss
+++ b/src/lib/viewers/controls/slider/VolumeSliderControl.scss
@@ -1,0 +1,78 @@
+@import '../styles';
+@import './variables';
+
+.bp-VolumeSliderControl {
+    @include bp-Control--outline;
+
+    position: relative;
+    cursor: pointer;
+}
+
+.bp-VolumeVerticalSliderControl {
+    @include bp-Control--outline;
+
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 140px;
+    margin: auto;
+    padding: 16px;
+    background: rgba(34, 34, 34, .9);
+    border: 1px solid rgba(255, 255, 255, .13);
+    border-radius: 16px;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .25);
+    cursor: pointer;
+
+    // force this to bottom of it's parent
+}
+
+.bp-VolumeSliderControl-thumb {
+    position: absolute;
+    top: calc(50% - #{$bp-SliderControl-thumb-radius});
+    width: 10px;
+    height: $bp-SliderControl-thumb-size;
+    margin-left: -#{$bp-SliderControl-thumb-radius};
+    background: $box-blue;
+    border: 0;
+    border-radius: $bp-SliderControl-thumb-size;
+    cursor: pointer;
+}
+
+.bp-VolumeSliderControl-track {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: $bp-SliderControl-track-size;
+    margin: auto $bp-SliderControl-track-space; // Center and allow the thumb to fully dock to edge of the track
+    background: transparent linear-gradient($white, $white) no-repeat center border-box;
+}
+
+.bp-VolumeVerticalSliderControl-track-container {
+    position: relative;
+    width: 8px;
+    height: 108px;
+}
+
+.bp-VolumeVerticalSliderControl-track-background {
+    position: relative;
+    left: 0;
+    width: 8px;
+    height: 108px;
+    background-color: #55554f;
+    border-radius: 20px;
+}
+
+.bp-VolumeVerticalSliderControl-track {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 8px;
+    background: white;
+    border-radius: 20px;
+}

--- a/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
+++ b/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
@@ -14,7 +14,6 @@ export type Props = React.HTMLAttributes<Ref> & {
     onUpdate?: (value: number) => void;
     step?: number;
     title: string;
-    track?: string;
     value: number;
     onMouseOver: () => void;
 };
@@ -33,7 +32,6 @@ export default function VolumeSliderControl({
     onUpdate = noop,
     step = 1,
     title,
-    track,
     value,
     onMouseOver,
     ...rest
@@ -79,11 +77,13 @@ export default function VolumeSliderControl({
         }
     };
 
-    const handleMouseDown = ({ button, ctrlKey, metaKey, pageY, clientY }: React.MouseEvent<Ref>): void => {
+    const handleMouseDown = (event: React.MouseEvent<Ref>): void => {
+        const { button, ctrlKey, metaKey, pageY, clientY, stopPropagation } = event;
         if (button > 1 || ctrlKey || metaKey) return;
-
         onUpdate(getPositionValue(pageY, clientY));
         setIsScrubbing(true);
+        // Prevent clicking on the slider from triggering the mouse down event on the parent slider track
+        event.stopPropagation();
     };
 
     const handleMouseMove = ({ pageY, clientY }: React.MouseEvent<Ref>): void => {

--- a/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
+++ b/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
@@ -1,0 +1,167 @@
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+import React from 'react';
+import { decodeKeydown } from '../../../util';
+import './VolumeSliderControl.scss';
+
+export type Ref = HTMLDivElement;
+
+export type Props = React.HTMLAttributes<Ref> & {
+    className?: string;
+    max?: number;
+    min?: number;
+    onMove?: (value: number, position: number, width: number) => void;
+    onUpdate?: (value: number) => void;
+    step?: number;
+    title: string;
+    track?: string;
+    value: number;
+    onMouseOver: () => void;
+};
+
+// VolumeSliderControls is a veritical slider that controls the volume of the media player.
+// It is different from the SliderControl in that it is vertical and the track is not a horizontal gradient.
+// Instead, it sets the tracks height relative to the volume value. As the volume goes up the tracks height goes up
+// and vice versa. The callbacks are the same as the SliderControl except the mouse movents are tracked vertically
+// instead of horizontally. With this comoponent, the only other use for the SliderControl is for the tracking the play
+// progress of a media player.
+export default function VolumeSliderControl({
+    className,
+    max = 100,
+    min = 0,
+    onMove = noop,
+    onUpdate = noop,
+    step = 1,
+    title,
+    track,
+    value,
+    onMouseOver,
+    ...rest
+}: Props): JSX.Element {
+    const [isScrubbing, setIsScrubbing] = React.useState(false);
+    const sliderElRef = React.useRef<Ref>(null);
+
+    const getPositionRelativeToSlider = React.useCallback((clientY: number) => {
+        const { current: sliderEl } = sliderElRef;
+        if (!sliderEl) return 0;
+
+        const { top: sliderTop, height: sliderHeight } = sliderEl.getBoundingClientRect();
+
+        // Calculate distance from bottom of slider
+        const sliderBottom = sliderTop + sliderHeight;
+        const distanceFromBottom = sliderBottom - clientY;
+
+        return Math.max(5, distanceFromBottom);
+    }, []);
+
+    const getPositionValue = React.useCallback(
+        (pageY: number, clientY: number) => {
+            const { current: sliderEl } = sliderElRef;
+            if (!sliderEl) return 0;
+            const { height: sliderHeight } = sliderEl.getBoundingClientRect();
+            const positionRelativeToSlider = getPositionRelativeToSlider(clientY);
+            const newValue = (positionRelativeToSlider / sliderHeight) * max;
+            return Math.max(min, Math.min(newValue, max));
+        },
+        [getPositionRelativeToSlider, max, min],
+    );
+
+    const handleKeydown = (event: React.KeyboardEvent): void => {
+        const key = decodeKeydown(event);
+        if (key === 'ArrowDown') {
+            event.stopPropagation(); // Prevents global key handling
+            onUpdate(Math.max(min, Math.min(value - step, max)));
+        }
+
+        if (key === 'ArrowUp') {
+            event.stopPropagation(); // Prevents global key handling
+            onUpdate(Math.max(min, Math.min(value + step, max)));
+        }
+    };
+
+    const handleMouseDown = ({ button, ctrlKey, metaKey, pageY, clientY }: React.MouseEvent<Ref>): void => {
+        if (button > 1 || ctrlKey || metaKey) return;
+
+        onUpdate(getPositionValue(pageY, clientY));
+        setIsScrubbing(true);
+    };
+
+    const handleMouseMove = ({ pageY, clientY }: React.MouseEvent<Ref>): void => {
+        const { current: sliderEl } = sliderElRef;
+        const { height: sliderHeight } = sliderEl ? sliderEl.getBoundingClientRect() : { height: 0 };
+        onMove(getPositionValue(pageY, clientY), getPositionRelativeToSlider(clientY), sliderHeight);
+    };
+
+    const handleTouchStart = ({ touches }: React.TouchEvent<Ref>): void => {
+        onUpdate(getPositionValue(touches[0].pageY, touches[0].clientY));
+        setIsScrubbing(true);
+    };
+
+    React.useEffect(() => {
+        const handleDocumentMoveStop = (): void => setIsScrubbing(false);
+        const handleDocumentMouseMove = (event: MouseEvent): void => {
+            if (!isScrubbing || event.button > 1 || event.ctrlKey || event.metaKey) return;
+
+            event.preventDefault();
+            onUpdate(getPositionRelativeToSlider(event.clientY));
+        };
+        const handleDocumentTouchMove = (event: TouchEvent): void => {
+            if (!isScrubbing || !event.touches || !event.touches[0]) return;
+
+            event.preventDefault();
+            onUpdate(getPositionRelativeToSlider(event.touches[0].clientY));
+        };
+
+        if (isScrubbing) {
+            document.addEventListener('mousemove', handleDocumentMouseMove);
+            document.addEventListener('mouseup', handleDocumentMoveStop);
+            document.addEventListener('touchend', handleDocumentMoveStop);
+            document.addEventListener('touchmove', handleDocumentTouchMove);
+        }
+
+        return (): void => {
+            document.removeEventListener('mousemove', handleDocumentMouseMove);
+            document.removeEventListener('mouseup', handleDocumentMoveStop);
+            document.removeEventListener('touchend', handleDocumentMoveStop);
+            document.removeEventListener('touchmove', handleDocumentTouchMove);
+        };
+    }, [isScrubbing, getPositionRelativeToSlider, onUpdate]);
+
+    const heightValueBasedOnVolume = value === 0 ? 5 : value;
+    return (
+        <div
+            className={classNames('bp-VolumeVerticalSliderControl', className, { 'bp-is-scrubbing': isScrubbing })}
+            {...rest}
+        >
+            <div className="bp-VolumeVerticalSliderControl-track-container">
+                <div
+                    ref={sliderElRef}
+                    className="bp-VolumeVerticalSliderControl-track-background"
+                    onMouseDown={handleMouseDown}
+                    role="button"
+                    tabIndex={0}
+                >
+                    <div
+                        aria-label={title}
+                        aria-valuemax={max}
+                        aria-valuemin={min}
+                        aria-valuenow={value}
+                        className="bp-VolumeVerticalSliderControl-track"
+                        data-testid="bp-volume-slider-control-track"
+                        onFocus={onMouseOver}
+                        onKeyDown={handleKeydown}
+                        onMouseDown={handleMouseDown}
+                        onMouseMove={handleMouseMove}
+                        onMouseOver={onMouseOver}
+                        onTouchStart={handleTouchStart}
+                        role="slider"
+                        style={{
+                            height: `${(heightValueBasedOnVolume / max) * 100}%`,
+                        }}
+                        tabIndex={0}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
+++ b/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
@@ -81,7 +81,7 @@ export default function VolumeSliderControl({
     };
 
     const handleMouseDown = (event: React.MouseEvent<Ref>): void => {
-        const { button, ctrlKey, metaKey, pageY, clientY, stopPropagation } = event;
+        const { button, ctrlKey, metaKey, pageY, clientY } = event;
         if (button > 1 || ctrlKey || metaKey) return;
         onUpdate(getPositionValue(pageY, clientY));
         setIsScrubbing(true);

--- a/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
+++ b/src/lib/viewers/controls/slider/VolumeSliderControl.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { decodeKeydown } from '../../../util';
 import './VolumeSliderControl.scss';
 
+const MIN_VOLUME_HEIGHT = 5;
+
 export type Ref = HTMLDivElement;
 
 export type Props = React.HTMLAttributes<Ref> & {
@@ -49,13 +51,14 @@ export default function VolumeSliderControl({
         const sliderBottom = sliderTop + sliderHeight;
         const distanceFromBottom = sliderBottom - clientY;
 
-        return Math.max(5, distanceFromBottom);
+        return Math.max(MIN_VOLUME_HEIGHT, distanceFromBottom);
     }, []);
 
     const getPositionValue = React.useCallback(
         (pageY: number, clientY: number) => {
             const { current: sliderEl } = sliderElRef;
             if (!sliderEl) return 0;
+
             const { height: sliderHeight } = sliderEl.getBoundingClientRect();
             const positionRelativeToSlider = getPositionRelativeToSlider(clientY);
             const newValue = (positionRelativeToSlider / sliderHeight) * max;
@@ -127,7 +130,7 @@ export default function VolumeSliderControl({
         };
     }, [isScrubbing, getPositionRelativeToSlider, onUpdate]);
 
-    const heightValueBasedOnVolume = value === 0 ? 5 : value;
+    const heightValueBasedOnVolume = value === 0 ? MIN_VOLUME_HEIGHT : value;
     return (
         <div
             className={classNames('bp-VolumeVerticalSliderControl', className, { 'bp-is-scrubbing': isScrubbing })}

--- a/src/lib/viewers/controls/slider/__tests__/VolumeSliderControl-test.tsx
+++ b/src/lib/viewers/controls/slider/__tests__/VolumeSliderControl-test.tsx
@@ -1,0 +1,447 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+import VolumeSliderControl from '../VolumeSliderControl';
+
+const getTouchEventDefaults = () => ({
+    clientX: 0,
+    clientY: 0,
+    force: 0,
+    identifier: 0,
+    pageX: 0,
+    pageY: 0,
+    radiusX: 0,
+    radiusY: 0,
+    rotationAngle: 0,
+    screenX: 0,
+    screenY: 0,
+    target: new EventTarget(),
+});
+
+describe('VolumeSliderControl', () => {
+    const defaultProps = {
+        title: 'Volume Slider',
+        value: 50,
+        onMouseOver: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+            (): DOMRect => ({
+                bottom: 0,
+                height: 100, // Height for vertical slider
+                left: 0,
+                right: 0,
+                top: 0,
+                toJSON: jest.fn(),
+                width: 20, // Width for vertical slider
+                x: 0,
+                y: 0,
+            }),
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('event handlers', () => {
+        test.each`
+            pageY  | clientY | result
+            ${-50} | ${-50}  | ${100}
+            ${0}   | ${0}    | ${100}
+            ${25}  | ${25}   | ${75}
+            ${50}  | ${50}   | ${50}
+            ${75}  | ${75}   | ${25}
+            ${100} | ${100}  | ${5}
+            ${150} | ${150}  | ${5}
+        `(
+            'should handle mousedown and update the value for pageY $pageY, clientY $clientY with 0 being the top of the slider',
+            ({ pageY, clientY, result }) => {
+                const onUpdate = jest.fn();
+                render(
+                    <VolumeSliderControl {...defaultProps} max={100} min={0} onUpdate={onUpdate} step={1} value={0} />,
+                );
+
+                fireEvent(
+                    screen.getByRole('slider')!,
+                    new MouseEventExtended('mousedown', {
+                        button: 0,
+                        bubbles: true,
+                        pageY,
+                        clientY,
+                    }),
+                );
+
+                expect(onUpdate).toHaveBeenCalledWith(result);
+            },
+        );
+
+        test('should handle mousemove by calling onMove with the value, position, and height', () => {
+            const onMove = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} onMove={onMove} step={1} value={0} />);
+
+            fireEvent(
+                screen.getByRole('slider')!,
+                new MouseEventExtended('mousemove', {
+                    button: 0,
+                    bubbles: true,
+                    pageY: 25,
+                    clientY: 25,
+                }),
+            );
+
+            expect(onMove).toHaveBeenCalledWith(75, 75, 100); // Value, position, height
+        });
+
+        test.each`
+            initial | result
+            ${0}    | ${0}
+            ${10}   | ${9}
+            ${100}  | ${99}
+        `('should handle keydown ArrowDown and decrement the value $initial to $result', ({ initial, result }) => {
+            const onUpdate = jest.fn();
+            render(
+                <VolumeSliderControl
+                    {...defaultProps}
+                    max={100}
+                    min={0}
+                    onUpdate={onUpdate}
+                    step={1}
+                    value={initial}
+                />,
+            );
+
+            fireEvent.keyDown(screen.getByRole('slider')!, { key: 'ArrowDown' });
+
+            expect(onUpdate).toHaveBeenCalledWith(result);
+        });
+
+        test.each`
+            initial | result
+            ${0}    | ${1}
+            ${10}   | ${11}
+            ${100}  | ${100}
+        `('should handle keydown ArrowUp and increment the value $initial to $result', ({ initial, result }) => {
+            const onUpdate = jest.fn();
+            render(
+                <VolumeSliderControl
+                    {...defaultProps}
+                    max={100}
+                    min={0}
+                    onUpdate={onUpdate}
+                    step={1}
+                    value={initial}
+                />,
+            );
+
+            fireEvent.keyDown(screen.getByRole('slider')!, { key: 'ArrowUp' });
+
+            expect(onUpdate).toHaveBeenCalledWith(result);
+        });
+
+        test('should handle touchstart and update the value', () => {
+            const onUpdate = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} onUpdate={onUpdate} step={1} value={0} />);
+
+            fireEvent(
+                screen.getByRole('slider')!,
+                new TouchEvent('touchstart', {
+                    touches: [
+                        {
+                            ...getTouchEventDefaults(),
+                            pageY: 25,
+                            clientY: 25,
+                        },
+                    ],
+                    bubbles: true,
+                }),
+            );
+
+            expect(onUpdate).toHaveBeenCalledWith(75);
+        });
+
+        test('should call onMouseOver when mouse over event occurs', () => {
+            const onMouseOver = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} onMouseOver={onMouseOver} value={50} />);
+
+            fireEvent.mouseOver(screen.getByRole('slider')!);
+
+            expect(onMouseOver).toHaveBeenCalled();
+        });
+
+        test('should call onMouseOver when focus event occurs', () => {
+            const onMouseOver = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} onMouseOver={onMouseOver} value={50} />);
+
+            fireEvent.focus(screen.getByRole('slider')!);
+
+            expect(onMouseOver).toHaveBeenCalled();
+        });
+
+        test('should not handle mousedown with right button or modifier keys', () => {
+            const onUpdate = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} onUpdate={onUpdate} value={50} />);
+
+            // Right button
+            fireEvent(
+                screen.getByRole('slider')!,
+                new MouseEventExtended('mousedown', {
+                    button: 2,
+                    bubbles: true,
+                    pageY: 25,
+                    clientY: 25,
+                }),
+            );
+
+            // Ctrl key
+            fireEvent(
+                screen.getByRole('slider')!,
+                new MouseEventExtended('mousedown', {
+                    button: 0,
+                    bubbles: true,
+                    ctrlKey: true,
+                    pageY: 25,
+                    clientY: 25,
+                }),
+            );
+
+            // Meta key
+            fireEvent(
+                screen.getByRole('slider')!,
+                new MouseEventExtended('mousedown', {
+                    button: 0,
+                    bubbles: true,
+                    metaKey: true,
+                    pageY: 25,
+                    clientY: 25,
+                }),
+            );
+
+            expect(onUpdate).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('effects', () => {
+        beforeEach(() => {
+            jest.spyOn(document, 'addEventListener');
+            jest.spyOn(document, 'removeEventListener');
+        });
+
+        test('should add document-level event handlers when scrubbing starts', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={0} />);
+
+            fireEvent.mouseDown(screen.getByRole('slider')!);
+
+            expect(document.addEventListener).toHaveBeenCalledWith('mousemove', expect.any(Function));
+            expect(document.addEventListener).toHaveBeenCalledWith('mouseup', expect.any(Function));
+            expect(document.addEventListener).toHaveBeenCalledWith('touchend', expect.any(Function));
+            expect(document.addEventListener).toHaveBeenCalledWith('touchmove', expect.any(Function));
+        });
+
+        test('should remove document-level event handlers when scrubbing stops', async () => {
+            const user = userEvent.setup();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={0} />);
+
+            fireEvent.mouseDown(screen.getByRole('slider')!);
+            await user.click(document.body);
+
+            expect(document.removeEventListener).toHaveBeenCalledWith('mousemove', expect.any(Function));
+            expect(document.removeEventListener).toHaveBeenCalledWith('mouseup', expect.any(Function));
+            expect(document.removeEventListener).toHaveBeenCalledWith('touchend', expect.any(Function));
+            expect(document.removeEventListener).toHaveBeenCalledWith('touchmove', expect.any(Function));
+        });
+
+        test('should handle document-level mousemove events and call onUpdate', () => {
+            const onUpdate = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} onUpdate={onUpdate} step={1} value={0} />);
+
+            fireEvent.mouseDown(screen.getByRole('slider')!);
+            fireEvent(
+                document,
+                new MouseEventExtended('mousemove', {
+                    bubbles: true,
+                    clientY: 25,
+                }),
+            );
+
+            // The document-level mousemove calls getPositionRelativeToSlider directly, which returns raw position
+            expect(onUpdate).toHaveBeenCalledWith(75);
+        });
+
+        test('should handle document-level touchmove events and call onUpdate', () => {
+            const onUpdate = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} onUpdate={onUpdate} step={1} value={0} />);
+
+            fireEvent(
+                screen.getByRole('slider')!,
+                new TouchEvent('touchstart', {
+                    touches: [
+                        {
+                            ...getTouchEventDefaults(),
+                            pageY: 25,
+                            clientY: 25,
+                        },
+                    ],
+                    bubbles: true,
+                }),
+            );
+            fireEvent(
+                document,
+                new TouchEvent('touchmove', {
+                    touches: [
+                        {
+                            ...getTouchEventDefaults(),
+                            clientY: 25,
+                        },
+                    ],
+                }),
+            );
+
+            // The document-level touchmove calls getPositionRelativeToSlider directly, which returns raw position
+            expect(onUpdate).toHaveBeenCalledWith(75);
+        });
+
+        test('should not handle document-level mousemove when not scrubbing', () => {
+            const onUpdate = jest.fn();
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} onUpdate={onUpdate} step={1} value={0} />);
+
+            fireEvent(
+                document,
+                new MouseEventExtended('mousemove', {
+                    bubbles: true,
+                    clientY: 25,
+                }),
+            );
+
+            expect(onUpdate).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('render', () => {
+        test('should return a valid wrapper with correct classes', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={50} />);
+
+            const container = screen.getByRole('slider').closest('.bp-VolumeVerticalSliderControl');
+            expect(container).toBeInTheDocument();
+            expect(container).toHaveClass('bp-VolumeVerticalSliderControl');
+        });
+
+        test('should apply custom className', () => {
+            render(
+                <VolumeSliderControl
+                    {...defaultProps}
+                    className="custom-class"
+                    max={100}
+                    min={0}
+                    step={1}
+                    value={50}
+                />,
+            );
+
+            const container = screen.getByRole('slider').closest('.bp-VolumeVerticalSliderControl');
+            expect(container).toHaveClass('custom-class');
+        });
+
+        test('should apply scrubbing class when scrubbing', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={50} />);
+
+            const container = screen.getByRole('slider').closest('.bp-VolumeVerticalSliderControl');
+            expect(container).not.toHaveClass('bp-is-scrubbing');
+
+            fireEvent.mouseDown(screen.getByRole('slider')!);
+
+            expect(container).toHaveClass('bp-is-scrubbing');
+        });
+
+        test('should set correct accessibility attributes', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={50} />);
+
+            const slider = screen.getByRole('slider');
+            expect(slider).toHaveAttribute('aria-label', 'Volume Slider');
+            expect(slider).toHaveAttribute('aria-valuemax', '100');
+            expect(slider).toHaveAttribute('aria-valuemin', '0');
+            expect(slider).toHaveAttribute('aria-valuenow', '50');
+            expect(slider).toHaveAttribute('tabIndex', '0');
+        });
+
+        test('should set correct height style based on value', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={25} />);
+
+            const slider = screen.getByRole('slider');
+            expect(slider).toHaveStyle({
+                height: '25%',
+            });
+        });
+
+        test('should set minimum height of 5% when value is 0', () => {
+            render(<VolumeSliderControl {...defaultProps} max={100} min={0} step={1} value={0} />);
+
+            const slider = screen.getByRole('slider');
+            expect(slider).toHaveStyle({
+                height: '5%',
+            });
+        });
+
+        test('should forward additional props to the container', () => {
+            render(
+                <VolumeSliderControl
+                    {...defaultProps}
+                    data-testid="volume-slider"
+                    max={100}
+                    min={0}
+                    step={1}
+                    value={50}
+                />,
+            );
+
+            const container = screen.getByTestId('volume-slider');
+            expect(container).toHaveClass('bp-VolumeVerticalSliderControl');
+        });
+    });
+
+    describe('custom props', () => {
+        test('should use custom min, max, and step values', () => {
+            const onUpdate = jest.fn();
+            render(
+                <VolumeSliderControl {...defaultProps} max={200} min={50} onUpdate={onUpdate} step={5} value={100} />,
+            );
+
+            const slider = screen.getByRole('slider');
+            expect(slider).toHaveAttribute('aria-valuemax', '200');
+            expect(slider).toHaveAttribute('aria-valuemin', '50');
+            expect(slider).toHaveAttribute('aria-valuenow', '100');
+
+            // Test step increment
+            fireEvent.keyDown(slider, { key: 'ArrowUp' });
+            expect(onUpdate).toHaveBeenCalledWith(105);
+
+            // Test step decrement
+            fireEvent.keyDown(slider, { key: 'ArrowDown' });
+            expect(onUpdate).toHaveBeenCalledWith(95);
+        });
+
+        test('should respect min and max bounds in keyboard navigation', () => {
+            const onUpdate = jest.fn();
+
+            // Test min bound
+            const { rerender } = render(
+                <VolumeSliderControl {...defaultProps} max={100} min={10} onUpdate={onUpdate} step={1} value={10} />,
+            );
+
+            const slider = screen.getByRole('slider');
+
+            // Should not go below min
+            fireEvent.keyDown(slider, { key: 'ArrowDown' });
+            expect(onUpdate).toHaveBeenCalledWith(10);
+
+            // Test max bound
+            rerender(
+                <VolumeSliderControl {...defaultProps} max={100} min={10} onUpdate={onUpdate} step={1} value={100} />,
+            );
+
+            fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowUp' });
+            expect(onUpdate).toHaveBeenCalledWith(100);
+        });
+    });
+});

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -410,7 +410,11 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     handleVolume() {
-        const volume = this.cache.has(MEDIA_VOLUME_CACHE_KEY) ? this.cache.get(MEDIA_VOLUME_CACHE_KEY) : DEFAULT_VOLUME;
+        let volume = this.cache.has(MEDIA_VOLUME_CACHE_KEY) ? this.cache.get(MEDIA_VOLUME_CACHE_KEY) : DEFAULT_VOLUME;
+        // Make sure the value is always between 0 and 1. If the value in the local storage is greater than
+        // 1 then video player will error out and the only way to fix it is to clear the local storage and reload
+        // the page. Theoretically this should not happen but as this is a known possibility, we are adding this check.
+        volume = Math.min(1, volume);
         if (volume !== 0) {
             this.oldVolume = volume;
         }
@@ -625,6 +629,7 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     setVolume(volume) {
+        console.log('setVolume', volume);
         this.cache.set(MEDIA_VOLUME_CACHE_KEY, volume, true);
         this.handleVolume();
     }

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -629,7 +629,6 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     setVolume(volume) {
-        console.log('setVolume', volume);
         this.cache.set(MEDIA_VOLUME_CACHE_KEY, volume, true);
         this.handleVolume();
     }

--- a/src/lib/viewers/media/__tests__/MP3Controls-test.jsx
+++ b/src/lib/viewers/media/__tests__/MP3Controls-test.jsx
@@ -70,7 +70,7 @@ describe('MP3Controls', () => {
             const volume = await screen.findByRole('slider', { name: __('media_volume_slider') });
             const muteButton = await screen.findByTitle(__('media_mute'));
 
-            fireEvent.keyDown(volume, { key: 'ArrowLeft' });
+            fireEvent.keyDown(volume, { key: 'ArrowUp' });
             await userEvent.click(muteButton);
 
             expect(onVolumeChange).toHaveBeenCalled();

--- a/src/lib/viewers/media/__tests__/MP4Controls-test.jsx
+++ b/src/lib/viewers/media/__tests__/MP4Controls-test.jsx
@@ -81,7 +81,7 @@ describe('MP4Controls', () => {
             const volume = await screen.findByRole('slider', { name: __('media_volume_slider') });
             const muteButton = await screen.findByTitle(__('media_mute'));
 
-            fireEvent.keyDown(volume, { key: 'ArrowLeft' });
+            fireEvent.keyDown(volume, { key: 'ArrowUp' });
             await userEvent.click(muteButton);
 
             expect(onVolumeChange).toHaveBeenCalled();


### PR DESCRIPTION
This PR adds the vertical volume slider to the video controls. The previous volume slider used the same component as the horizontal video playback slider and all of the volume calculations were based on the sliders width. Now those calculations are based on the sliders height. 


![2025-09-29 22 02 40](https://github.com/user-attachments/assets/51c052e6-a959-43ac-b788-a6f8b1da29b5)


PR Notes:

* The slider height is determined based on the volume PR [Reference](https://github.com/box/box-content-preview/pull/1581/files#diff-637ca22bd00a86eb52104d57bfd67e88b359dea42264160a56980b9acf44d7d3R158-R160)

* The  callbacks in the new VolumeSliderControl are the same as in the original [Slider](https://github.com/box/box-content-preview/blob/master/src/lib/viewers/controls/slider/SliderControl.tsx) with the difference being that they use height values instead when they get the mouse position value to base the volume calculation off of. PR [Reference](https://github.com/box/box-content-preview/pull/1581/files#diff-637ca22bd00a86eb52104d57bfd67e88b359dea42264160a56980b9acf44d7d3R55-R65)

* Added a check in the handleVolume function in MediaBaseViewer to guard against an invalid stored volume level breaking the video preview. In this case, if the volume value is greater than 1 then an error is thrown and the preview is stuck in a spinning state. I discovered this while developing the vertical slider when I dragged the slider to the top of the track but still kept moving my mouse up passed the bounds of the slider. This should not happen as I've fixed that issue [here](https://github.com/box/box-content-preview/pull/1581/files#diff-2ae8121a06738669330b14bf4f2e8f0fccfd7024dbcdb230695078492135ec61R41-R46) but it's worth adding the check because this will cause all video previews not to work until that value is removed from local storage. The screenshot below shows this happening. PR [Reference](https://github.com/box/box-content-preview/pull/1581/files#diff-242d253d5790db64a7f3a5f5a65fe30ee9045543c45bd03b46c77271058002d0R413-R417)

     
<img width="1313" height="690" alt="Screenshot 2025-09-29 at 8 58 46 PM" src="https://github.com/user-attachments/assets/cb179a25-5c2f-47ed-900f-2d4a975c5b70" />






