### PR TITLE
feat(auth): migrate doc viewers to use Authorization header

### DIFF
--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -779,6 +779,18 @@ describe('lib/util', () => {
             expect(mockApi.get).toHaveBeenCalledWith('webp-url8.webp', expect.any(Object));
             expect(promises.length).toBe(8);
         });
+
+        it('should pass options to api.get calls', () => {
+            const jpegPagedUrl = '';
+            const webpPagedUrl = 'webp-urlpage_number';
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            util.getPreloadImageRequestPromises(mockApi, jpegPagedUrl, 3, webpPagedUrl, options);
+
+            expect(mockApi.get).toHaveBeenCalledWith('webp-url1.webp', { type: 'blob', headers: mockHeaders });
+            expect(mockApi.get).toHaveBeenCalledWith('webp-url2.webp', { type: 'blob', headers: mockHeaders });
+            expect(mockApi.get).toHaveBeenCalledWith('webp-url3.webp', { type: 'blob', headers: mockHeaders });
+        });
     });
 
     describe('createPageUrl()', () => {
@@ -819,6 +831,21 @@ describe('lib/util', () => {
             const result = await util.fetchPageImage(mockApi, 'https://example.com/page.webp');
 
             expect(result).toBe(mockError);
+        });
+
+        it('should pass options to api.get call', async () => {
+            const mockBlob = new Blob(['test']);
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            jest.spyOn(mockApi, 'get').mockResolvedValue(mockBlob);
+
+            const result = await util.fetchPageImage(mockApi, 'https://example.com/page.webp', options);
+
+            expect(mockApi.get).toHaveBeenCalledWith('https://example.com/page.webp', {
+                type: 'blob',
+                headers: mockHeaders,
+            });
+            expect(result).toBe(mockBlob);
         });
     });
 
