### PR TITLE
feat(doc): add subtle hover animation to PDF thumbnail sidebar

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -35,9 +35,12 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         margin-right: 20px;
         margin-left: 20px;
         cursor: pointer;
+        transition: transform .2s ease-in-out;
 
         &:focus,
         &:hover {
+            transform: translateY(-1px) scale(1.02);
+
             .bp-thumbnail-page-number {
                 background: $seventy-sixers;
                 opacity: 1;
@@ -84,6 +87,7 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         background-color: $d-eight;
         border-radius: $thumbnail-border-radius;
         box-shadow: 0 0 0 1px $off-white, 0 1px 4px 0 rgba(0, 0, 0, .08);
+        transition: box-shadow .2s ease-in-out;
     }
 
     .bp-thumbnail-page-number {


### PR DESCRIPTION
## Summary
- Adds a subtle lift (`translateY(-1px)`) and scale (`1.02`) animation on thumbnail hover in the PDF sidebar
- Adds smooth `transition` (0.2s ease-in-out) to both the thumbnail container and its box-shadow
- Improves visual feedback when browsing pages without being distracting

Video:

https://github.com/user-attachments/assets/3288e3c6-cc35-4427-a43f-9e444fc064ee




## Test plan
- [x] Open a multi-page PDF in preview
- [x] Open the thumbnails sidebar
- [x] Hover over thumbnails and verify the subtle lift + scale animation
- [x] Verify selected thumbnail styling is unaffected
- [x] Verify dark mode thumbnail styling is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)