### PR TITLE
fix(auth): stop sending shared_link in both URL and BoxApi header

### DIFF
--- a/src/lib/RepStatus.js
+++ b/src/lib/RepStatus.js
@@ -70,9 +70,8 @@ class RepStatus extends EventEmitter {
         // Some representations (e.g. ORIGINAL) may not have an info url
         const repInfo = this.representation.info;
         if (migrateAccessTokenToHeader) {
-            // Send auth via headers only — no access_token in URL
             this.infoUrl = repInfo ? appendAuthParamsV2(repInfo.url, sharedLink, sharedLinkPassword) : '';
-            this.headers = getHeaders({}, token, sharedLink, sharedLinkPassword);
+            this.headers = getHeaders({}, token);
         } else {
             this.infoUrl = repInfo ? appendAuthParams(repInfo.url, token, sharedLink, sharedLinkPassword) : '';
         }

--- a/src/lib/__tests__/RepStatus-test.js
+++ b/src/lib/__tests__/RepStatus-test.js
@@ -109,6 +109,7 @@ describe('lib/RepStatus', () => {
             });
 
             expect(util.appendAuthParamsV2).toBeCalledWith(rep.info.url, 'sharedLink', 'password');
+            expect(util.getHeaders).toBeCalledWith({}, 'token');
             expect(repStatus.infoUrl).toBe(v2Url);
             expect(repStatus.headers).toEqual({ Authorization: 'Bearer token' });
         });

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -519,8 +519,8 @@ class BaseViewer extends EventEmitter {
      * @return {Object} fetch headers
      */
     appendAuthHeader(headers = {}) {
-        const { token, sharedLink, sharedLinkPassword } = this.options;
-        return getHeaders(headers, token, sharedLink, sharedLinkPassword);
+        const { token } = this.options;
+        return getHeaders(headers, token);
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -432,7 +432,7 @@ describe('lib/viewers/BaseViewer', () => {
 
             const result = base.appendAuthHeader(headers);
             expect(result).toBe(headers);
-            expect(util.getHeaders).toBeCalledWith(headers, token, sharedLink, sharedLinkPassword);
+            expect(util.getHeaders).toBeCalledWith(headers, token);
         });
     });
 


### PR DESCRIPTION
## Summary

When the `migrateAccessTokenToHeader` flag is on, document previews fail with HTTP 400 from the representations host. The API responds:

> Invalid value 'shared_link'. The shared link must only be set once in shared_access_code from headers, shared_link from headers, or the query string.

`appendAuthParamsV2()` puts `shared_link`/`shared_link_password` in the URL query string. At the same time, `BaseViewer.appendAuthHeader()` and the migration branch in `RepStatus` were calling `getHeaders(headers, token, sharedLink, sharedLinkPassword)`, which adds a `BoxApi: shared_link=...` header. The API rejects requests that carry `shared_link` in both places.

The flag was only meant to migrate `access_token` from URL to `Authorization` header. This change scopes the header to that responsibility and leaves shared-link auth in the URL.

## Changes

- `src/lib/viewers/BaseViewer.js` — `appendAuthHeader()` passes only `token` to `getHeaders()`.
- `src/lib/RepStatus.js` — same fix on the `migrateAccessTokenToHeader` branch.
- `src/lib/viewers/__tests__/BaseViewer-test.js` — updated assertion to match.

## Test plan

- [x] `yarn jest --testPathPattern="(BaseViewer|RepStatus)-test"` passes (821 tests)
- [ ] Verify document preview loads via shared link with the flag ON
- [ ] Verify document preview still loads via shared link with the flag OFF (legacy path unchanged)
- [ ] Verify direct (non-shared-link) preview is unaffected
