### PR TITLE
feat(auth): migrate archive viewer to use Authorization header

### DIFF
--- a/src/lib/viewers/archive/ArchiveViewer.js
+++ b/src/lib/viewers/archive/ArchiveViewer.js
@@ -48,9 +48,14 @@ class ArchiveViewer extends BaseViewer {
             .then(() => {
                 const { representation } = this.options;
                 const template = get(representation, 'content.url_template');
-                const contentUrl = this.createContentUrlWithAuthParams(template);
                 this.startLoadTimer();
 
+                if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                    const contentUrl = this.createContentUrlV2(template);
+                    return this.api.get(contentUrl, { headers: this.appendAuthHeader() });
+                }
+
+                const contentUrl = this.createContentUrlWithAuthParams(template);
                 return this.api.get(contentUrl);
             })
             .then(this.finishLoading)

--- a/src/lib/viewers/archive/__tests__/ArchiveViewer-test.js
+++ b/src/lib/viewers/archive/__tests__/ArchiveViewer-test.js
@@ -80,13 +80,28 @@ describe('lib/viewers/archive/ArchiveViewer', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: loadFunc });
         });
 
-        test('should call createContentUrlWithAuthParams with right template', () => {
+        test('should call createContentUrlWithAuthParams with right template when flag is off', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: jest.fn() });
 
+            jest.spyOn(archive, 'featureEnabled').mockReturnValue(false);
             jest.spyOn(archive, 'createContentUrlWithAuthParams');
 
             return archive.load().then(() => {
                 expect(archive.createContentUrlWithAuthParams).toBeCalledWith('archiveUrl{+asset_path}');
+            });
+        });
+
+        test('should use auth headers when migrateAccessTokenToHeader flag is on', () => {
+            Object.defineProperty(BaseViewer.prototype, 'load', { value: jest.fn() });
+
+            const mockHeaders = { Authorization: 'Bearer token' };
+            jest.spyOn(archive, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(archive, 'createContentUrlV2').mockReturnValue('contentUrl');
+            jest.spyOn(archive, 'appendAuthHeader').mockReturnValue(mockHeaders);
+
+            return archive.load().then(() => {
+                expect(archive.createContentUrlV2).toBeCalledWith('archiveUrl{+asset_path}');
+                expect(stubs.api.get).toBeCalledWith('contentUrl', { headers: mockHeaders });
             });
         });
 


### PR DESCRIPTION
Replaces https://github.com/box/box-content-preview/pull/1624

## Summary
- Migrates ArchiveViewer from passing access_token as URL query param to using Authorization: Bearer header
- Uses createContentUrlV2() + appendAuthHeader() when migrateAccessTokenToHeader feature flag is on
- No behavior change when flag is off

## Test plan
- [x] yarn test — all 275 tests pass
- [x] Verify ZIP/archive files load correctly with flag ON (no access_token in URL, Authorization header present)
- [x] Verify ZIP/archive files load correctly with flag OFF (no regression)

--JG-Claude-🔶