### PR TITLE
feat(zoom): add trackpad pinch-to-zoom for images

### DIFF
--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -9,6 +9,9 @@ import { openContentInsideIframe } from '../../util';
 const CSS_CLASS_PANNING = 'panning';
 const CSS_CLASS_ZOOMABLE = 'zoomable';
 const CSS_CLASS_PANNABLE = 'pannable';
+const MIN_PINCH_SCALE_DELTA = 0.01;
+const WHEEL_ZOOM_MAX_SCALE = 100;
+const WHEEL_ZOOM_MIN_SCALE = 0.1;
 
 class ImageBaseViewer extends BaseViewer {
     /** @inheritdoc */
@@ -31,6 +34,8 @@ class ImageBaseViewer extends BaseViewer {
         this.finishLoading = this.finishLoading.bind(this);
         this.isDiscoverabilityEnabled = this.isDiscoverabilityEnabled.bind(this);
 
+        // Trackpad pinch-to-zoom support
+        this.wheelZoomHandler = this.wheelZoomHandler.bind(this);
         if (this.isMobile) {
             if (Browser.isIOS()) {
                 this.mobileZoomStartHandler = this.mobileZoomStartHandler.bind(this);
@@ -272,6 +277,8 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.addEventListener('mousedown', this.handleMouseDown);
         this.imageEl.addEventListener('mouseup', this.handleMouseUp);
         this.imageEl.addEventListener('dragstart', this.cancelDragEvent);
+        // Trackpad pinch-to-zoom
+        this.imageEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false });
 
         if (this.isMobile) {
             if (Browser.isIOS()) {
@@ -302,12 +309,98 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.removeEventListener('mousedown', this.handleMouseDown);
         this.imageEl.removeEventListener('mouseup', this.handleMouseUp);
         this.imageEl.removeEventListener('dragstart', this.cancelDragEvent);
+        this.imageEl.removeEventListener('wheel', this.wheelZoomHandler);
 
         this.imageEl.removeEventListener('gesturestart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('gestureend', this.mobileZoomEndHandler);
         this.imageEl.removeEventListener('touchstart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('touchmove', this.mobileZoomChangeHandler);
         this.imageEl.removeEventListener('touchend', this.mobileZoomEndHandler);
+    }
+
+    /**
+     * Handles trackpad pinch-to-zoom via wheel events with ctrlKey.
+     * On Mac trackpads, pinch gestures fire wheel events with ctrlKey set to true.
+     *
+     * @protected
+     * @param {WheelEvent} event - wheel event object
+     * @return {void}
+     */
+    wheelZoomHandler(event) {
+        if (!event.ctrlKey || !this.imageEl || !this.wrapperEl) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const currentWidth = this.imageEl.offsetWidth;
+        if (!currentWidth) {
+            return;
+        }
+
+        const originalWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10);
+        const minWidth = originalWidth ? originalWidth * WHEEL_ZOOM_MIN_SCALE : currentWidth * 0.1;
+        const maxWidth = originalWidth ? originalWidth * WHEEL_ZOOM_MAX_SCALE : currentWidth * 100;
+
+        const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
+        const newWidth = Math.min(maxWidth, Math.max(minWidth, currentWidth * (1 + delta)));
+        const ratio = newWidth / currentWidth;
+
+        // Capture the point within the image that's under the cursor, in image-local coords.
+        // This is what we'll keep anchored to the cursor through the zoom.
+        const oldImageRect = this.imageEl.getBoundingClientRect();
+        const pointInImageX = event.clientX - oldImageRect.left;
+        const pointInImageY = event.clientY - oldImageRect.top;
+
+        this.imageEl.style.width = `${newWidth}px`;
+        this.imageEl.style.height = '';
+
+        // adjustImageZoomPadding re-centers the image via style.left/top and scrollLeft/Top;
+        // we override both below so the cursor-anchored point stays under the cursor.
+        if (typeof this.adjustImageZoomPadding === 'function') {
+            this.adjustImageZoomPadding();
+        }
+
+        // Compute the delta needed to place the cursor-anchored point back under the cursor.
+        // Apply it first via scroll (when the image overflows the wrapper), and absorb any
+        // clamped remainder by shifting the image's CSS offset (when the image fits the
+        // wrapper and adjustImageZoomPadding re-centered it via style.left/top).
+        const newImageRect = this.imageEl.getBoundingClientRect();
+        const dx = newImageRect.left + pointInImageX * ratio - event.clientX;
+        const dy = newImageRect.top + pointInImageY * ratio - event.clientY;
+
+        const prevScrollLeft = this.wrapperEl.scrollLeft;
+        const prevScrollTop = this.wrapperEl.scrollTop;
+        this.wrapperEl.scrollLeft += dx;
+        this.wrapperEl.scrollTop += dy;
+
+        const remainderX = dx - (this.wrapperEl.scrollLeft - prevScrollLeft);
+        const remainderY = dy - (this.wrapperEl.scrollTop - prevScrollTop);
+        if (remainderX !== 0 || remainderY !== 0) {
+            const currentLeft = parseFloat(this.imageEl.style.left) || 0;
+            const currentTop = parseFloat(this.imageEl.style.top) || 0;
+            this.imageEl.style.left = `${currentLeft - remainderX}px`;
+            this.imageEl.style.top = `${currentTop - remainderY}px`;
+        }
+
+        // setScale emits 'scale', which triggers annotation re-render. Call it AFTER
+        // final image position is set so the overlay reads correct offsetLeft/offsetTop.
+        if (typeof this.setScale === 'function') {
+            this.setScale(newWidth, null);
+        }
+
+        if (typeof this.updatePannability === 'function') {
+            if (this.wheelZoomRAF) {
+                cancelAnimationFrame(this.wheelZoomRAF);
+            }
+            this.wheelZoomRAF = requestAnimationFrame(this.updatePannability);
+        }
+
+        this.emit('zoom', {
+            newScale: [newWidth, this.imageEl.offsetHeight],
+            canZoomIn: newWidth < maxWidth,
+            canZoomOut: newWidth > minWidth,
+        });
     }
 
     /**

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -327,7 +327,7 @@ class ImageBaseViewer extends BaseViewer {
      * @return {void}
      */
     wheelZoomHandler(event) {
-        if (!event.ctrlKey || !this.imageEl || !this.wrapperEl) {
+        if (!event.ctrlKey || !this.imageEl || !this.wrapperEl || !this.featureEnabled('pinchToZoom.enabled')) {
             return;
         }
 

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -346,7 +346,7 @@ class ImageBaseViewer extends BaseViewer {
         const newWidth = Math.min(maxWidth, Math.max(minWidth, currentWidth * (1 + delta)));
         const ratio = newWidth / currentWidth;
 
-        // Capture the point within the image that's under the cursor, in image-local coords.
+        // Record where the cursor sits within the image (in image-local coords).
         // This is what we'll keep anchored to the cursor through the zoom.
         const oldImageRect = this.imageEl.getBoundingClientRect();
         const pointInImageX = event.clientX - oldImageRect.left;
@@ -364,9 +364,8 @@ class ImageBaseViewer extends BaseViewer {
         }
 
         // Compute the delta needed to place the cursor-anchored point back under the
-        // cursor after the resize + re-centering applied above. Apply it first by scrolling
-        // the container, and if scroll is clamped, shift the image's CSS left/top to cover
-        // the remainder.
+        // cursor. Apply it first adjusting scroll position, and if scroll is clamped,
+        // shift the image's CSS left/top to cover the remainder.
         const newImageRect = this.imageEl.getBoundingClientRect();
         const dx = newImageRect.left + pointInImageX * ratio - event.clientX;
         const dy = newImageRect.top + pointInImageY * ratio - event.clientY;

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -338,9 +338,9 @@ class ImageBaseViewer extends BaseViewer {
             return;
         }
 
-        const originalWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10);
-        const minWidth = originalWidth ? originalWidth * WHEEL_ZOOM_MIN_SCALE : currentWidth * 0.1;
-        const maxWidth = originalWidth ? originalWidth * WHEEL_ZOOM_MAX_SCALE : currentWidth * 100;
+        const baseWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10) || currentWidth;
+        const minWidth = baseWidth * WHEEL_ZOOM_MIN_SCALE;
+        const maxWidth = baseWidth * WHEEL_ZOOM_MAX_SCALE;
 
         const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
         const newWidth = Math.min(maxWidth, Math.max(minWidth, currentWidth * (1 + delta)));
@@ -352,6 +352,8 @@ class ImageBaseViewer extends BaseViewer {
         const pointInImageX = event.clientX - oldImageRect.left;
         const pointInImageY = event.clientY - oldImageRect.top;
 
+        // Resize the image. This grows/shrinks from the top-left corner, so the exact
+        // pixel that was under the cursor is now at a different screen position.
         this.imageEl.style.width = `${newWidth}px`;
         this.imageEl.style.height = '';
 
@@ -361,10 +363,10 @@ class ImageBaseViewer extends BaseViewer {
             this.adjustImageZoomPadding();
         }
 
-        // Compute the delta needed to place the cursor-anchored point back under the cursor.
-        // Apply it first via scroll (when the image overflows the wrapper), and absorb any
-        // clamped remainder by shifting the image's CSS offset (when the image fits the
-        // wrapper and adjustImageZoomPadding re-centered it via style.left/top).
+        // Compute the delta needed to place the cursor-anchored point back under the
+        // cursor after the resize + re-centering applied above. Apply it first by scrolling
+        // the container, and if scroll is clamped, shift the image's CSS left/top to cover
+        // the remainder.
         const newImageRect = this.imageEl.getBoundingClientRect();
         const dx = newImageRect.left + pointInImageX * ratio - event.clientX;
         const dy = newImageRect.top + pointInImageY * ratio - event.clientY;

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -82,6 +82,8 @@ class ImageBaseViewer extends BaseViewer {
         const loadOriginalDimensions = this.setOriginalImageSize(this.imageEl);
         loadOriginalDimensions.then(() => {
             this.zoom();
+            this.initialWidth = this.imageEl.offsetWidth;
+            this.initialRect = this.getInitialImageRect();
             this.loadUI();
 
             this.imageEl.classList.remove(CLASS_INVISIBLE);
@@ -115,6 +117,8 @@ class ImageBaseViewer extends BaseViewer {
      */
     resize() {
         this.zoom();
+        this.initialWidth = this.imageEl.offsetWidth;
+        this.initialRect = this.getInitialImageRect();
         super.resize();
     }
 
@@ -278,7 +282,7 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.addEventListener('mouseup', this.handleMouseUp);
         this.imageEl.addEventListener('dragstart', this.cancelDragEvent);
         // Trackpad pinch-to-zoom
-        this.imageEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false });
+        this.wrapperEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false });
 
         if (this.isMobile) {
             if (Browser.isIOS()) {
@@ -309,13 +313,36 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.removeEventListener('mousedown', this.handleMouseDown);
         this.imageEl.removeEventListener('mouseup', this.handleMouseUp);
         this.imageEl.removeEventListener('dragstart', this.cancelDragEvent);
-        this.imageEl.removeEventListener('wheel', this.wheelZoomHandler);
+        if (this.wrapperEl) {
+            this.wrapperEl.removeEventListener('wheel', this.wheelZoomHandler);
+        }
 
         this.imageEl.removeEventListener('gesturestart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('gestureend', this.mobileZoomEndHandler);
         this.imageEl.removeEventListener('touchstart', this.mobileZoomStartHandler);
         this.imageEl.removeEventListener('touchmove', this.mobileZoomChangeHandler);
         this.imageEl.removeEventListener('touchend', this.mobileZoomEndHandler);
+    }
+
+    /**
+     * Returns the image's bounding rect relative to the wrapper.
+     * Used to capture the initial position for zoom-out clamping.
+     *
+     * @protected
+     * @return {Object} Rect with left, top, right, bottom relative to wrapper
+     */
+    getInitialImageRect() {
+        if (!this.imageEl || !this.wrapperEl) {
+            return null;
+        }
+        const imageRect = this.imageEl.getBoundingClientRect();
+        const wrapperRect = this.wrapperEl.getBoundingClientRect();
+        return {
+            left: imageRect.left - wrapperRect.left,
+            top: imageRect.top - wrapperRect.top,
+            right: imageRect.right - wrapperRect.left,
+            bottom: imageRect.bottom - wrapperRect.top,
+        };
     }
 
     /**
@@ -328,8 +355,30 @@ class ImageBaseViewer extends BaseViewer {
      */
     wheelZoomHandler(event) {
         if (!event.ctrlKey || !this.imageEl || !this.wrapperEl || !this.featureEnabled('pinchToZoom.enabled')) {
+            this.isPinching = false;
             return;
         }
+
+        // Only start a pinch session if the gesture begins over the image.
+        // Once active, continue even if the cursor drifts outside the image.
+        if (!this.isPinching) {
+            const imageRect = this.imageEl.getBoundingClientRect();
+            const isOverImage =
+                event.clientX >= imageRect.left &&
+                event.clientX <= imageRect.right &&
+                event.clientY >= imageRect.top &&
+                event.clientY <= imageRect.bottom;
+            if (!isOverImage) {
+                return;
+            }
+            this.isPinching = true;
+        }
+
+        // Reset pinch session after a brief idle (no explicit "pinch end" event exists)
+        clearTimeout(this.pinchIdleTimer);
+        this.pinchIdleTimer = setTimeout(() => {
+            this.isPinching = false;
+        }, 200);
 
         event.preventDefault();
 
@@ -339,7 +388,7 @@ class ImageBaseViewer extends BaseViewer {
         }
 
         const baseWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10) || currentWidth;
-        const minWidth = baseWidth * WHEEL_ZOOM_MIN_SCALE;
+        const minWidth = this.initialWidth || baseWidth * WHEEL_ZOOM_MIN_SCALE;
         const maxWidth = baseWidth * WHEEL_ZOOM_MAX_SCALE;
 
         const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
@@ -357,19 +406,39 @@ class ImageBaseViewer extends BaseViewer {
         this.imageEl.style.width = `${newWidth}px`;
         this.imageEl.style.height = '';
 
-        // adjustImageZoomPadding re-centers the image via style.left/top and scrollLeft/Top;
-        // we override both below so the cursor-anchored point stays under the cursor.
-        if (typeof this.adjustImageZoomPadding === 'function') {
-            this.adjustImageZoomPadding();
+        // Compute how far the image pixel drifted from the cursor after resizing.
+        const newImageRect = this.imageEl.getBoundingClientRect();
+        const wrapperRect = this.wrapperEl.getBoundingClientRect();
+        let dx = newImageRect.left + pointInImageX * ratio - event.clientX;
+        let dy = newImageRect.top + pointInImageY * ratio - event.clientY;
+
+        // When zooming out, clamp so edges don't retreat past the initial rect.
+        // This guides the image back to its initial position as it shrinks.
+        if (newWidth < currentWidth && this.initialRect) {
+            // Where the image would end up after full cursor-anchor correction
+            let targetLeft = newImageRect.left - wrapperRect.left - dx;
+            let targetTop = newImageRect.top - wrapperRect.top - dy;
+            const targetRight = targetLeft + newImageRect.width;
+            const targetBottom = targetTop + newImageRect.height;
+
+            // Clamp: don't let an edge retreat past its initial boundary
+            if (targetLeft > this.initialRect.left) {
+                targetLeft = this.initialRect.left;
+            } else if (targetRight < this.initialRect.right) {
+                targetLeft = this.initialRect.right - newImageRect.width;
+            }
+
+            if (targetTop > this.initialRect.top) {
+                targetTop = this.initialRect.top;
+            } else if (targetBottom < this.initialRect.bottom) {
+                targetTop = this.initialRect.bottom - newImageRect.height;
+            }
+
+            dx = newImageRect.left - wrapperRect.left - targetLeft;
+            dy = newImageRect.top - wrapperRect.top - targetTop;
         }
 
-        // Compute the delta needed to place the cursor-anchored point back under the
-        // cursor. Apply it first adjusting scroll position, and if scroll is clamped,
-        // shift the image's CSS left/top to cover the remainder.
-        const newImageRect = this.imageEl.getBoundingClientRect();
-        const dx = newImageRect.left + pointInImageX * ratio - event.clientX;
-        const dy = newImageRect.top + pointInImageY * ratio - event.clientY;
-
+        // Apply correction: scroll first, then CSS offset for any remainder.
         const prevScrollLeft = this.wrapperEl.scrollLeft;
         const prevScrollTop = this.wrapperEl.scrollTop;
         this.wrapperEl.scrollLeft += dx;
@@ -384,18 +453,18 @@ class ImageBaseViewer extends BaseViewer {
             this.imageEl.style.top = `${currentTop - remainderY}px`;
         }
 
+        // When we've reached the minimum width, snap to the correct centered position
+        // via adjustImageZoomPadding. This handles rotation where the initial rect is stale.
+        if (newWidth <= minWidth && typeof this.adjustImageZoomPadding === 'function') {
+            this.adjustImageZoomPadding();
+        }
+
         // setScale emits 'scale', which triggers annotation re-render. Call it AFTER
         // final image position is set so the overlay reads correct offsetLeft/offsetTop.
         if (typeof this.setScale === 'function') {
             this.setScale(newWidth, null);
         }
-
-        if (typeof this.updatePannability === 'function') {
-            if (this.wheelZoomRAF) {
-                cancelAnimationFrame(this.wheelZoomRAF);
-            }
-            this.wheelZoomRAF = requestAnimationFrame(this.updatePannability);
-        }
+        this.updatePannability();
 
         this.emit('zoom', {
             newScale: [newWidth, this.imageEl.offsetHeight],

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -444,9 +444,14 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
                 addEventListener: jest.fn(),
                 removeEventListener: jest.fn(),
             };
+            imageBase.wrapperEl = {
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+            };
 
             jest.spyOn(document, 'addEventListener');
             stubs.listeners = imageBase.imageEl.addEventListener;
+            stubs.wrapperListeners = imageBase.wrapperEl.addEventListener;
             imageBase.isMobile = true;
             imageBase.mobileZoomStartHandler = imageBase.mobileZoomStartHandler.bind(imageBase);
             imageBase.mobileZoomChangeHandler = imageBase.mobileZoomChangeHandler.bind(imageBase);
@@ -460,9 +465,9 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('dragstart', imageBase.cancelDragEvent);
         });
 
-        test('should bind wheel listener for trackpad zoom', () => {
+        test('should bind wheel listener on wrapper for trackpad zoom', () => {
             imageBase.bindDOMListeners();
-            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler, { passive: false });
+            expect(stubs.wrapperListeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler, { passive: false });
         });
 
         test('should bind all iOS listeners when hasTouch is true', () => {
@@ -495,9 +500,14 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
                 addEventListener: jest.fn(),
                 removeEventListener: jest.fn(),
             };
+            imageBase.wrapperEl = {
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+            };
 
             imageBase.imageEl.removeEventListener = jest.fn();
             stubs.listeners = imageBase.imageEl.removeEventListener;
+            stubs.wrapperListeners = imageBase.wrapperEl.removeEventListener;
             stubs.documentListener = jest.spyOn(document, 'removeEventListener');
             imageBase.hasTouch = true;
         });
@@ -518,9 +528,9 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('gestureend', imageBase.mobileZoomEndHandler);
         });
 
-        test('should unbind wheel listener', () => {
+        test('should unbind wheel listener from wrapper', () => {
             imageBase.unbindDOMListeners();
-            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler);
+            expect(stubs.wrapperListeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler);
         });
 
         test('should unbind all document listeners', () => {
@@ -546,11 +556,17 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 100, configurable: true });
             imageBase.imageEl.getBoundingClientRect = jest
                 .fn()
-                .mockReturnValueOnce({ left: 0, top: 0, width: 100, height: 100 })
-                .mockReturnValue({ left: 0, top: 0, width: 105, height: 105 });
+                .mockReturnValueOnce({ left: 0, top: 0, width: 100, height: 100, right: 100, bottom: 100 })
+                .mockReturnValue({ left: 0, top: 0, width: 105, height: 105, right: 105, bottom: 105 });
             imageBase.wrapperEl = document.createElement('div');
             imageBase.wrapperEl.scrollLeft = 0;
             imageBase.wrapperEl.scrollTop = 0;
+            imageBase.wrapperEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValue({ left: 0, top: 0, width: 800, height: 600 });
+            imageBase.updatePannability = jest.fn();
+            // Pre-set isPinching so most tests skip the hit-test logic
+            imageBase.isPinching = true;
             jest.spyOn(imageBase, 'emit').mockImplementation();
             jest.spyOn(imageBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
         });
@@ -584,6 +600,37 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(imageBase.emit).not.toBeCalled();
         });
 
+        test('should not start pinch if cursor is outside the image', () => {
+            imageBase.isPinching = false;
+            imageBase.imageEl.getBoundingClientRect = jest.fn().mockReturnValue({
+                left: 100,
+                top: 100,
+                right: 200,
+                bottom: 200,
+                width: 100,
+                height: 100,
+            });
+            // Cursor at (50, 50) is outside the image rect (100-200, 100-200)
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).not.toBeCalled();
+            expect(imageBase.emit).not.toBeCalled();
+        });
+
+        test('should start pinch if cursor is over the image', () => {
+            imageBase.isPinching = false;
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 })
+                .mockReturnValue({ left: 0, top: 0, right: 105, bottom: 105, width: 105, height: 105 });
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).toBeCalled();
+            expect(imageBase.isPinching).toBe(true);
+        });
+
         test('should preventDefault and apply proportional zoom on pinch in', () => {
             const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
 
@@ -604,18 +651,6 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             imageBase.wheelZoomHandler(event);
             // deltaY=5, delta=-0.05, newWidth = 100 * 0.95 = 95
             expect(imageBase.imageEl.style.width).toBe('95px');
-        });
-
-        test('should call adjustImageZoomPadding if available', () => {
-            imageBase.adjustImageZoomPadding = jest.fn();
-            imageBase.wheelZoomHandler({
-                clientX: 0,
-                clientY: 0,
-                ctrlKey: true,
-                deltaY: -5,
-                preventDefault: jest.fn(),
-            });
-            expect(imageBase.adjustImageZoomPadding).toBeCalled();
         });
 
         test('should call setScale with width and null height', () => {
@@ -696,11 +731,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(imageBase.emit).toBeCalledWith('zoom', expect.objectContaining({ canZoomIn: false }));
         });
 
-        test('should use requestAnimationFrame for updatePannability', () => {
-            imageBase.updatePannability = jest.fn();
-            jest.spyOn(window, 'requestAnimationFrame').mockImplementation();
-            jest.spyOn(window, 'cancelAnimationFrame').mockImplementation();
-
+        test('should call updatePannability', () => {
             imageBase.wheelZoomHandler({
                 clientX: 0,
                 clientY: 0,
@@ -708,24 +739,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
                 deltaY: -5,
                 preventDefault: jest.fn(),
             });
-            expect(window.requestAnimationFrame).toBeCalledWith(imageBase.updatePannability);
-        });
-
-        test('should cancel previous requestAnimationFrame before scheduling new one', () => {
-            imageBase.updatePannability = jest.fn();
-            imageBase.wheelZoomRAF = 456;
-            jest.spyOn(window, 'requestAnimationFrame').mockImplementation();
-            jest.spyOn(window, 'cancelAnimationFrame').mockImplementation();
-
-            imageBase.wheelZoomHandler({
-                clientX: 0,
-                clientY: 0,
-                ctrlKey: true,
-                deltaY: -5,
-                preventDefault: jest.fn(),
-            });
-            expect(window.cancelAnimationFrame).toBeCalledWith(456);
-            expect(window.requestAnimationFrame).toBeCalledWith(imageBase.updatePannability);
+            expect(imageBase.updatePannability).toBeCalled();
         });
 
         test('should anchor zoom at cursor by adjusting wrapperEl scroll', () => {
@@ -738,6 +752,41 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
 
             imageBase.wheelZoomHandler(event);
 
+            expect(imageBase.wrapperEl.scrollLeft).toBeCloseTo(2.5);
+            expect(imageBase.wrapperEl.scrollTop).toBeCloseTo(2.5);
+        });
+
+        test('should clamp left edge to initial rect when zooming out', () => {
+            // Image is zoomed in: 200px wide, positioned at left=-50 (overflows left of initial).
+            // Initial rect has left=50. On zoom out, cursor-anchoring would push left to 60 (past initial).
+            // Clamping should pin it to initialRect.left=50.
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 200, configurable: true });
+            imageBase.initialWidth = 100;
+            imageBase.initialRect = { left: 50, top: 50, right: 150, bottom: 150 };
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: -50, top: -50, width: 200, height: 200 }) // before resize
+                .mockReturnValue({ left: -50, top: -50, width: 190, height: 190 }); // after resize
+
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: 5, preventDefault: jest.fn() };
+            imageBase.wheelZoomHandler(event);
+
+            // The image left edge should not go past initialRect.left (50 relative to wrapper)
+            const imageRect = imageBase.imageEl.getBoundingClientRect();
+            const wrapperRect = imageBase.wrapperEl.getBoundingClientRect();
+            const finalLeft = imageRect.left - wrapperRect.left + imageBase.wrapperEl.scrollLeft;
+            expect(finalLeft).toBeLessThanOrEqual(50);
+        });
+
+        test('should not apply clamping when zooming in', () => {
+            // Even with initialRect set, zoom-in should use pure cursor-anchoring
+            imageBase.initialRect = { left: 50, top: 50, right: 150, bottom: 150 };
+            imageBase.initialWidth = 100;
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+
+            // Should still apply cursor-anchoring (scroll adjusts)
             expect(imageBase.wrapperEl.scrollLeft).toBeCloseTo(2.5);
             expect(imageBase.wrapperEl.scrollTop).toBeCloseTo(2.5);
         });