@@ -864,6 +891,27 @@ describe('lib/util', () => {
             expect(promises.length).toBe(1);
             expect(mockApi.get).toHaveBeenCalledTimes(1);
             expect(mockApi.get).toHaveBeenCalledWith('https://example.com/3.webp', { type: 'blob' });
+        });
+
+        it('should pass options to api.get calls', () => {
+            const pagedUrl = 'https://example.com/page_number';
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            const promises = util.getPreloadImageRequestPromisesByBatch(mockApi, pagedUrl, 2, 4, options);
+
+            expect(promises.length).toBe(3);
+            expect(mockApi.get).toHaveBeenCalledWith('https://example.com/2.webp', {
+                type: 'blob',
+                headers: mockHeaders,
+            });
+            expect(mockApi.get).toHaveBeenCalledWith('https://example.com/3.webp', {
+                type: 'blob',
+                headers: mockHeaders,
+            });
+            expect(mockApi.get).toHaveBeenCalledWith('https://example.com/4.webp', {
+                type: 'blob',
+                headers: mockHeaders,
+            });
         });
     });
 });

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -788,7 +788,7 @@ export function handleRepresentationBlobFetch(response) {
  * @param {string} pagedPreLoadUrlWithAuth - Paged preload URL template with auth
  * @return {Array<Promise>} Array of promises for image requests
  */
-export function getPreloadImageRequestPromises(api, preloadUrlWithAuth, pages, pagedPreLoadUrlWithAuth) {
+export function getPreloadImageRequestPromises(api, preloadUrlWithAuth, pages, pagedPreLoadUrlWithAuth, options = {}) {
     const PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER = 'page_number';
     const MAX_PRELOAD_PAGES = 8;
 
@@ -799,13 +799,13 @@ export function getPreloadImageRequestPromises(api, preloadUrlWithAuth, pages, p
 
     const useNonPagedJpegRep = !pagedPreLoadUrlWithAuth && preloadUrlWithAuth;
     if (useNonPagedJpegRep) {
-        const promise = api.get(preloadUrlWithAuth, { type: 'blob' });
+        const promise = api.get(preloadUrlWithAuth, { type: 'blob', ...options });
         promises.push(promise.catch(e => e));
     } else if (pagedPreLoadUrlWithAuth) {
         const count = pages > MAX_PRELOAD_PAGES ? MAX_PRELOAD_PAGES : pages;
         for (let i = 1; i <= count; i += 1) {
             const url = pagedPreLoadUrlWithAuth.replace(PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER, `${i}.webp`);
-            const promise = api.get(url, { type: 'blob' });
+            const promise = api.get(url, { type: 'blob', ...options });
             promises.push(promise.catch(e => e));
         }
     }
@@ -832,8 +832,8 @@ export function createPageUrl(pagedPreLoadUrlWithAuth, pageNumber) {
  * @param {string} url - URL to fetch
  * @return {Promise} Promise that resolves with blob or error
  */
-export function fetchPageImage(api, url) {
-    return api.get(url, { type: 'blob' }).catch(e => e);
+export function fetchPageImage(api, url, options = {}) {
+    return api.get(url, { type: 'blob', ...options }).catch(e => e);
 }
 
 /**
@@ -845,14 +845,14 @@ export function fetchPageImage(api, url) {
  * @param {number} endPage - Last page to fetch (inclusive)
  * @return {Array<Promise>} Array of promises that resolve with blobs
  */
-export function getPreloadImageRequestPromisesByBatch(api, pagedPreLoadUrlWithAuth, startPage, endPage) {
+export function getPreloadImageRequestPromisesByBatch(api, pagedPreLoadUrlWithAuth, startPage, endPage, options = {}) {
     const promises = [];
     if (!pagedPreLoadUrlWithAuth || startPage > endPage) {
         return promises;
     }
     for (let i = startPage; i <= endPage; i += 1) {
         const url = createPageUrl(pagedPreLoadUrlWithAuth, i);
-        promises.push(fetchPageImage(api, url));
+        promises.push(fetchPageImage(api, url, options));
     }
     return promises;
 }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -380,10 +380,15 @@ class DocBaseViewer extends BaseViewer {
             jpegPreloadRep && this.isRepresentationReady(jpegPreloadRep) && jpegPreloadRep.content?.url_template;
         const onlyJpegRepAvailable = jpegRepReady && !pagedWebpRepReady;
 
+        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
+        const headersOption = useHeaders ? { headers: this.appendAuthHeader() } : {};
+
         if (onlyJpegRepAvailable) {
             const { url_template: jpegUrlTemplate = '' } = jpegPreloadRep.content;
-            const jpegUrlAuthTemplate = this.createContentUrlWithAuthParams(jpegUrlTemplate);
-            const promises = getPreloadImageRequestPromises(this.api, jpegUrlAuthTemplate, 1, '');
+            const jpegUrlAuthTemplate = useHeaders
+                ? this.createContentUrlV2(jpegUrlTemplate)
+                : this.createContentUrlWithAuthParams(jpegUrlTemplate);
+            const promises = getPreloadImageRequestPromises(this.api, jpegUrlAuthTemplate, 1, '', headersOption);
             Promise.all(promises).then(() => {
                 this.preloaderImagesPrefetched = true;
             });
@@ -391,7 +396,9 @@ class DocBaseViewer extends BaseViewer {
             const { url_template: pagedUrlTemplate = '' } = pagedWebpRep.content;
             const pageCount = pagedWebpRep.metadata?.pages || 8;
             const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
-            const pagedUrlAuthTemplate = this.createContentUrlWithAuthParams(newPagedUrlTemplate);
+            const pagedUrlAuthTemplate = useHeaders
+                ? this.createContentUrlV2(newPagedUrlTemplate)
+                : this.createContentUrlWithAuthParams(newPagedUrlTemplate);
 
             if (docFirstPagesConfig && docFirstPagesConfig.priorityPages) {
                 const {
@@ -406,6 +413,7 @@ class DocBaseViewer extends BaseViewer {
                     pagedUrlAuthTemplate,
                     1,
                     priorityPages,
+                    headersOption,
                 );
                 Promise.all(priorityPromises).then(() => {
                     this.preloaderImagesPrefetched = true;
@@ -420,12 +428,19 @@ class DocBaseViewer extends BaseViewer {
                             pagedUrlAuthTemplate,
                             priorityPages + 1,
                             Math.min(pageCount, maxPreloadPages),
+                            headersOption,
                         );
                         Promise.all(remainingPromises);
                     }, secondBatchDelayMs);
                 });
             } else {
-                const promises = getPreloadImageRequestPromises(this.api, '', pageCount, pagedUrlAuthTemplate);
+                const promises = getPreloadImageRequestPromises(
+                    this.api,
+                    '',
+                    pageCount,
+                    pagedUrlAuthTemplate,
+                    headersOption,
+                );
                 Promise.all(promises).then(() => {
                     this.preloaderImagesPrefetched = true;
                 });
@@ -460,7 +475,12 @@ class DocBaseViewer extends BaseViewer {
                     const { url_template: template } = preloadRep.content;
 
                     // Prefetch as blob since preload needs to load image as a blob
-                    this.api.get(this.createContentUrlWithAuthParams(template), { type: 'blob' });
+                    if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                        const contentUrl = this.createContentUrlV2(template);
+                        this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() });
+                    } else {
+                        this.api.get(this.createContentUrlWithAuthParams(template), { type: 'blob' });
+                    }
                 }
             } else {
                 this.prefetchPreloaderImages(file);
@@ -469,7 +489,12 @@ class DocBaseViewer extends BaseViewer {
 
         if (content && !isWatermarked && this.isRepresentationReady(representation)) {
             const { url_template: template } = representation.content;
-            this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            if (this.featureEnabled('migrateAccessTokenToHeader')) {
+                const contentUrl = this.createContentUrlV2(template);
+                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
+            } else {
+                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
+            }
         }
     }
 
@@ -517,11 +542,15 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const { url_template: template = '' } = preloadRep?.content || {};
-        const preloadUrlWithAuth = this.createContentUrlWithAuthParams(template);
+        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
+        const preloadUrl = useHeaders
+            ? this.createContentUrlV2(template)
+            : this.createContentUrlWithAuthParams(template);
+        const headersOption = useHeaders ? { headers: this.appendAuthHeader() } : {};
 
         if (!this.docFirstPagesEnabled) {
             this.startPreloadTimer();
-            this.preloader.showPreload(preloadUrlWithAuth, this.containerEl);
+            this.preloader.showPreload(preloadUrl, this.containerEl, headersOption);
         } else {
             // Skip single-page preload if images were prefetched via prefetch().
             // When prefetch() is called (e.g., on hover), both the preload images and
@@ -533,14 +562,15 @@ class DocBaseViewer extends BaseViewer {
             }
             this.startPreloadTimer();
             if (!pagedWebpRepReady) {
-                this.preloader.showPreload(preloadUrlWithAuth, this.containerEl, null, 1, this);
+                this.preloader.showPreload(preloadUrl, this.containerEl, null, 1, this, headersOption);
             } else {
                 const { pages: pageCount = 1 } = preloadRepPaged?.metadata || {};
                 const { url_template: pagedUrlTemplate = '' } = preloadRepPaged?.content || {};
                 const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
-                const pagedPreLoadUrlWithAuth =
-                    newPagedUrlTemplate && this.createContentUrlWithAuthParams(newPagedUrlTemplate);
-                this.preloader.showPreload(null, this.containerEl, pagedPreLoadUrlWithAuth, pageCount, this);
+                const pagedPreLoadUrl = useHeaders
+                    ? this.createContentUrlV2(newPagedUrlTemplate)
+                    : this.createContentUrlWithAuthParams(newPagedUrlTemplate);
+                this.preloader.showPreload(null, this.containerEl, pagedPreLoadUrl, pageCount, this, headersOption);
             }
         }
     }
@@ -581,7 +611,11 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const template = this.options.representation.content.url_template;
-        this.pdfUrl = this.createContentUrlWithAuthParams(template);
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            this.pdfUrl = this.createContentUrlV2(template);
+        } else {
+            this.pdfUrl = this.createContentUrlWithAuthParams(template);
+        }
         const jsAssets = this.docFirstPagesEnabled ? JS_NO_EXIF : JS;
         return Promise.all([this.loadAssets(jsAssets, CSS), this.getRepStatus().getPromise()])
             .then(this.handleAssetAndRepLoad)
@@ -912,7 +946,7 @@ class DocBaseViewer extends BaseViewer {
         const disableStream = this.getViewerOption('disableStream') !== false;
 
         // Load PDF from representation URL and set as document for pdf.js. Cache task for destruction
-        this.pdfLoadingTask = this.pdfjsLib.getDocument({
+        const pdfDocConfig = {
             cMapPacked: true,
             cMapUrl: assetUrlCreator(CMAP),
             disableCreateObjectURL,
@@ -922,7 +956,13 @@ class DocBaseViewer extends BaseViewer {
             isEvalSupported: false,
             rangeChunkSize,
             url: pdfUrl,
-        });
+        };
+
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            pdfDocConfig.httpHeaders = this.appendAuthHeader();
+        }
+
+        this.pdfLoadingTask = this.pdfjsLib.getDocument(pdfDocConfig);
 
         if (this.pageTracker) {
             this.addListener('preview_event_report', this.handlePreviewEventReport);
@@ -1212,7 +1252,11 @@ class DocBaseViewer extends BaseViewer {
      * @return {Promise} Promise setting print blob
      */
     fetchPrintBlob(pdfUrl) {
-        return this.api.get(pdfUrl, { type: 'blob' }).then(blob => {
+        const options = { type: 'blob' };
+        if (this.featureEnabled('migrateAccessTokenToHeader')) {
+            options.headers = this.appendAuthHeader();
+        }
+        return this.api.get(pdfUrl, options).then(blob => {
             this.printBlob = blob;
         });
     }

--- a/src/lib/viewers/doc/DocFirstPreloader.js
+++ b/src/lib/viewers/doc/DocFirstPreloader.js
@@ -87,6 +87,9 @@ class DocFirstPreloader extends EventEmitter {
     /** @property {Object} - Configuration for staggered loading */
     config = {};
 
+    /** @property {Object} - Options to pass to fetch calls (e.g. auth headers) */
+    fetchOptions = {};
+
     /** @property {boolean} - Whether second batch has started */
     secondBatchStarted = false;
 
@@ -192,11 +195,12 @@ class DocFirstPreloader extends EventEmitter {
      * @param {string} preloadUrlWithAuth - URL for preload content with authorization query params
      * @return {Promise} Promise to show preload
      */
-    async showPreload(preloadUrlWithAuth, containerEl, pagedPreLoadUrlWithAuth, pages, docBaseViewer) {
+    async showPreload(preloadUrlWithAuth, containerEl, pagedPreLoadUrlWithAuth, pages, docBaseViewer, options = {}) {
         if (this.pdfJsDocLoadComplete()) {
             return;
         }
 
+        this.fetchOptions = options;
         this.hidePreviewMask();
         try {
             this.numPages = pages;
@@ -230,7 +234,7 @@ class DocFirstPreloader extends EventEmitter {
      * @return {Promise} Promise that resolves when preload is shown
      */
     async showPreloadSingleImage(preloadUrlWithAuth, pages, docBaseViewer) {
-        const response = await this.api.get(preloadUrlWithAuth, { type: 'blob' });
+        const response = await this.api.get(preloadUrlWithAuth, { type: 'blob', ...this.fetchOptions });
         const blob = await handleRepresentationBlobFetch(response);
 
         this.wrapperEl.appendChild(this.preloadEl);
@@ -287,8 +291,8 @@ class DocFirstPreloader extends EventEmitter {
     async loadBatchAsBlobs(preloadUrl, pagedUrl, endPage, startPage = 1) {
         const promises =
             startPage === 1 && preloadUrl
-                ? getPreloadImageRequestPromises(this.api, preloadUrl, endPage, pagedUrl)
-                : getPreloadImageRequestPromisesByBatch(this.api, pagedUrl, startPage, endPage);
+                ? getPreloadImageRequestPromises(this.api, preloadUrl, endPage, pagedUrl, this.fetchOptions)
+                : getPreloadImageRequestPromisesByBatch(this.api, pagedUrl, startPage, endPage, this.fetchOptions);
 
         const responses = await Promise.all(promises);
         const blobs = await Promise.all(responses.map(r => handleRepresentationBlobFetch(r)));

--- a/src/lib/viewers/doc/DocPreloader.js
+++ b/src/lib/viewers/doc/DocPreloader.js
@@ -80,13 +80,13 @@ class DocPreloader extends EventEmitter {
      * @param {string} preloadUrlWithAuth - URL for preload content with authorization query params
      * @return {Promise} Promise to show preload
      */
-    showPreload(preloadUrlWithAuth, containerEl) {
+    showPreload(preloadUrlWithAuth, containerEl, options = {}) {
         this.containerEl = containerEl;
 
         // Need to load image as a blob to read EXIF
 
         return this.api
-            .get(preloadUrlWithAuth, { type: 'blob' })
+            .get(preloadUrlWithAuth, { type: 'blob', ...options })
             .then(handleRepresentationBlobFetch)
             .then(imgBlob => {
                 if (this.checkDocumentLoaded()) {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -553,6 +553,79 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     .never();
                 docBase.prefetch({ assets: false, preload: false, content: true });
             });
+
+            test('should use createContentUrlV2 and pass headers when prefetching preload with migrateAccessTokenToHeader flag on', () => {
+                const preloadRep = {
+                    content: {
+                        url_template: 'preload-template',
+                    },
+                    status: {
+                        state: 'success',
+                    },
+                };
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
+                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+                jest.spyOn(stubs.api, 'get');
+
+                docBase.prefetch({ assets: false, preload: true, content: false });
+
+                expect(docBase.createContentUrlV2).toHaveBeenCalledWith('preload-template');
+                expect(stubs.api.get).toHaveBeenCalledWith('url-without-token', { type: 'blob', headers: mockHeaders });
+            });
+
+            test('should use createContentUrlWithAuthParams when prefetching preload with migrateAccessTokenToHeader flag off', () => {
+                const preloadRep = {
+                    content: {
+                        url_template: 'preload-template',
+                    },
+                    status: {
+                        state: 'success',
+                    },
+                };
+                jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
+                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
+                jest.spyOn(stubs.api, 'get');
+
+                docBase.prefetch({ assets: false, preload: true, content: false });
+
+                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('preload-template');
+                expect(stubs.api.get).toHaveBeenCalledWith('url-with-token', { type: 'blob' });
+            });
+
+            test('should use createContentUrlV2 and pass headers when prefetching content with migrateAccessTokenToHeader flag on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+                jest.spyOn(stubs.api, 'get');
+
+                docBase.prefetch({ assets: false, preload: false, content: true });
+
+                expect(docBase.createContentUrlV2).toHaveBeenCalledWith('foo');
+                expect(stubs.api.get).toHaveBeenCalledWith('url-without-token', {
+                    type: 'document',
+                    headers: mockHeaders,
+                });
+            });
+
+            test('should use createContentUrlWithAuthParams when prefetching content with migrateAccessTokenToHeader flag off', () => {
+                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
+                jest.spyOn(stubs.api, 'get');
+
+                docBase.prefetch({ assets: false, preload: false, content: true });
+
+                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
+                expect(stubs.api.get).toHaveBeenCalledWith('url-with-token', { type: 'document' });
+            });
         });
 
         describe('showPreload()', () => {
@@ -820,7 +893,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.docFirstPagesEnabled = true;
                 docBase.showPreload();
                 expect(startPreloadTimerStub).toHaveBeenCalled();
-                expect(docBase.preloader.showPreload).toHaveBeenCalledWith(null, containerEl, 'paged-url', 4, docBase);
+                expect(docBase.preloader.showPreload).toHaveBeenCalledWith(
+                    null,
+                    containerEl,
+                    'paged-url',
+                    4,
+                    docBase,
+                    {},
+                );
             });
 
             test('should not throw an error in doc first preloader and use jpeg rep if no webp rep available', () => {
@@ -843,6 +923,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
+                    {},
                 );
             });
 
@@ -878,6 +959,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
+                    {},
                 );
             });
 
@@ -922,6 +1004,62 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
+                    {},
+                );
+            });
+
+            test('should use createContentUrlV2 and pass headers when migrateAccessTokenToHeader flag is on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+                jest.spyOn(docBase.preloader, 'showPreload').mockImplementation();
+
+                docBase.showPreload();
+
+                expect(docBase.createContentUrlV2).toHaveBeenCalled();
+                expect(docBase.appendAuthHeader).toHaveBeenCalled();
+                expect(docBase.preloader.showPreload).toHaveBeenCalledWith('url-without-token', containerEl, {
+                    headers: mockHeaders,
+                });
+            });
+
+            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
+                jest.spyOn(docBase, 'appendAuthHeader');
+                jest.spyOn(docBase.preloader, 'showPreload').mockImplementation();
+
+                docBase.showPreload();
+
+                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalled();
+                expect(docBase.appendAuthHeader).not.toHaveBeenCalled();
+                expect(docBase.preloader.showPreload).toHaveBeenCalledWith('url-with-token', containerEl, {});
+            });
+
+            test('should use createContentUrlV2 for paged preload when migrateAccessTokenToHeader flag is on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
+                    if (url.includes(PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER)) {
+                        return 'paged-url-without-token';
+                    }
+                    return 'preload-url-without-token';
+                });
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+                jest.spyOn(docBase.preloader, 'showPreload').mockImplementation();
+                docBase.docFirstPagesEnabled = true;
+
+                docBase.showPreload();
+
+                expect(docBase.createContentUrlV2).toHaveBeenCalled();
+                expect(docBase.preloader.showPreload).toHaveBeenCalledWith(
+                    null,
+                    containerEl,
+                    'paged-url-without-token',
+                    4,
+                    docBase,
+                    { headers: mockHeaders },
                 );
             });
         });
@@ -989,6 +1127,24 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect(docBase.setup).not.toHaveBeenCalled();
                     expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
                     expect(docBase.handleAssetAndRepLoad).toHaveBeenCalled();
+                });
+            });
+
+            test('should use createContentUrlV2 when migrateAccessTokenToHeader flag is on', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
+
+                return docBase.load().then(() => {
+                    expect(docBase.createContentUrlV2).toHaveBeenCalledWith('foo');
+                    expect(docBase.pdfUrl).toBe('url-without-token');
+                });
+            });
+
+            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+
+                return docBase.load().then(() => {
+                    expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
                 });
             });
         });
