### PR TITLE
feat(annotations): forward onCopyLink option to annotator

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1091,6 +1091,7 @@ class BaseViewer extends EventEmitter {
             initialMode: this.getInitialAnnotationMode(),
             intl: (options && options.intl) || intlUtil.createAnnotatorIntl(),
             modeButtons: ANNOTATION_BUTTONS,
+            onCopyLink: options && options.onCopyLink,
         });
 
         this.annotator = new this.annotatorConf.CONSTRUCTOR(annotatorOptions);

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1288,6 +1288,21 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.createAnnotatorOptions).toBeCalledWith(expect.objectContaining(createOptionsArg));
         });
 
+        test('should forward onCopyLink from boxAnnotations options to createAnnotatorOptions', () => {
+            const onCopyLink = jest.fn();
+            jest.spyOn(base, 'areAnnotationsEnabled').mockReturnValue(true);
+            jest.spyOn(base, 'createAnnotatorOptions');
+
+            base.options.boxAnnotations = {
+                determineAnnotator: jest.fn().mockReturnValue(conf),
+                getOptions: jest.fn().mockReturnValue({ ...annotationsOptions, onCopyLink }),
+            };
+
+            base.createAnnotator();
+
+            expect(base.createAnnotatorOptions).toBeCalledWith(expect.objectContaining({ onCopyLink }));
+        });
+
         test('should use default intl lib if annotator options not present ', () => {
             jest.spyOn(base, 'areAnnotationsEnabled').mockReturnValue(true);
             jest.spyOn(base, 'createAnnotatorOptions');


### PR DESCRIPTION
## Summary

- Forward `onCopyLink` from `boxAnnotations.getOptions()` through `createAnnotatorOptions` in `BaseViewer.createAnnotator`, mirroring the same defensive `options && options.X` pattern used by sibling fields (`features`, `intl`).
- Lets a downstream annotator render a copy-link menu item when consumers provide the callback. When the option is absent, the value is `undefined` and the feature is a no-op (annotator hides the menu item).

## Test plan

- [x] Added unit test in `BaseViewer-test.js` asserting `createAnnotatorOptions` is called with the forwarded `onCopyLink` reference when `boxAnnotations.getOptions()` returns it.
- [x] `yarn test` passes (1852 tests).
- [x] `yarn build:dev` succeeds; `annotations.js`, `preview.js`, `csv.js`, `archive.js` emit cleanly.
- [ ] Manual smoke: load a preview with a consumer that passes `onCopyLink` and verify the copy-link menu item appears.
- [ ] Manual smoke: load a preview without the callback and verify the menu item is hidden.