### PR TITLE
feat(auth): accept optional features in prefetch()

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -693,6 +693,7 @@ class Preview extends EventEmitter {
      * @param {string} options.sharedLink - Shared link
      * @param {string} options.sharedLinkPassword - Shared link password
      * @param {boolean} options.preload - Is this prefetch for a preload
+     * @param {Object} [options.features] - Feature flags to merge into viewer options for this prefetch
      * @param {string} token - Access token
      * @return {void}
      */
@@ -705,6 +706,7 @@ class Preview extends EventEmitter {
         preload = false,
         isDocFirstPrefetchEnabled = false,
         docFirstPagesConfig = null,
+        features,
     }) {
         let file;
         let loader;
@@ -745,6 +747,13 @@ class Preview extends EventEmitter {
             options.sharedLinkPassword = sharedLinkPassword;
             options.isDocFirstPrefetchEnabled = isDocFirstPrefetchEnabled;
             options.docFirstPagesConfig = docFirstPagesConfig;
+        }
+
+        // If features are passed in for this prefetch call (e.g. from callers that
+        // invoke prefetch() before show() has set this.options.features), merge them
+        // into the viewer options for this call without mutating this.options.
+        if (features) {
+            options.features = { ...this.options.features, ...features };
         }
 
         const viewerInstance = new viewer.CONSTRUCTOR(this.createViewerOptions(options));

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -693,7 +693,6 @@ class Preview extends EventEmitter {
      * @param {string} options.sharedLink - Shared link
      * @param {string} options.sharedLinkPassword - Shared link password
      * @param {boolean} options.preload - Is this prefetch for a preload
-     * @param {Object} [options.features] - Feature flags to merge into viewer options for this prefetch
      * @param {string} token - Access token
      * @return {void}
      */
@@ -706,7 +705,7 @@ class Preview extends EventEmitter {
         preload = false,
         isDocFirstPrefetchEnabled = false,
         docFirstPagesConfig = null,
-        features,
+        isAccessTokenHeaderEnabled = false,
     }) {
         let file;
         let loader;
@@ -747,13 +746,10 @@ class Preview extends EventEmitter {
             options.sharedLinkPassword = sharedLinkPassword;
             options.isDocFirstPrefetchEnabled = isDocFirstPrefetchEnabled;
             options.docFirstPagesConfig = docFirstPagesConfig;
-        }
-
-        // If features are passed in for this prefetch call (e.g. from callers that
-        // invoke prefetch() before show() has set this.options.features), merge them
-        // into the viewer options for this call without mutating this.options.
-        if (features) {
-            options.features = { ...this.options.features, ...features };
+            options.features = {
+                ...this.options.features,
+                migrateAccessTokenToHeader: isAccessTokenHeaderEnabled,
+            };
         }
 
         const viewerInstance = new viewer.CONSTRUCTOR(this.createViewerOptions(options));

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -737,6 +737,7 @@ describe('lib/Preview', () => {
                 sharedLinkPassword,
                 isDocFirstPrefetchEnabled: false,
                 docFirstPagesConfig: null,
+                features: { migrateAccessTokenToHeader: false },
             });
         });
 
@@ -799,7 +800,7 @@ describe('lib/Preview', () => {
             preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword, preload: true });
         });
 
