### PR TITLE
feat(auth): migrate media viewers to use Authorization header

### DIFF
--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -176,7 +176,12 @@ class DashViewer extends VideoBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            this.api.get(this.createContentUrlWithAuthParams(template, MANIFEST), { type: 'document' });
+            if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                const contentUrl = this.createContentUrlV2(template, MANIFEST);
+                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
+            } else {
+                this.api.get(this.createContentUrlWithAuthParams(template, MANIFEST), { type: 'document' });
+            }
         }
     }
 
@@ -315,13 +320,24 @@ class DashViewer extends VideoBaseViewer {
     requestFilter(type, request) {
         const asset = type === shaka.net.NetworkingEngine.RequestType.MANIFEST ? MANIFEST : undefined;
         /* eslint-disable no-param-reassign */
-        request.uris = request.uris.map(uri => {
-            let newUri = this.createContentUrlWithAuthParams(uri, asset);
-            if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
-                newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
-            }
-            return newUri;
-        });
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            request.uris = request.uris.map(uri => {
+                let newUri = this.createContentUrlV2(uri, asset);
+                if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
+                    newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
+                }
+                return newUri;
+            });
+            Object.assign(request.headers, this.appendAuthHeader());
+        } else {
+            request.uris = request.uris.map(uri => {
+                let newUri = this.createContentUrlWithAuthParams(uri, asset);
+                if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
+                    newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
+                }
+                return newUri;
+            });
+        }
         /* eslint-enable no-param-reassign */
     }
 
@@ -887,7 +903,9 @@ class DashViewer extends VideoBaseViewer {
         const filmstripInterval = filmstrip && filmstrip.metadata && filmstrip.metadata.interval;
 
         if (filmstripInterval > 0) {
-            const url = this.createContentUrlWithAuthParams(filmstrip.content.url_template);
+            const url = this.featureEnabled('migrateAccessTokenToHeader')
+                ? this.createContentUrlV2(filmstrip.content.url_template)
+                : this.createContentUrlWithAuthParams(filmstrip.content.url_template);
 
             this.filmstripInterval = filmstripInterval;
             this.filmstripStatus = this.getRepStatus(filmstrip);

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -144,6 +144,10 @@ class MediaBaseViewer extends BaseViewer {
      * @return {void}
      */
     destroy() {
+        if (this.mediaBlobUrl) {
+            URL.revokeObjectURL(this.mediaBlobUrl);
+        }
+
         // Attempt to process the playback metrics at whatever point of playback has occurred
         // before we destroy the viewer
         this.processMetrics();
@@ -192,7 +196,6 @@ class MediaBaseViewer extends BaseViewer {
         this.addEventListenersForMediaLoad();
 
         const template = this.options.representation.content.url_template;
-        this.mediaUrl = this.createContentUrlWithAuthParams(template);
 
         this.mediaEl.addEventListener('error', this.errorHandler);
         this.mediaEl.setAttribute('title', this.options.file.name);
@@ -204,6 +207,23 @@ class MediaBaseViewer extends BaseViewer {
             this.mediaEl.autoplay = true;
         }
 
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            const contentUrl = this.createContentUrlV2(template);
+            return this.getRepStatus()
+                .getPromise()
+                .then(() => {
+                    this.startLoadTimer();
+                    return this.fetchContentAsBlobUrl(contentUrl);
+                })
+                .then(blobUrl => {
+                    this.mediaBlobUrl = blobUrl;
+                    this.mediaUrl = blobUrl;
+                    this.mediaEl.src = blobUrl;
+                })
+                .catch(this.handleAssetError);
+        }
+
+        this.mediaUrl = this.createContentUrlWithAuthParams(template);
         return this.getRepStatus()
             .getPromise()
             .then(() => {
@@ -314,6 +334,20 @@ class MediaBaseViewer extends BaseViewer {
         const { currentTime } = this.mediaEl;
         this.currentTime = currentTime;
         this.options.token = newToken;
+
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            if (this.mediaBlobUrl) {
+                URL.revokeObjectURL(this.mediaBlobUrl);
+            }
+            const contentUrl = this.createContentUrlV2(this.options.representation.content.url_template);
+            this.fetchContentAsBlobUrl(contentUrl).then(blobUrl => {
+                this.mediaBlobUrl = blobUrl;
+                this.mediaUrl = blobUrl;
+                this.mediaEl.src = blobUrl;
+            });
+            return;
+        }
+
         this.mediaUrl = this.createContentUrlWithAuthParams(this.options.representation.content.url_template);
         this.mediaEl.src = this.mediaUrl;
     }

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -177,7 +177,6 @@ class VideoBaseViewer extends MediaBaseViewer {
         }
 
         const { url_template: template } = preloadRep.content;
-        const preloadUrlWithAuth = this.createContentUrlWithAuthParams(template);
         const options = {
             onImageClick: () => this.handlePlayRequest(),
         };
@@ -188,7 +187,17 @@ class VideoBaseViewer extends MediaBaseViewer {
                 height: this.wrapperEl.clientHeight - controlsHeight,
             };
         }
-        this.preloader.showPreload(preloadUrlWithAuth, this.mediaContainerEl, options);
+
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            const contentUrl = this.createContentUrlV2(template);
+            this.fetchContentAsBlobUrl(contentUrl).then(blobUrl => {
+                this.preloadBlobUrl = blobUrl;
+                this.preloader.showPreload(blobUrl, this.mediaContainerEl, options);
+            });
+        } else {
+            const preloadUrlWithAuth = this.createContentUrlWithAuthParams(template);
+            this.preloader.showPreload(preloadUrlWithAuth, this.mediaContainerEl, options);
+        }
         this.mediaEl.classList.add(CLASS_INVISIBLE);
     }
 
@@ -225,8 +234,13 @@ class VideoBaseViewer extends MediaBaseViewer {
         if (!preloadRep || !this.isRepresentationReady(preloadRep) || !preloadRep.content?.url_template) {
             return;
         }
-        const preloadUrlWithAuth = this.createContentUrlWithAuthParams(preloadRep.content.url_template);
-        this.api.get(preloadUrlWithAuth, { type: 'blob' }).catch(() => {});
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            const contentUrl = this.createContentUrlV2(preloadRep.content.url_template);
+            this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() }).catch(() => {});
+        } else {
+            const preloadUrlWithAuth = this.createContentUrlWithAuthParams(preloadRep.content.url_template);
+            this.api.get(preloadUrlWithAuth, { type: 'blob' }).catch(() => {});
+        }
     }
 
     buildPlayButtonWithSeekButtons() {
@@ -289,6 +303,10 @@ class VideoBaseViewer extends MediaBaseViewer {
      * @return {void}
      */
     destroy() {
+        if (this.preloadBlobUrl) {
+            URL.revokeObjectURL(this.preloadBlobUrl);
+        }
+
         if (this.mediaEl) {
             this.mediaEl.removeEventListener('mousemove', this.mousemoveHandler);
             this.mediaEl.removeEventListener('click', this.pointerHandler);

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1895,4 +1895,172 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(props).toHaveProperty('videoAnnotationsEnabled', false);
         });
     });
