### PR TITLE
feat(zoom): add trackpad pinch-to-zoom support

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -159,6 +159,7 @@ class DocBaseViewer extends BaseViewer {
         this.pinchToZoomChangeHandler = this.pinchToZoomChangeHandler.bind(this);
         this.pinchToZoomEndHandler = this.pinchToZoomEndHandler.bind(this);
         this.pinchToZoomStartHandler = this.pinchToZoomStartHandler.bind(this);
+        this.wheelZoomHandler = this.wheelZoomHandler.bind(this); // Trackpad pinch-to-zoom support
         this.print = this.print.bind(this);
         this.setPage = this.setPage.bind(this);
         this.throttledScrollHandler = this.getScrollHandler().bind(this);
@@ -1367,6 +1368,7 @@ class DocBaseViewer extends BaseViewer {
     bindDOMListeners() {
         this.docEl.addEventListener('keydown', this.handleDocElKeydown);
         this.docEl.addEventListener('scroll', this.throttledScrollHandler);
+        this.docEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false }); // Trackpad pinch-to-zoom
 
         if (this.hasTouch) {
             this.docEl.addEventListener('touchstart', this.pinchToZoomStartHandler);
@@ -1385,6 +1387,7 @@ class DocBaseViewer extends BaseViewer {
         if (this.docEl) {
             this.docEl.removeEventListener('keydown', this.handleDocElKeydown);
             this.docEl.removeEventListener('scroll', this.throttledScrollHandler);
+            this.docEl.removeEventListener('wheel', this.wheelZoomHandler);
 
             if (this.hasTouch) {
                 this.docEl.removeEventListener('touchstart', this.pinchToZoomStartHandler);
@@ -1621,6 +1624,30 @@ class DocBaseViewer extends BaseViewer {
                 this.isMobile ? 500 : 250,
             );
         }, SCROLL_EVENT_THROTTLE_INTERVAL);
+    }
+
+    /**
+     * Handles trackpad pinch-to-zoom via wheel events with ctrlKey.
+     * On Mac trackpads, pinch gestures fire wheel events with ctrlKey set to true.
+     *
+     * @protected
+     * @param {WheelEvent} event - wheel event object
+     * @return {void}
+     */
+    wheelZoomHandler(event) {
+        if (!event.ctrlKey) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const { currentScale } = this.pdfViewer;
+        const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
+        const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, currentScale * (1 + delta)));
+
+        if (newScale !== currentScale) {
+            this.updateScale(parseFloat(newScale.toFixed(MAX_PINCH_SCALE_VALUE)));
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2449,6 +2449,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 expect(stubs.addEventListener).toBeCalledWith('keydown', docBase.handleDocElKeydown);
                 expect(stubs.addEventListener).toBeCalledWith('scroll', docBase.throttledScrollHandler);
+                expect(stubs.addEventListener).toBeCalledWith('wheel', docBase.wheelZoomHandler, { passive: false });
                 expect(stubs.addEventListener).not.toBeCalledWith('touchstart', docBase.pinchToZoomStartHandler);
                 expect(stubs.addEventListener).not.toBeCalledWith('touchmove', docBase.pinchToZoomChangeHandler);
                 expect(stubs.addEventListener).not.toBeCalledWith('touchend', docBase.pinchToZoomEndHandler);
@@ -2475,6 +2476,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 expect(stubs.removeEventListener).toBeCalledWith('keydown', docBase.handleDocElKeydown);
                 expect(stubs.removeEventListener).toBeCalledWith('scroll', docBase.throttledScrollHandler);
+                expect(stubs.removeEventListener).toBeCalledWith('wheel', docBase.wheelZoomHandler);
             });
 
             test('should not remove the doc element listeners if the doc element does not exist', () => {
@@ -2858,6 +2860,62 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 jest.advanceTimersByTime(SCROLL_END_TIMEOUT + 1);
                 expect(stubs.emit).toBeCalledWith('scrollend', { scrollLeft: 0, scrollTop: 0 });
+            });
+        });
+
+        describe('wheelZoomHandler()', () => {
+            test('should do nothing if ctrlKey is not pressed', () => {
+                jest.spyOn(docBase, 'updateScale').mockImplementation();
+                const event = { ctrlKey: false, deltaY: -1, preventDefault: jest.fn() };
+
+                docBase.wheelZoomHandler(event);
+                expect(event.preventDefault).not.toBeCalled();
+                expect(docBase.updateScale).not.toBeCalled();
+            });
+
+            test('should zoom in smoothly when deltaY is negative', () => {
+                docBase.pdfViewer = { currentScale: 1.0 };
+                jest.spyOn(docBase, 'updateScale').mockImplementation();
+                const event = { ctrlKey: true, deltaY: -10, preventDefault: jest.fn() };
+
+                docBase.wheelZoomHandler(event);
+                expect(event.preventDefault).toBeCalled();
+                expect(docBase.updateScale).toBeCalledWith(expect.any(Number));
+                expect(docBase.updateScale.mock.calls[0][0]).toBeGreaterThan(1.0);
+            });
+
+            test('should zoom out smoothly when deltaY is positive', () => {
+                docBase.pdfViewer = { currentScale: 1.0 };
+                jest.spyOn(docBase, 'updateScale').mockImplementation();
+                const event = { ctrlKey: true, deltaY: 10, preventDefault: jest.fn() };
+
+                docBase.wheelZoomHandler(event);
+                expect(event.preventDefault).toBeCalled();
+                expect(docBase.updateScale).toBeCalledWith(expect.any(Number));
+                expect(docBase.updateScale.mock.calls[0][0]).toBeLessThan(1.0);
+            });
+
+            test('should not exceed MAX_SCALE', () => {
+                docBase.pdfViewer = { currentScale: 10.0 };
+                jest.spyOn(docBase, 'updateScale').mockImplementation();
+                const event = { ctrlKey: true, deltaY: -100, preventDefault: jest.fn() };
+
+                docBase.wheelZoomHandler(event);
+                // Scale should be capped, so updateScale should not be called with a value above 10
+                if (docBase.updateScale.mock.calls.length > 0) {
+                    expect(docBase.updateScale.mock.calls[0][0]).toBeLessThanOrEqual(10.0);
+                }
+            });
+
+            test('should not go below MIN_SCALE', () => {
+                docBase.pdfViewer = { currentScale: 0.1 };
+                jest.spyOn(docBase, 'updateScale').mockImplementation();
+                const event = { ctrlKey: true, deltaY: 100, preventDefault: jest.fn() };
+
+                docBase.wheelZoomHandler(event);
+                if (docBase.updateScale.mock.calls.length > 0) {
+                    expect(docBase.updateScale.mock.calls[0][0]).toBeGreaterThanOrEqual(0.1);
+                }
             });
         });
 

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -9,6 +9,7 @@ import { openContentInsideIframe } from '../../util';
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
 const CSS_CLASS_PANNABLE = 'pannable';
