### PR TITLE
fix(doc): extend too-many-ops check to xlsx files

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1005,8 +1005,8 @@ class DocBaseViewer extends BaseViewer {
 
         return this.pdfLoadingTask.promise
             .then(doc => {
-                // Only check operations for .numbers files
-                if (file.extension === 'numbers') {
+                // Only check operations for .numbers and .xlsx files
+                if (file.extension === 'numbers' || file.extension === 'xlsx') {
                     return countPdfOperations(doc, MAX_OPERATION_PAGES).then(opCount => {
                         if (opCount > MAX_OPERATIONS) {
                             throw new Error(MAX_OPERATIONS_ERROR_MESSAGE);

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2126,7 +2126,59 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     });
                 });
 
-                test.each([['doc'], ['docx'], ['ppt'], ['pptx'], ['xls'], ['xlsx'], ['pdf']])(
+                test('should check operations count for .xlsx files', async () => {
+                    docBase.options.file.extension = 'xlsx';
+
+                    const mockDoc = {
+                        numPages: 2,
+                        getPage: jest.fn(),
+                    };
+
+                    const mockPage = {
+                        getOperatorList: jest.fn().mockResolvedValue({ fnArray: new Array(100000) }),
+                    };
+
+                    mockDoc.getPage.mockReturnValue(Promise.resolve(mockPage));
+                    stubs.getDocument.mockReturnValue({
+                        destroy: jest.fn(),
+                        promise: Promise.resolve(mockDoc),
+                    });
+
+                    await docBase.initViewer('url');
+
+                    expect(mockDoc.getPage).toHaveBeenCalledWith(1);
+                    expect(mockDoc.getPage).toHaveBeenCalledWith(2);
+                    expect(docBase.pdfLinkService.setDocument).toHaveBeenCalledWith(mockDoc, 'url');
+                    expect(docBase.pdfViewer.setDocument).toHaveBeenCalledWith(mockDoc);
+                });
+
+                test('should throw error when .xlsx file has too many operations', async () => {
+                    docBase.options.file.extension = 'xlsx';
+
+                    const mockDoc = {
+                        numPages: 2,
+                        getPage: jest.fn(),
+                    };
+
+                    const mockPage = {
+                        getOperatorList: jest.fn().mockResolvedValue({ fnArray: new Array(200000) }),
+                    };
+
+                    mockDoc.getPage.mockReturnValue(Promise.resolve(mockPage));
+                    stubs.getDocument.mockReturnValue({
+                        destroy: jest.fn(),
+                        promise: Promise.resolve(mockDoc),
+                    });
+
+                    stubs.consoleError = jest.spyOn(console, 'error').mockImplementation();
+                    stubs.handleDownloadError = jest.spyOn(docBase, 'handleDownloadError').mockImplementation();
+
+                    await docBase.initViewer('url').catch(() => {
+                        expect(stubs.handleDownloadError).toHaveBeenCalled();
+                    });
+                });
+
+                test.each([['doc'], ['docx'], ['ppt'], ['pptx'], ['xls'], ['pdf']])(
                     'should skip operations check for %s files',
                     async extension => {
                         docBase.options.file.extension = extension;


### PR DESCRIPTION
## Summary
- Apply the existing PDF-operations-count guard (previously limited to `.numbers` files) to `.xlsx` files as well.
- Excel spreadsheets rendered to PDF can contain enough drawing operations to hang the viewer; triggering the guard surfaces a download prompt instead of locking up the browser.

## Test plan
- [x] Added `should check operations count for .xlsx files` test verifying `getPage` is invoked for the op-count scan
- [x] Added `should throw error when .xlsx file has too many operations` test verifying the download-error path
- [x] Removed `xlsx` from the `test.each` skip list so the existing non-guarded extensions stay non-guarded
- [x] `yarn test DocBaseViewer-test` — 332/332 pass
- [x] `yarn lint:js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)