+
+    describe('requestFilter() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            dash.options.file.watermark_info = { is_watermarked: false };
+            dash.watermarkCacheBust = 12345;
+        });
+
+        test('should use createContentUrlV2 and append auth headers when flag is enabled for manifest', () => {
+            const request = {
+                uris: ['http://localhost/original/manifest.mpd'],
+                headers: {},
+            };
+
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/manifest.mpd');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
+
+            dash.requestFilter(shaka.net.NetworkingEngine.RequestType.MANIFEST, request);
+
+            expect(dash.createContentUrlV2).toHaveBeenCalledWith(
+                'http://localhost/original/manifest.mpd',
+                'manifest.mpd',
+            );
+            expect(dash.appendAuthHeader).toHaveBeenCalled();
+            expect(request.uris).toEqual(['http://localhost/content/manifest.mpd']);
+            expect(request.headers).toEqual({ Authorization: 'Bearer token123' });
+        });
+
+        test('should use createContentUrlV2 and append auth headers when flag is enabled for segments', () => {
+            const request = {
+                uris: ['http://localhost/original/segment1.m4s'],
+                headers: {},
+            };
+
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/segment1.m4s');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
+
+            dash.requestFilter(shaka.net.NetworkingEngine.RequestType.SEGMENT, request);
+
+            expect(dash.createContentUrlV2).toHaveBeenCalledWith('http://localhost/original/segment1.m4s', undefined);
+            expect(dash.appendAuthHeader).toHaveBeenCalled();
+            expect(request.uris).toEqual(['http://localhost/content/segment1.m4s']);
+            expect(request.headers).toEqual({ Authorization: 'Bearer token123' });
+        });
+
+        test('should append watermark query param for segments when watermarked and flag is enabled', () => {
+            dash.options.file.watermark_info = { is_watermarked: true };
+            const request = {
+                uris: ['http://localhost/original/segment1.m4s'],
+                headers: {},
+            };
+
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/segment1.m4s');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
+
+            dash.requestFilter(shaka.net.NetworkingEngine.RequestType.SEGMENT, request);
+
+            expect(request.uris[0]).toContain('watermark_content=12345');
+        });
+
+        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
+            const request = {
+                uris: ['http://localhost/original/manifest.mpd'],
+                headers: {},
+            };
+
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
+
+            dash.requestFilter(shaka.net.NetworkingEngine.RequestType.MANIFEST, request);
+
+            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith(
+                'http://localhost/original/manifest.mpd',
+                'manifest.mpd',
+            );
+            expect(request.uris).toEqual(['http://localhost/content?token=abc']);
+        });
+    });
+
+    describe('prefetch() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            dash.options.representation = {
+                content: {
+                    url_template: 'www.box.com/dash',
+                },
+            };
+            jest.spyOn(dash, 'isRepresentationReady').mockReturnValue(true);
+        });
+
+        test('should use createContentUrlV2 with auth headers when flag is enabled', () => {
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/manifest.mpd');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
+            jest.spyOn(stubs.api, 'get').mockReturnValue(Promise.resolve());
+
+            dash.prefetch({ content: true });
+
+            expect(dash.createContentUrlV2).toHaveBeenCalledWith('www.box.com/dash', 'manifest.mpd');
+            expect(dash.appendAuthHeader).toHaveBeenCalled();
+            expect(stubs.api.get).toHaveBeenCalledWith('http://localhost/content/manifest.mpd', {
+                type: 'document',
+                headers: { Authorization: 'Bearer token123' },
+            });
+        });
+
+        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
+            jest.spyOn(stubs.api, 'get').mockReturnValue(Promise.resolve());
+
+            dash.prefetch({ content: true });
+
+            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/dash', 'manifest.mpd');
+            expect(stubs.api.get).toHaveBeenCalledWith('http://localhost/content?token=abc', { type: 'document' });
+        });
+    });
+
+    describe('loadFilmStrip() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            dash.options.file = {
+                id: 123,
+                representations: {
+                    entries: [
+                        {
+                            representation: 'filmstrip',
+                            content: {
+                                url_template: 'www.box.com/filmstrip.jpg',
+                            },
+                            metadata: {
+                                interval: 2,
+                            },
+                        },
+                    ],
+                },
+            };
+            dash.aspect = 1.78;
+            jest.spyOn(dash, 'getRepStatus').mockReturnValue({
+                getPromise: () => Promise.resolve(),
+                destroy: jest.fn(),
+            });
+        });
+
+        test('should use createContentUrlV2 when flag is enabled', () => {
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/filmstrip.jpg');
+            jest.spyOn(dash, 'useReactControls').mockReturnValue(false);
+
+            dash.loadFilmStrip();
+
+            expect(dash.createContentUrlV2).toHaveBeenCalledWith('www.box.com/filmstrip.jpg');
+            expect(dash.filmstripUrl).toBe('http://localhost/filmstrip.jpg');
+        });
+
+        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
+            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue(
+                'http://localhost/filmstrip.jpg?token=abc',
+            );
+            jest.spyOn(dash, 'useReactControls').mockReturnValue(false);
+
+            dash.loadFilmStrip();
+
+            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/filmstrip.jpg');
+            expect(dash.filmstripUrl).toBe('http://localhost/filmstrip.jpg?token=abc');
+        });
+    });
 });

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -1502,4 +1502,113 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             expect(media.processAnnotationModeChange).not.toHaveBeenCalled();
         });
     });
