### PR TITLE
feat(auth): migrate image viewers to use Authorization header

### DIFF
--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -107,9 +107,30 @@ class ImageViewer extends ImageBaseViewer {
 
         const { representation, viewer } = this.options;
         const template = representation.content.url_template;
-        const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
 
         this.bindDOMListeners();
+
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
+            return this.getRepStatus()
+                .getPromise()
+                .then(() => {
+                    this.startLoadTimer();
+                    // Reuse prefetched blob URL if available, otherwise fetch now
+                    return this.prefetchedBlobUrlPromise || this.fetchContentAsBlobUrl(contentUrl);
+                })
+                .then(blobUrl => {
+                    this.prefetchedBlobUrlPromise = null;
+                    this.imageEl.src = blobUrl;
+                    if (this.imageEl.complete) {
+                        this.finishLoading();
+                    }
+                    super.handleAssetAndRepLoad();
+                })
+                .catch(this.handleAssetError);
+        }
+
+        const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
         return this.getRepStatus()
             .getPromise()
             .then(() => this.handleAssetAndRepLoad(downloadUrl))
@@ -178,12 +199,18 @@ class ImageViewer extends ImageBaseViewer {
 
         if ((content || preload) && !isWatermarked && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            const preFetchedImg = document.createElement('img');
-            preFetchedImg.addEventListener('load', this.prefetchFinishedLoading);
-            preFetchedImg.classList.add(CLASS_PREFETCHED_IMAGE);
-            document.body.appendChild(preFetchedImg);
 
-            preFetchedImg.src = this.createContentUrlWithAuthParams(template, viewer.ASSET);
+            if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
+                this.prefetchedBlobUrlPromise = this.fetchContentAsBlobUrl(contentUrl);
+            } else {
+                const preFetchedImg = document.createElement('img');
+                preFetchedImg.addEventListener('load', this.prefetchFinishedLoading);
+                preFetchedImg.classList.add(CLASS_PREFETCHED_IMAGE);
+                document.body.appendChild(preFetchedImg);
+
+                preFetchedImg.src = this.createContentUrlWithAuthParams(template, viewer.ASSET);
+            }
         }
     }
 

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -132,7 +132,10 @@ class MultiImageViewer extends ImageBaseViewer {
         const asset = viewer.ASSET;
         this.pagesCount = metadata.pages;
 
-        const urlBase = this.createContentUrlWithAuthParams(template, asset);
+        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
+        const urlBase = useHeaders
+            ? this.createContentUrlV2(template, asset)
+            : this.createContentUrlWithAuthParams(template, asset);
         const urls = [];
         for (let pageNum = 1; pageNum <= this.pagesCount; pageNum += 1) {
             urls.push(urlBase.replace('{page}', pageNum));
@@ -158,7 +161,14 @@ class MultiImageViewer extends ImageBaseViewer {
         // Set page number. Page is index + 1.
         this.singleImageEls[index].setAttribute('data-page-number', index + 1);
         this.singleImageEls[index].classList.add(CLASS_MULTI_IMAGE_PAGE);
-        this.singleImageEls[index].src = imageUrl;
+
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            this.fetchContentAsBlobUrl(imageUrl).then(blobUrl => {
+                this.singleImageEls[index].src = blobUrl;
+            });
+        } else {
+            this.singleImageEls[index].src = imageUrl;
+        }
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -142,6 +142,64 @@ describe('lib/viewers/image/ImageViewer', () => {
                 })
                 .catch(() => {});
         });
