### PR TITLE
feat(doc): add PDF rotation support

### DIFF
--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -65,7 +65,8 @@ class Thumbnail {
         }
 
         return pdfDocument.getPage(1).then(page => {
-            const viewport = page.getViewport({ scale: 1 });
+            const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
+            const viewport = page.getViewport({ scale: 1, rotation });
             if (!viewport) {
                 return Promise.resolve(null);
             }
@@ -82,7 +83,7 @@ class Thumbnail {
             this.scale = THUMBNAIL_TOTAL_WIDTH / width;
             // Width : Height ratio of the page
             this.pageRatio = width / height;
-            const scaledViewport = page.getViewport({ scale: this.scale });
+            const scaledViewport = page.getViewport({ scale: this.scale, rotation });
             this.thumbnailHeight = Math.ceil(scaledViewport.height);
             return Promise.resolve(this.thumbnailHeight);
         });
@@ -180,7 +181,8 @@ class Thumbnail {
         return pdfDocument
             .getPage(pageNum)
             .then(page => {
-                const viewport = page.getViewport({ scale: 1 });
+                const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
+                const viewport = page.getViewport({ scale: 1, rotation });
                 if (!viewport || !isFinite(viewport.width) || !isFinite(viewport.height)) {
                     return Promise.reject(new Error('Invalid page viewport'));
                 }
@@ -209,7 +211,7 @@ class Thumbnail {
                 const scale = canvasWidth / width;
                 return page.render({
                     canvasContext: canvas.getContext('2d'),
-                    viewport: page.getViewport({ scale }),
+                    viewport: page.getViewport({ scale, rotation }),
                 }).promise;
             })
             .then(() => canvas.toDataURL());

--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -1,3 +1,4 @@
+import BoundedCache from './BoundedCache';
 import VirtualScroller from './VirtualScroller';
 import { decodeKeydown } from './util';
 import Thumbnail from './Thumbnail';
@@ -402,6 +403,41 @@ class ThumbnailsSidebar {
      */
     toggleClose() {
         this.isOpen = false;
+    }
+
+    refresh() {
+        if (!this.virtualScroller) {
+            return;
+        }
+
+        this.virtualScroller.destroy();
+        this.virtualScroller = new VirtualScroller(this.anchorEl);
+        this.currentThumbnails = [];
+
+        this.thumbnail.thumbnailImageCache.destroy();
+        this.thumbnail.thumbnailImageCache = new BoundedCache();
+
+        // Skip preloader path since preloader dimensions are unrotated
+        const savedPreloader = this.thumbnail.preloader;
+        this.thumbnail.preloader = null;
+
+        this.thumbnail.init().then(thumbnailHeight => {
+            this.thumbnail.preloader = savedPreloader;
+
+            if (thumbnailHeight) {
+                const count = this.pdfViewer?.pagesCount || this.preloader?.numPages;
+                this.virtualScroller.init({
+                    initialRowIndex: this.currentPage - 1,
+                    totalItems: count,
+                    itemHeight: thumbnailHeight,
+                    containerHeight: this.getContainerHeight(),
+                    margin: THUMBNAIL_MARGIN,
+                    renderItemFn: this.createPlaceholderThumbnail,
+                    onScrollEnd: this.generateThumbnailImages,
+                    onInit: this.generateThumbnailImages,
+                });
+            }
+        });
     }
 
     /**

--- a/src/lib/__tests__/Thumbnail-test.js
+++ b/src/lib/__tests__/Thumbnail-test.js
@@ -18,6 +18,7 @@ describe('Thumbnail', () => {
         page = {
             getViewport: stubs.getViewport,
             render: stubs.render,
+            rotate: 0,
         };
         pagePromise = Promise.resolve(page);
         stubs.getPage = jest.fn(() => pagePromise);
@@ -204,7 +205,7 @@ describe('Thumbnail', () => {
 
             return thumbnail.getThumbnailDataURL(1).then(() => {
                 expect(stubs.getPage).toBeCalled();
-                expect(stubs.getViewport).toBeCalledWith({ scale: expScale });
+                expect(stubs.getViewport).toBeCalledWith({ scale: expScale, rotation: 0 });
             });
         });
 
@@ -220,7 +221,7 @@ describe('Thumbnail', () => {
 
             return thumbnail.getThumbnailDataURL(0).then(() => {
                 expect(stubs.getPage).toBeCalled();
-                expect(stubs.getViewport).toBeCalledWith({ scale: expScale });
+                expect(stubs.getViewport).toBeCalledWith({ scale: expScale, rotation: 0 });
             });
         });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1396,8 +1396,7 @@ class DocBaseViewer extends BaseViewer {
         const canAnnotate = this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission();
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
-        // TODO: Replace with feature flag once wired through EUA → BUIE → BCP
-        const canRotate = true;
+        const canRotate = this.featureEnabled('rotate.enabled');
 
         this.controls.render(
             <DocControls

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -844,8 +844,10 @@ class DocBaseViewer extends BaseViewer {
      * @return {void}
      */
     rotateLeft() {
+        const currentPage = this.pdfViewer.currentPageNumber;
         this.rotationAngle = (((this.rotationAngle - 90) % 360) + 360) % 360;
         this.pdfViewer.pagesRotation = this.rotationAngle;
+        this.pdfViewer.currentPageNumber = currentPage;
 
         this.emit('rotate');
 
@@ -853,6 +855,10 @@ class DocBaseViewer extends BaseViewer {
             this.enableAnnotationControls();
         } else {
             this.disableAnnotationControls();
+        }
+
+        if (this.thumbnailsSidebar) {
+            this.thumbnailsSidebar.refresh();
         }
 
         this.renderUI();

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -160,6 +160,7 @@ class DocBaseViewer extends BaseViewer {
         this.pinchToZoomEndHandler = this.pinchToZoomEndHandler.bind(this);
         this.pinchToZoomStartHandler = this.pinchToZoomStartHandler.bind(this);
         this.print = this.print.bind(this);
+        this.rotateLeft = this.rotateLeft.bind(this);
         this.setPage = this.setPage.bind(this);
         this.throttledScrollHandler = this.getScrollHandler().bind(this);
         this.toggleFindBar = this.toggleFindBar.bind(this);
@@ -838,6 +839,26 @@ class DocBaseViewer extends BaseViewer {
     }
 
     /**
+     * Rotates all pages 90 degrees counterclockwise.
+     *
+     * @return {void}
+     */
+    rotateLeft() {
+        this.rotationAngle = (((this.rotationAngle - 90) % 360) + 360) % 360;
+        this.pdfViewer.pagesRotation = this.rotationAngle;
+
+        this.emit('rotate');
+
+        if (this.rotationAngle === 0) {
+            this.enableAnnotationControls();
+        } else {
+            this.disableAnnotationControls();
+        }
+
+        this.renderUI();
+    }
+
+    /**
      * Handles keyboard events for document viewer.
      *
      * @param {string} key - keydown key
@@ -1369,6 +1390,8 @@ class DocBaseViewer extends BaseViewer {
         const canAnnotate = this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission();
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
+        // TODO: Replace with feature flag once wired through EUA → BUIE → BCP
+        const canRotate = true;
 
         this.controls.render(
             <DocControls
@@ -1388,6 +1411,7 @@ class DocBaseViewer extends BaseViewer {
                 onFullscreenToggle={this.toggleFullscreen}
                 onPageChange={this.setPage}
                 onPageSubmit={this.handlePageSubmit}
+                onRotateLeft={canRotate ? this.rotateLeft : undefined}
                 onThumbnailsToggle={enableThumbnailsSidebar ? this.toggleThumbnails : undefined}
                 onZoomIn={this.zoomIn}
                 onZoomOut={this.zoomOut}

--- a/src/lib/viewers/doc/DocControls.tsx
+++ b/src/lib/viewers/doc/DocControls.tsx
@@ -6,6 +6,7 @@ import ExperiencesProvider, { Props as ExperiencesProviderProps } from '../contr
 import FindBarToggle, { Props as FindBarToggleProps } from '../controls/findbar';
 import FullscreenToggle, { Props as FullscreenToggleProps } from '../controls/fullscreen';
 import PageControls, { Props as PageControlsProps } from '../controls/page';
+import RotateControl, { Props as RotateControlProps } from '../controls/rotate/RotateControl';
 import ThumbnailsToggle, { Props as ThumbnailsToggleProps } from '../controls/sidebar';
 import ZoomControls, { Props as ZoomControlsProps } from '../controls/zoom';
 
@@ -15,6 +16,7 @@ export type Props = AnnotationsControlsProps &
     FindBarToggleProps &
     FullscreenToggleProps &
     PageControlsProps &
+    Partial<RotateControlProps> &
     ThumbnailsToggleProps &
     ZoomControlsProps;
 
@@ -35,6 +37,7 @@ export default function DocControls({
     onFullscreenToggle,
     onPageChange,
     onPageSubmit,
+    onRotateLeft,
     onThumbnailsToggle,
     onZoomIn,
     onZoomOut,
@@ -66,6 +69,11 @@ export default function DocControls({
                         scale={scale}
                     />
                 </ControlsBarGroup>
+                {onRotateLeft && (
+                    <ControlsBarGroup>
+                        <RotateControl onRotateLeft={onRotateLeft} />
+                    </ControlsBarGroup>
+                )}
                 <ControlsBarGroup>
                     <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
                     <AnnotationsControls

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2641,6 +2641,106 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     hasRegion: true,
                 });
             });
+
+            test('should pass onRotateLeft when rotate.enabled feature flag is true', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'rotate.enabled');
+                docBase.renderUI();
+
+                expect(getProps(docBase)).toMatchObject({
+                    onRotateLeft: docBase.rotateLeft,
+                });
+            });
+
+            test('should not pass onRotateLeft when rotate.enabled feature flag is false', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                docBase.renderUI();
+
+                expect(getProps(docBase)).toMatchObject({
+                    onRotateLeft: undefined,
+                });
+            });
+        });
+
+        describe('rotateLeft()', () => {
+            beforeEach(() => {
+                jest.spyOn(docBase, 'emit').mockImplementation();
+                jest.spyOn(docBase, 'enableAnnotationControls').mockImplementation();
+                jest.spyOn(docBase, 'disableAnnotationControls').mockImplementation();
+                jest.spyOn(docBase, 'renderUI').mockImplementation();
+
+                docBase.pdfViewer = {
+                    currentPageNumber: 3,
+                    pagesRotation: 0,
+                };
+                docBase.rotationAngle = 0;
+            });
+
+            test('should rotate 90 degrees counterclockwise', () => {
+                docBase.rotateLeft();
+
+                expect(docBase.rotationAngle).toBe(270);
+                expect(docBase.pdfViewer.pagesRotation).toBe(270);
+            });
+
+            test('should cycle through all rotation states', () => {
+                docBase.rotateLeft();
+                expect(docBase.rotationAngle).toBe(270);
+
+                docBase.rotateLeft();
+                expect(docBase.rotationAngle).toBe(180);
+
+                docBase.rotateLeft();
+                expect(docBase.rotationAngle).toBe(90);
+
+                docBase.rotateLeft();
+                expect(docBase.rotationAngle).toBe(0);
+            });
+
+            test('should preserve the current page number', () => {
+                docBase.rotateLeft();
+
+                expect(docBase.pdfViewer.currentPageNumber).toBe(3);
+            });
+
+            test('should emit a rotate event', () => {
+                docBase.rotateLeft();
+
+                expect(docBase.emit).toBeCalledWith('rotate');
+            });
+
+            test('should disable annotation controls when rotated', () => {
+                docBase.rotateLeft();
+
+                expect(docBase.disableAnnotationControls).toBeCalled();
+                expect(docBase.enableAnnotationControls).not.toBeCalled();
+            });
+
+            test('should enable annotation controls when rotation returns to 0', () => {
+                docBase.rotationAngle = 90;
+                docBase.rotateLeft();
+
+                expect(docBase.enableAnnotationControls).toBeCalled();
+                expect(docBase.disableAnnotationControls).not.toBeCalled();
+            });
+
+            test('should refresh thumbnails sidebar if present', () => {
+                docBase.thumbnailsSidebar = { refresh: jest.fn(), destroy: jest.fn() };
+                docBase.rotateLeft();
+
+                expect(docBase.thumbnailsSidebar.refresh).toBeCalled();
+            });
+
+            test('should not fail if thumbnails sidebar is not present', () => {
+                docBase.thumbnailsSidebar = null;
+
+                expect(() => docBase.rotateLeft()).not.toThrow();
+            });
+
+            test('should call renderUI', () => {
+                docBase.rotateLeft();
+
+                expect(docBase.renderUI).toBeCalled();
+            });
         });
 
         describe('bindDOMListeners()', () => {


### PR DESCRIPTION
## Summary
- Adds rotate-left button to the PDF document viewer controls, using PDF.js native `pagesRotation` for correct rendering
- Thumbnails sidebar rotates in sync with pages via a new `refresh()` method
- Annotation controls are disabled while the document is rotated (matching existing image viewer behavior)
- Gated behind `rotate.enabled` feature flag — no behavior change unless explicitly enabled by the consuming application

## Test plan
- [x] Unit tests for `rotateLeft()` — angle cycling, page preservation, event emission, annotation control toggling, thumbnail refresh
- [x] Unit tests for feature flag gating — `onRotateLeft` passed/undefined based on `featureEnabled('rotate.enabled')`
- [x] Existing Thumbnail, ThumbnailsSidebar, DocBaseViewer, and Preview tests all pass
- [x] Manual testing: rotate button appears when feature flag is enabled, hidden when disabled
- [x] Manual testing: rotating cycles 0→270→180→90→0, annotations hide when rotated, thumbnails update

🤖 Generated with [Claude Code](https://claude.com/claude-code)