@@ -1993,6 +2149,36 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     },
                 );
             });
+
+            test('should pass httpHeaders when migrateAccessTokenToHeader flag is on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+                const doc = {
+                    numPages: 1,
+                };
+                stubs.getDocument.mockReturnValue({ promise: Promise.resolve(doc) });
+
+                return docBase.initViewer('url').then(() => {
+                    expect(stubs.getDocument).toHaveBeenCalledWith(
+                        expect.objectContaining({ httpHeaders: mockHeaders }),
+                    );
+                });
+            });
+
+            test('should not pass httpHeaders when migrateAccessTokenToHeader flag is off', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                const doc = {
+                    numPages: 1,
+                };
+                stubs.getDocument.mockReturnValue({ promise: Promise.resolve(doc) });
+
+                return docBase.initViewer('url').then(() => {
+                    expect(stubs.getDocument).toHaveBeenCalledWith(
+                        expect.not.objectContaining({ httpHeaders: expect.anything() }),
+                    );
+                });
+            });
         });
 
         describe('resize()', () => {
@@ -2288,6 +2474,26 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test('should get and set the blob', () => {
                 return docBase.fetchPrintBlob('url').then(() => {
+                    expect(docBase.printBlob).toBe('blob');
+                });
+            });
+
+            test('should pass auth headers when migrateAccessTokenToHeader flag is on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+
+                return docBase.fetchPrintBlob('url').then(() => {
+                    expect(stubs.get).toHaveBeenCalledWith('url', { type: 'blob', headers: mockHeaders });
+                    expect(docBase.printBlob).toBe('blob');
+                });
+            });
+
+            test('should not pass auth headers when migrateAccessTokenToHeader flag is off', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+
+                return docBase.fetchPrintBlob('url').then(() => {
+                    expect(stubs.get).toHaveBeenCalledWith('url', { type: 'blob' });
                     expect(docBase.printBlob).toBe('blob');
                 });
             });
