### PR TITLE
fix(media): derive filmestrip frame width from actual image dimensions

### DIFF
--- a/src/lib/viewers/controls/media/Filmstrip.tsx
+++ b/src/lib/viewers/controls/media/Filmstrip.tsx
@@ -27,9 +27,12 @@ export default function Filmstrip({
     time = 0,
 }: Props): JSX.Element | null {
     const [isLoading, setIsLoading] = React.useState(true);
+    const [imageWidth, setImageWidth] = React.useState<number>(0);
     const frameNumber = Math.floor(time / interval); // Current frame based on current time
     const frameRow = Math.floor(frameNumber / FILMSTRIP_FRAMES_PER_ROW); // Row number if there is more than one row
-    const frameWidth = Math.floor(aspectRatio * FILMSTRIP_FRAME_HEIGHT) || FILMSTRIP_FRAME_WIDTH;
+    const frameWidth = imageWidth
+        ? Math.floor(imageWidth / FILMSTRIP_FRAMES_PER_ROW)
+        : Math.floor(aspectRatio * FILMSTRIP_FRAME_HEIGHT) || FILMSTRIP_FRAME_WIDTH;
     const frameBackgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * frameWidth; // Frame position in its row
     const frameBackgroundTop = -(frameRow * FILMSTRIP_FRAME_HEIGHT); // Row position in its filmstrip
     const filmstripLeft = Math.min(Math.max(0, position - frameWidth / 2), positionMax - frameWidth);
@@ -38,7 +41,10 @@ export default function Filmstrip({
         if (!imageUrl) return;
 
         const filmstripImage = document.createElement('img');
-        filmstripImage.onload = (): void => setIsLoading(false);
+        filmstripImage.onload = (): void => {
+            setImageWidth(filmstripImage.naturalWidth);
+            setIsLoading(false);
+        };
         filmstripImage.src = imageUrl;
     }, [imageUrl]);
 

--- a/src/lib/viewers/controls/media/__tests__/Filmstrip-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/Filmstrip-test.tsx
@@ -60,6 +60,37 @@ describe('Filmstrip', () => {
             expect(await screen.findByText('2:00')).toBeInTheDocument();
         });
 
+        test('should derive frame width from filmstrip image width after load', done => {
+            const mockImage = document.createElement('img');
+
+            Object.defineProperty(mockImage, 'naturalWidth', { value: 12800 });
+            Object.defineProperty(mockImage, 'src', {
+                set() {
+                    setTimeout(() => {
+                        React.act(() => {
+                            this.onload();
+                        });
+                        done();
+                    });
+                },
+            });
+
+            jest.useFakeTimers();
+
+            const { rerender } = getWrapper({ aspectRatio: 1.4167, imageUrl: null, time: 1 });
+            jest.spyOn(document, 'createElement').mockImplementation(() => mockImage);
+            rerender(getComponent({ aspectRatio: 1.4167, imageUrl: 'https://app.box.com', time: 1 }));
+
+            // Before image loads, frameWidth = Math.floor(1.4167 * 90) = 127
+            const frame = screen.getByTestId('bp-Filmstrip-frame');
+            expect(frame).toHaveStyle({ width: '127px' });
+
+            jest.advanceTimersByTime(0); // Simulate loading complete
+
+            // After image loads, frameWidth = Math.floor(12800 / 100) = 128
+            expect(frame).toHaveStyle({ width: '128px' });
+        });
+
         test('should display the crawler while the filmstrip image loads', done => {
             const mockImage = document.createElement('img');
 


### PR DESCRIPTION
Use the filmstrip image's naturalWidth to calculate frame width instead of relying solely on the aspect ratio, which can introduce rounding drift between the file's frame dimensions and the previewer's calculation. Falls back to the aspect ratio calculation when the image has not yet loaded.