+
+    describe('load() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            media.mediaEl = document.createElement('video');
+            media.mediaEl.addEventListener = jest.fn();
+        });
+
+        test('should use fetchContentAsBlobUrl when flag is enabled', () => {
+            const blobUrl = 'blob:http://localhost/abc-123';
+            jest.spyOn(media, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+            jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+
+            return media.load().then(() => {
+                expect(media.featureEnabled).toHaveBeenCalledWith('migrateAccessTokenToHeader');
+                expect(media.createContentUrlV2).toHaveBeenCalledWith('www.box.com');
+                expect(media.fetchContentAsBlobUrl).toHaveBeenCalledWith('http://localhost/content');
+                expect(media.mediaEl.src).toBe(blobUrl);
+                expect(media.mediaBlobUrl).toBe(blobUrl);
+                expect(media.mediaUrl).toBe(blobUrl);
+            });
+        });
+
+        test('should use createContentUrlWithAuthParams when flag is disabled', () => {
+            jest.spyOn(media, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(media, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
+            jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+
+            return media.load().then(() => {
+                expect(media.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com');
+                expect(media.mediaEl.src).toBe('http://localhost/content?token=abc');
+            });
+        });
+    });
+
+    describe('restartPlayback() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            media.mediaEl = document.createElement('video');
+            media.mediaEl.currentTime = 10;
+            media.options = {
+                token: 'old-token',
+                representation: {
+                    content: {
+                        url_template: 'www.box.com',
+                    },
+                },
+            };
+        });
+
+        test('should revoke old blob URL and fetch new one when flag is enabled', () => {
+            const oldBlobUrl = 'blob:http://localhost/old-123';
+            const newBlobUrl = 'blob:http://localhost/new-456';
+            media.mediaBlobUrl = oldBlobUrl;
+
+            jest.spyOn(URL, 'revokeObjectURL');
+            jest.spyOn(media, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(newBlobUrl));
+
+            media.restartPlayback('new-token');
+
+            expect(media.currentTime).toBe(10);
+            expect(media.options.token).toBe('new-token');
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith(oldBlobUrl);
+            expect(media.createContentUrlV2).toHaveBeenCalledWith('www.box.com');
+            expect(media.fetchContentAsBlobUrl).toHaveBeenCalledWith('http://localhost/content');
+
+            return media.fetchContentAsBlobUrl().then(() => {
+                expect(media.mediaBlobUrl).toBe(newBlobUrl);
+                expect(media.mediaUrl).toBe(newBlobUrl);
+                expect(media.mediaEl.src).toBe(newBlobUrl);
+            });
+        });
+
+        test('should use createContentUrlWithAuthParams when flag is disabled', () => {
+            jest.spyOn(media, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(media, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=new');
+
+            media.restartPlayback('new-token');
+
+            expect(media.options.token).toBe('new-token');
+            expect(media.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com');
+            expect(media.mediaEl.src).toBe('http://localhost/content?token=new');
+        });
+    });
+
+    describe('destroy() with migrateAccessTokenToHeader', () => {
+        test('should revoke mediaBlobUrl if it exists', () => {
+            const blobUrl = 'blob:http://localhost/abc-123';
+            media.mediaBlobUrl = blobUrl;
+
+            jest.spyOn(URL, 'revokeObjectURL');
+
+            media.destroy();
+
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith(blobUrl);
+        });
+
+        test('should not call revokeObjectURL if mediaBlobUrl does not exist', () => {
+            media.mediaBlobUrl = null;
+
+            jest.spyOn(URL, 'revokeObjectURL');
+
+            media.destroy();
+
+            expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1350,4 +1350,146 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.togglePlay).toBeCalled();
         });
     });
+
+    describe('showPreload() with migrateAccessTokenToHeader', () => {
+        beforeEach(() => {
+            videoBase.options.file = {
+                id: 123,
+                watermark_info: { is_watermarked: false },
+                representations: {
+                    entries: [
+                        {
+                            representation: 'jpg',
+                            content: {
+                                url_template: 'www.box.com/preload.jpg',
+                            },
+                            status: {
+                                state: 'success',
+                            },
+                        },
+                    ],
+                },
+            };
+            videoBase.getViewerOption = jest.fn().mockReturnValue(true);
+            videoBase.wrapperEl = document.createElement('div');
+            videoBase.wrapperEl.style.width = '800px';
+            videoBase.wrapperEl.style.height = '600px';
+        });
+
+        test('should fetch blob URL for poster image when flag is enabled', () => {
+            const blobUrl = 'blob:http://localhost/preload-123';
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('http://localhost/preload.jpg');
+            jest.spyOn(videoBase, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+            jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
+
+            videoBase.showPreload();
+
+            expect(videoBase.createContentUrlV2).toHaveBeenCalledWith('www.box.com/preload.jpg');
+            expect(videoBase.fetchContentAsBlobUrl).toHaveBeenCalledWith('http://localhost/preload.jpg');
+
+            return videoBase.fetchContentAsBlobUrl().then(() => {
+                expect(videoBase.preloadBlobUrl).toBe(blobUrl);
+                expect(VideoPreloader.prototype.showPreload).toHaveBeenCalledWith(
+                    blobUrl,
+                    videoBase.mediaContainerEl,
+                    expect.any(Object),
+                );
+            });
+        });
+
+        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(
+                'http://localhost/preload.jpg?token=abc',
+            );
+            jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
+
+            videoBase.showPreload();
+
+            expect(videoBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/preload.jpg');
+            expect(VideoPreloader.prototype.showPreload).toHaveBeenCalledWith(
+                'http://localhost/preload.jpg?token=abc',
+                videoBase.mediaContainerEl,
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('prefetch() with migrateAccessTokenToHeader', () => {
+        let mockApi;
+
+        beforeEach(() => {
+            mockApi = { get: jest.fn().mockReturnValue(Promise.resolve()) };
+            videoBase.api = mockApi;
+            videoBase.options.file = {
+                id: 123,
+                watermark_info: { is_watermarked: false },
+                representations: {
+                    entries: [
+                        {
+                            representation: 'jpg',
+                            content: {
+                                url_template: 'www.box.com/preload.jpg',
+                            },
+                            status: {
+                                state: 'success',
+                            },
+                        },
+                    ],
+                },
+            };
+            jest.spyOn(videoBase, 'isRepresentationReady').mockReturnValue(true);
+        });
+
+        test('should use createContentUrlV2 with auth headers when flag is enabled', () => {
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('http://localhost/preload.jpg');
+            jest.spyOn(videoBase, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
+
+            videoBase.prefetch({ preload: true });
+
+            expect(videoBase.createContentUrlV2).toHaveBeenCalledWith('www.box.com/preload.jpg');
+            expect(videoBase.appendAuthHeader).toHaveBeenCalled();
+            expect(mockApi.get).toHaveBeenCalledWith('http://localhost/preload.jpg', {
+                type: 'blob',
+                headers: { Authorization: 'Bearer token123' },
+            });
+        });
+
+        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(
+                'http://localhost/preload.jpg?token=abc',
+            );
+
+            videoBase.prefetch({ preload: true });
+
+            expect(videoBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/preload.jpg');
+            expect(mockApi.get).toHaveBeenCalledWith('http://localhost/preload.jpg?token=abc', { type: 'blob' });
+        });
+    });
+
+    describe('destroy() with migrateAccessTokenToHeader', () => {
+        test('should revoke preloadBlobUrl if it exists', () => {
+            const blobUrl = 'blob:http://localhost/preload-123';
+            videoBase.preloadBlobUrl = blobUrl;
+
+            jest.spyOn(URL, 'revokeObjectURL');
+
+            videoBase.destroy();
+
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith(blobUrl);
+        });
+
+        test('should not call revokeObjectURL if preloadBlobUrl does not exist', () => {
+            videoBase.preloadBlobUrl = null;
+
+            jest.spyOn(URL, 'revokeObjectURL');
+
+            videoBase.destroy();
+
+            expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
## Summary
  - Replace `access_token` query params with `Authorization: Bearer` headers in MediaBaseViewer, DashViewer, and VideoBaseViewer
  - Uses blob URLs for `<video>`/`<audio>` src elements (HTML media elements cannot send custom headers)
  - Uses Shaka Player `registerRequestFilter` for DASH streaming auth (no blob URLs needed)
  - Uses blob URLs for video preload poster images
  - Includes proper memory cleanup via `URL.revokeObjectURL()` in `destroy()` and `restartPlayback()`
  - All changes gated behind `migrateAccessTokenToHeader` feature flag

  ## Test plan
  - [ ] Verify MP4 video playback works with feature flag ON
  - [ ] Verify DASH video playback works with feature flag ON
  - [ ] Verify MP3 audio playback works with feature flag ON
  - [ ] Verify video preload poster images display correctly
  - [ ] Verify filmstrip thumbnails load correctly
  - [ ] Verify media files work with feature flag OFF (no regression)
  - [ ] Verify no memory leaks (blob URLs revoked on destroy)