### PR TITLE
feat(annotations): enable highlight annotations on rotated docs

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1405,7 +1405,7 @@ class DocBaseViewer extends BaseViewer {
                 annotationMode={this.annotationControlsFSM.getMode()}
                 experiences={this.experiences}
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
-                hasHighlight={canAnnotate && canDownload && isAnnotationsMode && this.rotationAngle === 0}
+                hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
                 hasRegion={canAnnotate && isAnnotationsMode}
                 isThumbnailsOpen={this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen}
                 maxScale={MAX_SCALE}

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2694,7 +2694,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should show drawing and region annotation create controls when rotated', () => {
+            test('should show all annotation create controls when rotated', () => {
                 docBase.currentAnnotatorViewMode = 'annotations';
                 docBase.options.showAnnotationsDrawingCreate = true;
                 docBase.rotationAngle = 90;
@@ -2702,7 +2702,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 expect(getProps(docBase)).toMatchObject({
                     hasDrawing: true,
-                    hasHighlight: false,
+                    hasHighlight: true,
                     hasRegion: true,
                 });
             });


### PR DESCRIPTION
**Summary**
- Removes the `rotationAngle === 0` restriction on highlight annotations, allowing users to create text highlight annotations on rotated documents
- This aligns highlight behavior with drawing and region annotations, which already support rotated files (enabled in #1644)

**Test plan**
- Open a document in Preview and rotate it (90°, 180°, 270°)
- Verify the highlight annotation control is available in the toolbar while rotated
- Create a highlight annotation on a rotated document and confirm it renders correctly
- Verify highlight annotations are still disabled when download permissions are missing
- Verify highlight annotations are still disabled outside of annotations mode