@@ -3922,7 +4128,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test('should clear sharedLink and sharedLinkPassword options and reset them after prefetching', () => {
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl);
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl, {});
                 expect(docBase.options.sharedLink).toBe('original-shared-link');
                 expect(docBase.options.sharedLinkPassword).toBe('original-password');
             });
@@ -3952,12 +4158,13 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     jpegUrl,
                     1, // default fallback page count when webp metadata is not available
                     '',
+                    {},
                 );
             });
 
             test('should only prefetch webp representations when webp is ready', () => {
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl);
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl, {});
             });
 
             test('should handle webp representation without metadata pages', () => {
@@ -3969,6 +4176,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '',
                     8,
                     expect.any(String),
+                    {},
                 );
             });
 
@@ -3982,6 +4190,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '', // jpegUrlAuthTemplate should be false when webp is available
                     8, // default page count when pages is not specified
                     expect.any(String),
+                    {},
                 );
             });
 
@@ -3993,13 +4202,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '', // jpegUrlAuthTemplate should be false when webp is available
                     5,
                     webpUrl,
+                    {},
                 );
             });
 
             test('should handle webp representation without content', () => {
                 webpRep.content = null;
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, jpegUrl, 1, '');
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, jpegUrl, 1, '', {});
             });
 
             test('should call Promise.all with the returned promises', () => {
@@ -4043,6 +4253,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
+                    {},
                 );
 
                 // Wait for promises to resolve
@@ -4128,6 +4339,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
+                    {},
                 );
                 expect(getPreloadImageRequestPromisesByBatchSpy).toHaveBeenCalledTimes(1);
 
