### PR TITLE
feat(auth): migrate text viewers to use Authorization header

### DIFF
--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -38,6 +38,9 @@ class CSVViewer extends TextBaseViewer {
      * @return {void}
      */
     destroy() {
+        if (this.blobUrl) {
+            URL.revokeObjectURL(this.blobUrl);
+        }
         if (this.csvComponent) {
             this.csvComponent.destroy();
         }
@@ -58,25 +61,37 @@ class CSVViewer extends TextBaseViewer {
         return Promise.all([this.loadAssets(JS), this.getRepStatus().getPromise()])
             .then(() => {
                 this.startLoadTimer();
-                const urlWithAuth = this.createContentUrlWithAuthParams(template);
-                Papa.parse(urlWithAuth, {
-                    download: true,
-                    error: (err, file, inputElem, reason) => {
-                        const error = new PreviewError(ERROR_CODE.LOAD_CSV, __('error_refresh'), { reason });
-                        this.handleDownloadError(error, urlWithAuth);
-                    },
-                    complete: results => {
-                        if (this.isDestroyed() || !results) {
-                            return;
-                        }
+                const parseCSV = url => {
+                    Papa.parse(url, {
+                        download: true,
+                        error: (err, file, inputElem, reason) => {
+                            const error = new PreviewError(ERROR_CODE.LOAD_CSV, __('error_refresh'), { reason });
+                            this.handleDownloadError(error, url);
+                        },
+                        complete: results => {
+                            if (this.isDestroyed() || !results) {
+                                return;
+                            }
 
-                        this.checkForParseErrors(results);
+                            this.checkForParseErrors(results);
 
-                        this.data = results.data;
-                        this.finishLoading();
-                    },
-                    worker: true,
-                });
+                            this.data = results.data;
+                            this.finishLoading();
+                        },
+                        worker: true,
+                    });
+                };
+
+                if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                    const contentUrl = this.createContentUrlV2(template);
+                    return this.fetchContentAsBlobUrl(contentUrl).then(blobUrl => {
+                        this.blobUrl = blobUrl;
+                        parseCSV(blobUrl);
+                    });
+                }
+
+                parseCSV(this.createContentUrlWithAuthParams(template));
+                return undefined;
             })
             .catch(this.handleAssetError);
     }
@@ -126,7 +141,12 @@ class CSVViewer extends TextBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                const contentUrl = this.createContentUrlV2(template);
+                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
+            } else {
+                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            }
         }
     }
 

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -69,7 +69,12 @@ class PlainTextViewer extends TextBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                const contentUrl = this.createContentUrlV2(template);
+                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
+            } else {
+                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            }
         }
     }
 
@@ -195,7 +200,13 @@ class PlainTextViewer extends TextBaseViewer {
         this.truncated = size > SIZE_LIMIT_BYTES;
         const headers = this.truncated ? { Range: `bytes=0-${SIZE_LIMIT_BYTES}` } : {};
 
-        const contentUrl = this.createContentUrlWithAuthParams(template);
+        let contentUrl;
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            contentUrl = this.createContentUrlV2(template);
+            Object.assign(headers, this.appendAuthHeader());
+        } else {
+            contentUrl = this.createContentUrlWithAuthParams(template);
+        }
         this.startLoadTimer();
         return this.api
             .get(contentUrl, { headers, type: 'text' })

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -71,6 +71,35 @@ describe('lib/viewers/text/CSVViewer', () => {
         });
     });
 
+    describe('destroy()', () => {
+        test('should revoke blob URL if it exists', () => {
+            const blobUrl = 'blob:http://localhost/abc123';
+            csv.blobUrl = blobUrl;
+            jest.spyOn(URL, 'revokeObjectURL').mockImplementation();
+
+            csv.destroy();
+
+            expect(URL.revokeObjectURL).toBeCalledWith(blobUrl);
+        });
+
+        test('should destroy csvComponent if it exists', () => {
+            csv.csvComponent = {
+                destroy: jest.fn(),
+            };
+
+            csv.destroy();
+
+            expect(csv.csvComponent.destroy).toBeCalled();
+        });
+
+        test('should not error if blobUrl does not exist', () => {
+            jest.spyOn(URL, 'revokeObjectURL').mockImplementation();
+
+            expect(() => csv.destroy()).not.toThrow();
+            expect(URL.revokeObjectURL).not.toBeCalled();
+        });
+    });
+
     describe('load()', () => {
         const loadFunc = TextBaseViewer.prototype.load;
 
@@ -122,6 +151,54 @@ describe('lib/viewers/text/CSVViewer', () => {
                 expect(csv.startLoadTimer).toBeCalled();
             });
         });
