### PR TITLE
feat(preview): emit client_name dimension on every event

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1110,6 +1110,7 @@ class Preview extends EventEmitter {
         this.options.previewMode = options.previewMode;
         this.options.sharedLinkAuth = options.sharedLinkAuth;
         this.options.preloadStatus = options.preloadStatus;
+        this.options.clientName = options.clientName;
 
         // Options that are applicable to certain file ids
         this.options.fileOptions = options.fileOptions || {};
@@ -1894,11 +1895,12 @@ class Preview extends EventEmitter {
      */
     emitLogEvent(name, payload = {}) {
         const file = this.file || {};
-        const { accessPattern, previewMode, sharedLinkAuth } = this.options || {};
+        const { accessPattern, clientName, previewMode, sharedLinkAuth } = this.options || {};
 
         this.emit(name, {
             ...payload,
             access_pattern: accessPattern,
+            client_name: clientName,
             content_type: getProp(this.viewer, 'options.viewer.NAME', ''),
             current_page_number: getProp(this.viewer, 'pdfViewer.currentPageNumber', ''),
             extension: file.extension || '',

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1665,11 +1665,13 @@ describe('lib/Preview', () => {
                 previewMode: 'shared_file',
                 sharedLinkAuth: 'logged_out',
                 preloadStatus: 'hit',
+                clientName: 'enduserapp',
             });
             expect(preview.options.accessPattern).toBe('direct_link');
             expect(preview.options.previewMode).toBe('shared_file');
             expect(preview.options.sharedLinkAuth).toBe('logged_out');
             expect(preview.options.preloadStatus).toBe('hit');
+            expect(preview.options.clientName).toBe('enduserapp');
         });
 
         test('should leave monitoring dimensions undefined when host omits them', () => {
@@ -1678,6 +1680,7 @@ describe('lib/Preview', () => {
             expect(preview.options.previewMode).toBeUndefined();
             expect(preview.options.sharedLinkAuth).toBeUndefined();
             expect(preview.options.preloadStatus).toBeUndefined();
+            expect(preview.options.clientName).toBeUndefined();
         });
     });
 
@@ -2859,6 +2862,7 @@ describe('lib/Preview', () => {
             preview.options.accessPattern = 'file_list';
             preview.options.previewMode = 'default';
             preview.options.sharedLinkAuth = 'na';
+            preview.options.clientName = 'enduserapp';
 
             preview.emitLogEvent('test');
 
@@ -2866,6 +2870,7 @@ describe('lib/Preview', () => {
                 'test',
                 expect.objectContaining({
                     access_pattern: 'file_list',
+                    client_name: 'enduserapp',
                     preview_mode: 'default',
                     shared_link_auth: 'na',
                 }),
@@ -2877,6 +2882,7 @@ describe('lib/Preview', () => {
             preview.options.accessPattern = undefined;
             preview.options.previewMode = undefined;
             preview.options.sharedLinkAuth = undefined;
+            preview.options.clientName = undefined;
 
             preview.emitLogEvent('test');
 
@@ -2884,6 +2890,7 @@ describe('lib/Preview', () => {
             expect(payload.access_pattern).toBeUndefined();
             expect(payload.preview_mode).toBeUndefined();
             expect(payload.shared_link_auth).toBeUndefined();
+            expect(payload.client_name).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary

Adds a new dimension to preview metric and error events:

- **`client_name`** — host application that loaded the preview (e.g. `enduserapp` / `preview-client`). Added as a `Preview.parseOptions` option, attached to every event via `emitLogEvent`. No-op default when host omits it.

This is a Phase 2 follow-up to [#1639](https://github.com/box/box-content-preview/pull/1639) (PREVIEW-224), which added `accessPattern`, `previewMode`, `sharedLinkAuth`, `preloadStatus`. Same emit pattern, just one more dimension.

## Why

EUA and preview-client both bundle this library. Without `client_name`, monitoring dashboards can't split traffic by host application — every event looks the same regardless of which app loaded it. This unblocks "EUA vs preview-client" panels in the Preview Performance Monitoring dashboards under [WEBAPP-53337](https://jira.inside-box.net/browse/WEBAPP-53337).

## Implementation

- `src/lib/Preview.js`: `parseOptions` now accepts `clientName`. `emitLogEvent` destructures `clientName` from `this.options` and includes `client_name` in the emitted payload alongside the existing access_pattern / preview_mode / shared_link_auth fields.
- `src/lib/__tests__/Preview-test.js`: extends the existing monitoring-dimensions tests to cover `clientName` (storage in parseOptions, presence on emitted events, undefined-passthrough when host omits it).

## Test plan

- [x] Unit tests: `clientName` parseOptions storage + emitLogEvent forwarding (set + omitted cases) — 3/3 monitoring-dimension tests pass
- [x] Full Preview-test.js suite passes (283 tests)
- [x] ESLint clean on touched files
- [x] No changes to existing event names, timing semantics, or behavior when host omits the option

## Companion tickets

Without these, the field is declared in box-content-preview but no traffic populates it:
- **box-ui-elements** ([PREVIEW-326](https://jira.inside-box.net/browse/PREVIEW-326)) — forward `clientName` prop through `<ContentPreview>`
- **EndUserApp** ([PREVIEW-327](https://jira.inside-box.net/browse/PREVIEW-327)) — pass `clientName='enduserapp'`
- **preview-client** ([PREVIEW-328](https://jira.inside-box.net/browse/PREVIEW-328)) — pass `clientName='preview-client'`
- **monitoring/analytics-schemas** ([PREVIEW-324](https://jira.inside-box.net/browse/PREVIEW-324)) — declare `client_name` field
- **data-platform** ([PREVIEW-323](https://jira.inside-box.net/browse/PREVIEW-323)) — add `client_name` to Zephyr metric tags

JIRA: [PREVIEW-325](https://jira.inside-box.net/browse/PREVIEW-325) | Umbrella: [PREVIEW-322](https://jira.inside-box.net/browse/PREVIEW-322) | Epic: [WEBAPP-53337](https://jira.inside-box.net/browse/WEBAPP-53337)

🤖 Generated with [Claude Code](https://claude.com/claude-code)