+const MIN_PINCH_SCALE_DELTA = 0.01;
 
 class ImageBaseViewer extends BaseViewer {
     /** @inheritdoc */
@@ -31,6 +32,8 @@ class ImageBaseViewer extends BaseViewer {
         this.finishLoading = this.finishLoading.bind(this);
         this.isDiscoverabilityEnabled = this.isDiscoverabilityEnabled.bind(this);
 
+        // Trackpad pinch-to-zoom support
+        this.wheelZoomHandler = this.wheelZoomHandler.bind(this);
         if (this.isMobile) {
             if (Browser.isIOS()) {
                 this.mobileZoomStartHandler = this.mobileZoomStartHandler.bind(this);
@@ -272,6 +275,8 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.addEventListener('mousedown', this.handleMouseDown);
         this.imageEl.addEventListener('mouseup', this.handleMouseUp);
         this.imageEl.addEventListener('dragstart', this.cancelDragEvent);
+        // Trackpad pinch-to-zoom
+        this.imageEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false });
 
         if (this.isMobile) {
             if (Browser.isIOS()) {
@@ -302,12 +307,54 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.removeEventListener('mousedown', this.handleMouseDown);
         this.imageEl.removeEventListener('mouseup', this.handleMouseUp);
         this.imageEl.removeEventListener('dragstart', this.cancelDragEvent);
+        this.imageEl.removeEventListener('wheel', this.wheelZoomHandler);
 
         this.imageEl.removeEventListener('gesturestart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('gestureend', this.mobileZoomEndHandler);
         this.imageEl.removeEventListener('touchstart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('touchmove', this.mobileZoomChangeHandler);
         this.imageEl.removeEventListener('touchend', this.mobileZoomEndHandler);
+    }
+
+    /**
+     * Handles trackpad pinch-to-zoom via wheel events with ctrlKey.
+     * On Mac trackpads, pinch gestures fire wheel events with ctrlKey set to true.
+     *
+     * @protected
+     * @param {WheelEvent} event - wheel event object
+     * @return {void}
+     */
+    wheelZoomHandler(event) {
+        if (!event.ctrlKey) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
+        const currentWidth = this.imageEl.offsetWidth;
+        const newWidth = currentWidth * (1 + delta);
+
+        this.imageEl.style.width = `${newWidth}px`;
+        this.imageEl.style.height = '';
+
+        if (typeof this.adjustImageZoomPadding === 'function') {
+            this.adjustImageZoomPadding();
+        }
+
+        if (typeof this.setScale === 'function') {
+            this.setScale(newWidth);
+        }
+
+        if (typeof this.updatePannability === 'function') {
+            setTimeout(this.updatePannability, 50);
+        }
+
+        this.emit('zoom', {
+            newScale: newWidth,
+            canZoomIn: true,
+            canZoomOut: true,
+        });
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -448,6 +448,9 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             jest.spyOn(document, 'addEventListener');
             stubs.listeners = imageBase.imageEl.addEventListener;
             imageBase.isMobile = true;
+            imageBase.mobileZoomStartHandler = imageBase.mobileZoomStartHandler.bind(imageBase);
+            imageBase.mobileZoomChangeHandler = imageBase.mobileZoomChangeHandler.bind(imageBase);
+            imageBase.mobileZoomEndHandler = imageBase.mobileZoomEndHandler.bind(imageBase);
         });
 
         test('should bind all default image listeners', () => {
@@ -457,19 +460,32 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('dragstart', imageBase.cancelDragEvent);
         });
 
-        test('should bind all iOS listeners', () => {
+        test('should bind wheel listener for trackpad zoom', () => {
+            imageBase.bindDOMListeners();
+            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler, { passive: false });
+        });
+
+        test('should bind all iOS listeners when hasTouch is true', () => {
             jest.spyOn(Browser, 'isIOS').mockReturnValue(true);
             imageBase.bindDOMListeners();
             expect(stubs.listeners).toBeCalledWith('gesturestart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('gestureend', imageBase.mobileZoomEndHandler);
         });
 
-        test('should bind all mobile and non-iOS listeners', () => {
+        test('should bind all touch listeners when hasTouch is true and not iOS', () => {
             jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
             imageBase.bindDOMListeners();
             expect(stubs.listeners).toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('touchmove', imageBase.mobileZoomChangeHandler);
             expect(stubs.listeners).toBeCalledWith('touchend', imageBase.mobileZoomEndHandler);
+        });
+
+        test('should not bind touch listeners when hasTouch is false', () => {
+            imageBase.isMobile = false;
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
+            imageBase.bindDOMListeners();
+            expect(stubs.listeners).not.toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
+            expect(stubs.listeners).not.toBeCalledWith('gesturestart', imageBase.mobileZoomStartHandler);
         });
     });
 
@@ -483,7 +499,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             imageBase.imageEl.removeEventListener = jest.fn();
             stubs.listeners = imageBase.imageEl.removeEventListener;
             stubs.documentListener = jest.spyOn(document, 'removeEventListener');
-            imageBase.isMobile = true;
+            imageBase.hasTouch = true;
         });
 
         test('should unbind all default image listeners if imageEl does not exist', () => {
@@ -502,6 +518,11 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('gestureend', imageBase.mobileZoomEndHandler);
         });
 
+        test('should unbind wheel listener', () => {
+            imageBase.unbindDOMListeners();
+            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler);
+        });
+
         test('should unbind all document listeners', () => {
             imageBase.unbindDOMListeners();
             expect(stubs.documentListener).toBeCalledWith('mousemove', imageBase.pan);
@@ -514,6 +535,59 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('touchmove', imageBase.mobileZoomChangeHandler);
             expect(stubs.listeners).toBeCalledWith('touchend', imageBase.mobileZoomEndHandler);
+        });
+    });
+
+    describe('wheelZoomHandler()', () => {
+        beforeEach(() => {
+            // Set up imageEl with a measurable width
+            imageBase.imageEl.style.width = '100px';
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 100, configurable: true });
+            jest.spyOn(imageBase, 'emit').mockImplementation();
+        });
+
+        test('should do nothing if ctrlKey is not pressed', () => {
+            imageBase.wheelZoomHandler({ ctrlKey: false, deltaY: -5, preventDefault: jest.fn() });
+            expect(imageBase.emit).not.toBeCalled();
+        });
+
+        test('should preventDefault and apply proportional zoom on pinch in', () => {
+            const event = { ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).toBeCalled();
+            // deltaY=-5, delta=0.05, newWidth = 100 * 1.05 = 105
+            expect(imageBase.imageEl.style.width).toBe('105px');
+            expect(imageBase.imageEl.style.height).toBe('');
+        });
+
+        test('should apply proportional zoom on pinch out', () => {
+            const event = { ctrlKey: true, deltaY: 5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            // deltaY=5, delta=-0.05, newWidth = 100 * 0.95 = 95
+            expect(imageBase.imageEl.style.width).toBe('95px');
+        });
+
+        test('should call adjustImageZoomPadding if available', () => {
+            imageBase.adjustImageZoomPadding = jest.fn();
+            imageBase.wheelZoomHandler({ ctrlKey: true, deltaY: -5, preventDefault: jest.fn() });
+            expect(imageBase.adjustImageZoomPadding).toBeCalled();
+        });
+
+        test('should call setScale if available', () => {
+            imageBase.setScale = jest.fn();
+            imageBase.wheelZoomHandler({ ctrlKey: true, deltaY: -5, preventDefault: jest.fn() });
+            expect(imageBase.setScale).toBeCalledWith(105);
+        });
+
+        test('should emit zoom event', () => {
+            imageBase.wheelZoomHandler({ ctrlKey: true, deltaY: -5, preventDefault: jest.fn() });
+            expect(imageBase.emit).toBeCalledWith('zoom', {
+                newScale: 105,
+                canZoomIn: true,
+                canZoomOut: true,
+            });
         });
     });
 

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import BaseViewer from '../BaseViewer';
+import Browser from '../../Browser';
 import ControlsRoot from '../controls';
 import TextControls from './TextControls';
 import { CLASS_IS_PRINTABLE, CLASS_IS_SELECTABLE, PERMISSION_DOWNLOAD } from '../../constants';