@@ -4168,6 +4380,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
+                    {},
                 );
 
                 // Wait for promises to resolve
@@ -4266,6 +4479,45 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 jest.useRealTimers();
                 getPreloadImageRequestPromisesByBatchSpy.mockRestore();
+            });
+
+            test('should use createContentUrlV2 and pass headers when migrateAccessTokenToHeader flag is on', () => {
+                const mockHeaders = { Authorization: 'Bearer token123' };
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
+                    if (url.includes('page_number')) {
+                        return 'webp-url-without-token';
+                    }
+                    return 'jpeg-url-without-token';
+                });
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
+
+                docBase.prefetchPreloaderImages(mockFile);
+
+                expect(docBase.createContentUrlV2).toHaveBeenCalled();
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                    docBase.api,
+                    '',
+                    5,
+                    'webp-url-without-token',
+                    { headers: mockHeaders },
+                );
+            });
+
+            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
+
+                docBase.prefetchPreloaderImages(mockFile);
+
+                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalled();
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                    docBase.api,
+                    '',
+                    5,
+                    'url-with-token',
+                    {},
+                );
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocFirstPreloader-test.js
@@ -259,6 +259,7 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
                 'mock-url',
                 4,
                 'mock-paged-image-url',
+                {},
             );
             expect(Object.keys(preloader.preloadedImages).length).toBe(4);
             expect(preloader.preloadedImages[1]).toBe('mock-object-url1');