+
+        test('should use createContentUrlV2 and fetchContentAsBlobUrl when migrateAccessTokenToHeader flag is on', () => {
+            const blobUrl = 'blob:http://example.com/blob-id';
+            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+            jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(image, 'startLoadTimer');
+            jest.spyOn(image, 'finishLoading');
+
+            return image
+                .load()
+                .then(() => {
+                    expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
+                    expect(image.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
+                    expect(image.imageEl.src).toBe(blobUrl);
+                    expect(image.startLoadTimer).toBeCalled();
+                })
+                .catch(() => {});
+        });
+
+        test('should reuse prefetchedBlobUrlPromise when migrateAccessTokenToHeader flag is on', () => {
+            const blobUrl = 'blob:http://example.com/prefetched-blob';
+            const prefetchedPromise = Promise.resolve(blobUrl);
+            image.prefetchedBlobUrlPromise = prefetchedPromise;
+
+            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'fetchContentAsBlobUrl');
+            jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(image, 'startLoadTimer');
+
+            return image
+                .load()
+                .then(() => {
+                    expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
+                    expect(image.imageEl.src).toBe(blobUrl);
+                    expect(image.prefetchedBlobUrlPromise).toBeNull();
+                })
+                .catch(() => {});
+        });
+
+        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
+            jest.spyOn(image, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue(imageUrl);
+            jest.spyOn(image, 'createContentUrl');
+            jest.spyOn(image, 'fetchContentAsBlobUrl');
+            jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+
+            return image
+                .load()
+                .then(() => {
+                    expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
+                    expect(image.createContentUrl).not.toHaveBeenCalled();
+                    expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
+                })
+                .catch(() => {});
+        });
     });
 
     describe('prefetch()', () => {
@@ -248,6 +306,42 @@ describe('lib/viewers/image/ImageViewer', () => {
 
             const prefetchedImg = document.querySelector('.bp-prefetched-image');
             expect(prefetchedImg).toBeTruthy();
+        });
+
+        test('should use fetchContentAsBlobUrl and store promise when migrateAccessTokenToHeader flag is on', () => {
+            const blobUrl = 'blob:http://example.com/prefetch-blob';
+            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+
+            image.prefetch({ content: true });
+
+            expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
+            expect(image.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
+            expect(image.prefetchedBlobUrlPromise).toBeDefined();
+            expect(image.prefetchedBlobUrlPromise).toBeInstanceOf(Promise);
+
+            // Should not create an img element in the DOM
+            const prefetchedImg = document.querySelector('.bp-prefetched-image');
+            expect(prefetchedImg).toBeFalsy();
+        });
+
+        test('should create img prefetch element when migrateAccessTokenToHeader flag is off', () => {
+            jest.spyOn(image, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'createContentUrl');
+            jest.spyOn(image, 'fetchContentAsBlobUrl');
+
+            image.prefetch({ content: true });
+
+            expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
+            expect(image.createContentUrl).not.toHaveBeenCalled();
+            expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
+            expect(image.prefetchedBlobUrlPromise).toBeUndefined();
+
+            const prefetchedImg = document.querySelector('.bp-prefetched-image');
+            expect(prefetchedImg).toBeTruthy();
+            expect(prefetchedImg.src).toBe('https://example.com/image.jpg');
         });
     });
 

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -193,6 +193,43 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             const result = multiImage.constructImageUrls('file/100/content/{page}.png');
             expect(result.length).toBe(3);
         });