-        test('should merge per-call features into viewer options when features are passed', () => {
+        test('should pass migrateAccessTokenToHeader feature to viewer options when isAccessTokenHeaderEnabled is true', () => {
             jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
             jest.spyOn(preview, 'createViewerOptions');
             preview.options.features = { existingFeature: true };
@@ -809,7 +810,8 @@ describe('lib/Preview', () => {
                 token,
                 sharedLink,
                 sharedLinkPassword,
-                features: { migrateAccessTokenToHeader: true },
+                preload: true,
+                isAccessTokenHeaderEnabled: true,
             });
 
             expect(preview.createViewerOptions).toHaveBeenCalledWith(
@@ -817,30 +819,21 @@ describe('lib/Preview', () => {
                     features: { existingFeature: true, migrateAccessTokenToHeader: true },
                 }),
             );
+            expect(preview.options.features).toEqual({ existingFeature: true });
         });
 
-        test('should not set features on viewer options when features are omitted', () => {
+        test('should pass migrateAccessTokenToHeader=false to viewer options when isAccessTokenHeaderEnabled is false', () => {
             jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
             jest.spyOn(preview, 'createViewerOptions');
-
-            preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword });
-
-            const callArgs = preview.createViewerOptions.mock.calls[0][0];
-            expect(callArgs).not.toHaveProperty('features');
-        });
-
-        test('should not mutate this.options.features when per-call features are passed', () => {
-            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
             preview.options.features = { existingFeature: true };
 
-            preview.prefetch({
-                fileId,
-                token,
-                sharedLink,
-                sharedLinkPassword,
-                features: { migrateAccessTokenToHeader: true },
-            });
+            preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword, preload: true });
 
+            expect(preview.createViewerOptions).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    features: { existingFeature: true, migrateAccessTokenToHeader: false },
+                }),
+            );
             expect(preview.options.features).toEqual({ existingFeature: true });
         });
     });

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -798,6 +798,51 @@ describe('lib/Preview', () => {
 
             preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword, preload: true });
         });
+
+        test('should merge per-call features into viewer options when features are passed', () => {
+            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
+            jest.spyOn(preview, 'createViewerOptions');
+            preview.options.features = { existingFeature: true };
+
+            preview.prefetch({
+                fileId,
+                token,
+                sharedLink,
+                sharedLinkPassword,
+                features: { migrateAccessTokenToHeader: true },
+            });
+
+            expect(preview.createViewerOptions).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    features: { existingFeature: true, migrateAccessTokenToHeader: true },
+                }),
+            );
+        });
+
+        test('should not set features on viewer options when features are omitted', () => {
+            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
+            jest.spyOn(preview, 'createViewerOptions');
+
+            preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword });
+
+            const callArgs = preview.createViewerOptions.mock.calls[0][0];
+            expect(callArgs).not.toHaveProperty('features');
+        });
+
+        test('should not mutate this.options.features when per-call features are passed', () => {
+            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
+            preview.options.features = { existingFeature: true };
+
+            preview.prefetch({
+                fileId,
+                token,
+                sharedLink,
+                sharedLinkPassword,
+                features: { migrateAccessTokenToHeader: true },
+            });
+
+            expect(preview.options.features).toEqual({ existingFeature: true });
+        });
     });
 
     describe('prefetchViewers()', () => {


### PR DESCRIPTION
### Description

`prefetch()` relied on `this.options.features`, which is only set during `Preview.show()`. Callers that prefetch before `show()` (for example, folder-list hover prefetch in a host application) had no way to opt into auth-header routing for the access token, so `featureEnabled('migrateAccessTokenToHeader')` checks inside viewer `prefetch()` methods always read the default (`false`).

This change adds an optional top-level `isAccessTokenHeaderEnabled = false` param to `prefetch()`, matching the shape of the existing `isDocFirstPrefetchEnabled` param. When the prefetch is for `preload`, the per-call viewer options merge in `features.migrateAccessTokenToHeader` so viewer `prefetch()` methods see the threaded value — without mutating `this.options.features`.

- Callers that omit the flag get byte-identical behavior.
- Subsequent `show()` / `prefetch()` calls aren't affected by prior per-call state.

### Test plan

- [x] `yarn test src/lib/__tests__/Preview-test.js` — 271 passing, including new tests covering flag-on (feature surfaced to viewer options) and flag-off (feature surfaced as `false`) paths
- [x] Host app verified hover-prefetch requests include `Authorization: Bearer` header (no `access_token` in URL) when passing `isAccessTokenHeaderEnabled: true`
- [x] Host app verified omitting / passing `false` preserves existing behavior

### Semantic release type

- [x] `feat` - New feature
