### PR TITLE
feat(auth): add createContentUrlV2 to BaseViewer

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -10,6 +10,7 @@ import {
     getProp,
     appendQueryParams,
     appendAuthParams,
+    appendAuthParamsV2,
     createContentUrl,
     getHeaders,
     loadStylesheets,
@@ -494,6 +495,20 @@ class BaseViewer extends EventEmitter {
         // Append optional query params
         const { queryParams } = this.options;
         return appendQueryParams(urlWithAuthParams, queryParams);
+    }
+
+    /**
+     * Creates content url with shared link params but without access_token.
+     * Used when auth is sent via Authorization header.
+     *
+     * @protected
+     * @param {string} template - url template to attach param to
+     * @param {string|void} [asset] - optional asset name needed to access file
+     * @return {string} content url with shared link params
+     */
+    createContentUrlV2(template, asset) {
+        const { sharedLink, sharedLinkPassword } = this.options;
+        return appendAuthParamsV2(this.createContentUrl(template, asset), sharedLink, sharedLinkPassword);
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -399,6 +399,19 @@ describe('lib/viewers/BaseViewer', () => {
         });
     });
 
+    describe('createContentUrlV2()', () => {
+        test('should return content url with shared link params but no access_token', () => {
+            jest.spyOn(util, 'createContentUrl').mockReturnValue('foo');
+            jest.spyOn(util, 'appendAuthParamsV2').mockReturnValue('bar');
+            base.options.sharedLink = 'https://app.box.com/s/HASH';
+            base.options.sharedLinkPassword = 'pass';
+            const result = base.createContentUrlV2('boo', 'hoo');
+            expect(result).toBe('bar');
+            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo');
+            expect(util.appendAuthParamsV2).toBeCalledWith('foo', 'https://app.box.com/s/HASH', 'pass');
+        });
+    });
+
     describe('appendAuthHeader()', () => {
         test('should return fetch headers', () => {
             const token = 'TOKEN';


### PR DESCRIPTION
Add a new method that creates content URLs with shared link query params (shared_link, shared_link_password, box_client_name, box_client_version) but without access_token. This is the flag-on equivalent of createContentUrlWithAuthParams for the auth header migration.