+
+        test('should use createContentUrlV2 when migrateAccessTokenToHeader flag is on', () => {
+            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
+                feature => feature === 'migrateAccessTokenToHeader',
+            );
+            jest.spyOn(multiImage, 'createContentUrlV2').mockReturnValue('https://example.com/image-{page}.jpg');
+            jest.spyOn(multiImage, 'createContentUrlWithAuthParams');
+
+            const result = multiImage.constructImageUrls('file/100/content/{page}.png');
+
+            expect(multiImage.createContentUrlV2).toHaveBeenCalledWith('file/100/content/{page}.png', '{page}.png');
+            expect(multiImage.createContentUrlWithAuthParams).not.toHaveBeenCalled();
+            expect(result.length).toBe(3);
+            expect(result[0]).toBe('https://example.com/image-1.jpg');
+            expect(result[1]).toBe('https://example.com/image-2.jpg');
+            expect(result[2]).toBe('https://example.com/image-3.jpg');
+        });
+
+        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
+            jest.spyOn(multiImage, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(multiImage, 'createContentUrlWithAuthParams').mockReturnValue(
+                'https://example.com/auth-image-{page}.jpg',
+            );
+            jest.spyOn(multiImage, 'createContentUrl');
+
+            const result = multiImage.constructImageUrls('file/100/content/{page}.png');
+
+            expect(multiImage.createContentUrlWithAuthParams).toHaveBeenCalledWith(
+                'file/100/content/{page}.png',
+                '{page}.png',
+            );
+            expect(multiImage.createContentUrl).not.toHaveBeenCalled();
+            expect(result.length).toBe(3);
+            expect(result[0]).toBe('https://example.com/auth-image-1.jpg');
+            expect(result[1]).toBe('https://example.com/auth-image-2.jpg');
+            expect(result[2]).toBe('https://example.com/auth-image-3.jpg');
+        });
     });
 
     describe('setupImageEls()', () => {
@@ -228,6 +265,58 @@ describe('lib/viewers/image/MultiImageViewer', () => {
 
             multiImage.setupImageEls('file/100/content/{page}.png', 0);
             expect(stubs.singleImageEl.classList.add).toBeCalledWith(CLASS_MULTI_IMAGE_PAGE);
+        });
+
+        test('should use fetchContentAsBlobUrl when migrateAccessTokenToHeader flag is on', () => {
+            const blobUrl = 'blob:http://example.com/image-blob';
+            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
+                feature => feature === 'migrateAccessTokenToHeader',
+            );
+            jest.spyOn(multiImage, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+            multiImage.singleImageEls = [stubs.singleImageEl];
+
+            multiImage.setupImageEls('https://example.com/image.jpg', 0);
+
+            expect(multiImage.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
+
+            // Wait for promise to resolve
+            return multiImage.fetchContentAsBlobUrl().then(() => {
+                expect(stubs.singleImageEl.src).toBe(blobUrl);
+            });
+        });
+
+        test('should set src directly when migrateAccessTokenToHeader flag is off', () => {
+            jest.spyOn(multiImage, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(multiImage, 'fetchContentAsBlobUrl');
+            multiImage.singleImageEls = [stubs.singleImageEl];
+
+            multiImage.setupImageEls('https://example.com/image-auth.jpg', 0);
+
+            expect(multiImage.fetchContentAsBlobUrl).not.toHaveBeenCalled();
+            expect(stubs.singleImageEl.src).toBe('https://example.com/image-auth.jpg');
+        });
+
+        test('should use fetchContentAsBlobUrl for each page when migrateAccessTokenToHeader flag is on', () => {
+            const blobUrl1 = 'blob:http://example.com/image1-blob';
+            const blobUrl2 = 'blob:http://example.com/image2-blob';
+            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
+                feature => feature === 'migrateAccessTokenToHeader',
+            );
+            const fetchSpy = jest
+                .spyOn(multiImage, 'fetchContentAsBlobUrl')
+                .mockReturnValueOnce(Promise.resolve(blobUrl1))
+                .mockReturnValueOnce(Promise.resolve(blobUrl2));
+
+            const singleImageEl1 = { ...stubs.singleImageEl, src: undefined };
+            const singleImageEl2 = { ...stubs.singleImageEl, src: undefined };
+            multiImage.singleImageEls = [singleImageEl1, singleImageEl2];
+
+            multiImage.setupImageEls('https://example.com/page1.jpg', 0);
+            multiImage.setupImageEls('https://example.com/page2.jpg', 1);
+
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+            expect(fetchSpy).toHaveBeenNthCalledWith(1, 'https://example.com/page1.jpg');
+            expect(fetchSpy).toHaveBeenNthCalledWith(2, 'https://example.com/page2.jpg');
         });
     });
 


### PR DESCRIPTION
## Summary
  - Replace `access_token` query params with `Authorization: Bearer` headers in ImageViewer and MultiImageViewer
  - Uses `fetchContentAsBlobUrl` for `<img>` src since HTML elements cannot send custom headers
  - Reuses prefetched blob URL promise in `load()` to avoid double-fetching
  - All changes gated behind `migrateAccessTokenToHeader` feature flag

  ## Test plan
  - [ ] Verify single image files load correctly with feature flag ON
  - [ ] Verify multi-page image files (TIFF) load correctly with feature flag ON
  - [ ] Verify image files load correctly with feature flag OFF (no regression)
  - [ ] Verify prefetch on hover works correctly