+
+        test('should use fetchContentAsBlobUrl and pass blob URL to PapaParse when migrateAccessTokenToHeader flag is enabled', () => {
+            Object.defineProperty(TextBaseViewer.prototype, 'load', { value: jest.fn() });
+            const contentUrl = 'someContentUrl';
+            const blobUrl = 'blob:http://localhost/abc123';
+
+            jest.spyOn(csv, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(csv, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(csv, 'fetchContentAsBlobUrl').mockResolvedValue(blobUrl);
+
+            return csv.load().then(() => {
+                expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+                expect(csv.createContentUrlV2).toBeCalled();
+                expect(csv.fetchContentAsBlobUrl).toBeCalledWith(contentUrl);
+                expect(csv.blobUrl).toBe(blobUrl);
+                expect(window.Papa.parse).toBeCalledWith(
+                    blobUrl,
+                    expect.objectContaining({
+                        download: true,
+                        error: expect.any(Function),
+                        complete: expect.any(Function),
+                        worker: true,
+                    }),
+                );
+            });
+        });
+
+        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is disabled', () => {
+            Object.defineProperty(TextBaseViewer.prototype, 'load', { value: jest.fn() });
+            const contentUrlWithAuth = 'contentUrlWithAuth';
+
+            jest.spyOn(csv, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(csv, 'createContentUrlWithAuthParams').mockReturnValue(contentUrlWithAuth);
+
+            return csv.load().then(() => {
+                expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+                expect(csv.createContentUrlWithAuthParams).toBeCalled();
+                expect(window.Papa.parse).toBeCalledWith(
+                    contentUrlWithAuth,
+                    expect.objectContaining({
+                        download: true,
+                        error: expect.any(Function),
+                        complete: expect.any(Function),
+                        worker: true,
+                    }),
+                );
+            });
+        });
     });
 
     describe('prefetch()', () => {
@@ -149,6 +226,37 @@ describe('lib/viewers/text/CSVViewer', () => {
             csv.prefetch({ assets: false, content: true });
 
             expect(csv.api.get).not.toBeCalled();
+        });
+
+        test('should prefetch content with auth header when migrateAccessTokenToHeader flag is enabled', () => {
+            const contentUrl = 'someContentUrl';
+            const headers = { Authorization: 'Bearer token' };
+            jest.spyOn(csv, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(csv, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(csv, 'appendAuthHeader').mockReturnValue(headers);
+            jest.spyOn(csv, 'isRepresentationReady').mockReturnValue(true);
+            jest.spyOn(csv.api, 'get').mockResolvedValue(undefined);
+
+            csv.prefetch({ assets: false, content: true });
+
+            expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+            expect(csv.createContentUrlV2).toBeCalled();
+            expect(csv.appendAuthHeader).toBeCalled();
+            expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document', headers });
+        });
+
+        test('should prefetch content with auth params when migrateAccessTokenToHeader flag is disabled', () => {
+            const contentUrl = 'someContentUrl';
+            jest.spyOn(csv, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(csv, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            jest.spyOn(csv, 'isRepresentationReady').mockReturnValue(true);
+            jest.spyOn(csv.api, 'get').mockResolvedValue(undefined);
+
+            csv.prefetch({ assets: false, content: true });
+
+            expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+            expect(csv.createContentUrlWithAuthParams).toBeCalled();
+            expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document' });
         });
     });
 

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -161,6 +161,41 @@ describe('lib/viewers/text/PlainTextViewer', () => {
                 .never();
             text.prefetch({ assets: false, content: true });
         });
+
+        test('should prefetch content with auth header when migrateAccessTokenToHeader flag is enabled', () => {
+            const contentUrl = 'someContentUrl';
+            const headers = { Authorization: 'Bearer token' };
+            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(headers);
+            jest.spyOn(text, 'isRepresentationReady').mockReturnValue(true);
+            sandbox
+                .mock(stubs.api)
+                .expects('get')
+                .withArgs(contentUrl, { type: 'document', headers });
+
+            text.prefetch({ assets: false, content: true });
+
+            expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+            expect(text.createContentUrlV2).toBeCalled();
+            expect(text.appendAuthHeader).toBeCalled();
+        });
+
+        test('should prefetch content with auth params when migrateAccessTokenToHeader flag is disabled', () => {
+            const contentUrl = 'someContentUrl';
+            jest.spyOn(text, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'isRepresentationReady').mockReturnValue(true);
+            sandbox
+                .mock(stubs.api)
+                .expects('get')
+                .withArgs(contentUrl, { type: 'document' });
+
+            text.prefetch({ assets: false, content: true });
+
+            expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+            expect(text.createContentUrlWithAuthParams).toBeCalled();
+        });
     });
 
     describe('print()', () => {
@@ -276,6 +311,67 @@ describe('lib/viewers/text/PlainTextViewer', () => {
 
             return promise.catch(() => {
                 expect(text.handleDownloadError).toBeCalled();
+            });
+        });
+
+        test('should use createContentUrl and merge auth headers when migrateAccessTokenToHeader flag is enabled', () => {
+            const contentUrl = 'someContentUrl';
+            const authHeaders = { Authorization: 'Bearer token' };
+            const getPromise = Promise.resolve('content');
+            text.options.file.size = 196608 - 1; // Small file
+
+            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
+            jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
+
+            text.postLoad();
+
+            return getPromise.then(() => {
+                expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+                expect(text.createContentUrlV2).toBeCalled();
+                expect(text.appendAuthHeader).toBeCalled();
+                expect(stubs.api.get).toBeCalledWith(contentUrl, { headers: authHeaders, type: 'text' });
+            });
+        });
+
+        test('should merge auth headers with Range header when file is truncated and migrateAccessTokenToHeader flag is enabled', () => {
+            const contentUrl = 'someContentUrl';
+            const authHeaders = { Authorization: 'Bearer token' };
+            const getPromise = Promise.resolve('content');
+            text.options.file.size = 196608 + 1; // Large file requiring truncation
+
+            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
+            jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
+
+            text.postLoad();
+
+            return getPromise.then(() => {
+                expect(text.truncated).toBe(true);
+                expect(stubs.api.get).toBeCalledWith(contentUrl, {
+                    headers: { Range: 'bytes=0-196608', ...authHeaders },
+                    type: 'text',
+                });
+            });
+        });
+
+        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is disabled', () => {
+            const contentUrl = 'someContentUrl';
+            const getPromise = Promise.resolve('content');
+            text.options.file.size = 196608 - 1; // Small file
+
+            jest.spyOn(text, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
+
+            text.postLoad();
+
+            return getPromise.then(() => {
+                expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
+                expect(text.createContentUrlWithAuthParams).toBeCalled();
+                expect(stubs.api.get).toBeCalledWith(contentUrl, { headers: {}, type: 'text' });
             });
         });
     });


### PR DESCRIPTION
## Summary
  - Replace `access_token` query params with `Authorization: Bearer` headers in PlainTextViewer and CSVViewer
  - Pre-fetches CSV content as blob URL for PapaParse web worker compatibility (workers cannot send custom headers)
  - Includes blob URL memory cleanup in `destroy()`
  - All changes gated behind `migrateAccessTokenToHeader` feature flag

  ## Test plan
  - [ ] Verify plain text files load correctly with feature flag ON
  - [ ] Verify CSV files load and render correctly with feature flag ON
  - [ ] Verify text/CSV files work with feature flag OFF (no regression)
  - [ ] Verify truncated text files load correctly (Range header merged with auth header)