### PR TITLE
feat(annotations): Enable drawing/region annotations on rotated files

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -852,12 +852,6 @@ class DocBaseViewer extends BaseViewer {
 
         this.emit('rotate');
 
-        if (this.rotationAngle === 0) {
-            this.enableAnnotationControls();
-        } else {
-            this.disableAnnotationControls();
-        }
-
         if (this.thumbnailsSidebar) {
             this.thumbnailsSidebar.refresh();
         }
@@ -1400,12 +1394,10 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const { enableThumbnailsSidebar, showAnnotationsDrawingCreate } = this.options;
-        const canAnnotate =
-            this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission() && this.rotationAngle === 0;
+        const canAnnotate = this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission();
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
-        const isPDF = ['pdf'].includes(this.options.file.extension);
-        const canRotate = isPDF && this.featureEnabled('rotate.enabled');
+        const canRotate = this.featureEnabled('rotate.enabled');
 
         this.controls.render(
             <DocControls
@@ -1413,7 +1405,7 @@ class DocBaseViewer extends BaseViewer {
                 annotationMode={this.annotationControlsFSM.getMode()}
                 experiences={this.experiences}
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
-                hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
+                hasHighlight={canAnnotate && canDownload && isAnnotationsMode && this.rotationAngle === 0}
                 hasRegion={canAnnotate && isAnnotationsMode}
                 isThumbnailsOpen={this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen}
                 maxScale={MAX_SCALE}

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2726,16 +2726,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     onRotateLeft: undefined,
                 });
             });
-
-            test('should not pass onRotateLeft for non-PDF files even when rotate.enabled is true', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'rotate.enabled');
-                docBase.options.file.extension = 'ppt';
-                docBase.renderUI();
-
-                expect(getProps(docBase)).toMatchObject({
-                    onRotateLeft: undefined,
-                });
-            });
         });
 
         describe('rotateLeft()', () => {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2694,16 +2694,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should hide annotation create controls when rotated', () => {
+            test('should show drawing and region annotation create controls when rotated', () => {
                 docBase.currentAnnotatorViewMode = 'annotations';
                 docBase.options.showAnnotationsDrawingCreate = true;
                 docBase.rotationAngle = 90;
                 docBase.renderUI();
 
                 expect(getProps(docBase)).toMatchObject({
-                    hasDrawing: false,
+                    hasDrawing: true,
                     hasHighlight: false,
-                    hasRegion: false,
+                    hasRegion: true,
                 });
             });
 
@@ -2783,21 +2783,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.rotateLeft();
 
                 expect(docBase.emit).toBeCalledWith('rotate');
-            });
-
-            test('should disable annotation controls when rotated', () => {
-                docBase.rotateLeft();
-
-                expect(docBase.disableAnnotationControls).toBeCalled();
-                expect(docBase.enableAnnotationControls).not.toBeCalled();
-            });
-
-            test('should enable annotation controls when rotation returns to 0', () => {
-                docBase.rotationAngle = 90;
-                docBase.rotateLeft();
-
-                expect(docBase.enableAnnotationControls).toBeCalled();
-                expect(docBase.disableAnnotationControls).not.toBeCalled();
             });
 
             test('should refresh thumbnails sidebar if present', () => {

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -254,13 +254,6 @@ class ImageViewer extends ImageBaseViewer {
         this.imageEl.style.transform = `rotate(${this.currentRotationAngle}deg)`;
         this.emit('rotate');
 
-        // Disallow creating annotations on rotated images
-        if (this.currentRotationAngle === 0) {
-            this.enableAnnotationControls();
-        } else {
-            this.disableAnnotationControls();
-        }
-
         // Re-adjust image position after rotation
         this.handleOrientationChange();
         this.setScale(this.imageEl.offsetwidth, this.imageEl.offsetHeight);
@@ -464,8 +457,7 @@ class ImageViewer extends ImageBaseViewer {
             return;
         }
 
-        const canAnnotate =
-            this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission() && this.currentRotationAngle === 0;
+        const canAnnotate = this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission();
         const canDraw = canAnnotate && this.options.showAnnotationsDrawingCreate;
 
         this.controls.render(


### PR DESCRIPTION
  ## Summary
  - Enables drawing and region annotation creation on rotated documents and images (previously all annotations were disabled on rotation)
  - Keeps highlight annotations disabled (highlight annotation button in toolbar is hidden) when rotated (since highlights depend on text selection which doesn't work correctly when rotated yet)
  - Removes the PDF-only restriction for the rotate feature, allowing all document types to use rotation when the feature flag is enabled

  ## Changes
  - **DocBaseViewer**: Removed logic that disabled all annotation controls on rotate; now only highlight is gated by `rotationAngle === 0`. Removed the PDF-only check for enabling the rotate button.
  - **ImageViewer**: Removed logic that disabled annotation controls on rotated images; annotations now remain enabled regardless of rotation.
  - **Tests**: Updated tests to reflect new behavior and removed obsolete test cases.

  ## Test plan
  - [ ] Verify drawing annotations can be created on a rotated PDF
  - [ ] Verify region annotations can be created on a rotated PDF
  - [ ] Verify highlight annotations are hidden when a PDF is rotated
  - [ ] Verify annotations work on rotated images
  - [ ] Verify rotate button appears for non-PDF document types when the feature flag is enabled
  - [ ] Run unit tests (`npm test`)
