### PR TITLE
feat(media): enable video previews for mxf filetypes

### DIFF
--- a/src/lib/viewers/media/MediaLoader.js
+++ b/src/lib/viewers/media/MediaLoader.js
@@ -22,6 +22,7 @@ const VIDEO_FORMATS = [
     'mpeg',
     'mpg',
     'mts',
+    'mxf',
     'ogg',
     'qt',
     'ts',


### PR DESCRIPTION
Enable mxf video preview.

mxf hdvideo/video conversion is enabled in dev/stg and restricted in prod.

<img width="1049" height="887" alt="image" src="https://github.com/user-attachments/assets/6a305e93-4b4f-4c72-b510-bda2f3ec9de8" />

