### PR TITLE
fix(doc): improve PDF rotation behavior for annotations

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -206,6 +206,7 @@ class DocBaseViewer extends BaseViewer {
         this.viewerEl = this.docEl.appendChild(document.createElement('div'));
         this.viewerEl.classList.add('pdfViewer');
 
+        this.rotationAngle = 0;
         this.loadTimeout = LOAD_TIMEOUT_MS;
 
         this.startPageNum = this.getStartPage(this.startAt);
@@ -862,6 +863,12 @@ class DocBaseViewer extends BaseViewer {
         }
 
         this.renderUI();
+
+        // Emit scale with rotation angle so annotations transform to match rotated content
+        this.emit('scale', {
+            scale: this.pdfViewer.currentScale,
+            rotationAngle: this.rotationAngle,
+        });
     }
 
     /**
@@ -1561,6 +1568,7 @@ class DocBaseViewer extends BaseViewer {
         this.emit('scale', {
             scale: this.pdfViewer.currentScale,
             pageNum: pageNumber,
+            rotationAngle: this.rotationAngle,
         });
 
         // Cleanup preload after a page is rendered

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1400,10 +1400,12 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const { enableThumbnailsSidebar, showAnnotationsDrawingCreate } = this.options;
-        const canAnnotate = this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission();
+        const canAnnotate =
+            this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission() && this.rotationAngle === 0;
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
-        const canRotate = this.featureEnabled('rotate.enabled');
+        const isPDF = ['pdf'].includes(this.options.file.extension);
+        const canRotate = isPDF && this.featureEnabled('rotate.enabled');
 
         this.controls.render(
             <DocControls

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2642,8 +2642,22 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should pass onRotateLeft when rotate.enabled feature flag is true', () => {
+            test('should hide annotation create controls when rotated', () => {
+                docBase.currentAnnotatorViewMode = 'annotations';
+                docBase.options.showAnnotationsDrawingCreate = true;
+                docBase.rotationAngle = 90;
+                docBase.renderUI();
+
+                expect(getProps(docBase)).toMatchObject({
+                    hasDrawing: false,
+                    hasHighlight: false,
+                    hasRegion: false,
+                });
+            });
+
+            test('should pass onRotateLeft when rotate.enabled feature flag is true and file is PDF', () => {
                 jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'rotate.enabled');
+                docBase.options.file.extension = 'pdf';
                 docBase.renderUI();
 
                 expect(getProps(docBase)).toMatchObject({
@@ -2653,6 +2667,17 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test('should not pass onRotateLeft when rotate.enabled feature flag is false', () => {
                 jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
+                docBase.options.file.extension = 'pdf';
+                docBase.renderUI();
+
+                expect(getProps(docBase)).toMatchObject({
+                    onRotateLeft: undefined,
+                });
+            });
+
+            test('should not pass onRotateLeft for non-PDF files even when rotate.enabled is true', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'rotate.enabled');
+                docBase.options.file.extension = 'ppt';
                 docBase.renderUI();
 
                 expect(getProps(docBase)).toMatchObject({

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2741,6 +2741,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 expect(docBase.renderUI).toBeCalled();
             });
+
+            test('should emit scale event with rotationAngle', () => {
+                docBase.pdfViewer.currentScale = 1.5;
+                docBase.rotateLeft();
+
+                expect(docBase.emit).toBeCalledWith('scale', {
+                    scale: 1.5,
+                    rotationAngle: 270,
+                });
+            });
         });
 
         describe('bindDOMListeners()', () => {
@@ -3001,6 +3011,28 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.emitMetric).not.toHaveBeenCalledWith({
                     data: 80,
                     name: 'preload_content_load_time_diff',
+                });
+            });
+
+            test('should include rotationAngle in scale event', () => {
+                docBase.rotationAngle = 90;
+                docBase.pagerenderedHandler(docBase.event);
+
+                expect(stubs.emit).toBeCalledWith('scale', {
+                    scale: 0.5,
+                    pageNum: 1,
+                    rotationAngle: 90,
+                });
+            });
+
+            test('should include rotationAngle of 0 in scale event when not rotated', () => {
+                docBase.rotationAngle = 0;
+                docBase.pagerenderedHandler(docBase.event);
+
+                expect(stubs.emit).toBeCalledWith('scale', {
+                    scale: 0.5,
+                    pageNum: 1,
+                    rotationAngle: 0,
                 });
             });
         });


### PR DESCRIPTION
**Summary**
This PR does 3 things:
- Restrict rotation to PDF files only - the rotate button no longer appears for Word documents, PowerPoints, and other non-PDF file types
- Hide annotation creation controls (highlight, region, drawing) when the PDF is in a rotated state, mirroring image viewer behavior
- Emit `rotationAngle` in scale events so the annotations library can transform annotation layers to match rotated page content

**Test plan**
- Verify rotate button appears for PDF files with rotate.enabled feature flag
- Verify rotate button does NOT appear for .docx, .pptx, and other non-PDF files
- Verify annotation controls (highlight, region, draw) disappear when PDF is rotated
- Verify annotation controls reappear when PDF is rotated back to 0°
- Verify existing annotations stay anchored to page content at 90°, 180°, 270° (requires companion box-annotations change)