@@ -9,6 +10,7 @@ const ZOOM_DEFAULT = 1.0;
 const ZOOM_MAX = 10;
 const ZOOM_MIN = 0.1;
 const ZOOM_STEP = 0.1;
+const MIN_PINCH_SCALE_DELTA = 0.01;
 
 class TextBaseViewer extends BaseViewer {
     /**
@@ -23,6 +25,7 @@ class TextBaseViewer extends BaseViewer {
         // Bind context for handlers;
         this.zoomOut = this.zoomOut.bind(this);
         this.zoomIn = this.zoomIn.bind(this);
+        this.wheelZoomHandler = this.wheelZoomHandler.bind(this); // Trackpad pinch-to-zoom support
     }
 
     /**
@@ -42,6 +45,8 @@ class TextBaseViewer extends BaseViewer {
      * @return {void}
      */
     destroy() {
+        this.unbindDOMListeners();
+
         // Destroy the controls
         if (this.controls && typeof this.controls.destroy === 'function') {
             this.controls.destroy();
@@ -113,7 +118,77 @@ class TextBaseViewer extends BaseViewer {
             this.containerEl.classList.add(CLASS_IS_SELECTABLE);
         }
 
+        this.bindDOMListeners();
         super.load();
+    }
+
+    /**
+     * Binds DOM listeners for text viewer pinch-to-zoom.
+     *
+     * @protected
+     * @return {void}
+     */
+    bindDOMListeners() {
+        this.containerEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false }); // Trackpad pinch-to-zoom
+
+        if (this.hasTouch) {
+            if (Browser.isIOS()) {
+                this.containerEl.addEventListener('gesturestart', this.mobileZoomStartHandler);
+                this.containerEl.addEventListener('gestureend', this.mobileZoomEndHandler);
+            } else {
+                this.containerEl.addEventListener('touchstart', this.mobileZoomStartHandler);
+                this.containerEl.addEventListener('touchmove', this.mobileZoomChangeHandler);
+                this.containerEl.addEventListener('touchend', this.mobileZoomEndHandler);
+            }
+        }
+    }
+
+    /**
+     * Unbinds DOM listeners for text viewer pinch-to-zoom.
+     *
+     * @protected
+     * @return {void}
+     */
+    unbindDOMListeners() {
+        if (this.containerEl) {
+            this.containerEl.removeEventListener('wheel', this.wheelZoomHandler);
+            this.containerEl.removeEventListener('gesturestart', this.mobileZoomStartHandler);
+            this.containerEl.removeEventListener('gestureend', this.mobileZoomEndHandler);
+            this.containerEl.removeEventListener('touchstart', this.mobileZoomStartHandler);
+            this.containerEl.removeEventListener('touchmove', this.mobileZoomChangeHandler);
+            this.containerEl.removeEventListener('touchend', this.mobileZoomEndHandler);
+        }
+    }
+
+    /**
+     * Handles trackpad pinch-to-zoom via wheel events with ctrlKey.
+     * On Mac trackpads, pinch gestures fire wheel events with ctrlKey set to true.
+     *
+     * @protected
+     * @param {WheelEvent} event - wheel event object
+     * @return {void}
+     */
+    wheelZoomHandler(event) {
+        if (!event.ctrlKey) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
+        let newScale = this.scale * (1 + delta);
+        newScale = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, newScale));
+
+        this.containerEl.querySelector('.bp-text').style.fontSize = `${Math.round(newScale * 100)}%`;
+
+        this.emit('zoom', {
+            canZoomIn: true,
+            canZoomOut: true,
+            zoom: newScale,
+        });
+
+        this.scale = newScale;
+        this.renderUI();
     }
 
     /**

--- a/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
+++ b/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Browser from '../../../Browser';
 import * as file from '../../../file';
 import BaseViewer from '../../BaseViewer';
 import ControlsRoot from '../../controls/controls-root';
@@ -46,6 +47,13 @@ describe('lib/viewers/text/TextBaseViewer', () => {
 
             textBase.destroy();
             expect(textBase.controls.destroy).toBeCalled();
+        });
+
+        test('should call unbindDOMListeners', () => {
+            jest.spyOn(textBase, 'unbindDOMListeners');
+
+            textBase.destroy();
+            expect(textBase.unbindDOMListeners).toBeCalled();
         });
     });
 
@@ -95,6 +103,135 @@ describe('lib/viewers/text/TextBaseViewer', () => {
 
             textBase.zoomOut();
             expect(textBase.zoom).toBeCalledWith('out');
+        });
+    });
+
+    describe('bindDOMListeners()', () => {
+        test('should always add wheel listener for trackpad pinch-to-zoom', () => {
+            textBase.hasTouch = false;
+            jest.spyOn(textBase.containerEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textBase.containerEl.addEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler, {
+                passive: false,
+            });
+        });
+
+        test('should add touch listeners if hasTouch is true and not iOS', () => {
+            textBase.hasTouch = true;
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
+            jest.spyOn(textBase.containerEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textBase.containerEl.addEventListener).toBeCalledWith('touchstart', textBase.mobileZoomStartHandler);
+            expect(textBase.containerEl.addEventListener).toBeCalledWith('touchmove', textBase.mobileZoomChangeHandler);
+            expect(textBase.containerEl.addEventListener).toBeCalledWith('touchend', textBase.mobileZoomEndHandler);
+        });
+
+        test('should add gesture listeners if hasTouch is true and iOS', () => {
+            textBase.hasTouch = true;
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(true);
+            jest.spyOn(textBase.containerEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textBase.containerEl.addEventListener).toBeCalledWith(
+                'gesturestart',
+                textBase.mobileZoomStartHandler,
+            );
+            expect(textBase.containerEl.addEventListener).toBeCalledWith('gestureend', textBase.mobileZoomEndHandler);
+        });
+
+        test('should not add touch listeners if hasTouch is false', () => {
+            textBase.hasTouch = false;
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
+            jest.spyOn(textBase.containerEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textBase.containerEl.addEventListener).not.toBeCalledWith(
+                'touchstart',
+                textBase.mobileZoomStartHandler,
+            );
+            expect(textBase.containerEl.addEventListener).not.toBeCalledWith(
+                'gesturestart',
+                textBase.mobileZoomStartHandler,
+            );
+        });
+    });
+
+    describe('unbindDOMListeners()', () => {
+        test('should remove all listeners', () => {
+            jest.spyOn(textBase.containerEl, 'removeEventListener');
+
+            textBase.unbindDOMListeners();
+
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler);
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith(
+                'gesturestart',
+                textBase.mobileZoomStartHandler,
+            );
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith(
+                'gestureend',
+                textBase.mobileZoomEndHandler,
+            );
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith(
+                'touchstart',
+                textBase.mobileZoomStartHandler,
+            );
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith(
+                'touchmove',
+                textBase.mobileZoomChangeHandler,
+            );
+            expect(textBase.containerEl.removeEventListener).toBeCalledWith('touchend', textBase.mobileZoomEndHandler);
+        });
+    });
+
+    describe('wheelZoomHandler()', () => {
+        let textEl;
+
+        beforeEach(() => {
+            textEl = document.createElement('div');
+            textEl.className = 'bp-text';
+            textBase.containerEl.appendChild(textEl);
+            textBase.renderUI = jest.fn();
+        });
+
+        afterEach(() => {
+            textBase.containerEl.removeChild(textEl);
+        });
+
+        test('should do nothing if ctrlKey is not pressed', () => {
+            jest.spyOn(textBase, 'emit');
+            const event = { ctrlKey: false, deltaY: -1, preventDefault: jest.fn() };
+
+            textBase.wheelZoomHandler(event);
+            expect(event.preventDefault).not.toBeCalled();
+            expect(textBase.emit).not.toBeCalled();
+        });
+
+        test('should zoom in smoothly when deltaY is negative', () => {
+            textBase.scale = 1.0;
+            jest.spyOn(textBase, 'emit');
+            const event = { ctrlKey: true, deltaY: -10, preventDefault: jest.fn() };
+
+            textBase.wheelZoomHandler(event);
+            expect(event.preventDefault).toBeCalled();
+            expect(textBase.scale).toBeGreaterThan(1.0);
+            expect(textBase.renderUI).toBeCalled();
+        });
+
+        test('should zoom out smoothly when deltaY is positive', () => {
+            textBase.scale = 1.0;
+            jest.spyOn(textBase, 'emit');
+            const event = { ctrlKey: true, deltaY: 10, preventDefault: jest.fn() };
+
+            textBase.wheelZoomHandler(event);
+            expect(event.preventDefault).toBeCalled();
+            expect(textBase.scale).toBeLessThan(1.0);
+            expect(textBase.renderUI).toBeCalled();
         });
     });
 


### PR DESCRIPTION
On Mac trackpads, pinch gestures emit wheel events with ctrlKey set to true. This change adds a wheelZoomHandler to DocBaseViewer, ImageBaseViewer, and TextBaseViewer that intercepts these events to provide smooth, proportional zoom behavior without triggering native browser zoom.

Summary of changes:
- DocBaseViewer: Added wheelZoomHandler that adjusts pdfViewer scale proportionally, clamped between MIN_SCALE and MAX_SCALE
- ImageBaseViewer: Added wheelZoomHandler that adjusts image element width proportionally and emits zoom events
- TextBaseViewer: Added wheelZoomHandler that adjusts font size proportionally, plus new bindDOMListeners/unbindDOMListeners lifecycle methods and proper cleanup in destroy()
- All viewers register the wheel listener with { passive: false } to allow preventDefault() and block native browser zoom
- Added comprehensive unit tests for all three viewers