@@ -271,6 +272,40 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
             expect(preloader.loadTime).toBeDefined();
             expect(preloader.hidePreviewMask).toHaveBeenCalled();
             expect(preloader.showPreviewMask).not.toHaveBeenCalled();
+        });
+
+        it('should pass options through showPreload to loadBatchAsBlobs', async () => {
+            const mockBlob = new Blob(['mock-content'], { type: 'image/webp' });
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            jest.spyOn(util, 'getPreloadImageRequestPromises').mockReturnValue([Promise.resolve(mockBlob)]);
+            jest.spyOn(preloader, 'isStaggeredLoadingEnabled').mockReturnValue(false);
+            mockDocBaseViewer.shouldThumbnailsBeToggled = jest.fn().mockReturnValue(false);
+
+            await preloader.showPreload('mock-url', mockContainer, 'mock-paged-url', 1, mockDocBaseViewer, options);
+
+            expect(preloader.fetchOptions).toEqual(options);
+            expect(util.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                mockApi,
+                'mock-url',
+                1,
+                'mock-paged-url',
+                options,
+            );
+        });
+
+        it('should pass options through showPreloadSingleImage to api.get', async () => {
+            const mockBlob = new Blob(['mock-content'], { type: 'image/jpeg' });
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            jest.spyOn(mockApi, 'get').mockResolvedValue(mockBlob);
+            jest.spyOn(preloader, 'isStaggeredLoadingEnabled').mockReturnValue(false);
+            jest.spyOn(preloader, 'renderFirstPage').mockResolvedValue(true);
+            preloader.config = { showPreloadForNonPaged: true };
+
+            await preloader.showPreload('mock-url', mockContainer, null, 1, mockDocBaseViewer, options);
+
+            expect(mockApi.get).toHaveBeenCalledWith('mock-url', { type: 'blob', headers: mockHeaders });
         });
 
         it('should emit firstRender event after first image is added to container', async () => {
@@ -1718,19 +1753,32 @@ describe('/lib/viewers/doc/DocFirstPreloader', () => {
                 'preload-url',
                 5,
                 'paged-url',
+                {},
             );
         });
 
         it('should use getPreloadImageRequestPromisesByBatch when preloadUrl is null', async () => {
             await preloader.loadBatchAsBlobs(null, 'paged-url', 5, 1);
 
-            expect(util.getPreloadImageRequestPromisesByBatch).toHaveBeenCalledWith(preloader.api, 'paged-url', 1, 5);
+            expect(util.getPreloadImageRequestPromisesByBatch).toHaveBeenCalledWith(
+                preloader.api,
+                'paged-url',
+                1,
+                5,
+                {},
+            );
         });
 
         it('should use getPreloadImageRequestPromisesByBatch when startPage is not 1', async () => {
             await preloader.loadBatchAsBlobs('preload-url', 'paged-url', 10, 6);
 
-            expect(util.getPreloadImageRequestPromisesByBatch).toHaveBeenCalledWith(preloader.api, 'paged-url', 6, 10);
+            expect(util.getPreloadImageRequestPromisesByBatch).toHaveBeenCalledWith(
+                preloader.api,
+                'paged-url',
+                6,
+                10,
+                {},
+            );
         });
 
         it('should return array of blobs', async () => {

--- a/src/lib/viewers/doc/__tests__/DocPreloader-test.js
+++ b/src/lib/viewers/doc/__tests__/DocPreloader-test.js
@@ -64,6 +64,17 @@ describe('lib/viewers/doc/DocPreloader', () => {
                 expect(docPreloader.bindDOMListeners).toBeCalled();
             });
         });
+
+        test('should spread options parameter into api.get call', () => {
+            const mockHeaders = { Authorization: 'Bearer token123' };
+            const options = { headers: mockHeaders };
+            jest.spyOn(stubs.api, 'get').mockResolvedValue({});
+            jest.spyOn(docPreloader, 'bindDOMListeners').mockImplementation();
+
+            return docPreloader.showPreload('someUrl', containerEl, options).then(() => {
+                expect(stubs.api.get).toHaveBeenCalledWith('someUrl', { type: 'blob', headers: mockHeaders });
+            });
+        });
     });
 
     describe('scaleAndShowPreload()', () => {


### PR DESCRIPTION
Replaces #1620

## Summary
- Migrates document viewers (PDF, DOCX, PPTX) from passing access_token as URL query param to using Authorization: Bearer header
- All 7 call sites in DocBaseViewer migrated (prefetch, showPreload, load) plus fetchPrintBlob and pdf.js httpHeaders
- Headers threaded through DocPreloader and DocFirstPreloader via options parameter
- Utility functions (getPreloadImageRequestPromises, fetchPageImage, getPreloadImageRequestPromisesByBatch) updated to accept optional headers
- All changes gated behind migrateAccessTokenToHeader feature flag — no behavior change when flag is off

## Test plan
- [x] yarn test — all 3029 tests pass
- [x] Verify PDF files load correctly with flag ON
- [x] Verify DOCX/PPTX files load correctly with flag ON
- [ ] Verify document files work with flag OFF (no regression)

--JG-Claude-🔶