@@ -803,6 +852,10 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
     });
 
     describe('enableViewerControls()', () => {
+        beforeEach(() => {
+            imageBase.wrapperEl = document.createElement('div');
+        });
+
         test('should enable viewer controls', () => {
             imageBase.controls = {
                 enable: jest.fn(),

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -448,6 +448,9 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             jest.spyOn(document, 'addEventListener');
             stubs.listeners = imageBase.imageEl.addEventListener;
             imageBase.isMobile = true;
+            imageBase.mobileZoomStartHandler = imageBase.mobileZoomStartHandler.bind(imageBase);
+            imageBase.mobileZoomChangeHandler = imageBase.mobileZoomChangeHandler.bind(imageBase);
+            imageBase.mobileZoomEndHandler = imageBase.mobileZoomEndHandler.bind(imageBase);
         });
 
         test('should bind all default image listeners', () => {
@@ -457,19 +460,32 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('dragstart', imageBase.cancelDragEvent);
         });
 
-        test('should bind all iOS listeners', () => {
+        test('should bind wheel listener for trackpad zoom', () => {
+            imageBase.bindDOMListeners();
+            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler, { passive: false });
+        });
+
+        test('should bind all iOS listeners when hasTouch is true', () => {
             jest.spyOn(Browser, 'isIOS').mockReturnValue(true);
             imageBase.bindDOMListeners();
             expect(stubs.listeners).toBeCalledWith('gesturestart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('gestureend', imageBase.mobileZoomEndHandler);
         });
 
-        test('should bind all mobile and non-iOS listeners', () => {
+        test('should bind all touch listeners when hasTouch is true and not iOS', () => {
             jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
             imageBase.bindDOMListeners();
             expect(stubs.listeners).toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('touchmove', imageBase.mobileZoomChangeHandler);
             expect(stubs.listeners).toBeCalledWith('touchend', imageBase.mobileZoomEndHandler);
+        });
+
+        test('should not bind touch listeners when hasTouch is false', () => {
+            imageBase.isMobile = false;
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(false);
+            imageBase.bindDOMListeners();
+            expect(stubs.listeners).not.toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
+            expect(stubs.listeners).not.toBeCalledWith('gesturestart', imageBase.mobileZoomStartHandler);
         });
     });
 
@@ -483,7 +499,7 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             imageBase.imageEl.removeEventListener = jest.fn();
             stubs.listeners = imageBase.imageEl.removeEventListener;
             stubs.documentListener = jest.spyOn(document, 'removeEventListener');
-            imageBase.isMobile = true;
+            imageBase.hasTouch = true;
         });
 
         test('should unbind all default image listeners if imageEl does not exist', () => {
@@ -502,6 +518,11 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('gestureend', imageBase.mobileZoomEndHandler);
         });
 
+        test('should unbind wheel listener', () => {
+            imageBase.unbindDOMListeners();
+            expect(stubs.listeners).toBeCalledWith('wheel', imageBase.wheelZoomHandler);
+        });
+
         test('should unbind all document listeners', () => {
             imageBase.unbindDOMListeners();
             expect(stubs.documentListener).toBeCalledWith('mousemove', imageBase.pan);
@@ -514,6 +535,201 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(stubs.listeners).toBeCalledWith('touchstart', imageBase.mobileZoomStartHandler);
             expect(stubs.listeners).toBeCalledWith('touchmove', imageBase.mobileZoomChangeHandler);
             expect(stubs.listeners).toBeCalledWith('touchend', imageBase.mobileZoomEndHandler);
+        });
+    });
+
+    describe('wheelZoomHandler()', () => {
+        beforeEach(() => {
+            // Set up imageEl and wrapperEl with measurable geometry
+            imageBase.imageEl.style.width = '100px';
+            imageBase.imageEl.setAttribute('originalWidth', '100');
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 100, configurable: true });
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: 0, top: 0, width: 100, height: 100 })
+                .mockReturnValue({ left: 0, top: 0, width: 105, height: 105 });
+            imageBase.wrapperEl = document.createElement('div');
+            imageBase.wrapperEl.scrollLeft = 0;
+            imageBase.wrapperEl.scrollTop = 0;
+            jest.spyOn(imageBase, 'emit').mockImplementation();
+        });
+
+        test('should do nothing if ctrlKey is not pressed', () => {
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: false,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(imageBase.emit).not.toBeCalled();
+        });
+
+        test('should do nothing if wrapperEl is missing', () => {
+            imageBase.wrapperEl = null;
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).not.toBeCalled();
+            expect(imageBase.emit).not.toBeCalled();
+        });
+
+        test('should preventDefault and apply proportional zoom on pinch in', () => {
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).toBeCalled();
+            // deltaY=-5, delta=0.05, newWidth = 100 * 1.05 = 105
+            expect(imageBase.imageEl.style.width).toBe('105px');
+            expect(imageBase.imageEl.style.height).toBe('');
+        });
+
+        test('should apply proportional zoom on pinch out', () => {
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: 5, preventDefault: jest.fn() };
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: 0, top: 0, width: 100, height: 100 })
+                .mockReturnValue({ left: 0, top: 0, width: 95, height: 95 });
+
+            imageBase.wheelZoomHandler(event);
+            // deltaY=5, delta=-0.05, newWidth = 100 * 0.95 = 95
+            expect(imageBase.imageEl.style.width).toBe('95px');
+        });
+
+        test('should call adjustImageZoomPadding if available', () => {
+            imageBase.adjustImageZoomPadding = jest.fn();
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: true,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(imageBase.adjustImageZoomPadding).toBeCalled();
+        });
+
+        test('should call setScale with width and null height', () => {
+            imageBase.setScale = jest.fn();
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: true,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(imageBase.setScale).toBeCalledWith(105, null);
+        });
+
+        test('should emit zoom event with [width, height] array and zoom capability flags', () => {
+            Object.defineProperty(imageBase.imageEl, 'offsetHeight', { value: 100, configurable: true });
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: true,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(imageBase.emit).toBeCalledWith('zoom', {
+                newScale: [105, 100],
+                canZoomIn: true,
+                canZoomOut: true,
+            });
+        });
+
+        test('should clamp zoom to minimum scale (10% of original)', () => {
+            // originalWidth=100, so minWidth = 100 * 0.1 = 10
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 11, configurable: true });
+            Object.defineProperty(imageBase.imageEl, 'offsetHeight', { value: 11, configurable: true });
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValue({ left: 0, top: 0, width: 10, height: 10 });
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: 100, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(imageBase.imageEl.style.width).toBe('10px');
+        });
+
+        test('should clamp zoom to maximum scale (10000% of original)', () => {
+            // originalWidth=100, so maxWidth = 100 * 100 = 10000
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 9999, configurable: true });
+            Object.defineProperty(imageBase.imageEl, 'offsetHeight', { value: 9999, configurable: true });
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValue({ left: 0, top: 0, width: 10000, height: 10000 });
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -100, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(imageBase.imageEl.style.width).toBe('10000px');
+        });
+
+        test('should report canZoomOut as false at minimum scale', () => {
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 11, configurable: true });
+            Object.defineProperty(imageBase.imageEl, 'offsetHeight', { value: 10, configurable: true });
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValue({ left: 0, top: 0, width: 10, height: 10 });
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: 100, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(imageBase.emit).toBeCalledWith('zoom', expect.objectContaining({ canZoomOut: false }));
+        });
+
+        test('should report canZoomIn as false at maximum scale', () => {
+            Object.defineProperty(imageBase.imageEl, 'offsetWidth', { value: 9999, configurable: true });
+            Object.defineProperty(imageBase.imageEl, 'offsetHeight', { value: 10000, configurable: true });
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValue({ left: 0, top: 0, width: 10000, height: 10000 });
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -100, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(imageBase.emit).toBeCalledWith('zoom', expect.objectContaining({ canZoomIn: false }));
+        });
+
+        test('should use requestAnimationFrame for updatePannability', () => {
+            imageBase.updatePannability = jest.fn();
+            jest.spyOn(window, 'requestAnimationFrame').mockImplementation();
+            jest.spyOn(window, 'cancelAnimationFrame').mockImplementation();
+
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: true,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(window.requestAnimationFrame).toBeCalledWith(imageBase.updatePannability);
+        });
+
+        test('should cancel previous requestAnimationFrame before scheduling new one', () => {
+            imageBase.updatePannability = jest.fn();
+            imageBase.wheelZoomRAF = 456;
+            jest.spyOn(window, 'requestAnimationFrame').mockImplementation();
+            jest.spyOn(window, 'cancelAnimationFrame').mockImplementation();
+
+            imageBase.wheelZoomHandler({
+                clientX: 0,
+                clientY: 0,
+                ctrlKey: true,
+                deltaY: -5,
+                preventDefault: jest.fn(),
+            });
+            expect(window.cancelAnimationFrame).toBeCalledWith(456);
+            expect(window.requestAnimationFrame).toBeCalledWith(imageBase.updatePannability);
+        });
+
+        test('should anchor zoom at cursor by adjusting wrapperEl scroll', () => {
+            // Cursor at (50, 50) within a 100x100 image rooted at (0, 0); image grows to 105x105.
+            // Image point under cursor = (50, 50). After zoom, same point is at (50 * 1.05, 50 * 1.05) = (52.5, 52.5).
+            // Scroll delta should push it back to (50, 50) → +2.5 on each axis.
+            imageBase.wrapperEl.scrollLeft = 0;
+            imageBase.wrapperEl.scrollTop = 0;
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+
+            expect(imageBase.wrapperEl.scrollLeft).toBeCloseTo(2.5);
+            expect(imageBase.wrapperEl.scrollTop).toBeCloseTo(2.5);
         });
     });
 

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -552,6 +552,16 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             imageBase.wrapperEl.scrollLeft = 0;
             imageBase.wrapperEl.scrollTop = 0;
             jest.spyOn(imageBase, 'emit').mockImplementation();
+            jest.spyOn(imageBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
+        });
+
+        test('should do nothing if pinchToZoom.enabled feature is off', () => {
+            imageBase.featureEnabled.mockReturnValue(false);
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+            expect(event.preventDefault).not.toBeCalled();
+            expect(imageBase.emit).not.toBeCalled();
         });
 
         test('should do nothing if ctrlKey is not pressed', () => {


### PR DESCRIPTION
## Summary
This PR adds trackpad pinch-to-zoom support for the image viewer in box-content-preview The feature is gated behind a `pinchToZoom.enabled` feature flag.

## How it works
The implementation listens for wheel events on the wrapper element with `ctrlKey === true` — this is how Mac trackpads expose pinch gestures to the browser.

**Zoom In**
- Triggered by a pinch-out gesture (fingers spreading apart), which produces wheel events with negative deltaY.
- The image width scales proportionally: `newWidth = currentWidth * (1 + delta)`, where `delta = -deltaY * 0.01.`
- The zoom is anchored to the cursor position — the pixel under the cursor stays pinned in place while the image grows around it. This is done by computing how far the anchor point drifted after resize, then correcting via scroll offset (and CSS left/top for any remainder that can't be scrolled).
- Maximum scale: 100x the original image width.

**Zoom Out**
- Triggered by a pinch-in gesture (fingers coming together), which produces wheel events with positive deltaY.
- The image shrinks proportionally using the same formula.
- Edge clamping ensures the image converges back toward its initial centered position as it shrinks — edges are not allowed to retreat past their initial boundaries. This prevents the image from drifting off to one side during zoom-out.
- Minimum scale: the image's initial fitted width (i.e., it can't shrink smaller than it was on first load).
- When the minimum width is reached, `adjustImageZoomPadding()` is called to snap the image cleanly to the centered position.

**Other details**
- Pinch session tracking: A pinch session starts only if the cursor is over the image and ends after 200ms of idle (no explicit "pinch end" event exists for trackpad gestures).
- Pannability: updatePannability() is called after each zoom step so the cursor style reflects whether the image is pannable.
- Scale/annotation sync: setScale() is called after positioning to emit a scale event, which triggers annotation overlay re-renders at the correct position.
- Resize handling: `initialWidth` and `initialRect` are recalculated on window resize so the clamping boundaries stay correct.

## Known issues / bugs (will be fixed in future PR's)
- When image is rotated, zooming out can be snappy as our `initialRect` is obtained from the original orientation of the image.
- When image overflows on left or top edge of screen first, we cannot scroll/pan to the portion of the image which is hidden/overflows. This is not an issue when the image also overflows the right or bottom edge of the screen. Current workaround is to just zoom out of the image.
- Currently zoom out is disabled past the initial size of the image (i.e. we can only zoom out if we have zoomed in a certain amount). This functionality may be included in the future but needs input from Product.