### PR TITLE
feat(build): ship legacy Preview class as npm package

### DIFF
--- a/build/lib-types/index.d.ts
+++ b/build/lib-types/index.d.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Hand-written type declarations for the legacy Preview class.
+// Loose typing for v1; tighten in follow-ups as consumer feedback comes in.
+
+export type BoxToken = string | ((fileIds: string | string[]) => Promise<string | Record<string, string>>);
+
+export interface BoxFile {
+    id: string;
+    type?: string;
+    name?: string;
+    extension?: string;
+    size?: number;
+    [key: string]: unknown;
+}
+
+export type PreviewEventName =
+    | 'load'
+    | 'preview_error'
+    | 'preview_metric'
+    | 'navigate'
+    | 'viewer'
+    | 'preload'
+    | 'progressstart'
+    | 'progressend'
+    | 'thumbnailsOpen'
+    | 'thumbnailsClose'
+    | 'annotator_create'
+    | string;
+
+export type PreviewEventListener = (data?: any) => void;
+
+export interface PreviewOptions {
+    apiHost?: string;
+    appHost?: string;
+    autoFocus?: boolean;
+    boxAnnotations?: any;
+    cache?: { inMemoryOnly?: boolean };
+    collection?: Array<string | BoxFile>;
+    container?: string | HTMLElement;
+    enableAnnotationsImageDiscoverability?: boolean;
+    enableThumbnailsSidebar?: boolean;
+    fileOptions?: Record<string, Record<string, unknown>>;
+    fixDependencies?: boolean;
+    header?: 'light' | 'dark' | 'none';
+    headerElement?: HTMLElement;
+    logoUrl?: string;
+    pauseRequireJS?: boolean;
+    previewWMPref?: string;
+    requestInterceptor?: (config: unknown) => unknown;
+    responseInterceptor?: (response: unknown) => unknown;
+    sharedLink?: string;
+    sharedLinkPassword?: string;
+    showAnnotations?: boolean;
+    showAnnotationsControls?: boolean;
+    showAnnotationsDiscoverability?: boolean;
+    showAnnotationsDrawingCreate?: boolean;
+    showAnnotationsImageDiscoverability?: boolean;
+    showAnnotationsOnlyControls?: boolean;
+    showDownload?: boolean;
+    showLoading?: boolean;
+    showProgress?: boolean;
+    skipServerUpdate?: boolean;
+    staticBaseURI?: string;
+    staticHost?: string;
+    token?: BoxToken;
+    useHotkeys?: boolean;
+    viewer?: { NAME: string };
+    viewers?: Record<string, { disabled?: boolean; viewerOptions?: Record<string, unknown> }>;
+    [key: string]: unknown;
+}
+
+export interface PreviewError {
+    code: string;
+    message: string;
+    displayMessage?: string;
+    details?: Record<string, unknown>;
+}
+
+export class Preview {
+    constructor();
+
+    destroy(): void;
+
+    show(fileIdOrFile: string | BoxFile, token: BoxToken, options?: PreviewOptions): void;
+
+    hide(): void;
+
+    reload(skipServerUpdate?: boolean): void;
+
+    resize(): void;
+
+    print(): void;
+
+    canPrint(): boolean;
+
+    download(): void;
+
+    updateToken(tokenOrTokenFunc: BoxToken, reload?: boolean): void;
+
+    updateCollection(collection: Array<string | BoxFile>): void;
+
+    updateFileCache(fileMetadata?: BoxFile[]): void;
+
+    getCurrentViewer(): unknown;
+
+    getCurrentFile(): BoxFile | null;
+
+    getCurrentCollection(): Array<string | BoxFile>;
+
+    getViewers(): Array<{ NAME: string; CONSTRUCTOR: unknown }>;
+
+    enableViewers(viewers?: string | string[]): void;
+
+    disableViewers(viewers?: string | string[]): void;
+
+    enableHotkeys(): void;
+
+    disableHotkeys(): void;
+
+    prefetchViewers(viewerNames?: string[]): void;
+
+    loadViewers(viewerNames?: string[]): void;
+
+    navigateLeft(): void;
+
+    navigateRight(): void;
+
+    setAnnotatorViewMode(viewMode: string): void;
+
+    showBoundingBoxHighlights(boundingBoxes?: Array<unknown>): void;
+
+    hideBoundingBoxHighlights(): void;
+
+    addListener(event: PreviewEventName, listener: PreviewEventListener): this;
+
+    removeListener(event: PreviewEventName, listener: PreviewEventListener): this;
+
+    on(event: PreviewEventName, listener: PreviewEventListener): this;
+
+    off(event: PreviewEventName, listener: PreviewEventListener): this;
+
+    once(event: PreviewEventName, listener: PreviewEventListener): this;
+
+    emit(event: PreviewEventName, ...args: any[]): boolean;
+}
+
+export default Preview;

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -24,11 +24,9 @@ class CopyAssetsPlugin {
 }
 
 const src = path.resolve('src');
-// Only copy the current pdfjs version. Older pdfjs versions in src/third-party/doc/
-// are retained for CDN-pinned URLs but the npm bundle only needs the runtime version.
-// Keep this in sync with DOC_STATIC_ASSETS_VERSION in src/lib/constants.js.
-const PDFJS_VERSION = '2.107.0';
-const thirdPartyDoc = path.resolve(`src/third-party/doc/${PDFJS_VERSION}`);
+// pdfjs comes from the npm package (pdfjs-dist) bundled by webpack — useNpmPdfjs is
+// always on for the npm path (see src/index.ts). The vendored src/third-party/doc/
+// directory is only used by CDN consumers and is intentionally NOT copied here.
 const thirdPartyMedia = path.resolve('src/third-party/media');
 const thirdPartyText = path.resolve('src/third-party/text');
 const thirdPartyModel3d = path.resolve('src/third-party/model3d');
@@ -121,8 +119,8 @@ module.exports = {
         new MiniCssExtractPlugin({ filename: '[name].css' }),
         new NormalModuleReplacementPlugin(/\/iconv-loader$/),
         // Copy static assets that the legacy code resolves at runtime via createAssetUrlCreator.
-        // These need to be served alongside the bundle for npm consumers.
-        new CopyAssetsPlugin(thirdPartyDoc, path.join(outDir, 'third-party/doc')),
+        // These need to be served alongside the bundle for npm consumers. pdfjs is excluded —
+        // it's bundled from the pdfjs-dist npm package (useNpmPdfjs=true on the npm path).
         new CopyAssetsPlugin(thirdPartyMedia, path.join(outDir, 'third-party')),
         new CopyAssetsPlugin(thirdPartyText, path.join(outDir, 'third-party')),
         new CopyAssetsPlugin(thirdPartyModel3d, path.join(outDir, 'third-party')),

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -55,12 +55,15 @@ module.exports = {
     experiments: {
         outputModule: true,
     },
-    externals: {
-        react: 'react',
-        'react-dom': 'react-dom',
-        'react-dom/client': 'react-dom/client',
-        'react/jsx-runtime': 'react/jsx-runtime',
-    },
+    externals: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'box-annotations',
+        /^box-ui-elements(\/.*)?$/,
+        /^@box\/react-virtualized(\/.*)?$/,
+    ],
     externalsType: 'module',
     module: {
         rules: [

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -62,6 +62,8 @@ module.exports = {
         'react/jsx-runtime',
         'box-annotations',
         /^box-ui-elements(\/.*)?$/,
+        /^@box\/blueprint-web(\/.*)?$/,
+        /^@box\/blueprint-web-assets(\/.*)?$/,
         /^@box\/react-virtualized(\/.*)?$/,
     ],
     externalsType: 'module',

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -1,10 +1,44 @@
+/* eslint-disable global-require, import/no-dynamic-require */
 const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { BannerPlugin } = require('webpack');
+const { BannerPlugin, DefinePlugin, NormalModuleReplacementPlugin } = require('webpack');
 const license = require('./license');
+const pkg = require('../package.json');
+
+// Like RsyncPlugin, but without --delete. Multiple instances can target the same
+// destination directory without clobbering earlier copies.
+class CopyAssetsPlugin {
+    constructor(source, destination) {
+        this.source = source;
+        this.destination = destination;
+    }
+
+    apply(compiler) {
+        compiler.hooks.done.tap('CopyAssetsPlugin', () => {
+            fs.mkdirSync(this.destination, { recursive: true });
+            execSync(`rsync -avzq --exclude=".*" "${this.source}" "${this.destination}"`, { stdio: 'inherit' });
+        });
+    }
+}
 
 const src = path.resolve('src');
+// Only copy the current pdfjs version. Older pdfjs versions in src/third-party/doc/
+// are retained for CDN-pinned URLs but the npm bundle only needs the runtime version.
+// Keep this in sync with DOC_STATIC_ASSETS_VERSION in src/lib/constants.js.
+const PDFJS_VERSION = '2.107.0';
+const thirdPartyDoc = path.resolve(`src/third-party/doc/${PDFJS_VERSION}`);
+const thirdPartyMedia = path.resolve('src/third-party/media');
+const thirdPartyText = path.resolve('src/third-party/text');
+const thirdPartyModel3d = path.resolve('src/third-party/model3d');
+const thirdPartySwf = path.resolve('src/third-party/swf');
+const exifAssets = path.resolve('src/lib/exif');
+const pdfjsCmaps = path.resolve('node_modules/pdfjs-dist/cmaps');
 const outDir = path.resolve('dist/lib');
+
+const language = 'en-US';
+const langJson = require(`${path.resolve('src/i18n/json')}/${language}.json`);
 
 module.exports = {
     bail: true,
@@ -23,37 +57,84 @@ module.exports = {
     experiments: {
         outputModule: true,
     },
-    externals: ['react', 'react-dom', 'react/jsx-runtime', /^@box\/blueprint-web(\/.*)?$/],
+    externals: {
+        react: 'react',
+        'react-dom': 'react-dom',
+        'react-dom/client': 'react-dom/client',
+        'react/jsx-runtime': 'react/jsx-runtime',
+    },
     externalsType: 'module',
     module: {
         rules: [
             {
-                test: /\.(ts|tsx)$/,
-                use: [{ loader: 'babel-loader' }],
-                include: [
-                    path.resolve('src/index.ts'),
-                    path.resolve('src/components'),
-                    path.resolve('src/hooks'),
-                    path.resolve('src/types'),
+                test: /\.(js|ts|tsx)$/,
+                use: [
+                    { loader: 'babel-loader' },
+                    {
+                        loader: path.resolve('build/i18n-loader.js'),
+                        options: { translations: langJson },
+                    },
                 ],
+                include: [path.resolve('src/lib'), path.resolve('src/index.ts')],
             },
             {
                 test: /\.s?css$/,
                 use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader', 'sass-loader'],
-                include: [path.resolve('src/components'), path.resolve('src/hooks')],
+                include: [
+                    path.resolve('src/lib'),
+                    path.resolve('node_modules/box-annotations'),
+                    path.resolve('node_modules/box-ui-elements'),
+                    path.resolve('node_modules/pdfjs-dist'),
+                ],
             },
             {
-                test: /\.svg$/,
+                test: /\.(svg|html)$/,
                 type: 'asset/source',
-                include: [path.resolve('src/components'), path.resolve('src/hooks')],
+                include: [path.resolve('src/lib')],
+            },
+            {
+                test: /\.(jpe?g|png|gif|woff2|woff)$/,
+                type: 'asset/resource',
+                include: [path.resolve('src/lib')],
+                generator: {
+                    filename: 'assets/[name][ext]',
+                },
             },
         ],
     },
     optimization: {
         minimize: false,
     },
-    plugins: [new BannerPlugin(license), new MiniCssExtractPlugin({ filename: '[name].css' })],
+    ignoreWarnings: [
+        // pdfjs-dist contains an internal dynamic require that webpack flags as a critical
+        // dependency. Safe to ignore — same suppression as the CDN webpack config.
+        { module: /pdfjs-dist/, message: /Critical dependency/ },
+    ],
+    plugins: [
+        new BannerPlugin(license),
+        new DefinePlugin({
+            __LANGUAGE__: JSON.stringify(language),
+            __NAME__: JSON.stringify(pkg.name),
+            __VERSION__: JSON.stringify(pkg.version),
+            'process.env.BABEL_ENV': JSON.stringify(process.env.BABEL_ENV),
+        }),
+        new MiniCssExtractPlugin({ filename: '[name].css' }),
+        new NormalModuleReplacementPlugin(/\/iconv-loader$/),
+        // Copy static assets that the legacy code resolves at runtime via createAssetUrlCreator.
+        // These need to be served alongside the bundle for npm consumers.
+        new CopyAssetsPlugin(thirdPartyDoc, path.join(outDir, 'third-party/doc')),
+        new CopyAssetsPlugin(thirdPartyMedia, path.join(outDir, 'third-party')),
+        new CopyAssetsPlugin(thirdPartyText, path.join(outDir, 'third-party')),
+        new CopyAssetsPlugin(thirdPartyModel3d, path.join(outDir, 'third-party')),
+        new CopyAssetsPlugin(thirdPartySwf, path.join(outDir, 'third-party')),
+        new CopyAssetsPlugin(exifAssets, outDir),
+        new CopyAssetsPlugin(pdfjsCmaps, outDir),
+    ],
     resolve: {
+        alias: {
+            'box-annotations-messages': path.resolve(`node_modules/box-annotations/i18n/${language}`),
+            'box-elements-messages': path.resolve(`node_modules/box-ui-elements/i18n/${language}`),
+        },
         extensions: ['.tsx', '.ts', '.js'],
         modules: [src, 'node_modules'],
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
     "publishConfig": {
         "access": "public"
     },
+    "dependencies": {
+        "axios": "^0.24.0",
+        "pdfjs-dist": "4.3.136"
+    },
     "peerDependencies": {
+        "@box/react-virtualized": "9.22.3-rc-box.2",
+        "box-annotations": "^5.2.1-beta.0",
+        "box-ui-elements": "^20.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
     },
@@ -54,7 +61,6 @@
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
         "autoprefixer": "^10.4.21",
-        "axios": "^0.24.0",
         "babel-loader": "^8.3.0",
         "babel-plugin-transform-require-ignore": "^0.1.1",
         "box-annotations": "^5.2.1-beta.0",
@@ -179,8 +185,5 @@
         "**/react-intl/**/@types/react": "18.3.1",
         "cheerio": "1.0.0-rc.12",
         "acorn": "8.14.0"
-    },
-    "dependencies": {
-        "pdfjs-dist": "4.3.136"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "pdfjs-dist": "4.3.136"
     },
     "peerDependencies": {
+        "@box/blueprint-web": "^14.32.1",
+        "@box/blueprint-web-assets": "^4.119.2",
         "@box/react-virtualized": "9.22.3-rc-box.2",
         "box-annotations": "^5.2.1-beta.0",
         "box-ui-elements": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -19,18 +19,12 @@
         "./styles.css": "./dist/lib/index.css",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
     },
@@ -136,9 +130,9 @@
         "build:ci": "yarn setup && yarn webpack --progress --config build/webpack.config.js",
         "build:dev": "BABEL_ENV=dev NODE_ENV=dev yarn webpack --progress --config build/webpack.config.js",
         "build:i18n": "mojito-rb-gen -s src/i18n -o src/i18n/json -b en-US.properties",
-        "build:lib": "yarn build:lib:js && yarn build:lib:types",
+        "build:lib": "yarn build:i18n && yarn build:lib:js && yarn build:lib:types",
         "build:lib:js": "BABEL_ENV=production NODE_ENV=production yarn webpack --config build/webpack.config.lib.js",
-        "build:lib:types": "tsc --project tsconfig.lib.json",
+        "build:lib:types": "cp build/lib-types/index.d.ts dist/lib/index.d.ts",
         "build:prod": "BABEL_ENV=production NODE_ENV=production node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --progress --config build/webpack.config.js",
         "clean": "rm -rf dist && rm -rf reports/coverage && rm -rf src/i18n/json",
         "cy:open": "yarn cy:wait; yarn cypress open",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
         "@babel/preset-env": "^7.18.6",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
+        "@box/blueprint-web": "^14.41.0",
+        "@box/blueprint-web-assets": "^4.119.2",
         "@box/frontend": "^6.4.0",
         "@box/languages": "^1.0.0",
         "@box/react-virtualized": "9.22.3-rc-box.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,6 @@
-export * from './components';
-export * from './hooks';
+// Re-export the legacy Preview class as the default export of the npm package.
+// Consumers can `import Preview from 'box-content-preview'` to use the imperative API.
+import Preview from './lib/Preview';
+
+export default Preview;
+export { Preview };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,17 @@
 // Re-export the legacy Preview class as the default export of the npm package.
 // Consumers can `import Preview from 'box-content-preview'` to use the imperative API.
-import Preview from './lib/Preview';
+import LegacyPreview from './lib/Preview';
+
+// npm consumers always use the bundled pdfjs-dist (PREVIEW-111) — there's no CDN serving
+// the vendored pdf.min.mjs at runtime. Inject useNpmPdfjs=true into options.features
+// before delegating to the underlying show().
+class Preview extends LegacyPreview {
+    show(fileIdOrFile: string | object, token: unknown, options: { features?: Record<string, unknown> } = {}): void {
+        const features = { useNpmPdfjs: true, ...(options.features ?? {}) };
+        // @ts-expect-error — LegacyPreview is a JS class without a typed signature.
+        return super.show(fileIdOrFile, token, { ...options, features });
+    }
+}
 
 export default Preview;
 export { Preview };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,12 +1299,17 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.20.7", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
   integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.5"
@@ -3986,9 +3991,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 box-annotations@^5.2.1-beta.0:
-  version "5.2.1-beta.0"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-5.2.1-beta.0.tgz#09ebd0538e045797f5d0c8cc893addf8ded28351"
-  integrity sha512-M6ZqiMWkm5rYqQHBLxNtjbEaZsvtzzxdGMsrhGxL+7+sbo4NpgCqNvV875DMqh4nSvLRQbUrPrIe32iYZxKxxw==
+  version "5.2.1-beta.14"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-5.2.1-beta.14.tgz#e082637d904ad21337bb2e4537a937bd38484e7c"
+  integrity sha512-jFTQkEv/7Mz5mUmIQ8124/X9SMrCEuay3lOj3xDR6bcXvzWllVEDLBspduqQQj1EKYzSA3d1dynrJwKLMzBosw==
 
 box-ui-elements@^20.0.0:
   version "20.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,34 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.0.tgz#728c484f4e10df03d5a3acd0d8adcbbebff8ad63"
   integrity sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==
 
+"@adobe/react-spectrum-ui@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@adobe/react-spectrum-ui/-/react-spectrum-ui-1.2.1.tgz#31651a1c664b014bd7b4f8a2265e26ae418aecec"
+  integrity sha512-wcrbEE2O/9WnEn6avBnaVRRx88S5PLFsPLr4wffzlbMfXeQsy+RMQwaJd3cbzrn18/j04Isit7f7Emfn0dhrJA==
+
+"@adobe/react-spectrum-workflow@2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.5.tgz#3f5adc5fe2bae25416805b7d92c1ff5bd1e061f0"
+  integrity sha512-b53VIPwPWKb/T5gzE3qs+QlGP5gVrw/LnWV3xMksDU+CRl3rzOKUwxIGiZO8ICyYh1WiyqY4myGlPU/nAynBUg==
+
+"@adobe/react-spectrum@^3.47.0":
+  version "3.47.1"
+  resolved "https://registry.yarnpkg.com/@adobe/react-spectrum/-/react-spectrum-3.47.1.tgz#46b9ef3d4dd16937cafdad6480edd19c4c412022"
+  integrity sha512-mijNyd8XmA6KoBMbqKc4Rp+S2voKdZkPydJFjQbG0SkOjOKcgqVpJdKGsKdLMZBn9Jk5SgEuklyrhc7Uvot2tA==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@react-types/shared" "^3.35.0"
+    "@spectrum-icons/ui" "^3.7.1"
+    "@spectrum-icons/workflow" "^4.3.1"
+    "@swc/helpers" "^0.5.0"
+    client-only "^0.0.1"
+    clsx "^2.0.0"
+    react-aria "3.49.0"
+    react-aria-components "1.18.0"
+    react-stately "3.47.0"
+    react-transition-group "^4.4.5"
+    use-sync-external-store "^1.6.0"
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -19,6 +47,27 @@
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
+
+"@ariakit/core@0.4.18":
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/@ariakit/core/-/core-0.4.18.tgz#e1a629e942c98b9371fd81b14f63b793f878c5eb"
+  integrity sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==
+
+"@ariakit/react-core@0.4.21":
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/@ariakit/react-core/-/react-core-0.4.21.tgz#175a2cf31566943dd2e1fae04e04e09d7684ad98"
+  integrity sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==
+  dependencies:
+    "@ariakit/core" "0.4.18"
+    "@floating-ui/dom" "^1.0.0"
+    use-sync-external-store "^1.2.0"
+
+"@ariakit/react@0.4.21":
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/@ariakit/react/-/react-0.4.21.tgz#851051d9f4cd5be53baf04cb8281123d139d56d0"
+  integrity sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==
+  dependencies:
+    "@ariakit/react-core" "0.4.21"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.5":
   version "7.22.5"
@@ -1299,6 +1348,11 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.24.4", "@babel/runtime@^7.5.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/runtime@^7.20.7", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
@@ -1408,6 +1462,47 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@box/blueprint-web-assets@^4.119.2", "@box/blueprint-web-assets@^4.121.0":
+  version "4.121.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.121.0.tgz#bf449341bad2121fbbb2eff4f1468c8d81e94925"
+  integrity sha512-jc7jwqOssUsglaR3q1GPfpD6CKOMUVC1R5LTNX0IhvLICXlgIJJU7IOEZlL+wfA8ZUleElcO4EaFLU8lslrhxg==
+
+"@box/blueprint-web@^14.41.0":
+  version "14.41.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.41.0.tgz#b7fe93d25a4672cabf15e5c680b892aece613fd7"
+  integrity sha512-coNCVzpw4d0tJzdHfZT0f15cgwIMjBJs+Jl8s/CYOGO7HBMvNWjqEkgqM0zMDUHtFZY8a8ZfCOCmDy5NY1OKWQ==
+  dependencies:
+    "@ariakit/react" "0.4.21"
+    "@ariakit/react-core" "0.4.21"
+    "@box/blueprint-web-assets" "^4.121.0"
+    "@internationalized/date" "^3.12.0"
+    "@radix-ui/react-accordion" "1.1.2"
+    "@radix-ui/react-checkbox" "1.0.4"
+    "@radix-ui/react-collapsible" "1.0.3"
+    "@radix-ui/react-context-menu" "2.1.5"
+    "@radix-ui/react-dialog" "1.0.5"
+    "@radix-ui/react-dropdown-menu" "2.0.6"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-popover" "1.0.7"
+    "@radix-ui/react-radio-group" "1.1.3"
+    "@radix-ui/react-scroll-area" "1.0.5"
+    "@radix-ui/react-select" "2.0.0"
+    "@radix-ui/react-slider" "1.1.2"
+    "@radix-ui/react-switch" "1.0.3"
+    "@radix-ui/react-toast" "1.1.5"
+    "@radix-ui/react-toggle-group" "1.0.4"
+    "@radix-ui/react-toolbar" "1.0.4"
+    "@radix-ui/react-tooltip" "1.0.7"
+    "@react-aria/i18n" "3.12.16"
+    "@react-aria/interactions" "3.27.1"
+    "@react-aria/utils" "3.33.1"
+    clsx "^1.2.1"
+    color "2.0.1"
+    lodash "^4.17.15"
+    react-aria "3.47.0"
+    react-aria-components "1.16.0"
+    type-fest "^3.2.0"
 
 "@box/frontend@^6.4.0":
   version "6.4.0"
@@ -1660,6 +1755,33 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.43.0.tgz#559ca3d9ddbd6bf907ad524320a0d14b85586af0"
   integrity sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==
 
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz#5fb5a20d10aafb9505f38c24f38d00c8e1598893"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
+  dependencies:
+    "@floating-ui/dom" "^1.7.6"
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
+
 "@formatjs/ecma402-abstract@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz#39197ab90b1c78b7342b129a56a7acdb8f512e17"
@@ -1668,12 +1790,38 @@
     "@formatjs/intl-localematcher" "0.5.4"
     tslib "^2.4.0"
 
+"@formatjs/ecma402-abstract@2.3.6":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz#d6ca9d3579054fe1e1a0a0b5e872e0d64922e4e1"
+  integrity sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==
+  dependencies:
+    "@formatjs/fast-memoize" "2.2.7"
+    "@formatjs/intl-localematcher" "0.6.2"
+    decimal.js "^10.4.3"
+    tslib "^2.8.0"
+
 "@formatjs/fast-memoize@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz#33bd616d2e486c3e8ef4e68c99648c196887802b"
   integrity sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==
   dependencies:
     tslib "^2.4.0"
+
+"@formatjs/fast-memoize@2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz#707f9ddaeb522a32f6715bb7950b0831f4cc7b15"
+  integrity sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==
+  dependencies:
+    tslib "^2.8.0"
+
+"@formatjs/icu-messageformat-parser@2.11.4":
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz#63bd2cd82d08ae2bef55adeeb86486df68826f32"
+  integrity sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.6"
+    "@formatjs/icu-skeleton-parser" "1.8.16"
+    tslib "^2.8.0"
 
 "@formatjs/icu-messageformat-parser@2.7.8":
   version "2.7.8"
@@ -1683,6 +1831,14 @@
     "@formatjs/ecma402-abstract" "2.0.0"
     "@formatjs/icu-skeleton-parser" "1.8.2"
     tslib "^2.4.0"
+
+"@formatjs/icu-skeleton-parser@1.8.16":
+  version "1.8.16"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz#13f81f6845c7cf6599623006aacaf7d6b4ad2970"
+  integrity sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.6"
+    tslib "^2.8.0"
 
 "@formatjs/icu-skeleton-parser@1.8.2":
   version "1.8.2"
@@ -1716,6 +1872,13 @@
   integrity sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==
   dependencies:
     tslib "^2.4.0"
+
+"@formatjs/intl-localematcher@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz#e9ebe0b4082d7d48e5b2d753579fb7ece4eaefea"
+  integrity sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==
+  dependencies:
+    tslib "^2.8.0"
 
 "@formatjs/intl-unified-numberformat@^3.2.0":
   version "3.3.7"
@@ -1777,6 +1940,35 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
+
+"@internationalized/date@^3.12.0", "@internationalized/date@^3.12.1", "@internationalized/date@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.12.2.tgz#08a65edd2a29775e22c168ddc029fb54bf9b8a85"
+  integrity sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/message@^3.1.8", "@internationalized/message@^3.1.9":
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/@internationalized/message/-/message-3.1.10.tgz#e87b25d9f545c7c8edb9b6ccb1a17005a0c052a0"
+  integrity sha512-nc0Or6EdWHqZRcsXb6P9hBIpLsfSl/ILh0rk5h/OVBpzmhdExXtPy2cQtWsq8XKRBpRHwDNnAHt4OpolcB7dog==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    intl-messageformat "^10.1.0"
+
+"@internationalized/number@^3.6.5", "@internationalized/number@^3.6.7":
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.6.7.tgz#5a0a8fa413b5f8679a59dcf37e2a74dc508b8371"
+  integrity sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/string@^3.2.7", "@internationalized/string@^3.2.8", "@internationalized/string@^3.2.9":
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.2.9.tgz#0e50385c411eac1275d91cdeb56dd7fbc234997f"
+  integrity sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2454,6 +2646,1159 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
+"@radix-ui/number@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.1.tgz#644161a3557f46ed38a042acf4a770e826021674"
+  integrity sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-accordion@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-accordion/-/react-accordion-1.1.2.tgz#738441f7343e5142273cdef94d12054c3287966f"
+  integrity sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collapsible" "1.0.3"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-arrow@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
+  integrity sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-checkbox@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz#98f22c38d5010dd6df4c5744cac74087e3275f4b"
+  integrity sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-collapsible@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz#df0e22e7a025439f13f62d4e4a9e92c4a0df5b81"
+  integrity sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-collection@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.3.tgz#9595a66e09026187524a36c6e7e9c7d286469159"
+  integrity sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context-menu@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context-menu/-/react-context-menu-2.1.5.tgz#1bdbd72761439f9166f75dc4598f276265785c83"
+  integrity sha512-R5XaDj06Xul1KGb+WP8qiOh7tKJNz2durpLBXAGZjSVtctcRFCuEvy2gtMwRJGePwQQE5nV77gs4FwRi8T+r2g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-menu" "2.0.6"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz#71657b1b116de6c7a0b03242d7d43e01062c7300"
+  integrity sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-direction@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.1.tgz#9cb61bf2ccf568f3421422d182637b7f47596c9b"
+  integrity sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dismissable-layer@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz#3f98425b82b9068dfbab5db5fff3df6ebf48b9d4"
+  integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-dropdown-menu@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.6.tgz#cdf13c956c5e263afe4e5f3587b3071a25755b63"
+  integrity sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-menu" "2.0.6"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-focus-guards@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
+  integrity sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz#2ac45fce8c5bb33eb18419cdc1905ef4f1906525"
+  integrity sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-id@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"
+  integrity sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-menu@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.0.6.tgz#2c9e093c1a5d5daa87304b2a2f884e32288ae79e"
+  integrity sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-popover@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.0.7.tgz#23eb7e3327330cb75ec7b4092d685398c1654e3c"
+  integrity sha512-shtvVnlsxT6faMnK/a7n0wptwBD23xc1Z5mdrtKLwVEfsEMXodS0r5s0/g5P0hX//EKYZS2sxUjqfzlg52ZSnQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-portal@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.4.tgz#df4bfd353db3b1e84e639e9c63a5f2565fb00e15"
+  integrity sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-radio-group@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.1.3.tgz#3197f5dcce143bcbf961471bf89320735c0212d3"
+  integrity sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-roving-focus@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz#e90c4a6a5f6ac09d3b8c1f5b5e81aab2f0db1974"
+  integrity sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-scroll-area@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz#01160c6893f24a2ddb5aa399ae5b3ba84ad4d3cc"
+  integrity sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-select@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.0.0.tgz#a3511792a51a7018d6559357323a7f52e0e38887"
+  integrity sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-separator@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.0.3.tgz#be5a931a543d5726336b112f465f58585c04c8aa"
+  integrity sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-slider@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.1.2.tgz#330ff2a0e1f6c19aace76590004f229a7e8fbe6c"
+  integrity sha512-NKs15MJylfzVsCagVSWKhGGLNR1W9qWs+HtgbmjjVUB3B9+lb3PYoXxVju3kOrpf0VKyVCtZp+iTwVoqpa1Chw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-slot@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-switch@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.0.3.tgz#6119f16656a9eafb4424c600fdb36efa5ec5837e"
+  integrity sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-toast@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.1.5.tgz#f5788761c0142a5ae9eb97f0051fd3c48106d9e6"
+  integrity sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+
+"@radix-ui/react-toggle-group@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle-group/-/react-toggle-group-1.0.4.tgz#f5b5c8c477831b013bec3580c55e20a68179d6ec"
+  integrity sha512-Uaj/M/cMyiyT9Bx6fOZO0SAG4Cls0GptBWiBmBxofmDbNVnYYoyRWj/2M/6VCi/7qcXFWnHhRUfdfZFvvkuu8A==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-toggle" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toggle@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz#aecb2945630d1dc5c512997556c57aba894e539e"
+  integrity sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toolbar@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toolbar/-/react-toolbar-1.0.4.tgz#3211a105567fa016e89921b5b514877f833de559"
+  integrity sha512-tBgmM/O7a07xbaEkYJWYTXkIdU/1pW4/KZORR43toC/4XWyBCURK0ei9kMUdp+gTPPKBgYLxXmRSH1EVcIDp8Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-separator" "1.0.3"
+    "@radix-ui/react-toggle-group" "1.0.4"
+
+"@radix-ui/react-tooltip@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz#8f55070f852e7e7450cc1d9210b793d2e5a7686e"
+  integrity sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+
+"@radix-ui/react-use-callback-ref@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-previous@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz#b595c087b07317a4f143696c6a01de43b0d0ec66"
+  integrity sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz#fde50b3bb9fd08f4a1cd204572e5943c244fcec2"
+  integrity sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-use-size@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz#1c5f5fea940a7d7ade77694bb98116fb49f870b2"
+  integrity sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz#51aed9dd0fe5abcad7dee2a234ad36106a6984ac"
+  integrity sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.1.tgz#bf8e7d947671996da2e30f4904ece343bc4a883f"
+  integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@react-aria/autocomplete@3.0.0-rc.6":
+  version "3.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.6.tgz#34a8194e58fca1582495f1f71e4dc62d98c1ca41"
+  integrity sha512-uymUNJ8NW+dX7lmgkHE+SklAbxwktycAJcI5lBBw6KPZyc0EdMHC+/Fc5CUz3enIAhNwd2oxxogcSHknquMzQA==
+  dependencies:
+    "@react-aria/combobox" "^3.15.0"
+    "@react-aria/focus" "^3.21.5"
+    "@react-aria/i18n" "^3.12.16"
+    "@react-aria/interactions" "^3.27.1"
+    "@react-aria/listbox" "^3.15.3"
+    "@react-aria/searchfield" "^3.8.12"
+    "@react-aria/textfield" "^3.18.5"
+    "@react-aria/utils" "^3.33.1"
+    "@react-stately/autocomplete" "3.0.0-beta.4"
+    "@react-stately/combobox" "^3.13.0"
+    "@react-types/autocomplete" "3.0.0-alpha.38"
+    "@react-types/button" "^3.15.1"
+    "@react-types/shared" "^3.33.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/breadcrumbs@^3.5.32":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/breadcrumbs/-/breadcrumbs-3.6.1.tgz#ea3349d9922d91296b4de230df6013f5b747133f"
+  integrity sha512-dpqiP8N0RdTLmI0pSZfL0tdjumS8bovPNRvb+SmXsXBeBRlT8Rg0oJiP7VCUgCIDMuc6BqdQ1QRzGK1nAwyVvQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/button@^3.14.5", "@react-aria/button@^3.15.0":
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/button/-/button-3.15.1.tgz#2ec0c6480246863cc542ae2886a6e9eb7264cdc4"
+  integrity sha512-SBMn8ZLvjuWCpSqi6o1hOjsqQqkdYFfzIdl/0LgNPUpTclkJuMx7gNXfM3mjgxzSCoS5CD/XdicvqJanMw6jCw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/calendar@^3.9.5":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/calendar/-/calendar-3.10.1.tgz#0e78dd048f6fa7147e1d3c470139d450cca7a1d9"
+  integrity sha512-0QYoKYyCHFVvfOlXgftTzDttTXtbnYa0GQ6i970Rjdx/0VrMdJe2TXSm60OEISwB3w0aZWAnn3CBiDVtOYQtEw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+    react-stately "^3.46.0"
+
+"@react-aria/checkbox@^3.16.5":
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/checkbox/-/checkbox-3.17.1.tgz#ce184c1a52f4484ee509d381dbcf0c47bbcc74e0"
+  integrity sha512-742B+UhH87TK02SYsFJZOgQ9VZpFEythH5LXRnwxt/xShoKOp+eqXPaVah79s/+B9sxY1mF0wNORQ2RVAQFSKw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/collections@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/collections/-/collections-3.1.1.tgz#b44d023586fd18562da68959e89dad70f328fe21"
+  integrity sha512-54NpHYVnv1+47L5e2DZ34WvzPSOg6dgl4E78EfZo3kNdyM8xhM2vCuYuS8uUs1xCPr7HcBBmnn/maHOxfSabeg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/color@^3.1.5":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/color/-/color-3.2.1.tgz#80701873fb26cd737de6c388650f3899ccdfb171"
+  integrity sha512-v/pZh1yBNeayQ5Kio0xRIX0gBf6uu+KjCRW4QSydTyRpmhvk6sMzHT9i9/vIMdaDHaYHBXlXF+Tp/mvS9CG4Zw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/combobox@^3.15.0", "@react-aria/combobox@^3.16.0":
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/combobox/-/combobox-3.16.1.tgz#4a80ad97d5513a7228fad037acd6100413a6ad44"
+  integrity sha512-Ufoos0z66dRx8bxN3OJ25ASqksukPQaxVP5thr7dnu2QqqhxlZb1Va1ebaVxzMAnSrB78oQh3h1d9/hS4uhcPQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/datepicker@^3.16.1":
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/datepicker/-/datepicker-3.17.1.tgz#0a47282453c6a9761512625e50005ff553d5a949"
+  integrity sha512-+uK1jki+iRMsbaqFBfCnBNFPQHJZLgKl7tniK7CjC2pJeWWS+ZMBo4J/yKZihq+IkKv5UKV2R5gotk6iJuBusw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+    react-stately "^3.46.0"
+
+"@react-aria/dialog@^3.5.34":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/dialog/-/dialog-3.6.1.tgz#8e305ca9e94f4d08826be905b5791db137209c63"
+  integrity sha512-Eo3Kj23TjENuERUYrGkH+VN1PJvK8/zep76pfwBg29erUVDpGdfagYRq82aGcxJ/ohG8iRxZDwp2tTrU1RG1MQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/disclosure@^3.1.3":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/disclosure/-/disclosure-3.2.1.tgz#95e222adde9bcbcf0b8bab51630c25d29261ef79"
+  integrity sha512-ornniPdbuyrI0Qt4UX1NYGcx9o6JY1zcHv8HgYM3aPVjZ2zlWk811QpBlB6e1AVXuBjfrFFigj28s9ayYdyoyQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/dnd@^3.11.6":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/dnd/-/dnd-3.12.1.tgz#63b52732a4da989d2693bb2df679555a4e11326e"
+  integrity sha512-gAFsHChr2K9enfTOyY3h+7c+hb8fM7GGSWRlcE63If+jrdBRPicQ0wyiRr1ChFU3KVH3Nk2PZUUMET58QlUYVQ==
+  dependencies:
+    "@react-types/shared" "^3.34.0"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/focus@^3.21.5":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.22.1.tgz#7e7ba6a2250135728eb68ffa21e422ec25a16800"
+  integrity sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/gridlist@^3.14.4":
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/gridlist/-/gridlist-3.15.1.tgz#4b784d1c78fc1e01aaa678628d85e013a24b652d"
+  integrity sha512-NBcAklJVaJiWPaqW0xaytxr/JJAd2FuSulq/j2jEe6jLO8bb74DNmyOR5vGVMUa5gXbIc/Yi3FGKFRn/7R2xDQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/i18n@3.12.16":
+  version "3.12.16"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.12.16.tgz#f11950d43db23a6a50cea22f2f908d6090afc895"
+  integrity sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==
+  dependencies:
+    "@internationalized/date" "^3.12.0"
+    "@internationalized/message" "^3.1.8"
+    "@internationalized/number" "^3.6.5"
+    "@internationalized/string" "^3.2.7"
+    "@react-aria/ssr" "^3.9.10"
+    "@react-aria/utils" "^3.33.1"
+    "@react-types/shared" "^3.33.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/i18n@^3.12.16":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.13.1.tgz#a40f339c3dd396e2c9782edbe8a8a3986ae4b5cb"
+  integrity sha512-z56ZYcbfpNmMyiGLhyEjytpmEfoTlBaksk84q4kds3HvNkf7QWKj+DJVfVDrJX+c1LyuBsszLSX7yxJRiHsYKQ==
+  dependencies:
+    "@internationalized/date" "^3.12.1"
+    "@internationalized/message" "^3.1.9"
+    "@internationalized/string" "^3.2.8"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/interactions@3.27.1":
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.27.1.tgz#0f4d3eafb7a9acd25d864e9ab1e4a8a68602db2a"
+  integrity sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==
+  dependencies:
+    "@react-aria/ssr" "^3.9.10"
+    "@react-aria/utils" "^3.33.1"
+    "@react-stately/flags" "^3.1.2"
+    "@react-types/shared" "^3.33.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/interactions@^3.27.1":
+  version "3.28.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.28.1.tgz#852294ae63f6a7d8aeeba3a1e7343daa8cd8507c"
+  integrity sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==
+  dependencies:
+    "@react-types/shared" "^3.34.0"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/label@^3.7.25":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.8.1.tgz#8d0383100ce5736e0deccf6e9cff8f2e5283bf12"
+  integrity sha512-zf6hG22PnxZ9kEUwxORClBicHK5pcvucDU+lotGsI6ENbdIvJAMNn9X0oiPPae56CVf2T0KEL9NB8LKdAfzCIw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/landmark@^3.0.10":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/landmark/-/landmark-3.1.1.tgz#2ba97687bf99cb0f788979adc3db7473e2593350"
+  integrity sha512-Njn/UVrCb2BPW1CPLHA1vrH51+ug62xLMNGUu2qtYj1rAxkLG1m3151hewgcxYtpmPxYlnRtOAmSuu/oD5YTFA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/link@^3.8.9":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/link/-/link-3.9.1.tgz#c660efe8934404213245abfd484faa9bf51c18b5"
+  integrity sha512-lup+i3TVgVjRJOt6kpngZfP+3bmeABqcDRhEaE+7xg7DRpbeiccNYVMtKySiFTZePwP3fcbCyTGxZe6DY4CLmA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/listbox@^3.15.3":
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/listbox/-/listbox-3.16.1.tgz#dcd433ceddd735ad899a318fdc67828ff6d06f90"
+  integrity sha512-FbNeUXmo/H2Qp+yKboNod1eVhfmQDv1YexzEIAHsKL5Cx8uA7wZID9Pbq28jPC4plPISgS5KLBodaDikOXqviA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/live-announcer@^3.4.4":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/live-announcer/-/live-announcer-3.5.1.tgz#56ff6eec9c1bc5b1774e30e04edd057b6c8f6cb1"
+  integrity sha512-kLvwHjM3D7KgdquiAhUpRnMLKFrvl2r8naDXqPUlSWGRG15wsJRLhQOHLxGp0Umyg7KcSA+OD1mhQV5aRv0P1w==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/menu@^3.21.0":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/menu/-/menu-3.22.1.tgz#543440b952707e04d680c2ddd9eb50362b805aef"
+  integrity sha512-ASP2u11+jg4OQh+QaDlWb7upMgsMITBQTjPFPbUJp6eE4q/cddLPYf4/9yfxh/bwTg0iDdzoDrgdtbwNGYNSfg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/meter@^3.4.30":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/meter/-/meter-3.5.1.tgz#1ff3b2400f0509438f84e15a481e70a00e4589e0"
+  integrity sha512-e7QN/Q/gpljItmeiHSf8+7dajU+Ix1rWAPjPoAoqcAuzfItIPQprnz6TCFUU27ozgh3L7UnLzROwfIz1eUEkuw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/numberfield@^3.12.5":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/numberfield/-/numberfield-3.13.1.tgz#8c478c7ad28765c9060fc5a20fb76d036ace11ee"
+  integrity sha512-hbDCWexlBpW/wW4APsWWEoVOi6D3iXPng/P1hCmLIVqB5Z8h/Y8myAA8mNj4X2MbfvFOr/WlOk/CJdpa8R3/Ew==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/overlays@^3.31.2":
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/overlays/-/overlays-3.32.1.tgz#7db09e6d07cb24b26c37d60dbad17233445afbd2"
+  integrity sha512-jjVLcEK5qaGsz3SmW+eLV3QFiJzdDFzgNofPwvzBS1KTPox0a2x5u1ITUPmHwyUNiyexy531h5eVjN3tULEzHQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/progress@^3.4.30":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/progress/-/progress-3.5.1.tgz#230d54a4856b81c3f50862f448c88d9eec032994"
+  integrity sha512-WTBgCkizRdulrqS+CAh/jfrvNqz09fRyg2VnFPF7OkCTmq8VNX6n3e1FZyQnpvLldpJGCAcfS3wAQB0sZBnZ9A==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/radio@^3.12.5":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/radio/-/radio-3.13.1.tgz#89c1cf8801e42b8e0238d4fc8af530de01c437d5"
+  integrity sha512-Rsl/knBduhNKQfHGO3i+Jc3P3tFo213UPD3HU3W1GjZtYlUEBYL0m5ehA6cT7alse3aCWp/icoXCcYbgBHBQHw==
+  dependencies:
+    "@react-types/shared" "^3.34.0"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/searchfield@^3.8.12", "@react-aria/searchfield@^3.9.0":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/searchfield/-/searchfield-3.9.1.tgz#9b83624b35435d1e17ae9592bd09892d9f15a41b"
+  integrity sha512-BBJMq07CCcn7uaAyKKzFPRafX2x16gWluGNwMvpvuK9E0JNeTqQXKxYVzJ6EE39dYN9D97Icc1/2MtUaKJFETA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/select@^3.17.3":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/select/-/select-3.18.1.tgz#6d838ea1b073a2b792a91cc6cafb4849b532ab2f"
+  integrity sha512-0Y0Jzhgbasa3F+teRrbL9yePJY+RvIAT9/D0EBBXoMKNCHfSn9iB+rip833XDmkUPEfQqO8X8bQGPDMh1K5Q3w==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/selection@^3.27.2":
+  version "3.28.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/selection/-/selection-3.28.1.tgz#4d92807cf062240d7827ccd11a7892116752f22a"
+  integrity sha512-gGa9HkRnWsKxRhrtVASvecNyetMtP9fNF/Vcsy9Z+6NigjGUSN4SU0bhfglZ706B4t/NSMoVhcBJXlyFiG0hQw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/separator@^3.4.16":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/separator/-/separator-3.5.1.tgz#434e72b693eb9bf8cb503e75bdfdbf4cc2fda06b"
+  integrity sha512-Rba/w3/F13p+R85Z0dzxKI1mkeYxusiBcX0v6wSMD36cIpqYxP+/nuf05pr+kiMDWFZ/Wbe6TDiWfex9+QVukA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/slider@^3.8.5":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/slider/-/slider-3.9.1.tgz#b4ec3c77b327a9d7dd46102314e256cb1ae288fc"
+  integrity sha512-bFWhyM6mP9TzAjCpOKybS7x0RTsFa2+49XKytKN53xS7bdHEnWGbWpsdJ09qZ6z1fnrwFcq/j/hhj/0gVO8kdQ==
+  dependencies:
+    "@react-types/shared" "^3.34.0"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/ssr@^3.9.10":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.10.1.tgz#d082600c811e35e8ab780c55c47b5d731359aaf7"
+  integrity sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/switch@^3.7.11":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/switch/-/switch-3.8.1.tgz#7be09fd50096d9cbf87eb857ab06508606a8581e"
+  integrity sha512-WzkJG3xJnBdd9rdBxG+0RgWdopAqwI61Ni4ZQtA2rgFuG9UpZIrhsL7qgFO/+R6oEgoeGAMeUlvCf97Ppj2uTg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/table@^3.17.11":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/table/-/table-3.18.1.tgz#e705cac3caafc3419676a31c5af4ba6104555629"
+  integrity sha512-lmSIZ/u9NoZgD2py8q8/mGKaBs37D5JYtsmC1eJAktnQPHLTwKLwVAQ4A2uhWh01qOayx5qAPjfVCYUvvpsQUQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/tabs@^3.11.1":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/tabs/-/tabs-3.12.1.tgz#f83dc82f90933ddb5bd0ef5467ae72b5593f9151"
+  integrity sha512-fGMxbqSnqtn3GRiicLfnhWcnD6Auch0qCyt5ArfndYrISmSZkzq7PVZtDj85TEqC6p8WSw/M7HjWBBUX5/Of0g==
+  dependencies:
+    "@react-types/shared" "^3.34.0"
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/tag@^3.8.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/tag/-/tag-3.9.1.tgz#c6c4e8673f1b35f987f46531b126e5e32249f3f6"
+  integrity sha512-AhK6w8pxt+MkzoEamZLXnZ/MkJcBiev6p7A5/OKqcjdp54bP8awS2NDcQLlD44CBbJ5Le9LPoxGHQCE/kbI9aQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/textfield@^3.18.5":
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/textfield/-/textfield-3.19.1.tgz#731466d4d2aa64539aaf22269eb3e771be670111"
+  integrity sha512-zYxQvOgN2CkvNvKchHEDu9UAOrwYzsaeUKVbrFcXJ2iIeZuZnEcNNJpp7WVCfV+9XeP+Jzjjnmjg9BH1H52ebg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/toast@^3.0.11":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/toast/-/toast-3.1.1.tgz#dd86a17117a320d06396e31ae91e80f4282f2ee4"
+  integrity sha512-n1KuOOPa+UiSrtI6p3VzxmwmBFv6zzxO5MGx/YGa+271nvU1NlKNIzNhnGR3Qhc1WWCZs/lrBkpekS5xzeutjA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/toolbar@3.0.0-beta.24":
+  version "3.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/@react-aria/toolbar/-/toolbar-3.0.0-beta.24.tgz#6a74e0b28dfad6a5f5a22c6c971facb88d8ddbdc"
+  integrity sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg==
+  dependencies:
+    "@react-aria/focus" "^3.21.5"
+    "@react-aria/i18n" "^3.12.16"
+    "@react-aria/utils" "^3.33.1"
+    "@react-types/shared" "^3.33.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/tooltip@^3.9.2":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/tooltip/-/tooltip-3.10.1.tgz#6f5cd285876b45e94717c3c492e25b92eaabddb8"
+  integrity sha512-rdA8uX2Byzo9fbqVsJ29ebnufnOG/8DvFFlSHL7X+hUy6onQo/dByl8Q7mINCM2eYdF4VlTtMZKdoVtIMcIAdg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+    react-stately "^3.46.0"
+
+"@react-aria/tree@^3.1.7":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/tree/-/tree-3.2.1.tgz#9f0c7805b63b781fd855fbe52c58d98e9a6db274"
+  integrity sha512-xfwNmalxFXTK+H5lSYIr1eer9OMk8khdObJMGrtG0DPDIonQY03XQlEKw+zJoqP4y/TvbppSO6ZkVQqcRhfEpg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/utils@3.33.1":
+  version "3.33.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.33.1.tgz#a80321f51ad1dc09071b9c55863c0808ba5b3038"
+  integrity sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==
+  dependencies:
+    "@react-aria/ssr" "^3.9.10"
+    "@react-stately/flags" "^3.1.2"
+    "@react-stately/utils" "^3.11.0"
+    "@react-types/shared" "^3.33.1"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-aria/utils@^3.33.1":
+  version "3.34.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.34.1.tgz#ced8c328cf7ded923a2901961325fb397a1b53c8"
+  integrity sha512-H6+rGZL+0f58bBNaUMfctEnT+NogqwAk+nHiB8sR3K+YlQ37GTuCijy2U/pPvQtFMS5mURrjZeBH5JNNXsx14A==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+    react-stately "^3.46.0"
+
+"@react-aria/virtualizer@^4.1.13":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/virtualizer/-/virtualizer-4.2.1.tgz#3680ad6b3bcb47df76b0c42f393406bc94558d18"
+  integrity sha512-6zwKVC64Z/wpo8XGIZ/IUzyjSb23iKDBfQQYpvzk9YSLA5MDqNj5//esc3cYud1iKYRPoBjNkXT23fufDoikKA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-aria/visually-hidden@^3.8.31":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.9.1.tgz#d2a6c96bb9b1d7be1245377a945e2c1bbad73d5f"
+  integrity sha512-PWuth+NTmUiBJAIyrfk7dJ5BxOBupDt0iFGlBiYr5FElSYvwN9LAk1kgkzm6hT2qzq4FmYdQgBSPkGeaxOui6w==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-aria "^3.48.0"
+
+"@react-spectrum/button@^3.18.0":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@react-spectrum/button/-/button-3.18.1.tgz#67f63c59fa7bdddd58816ffee4dd1293733e57e7"
+  integrity sha512-FW+1d6zfKesMLaBrsRsnnYnsLfvf2qFKuatkCo62o1oGUBtEYI/kae+lwGwlfiX5q9P5OgR2y1IqKtxabf/JKQ==
+  dependencies:
+    "@adobe/react-spectrum" "^3.47.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-spectrum/combobox@^3.17.0":
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/@react-spectrum/combobox/-/combobox-3.17.1.tgz#6b05a5e966a4c53a03523be6ae3ff575ddd7b256"
+  integrity sha512-687FgU6lYIFSUducoqp77YJaAL5BZDhuwB6q7B01pNMuq6oAa6PAW6b2iNA8QGbI/JBw/UMVga8DAziiZchcug==
+  dependencies:
+    "@adobe/react-spectrum" "^3.47.0"
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-spectrum/form@^3.8.0":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@react-spectrum/form/-/form-3.8.1.tgz#fbfea77f2b4ee0604611837111542881ff62490c"
+  integrity sha512-hH98Izifw6F7MgIY0VPLG7h1FR/My+BHc6OavYJQJw3VxODNJjIqMcO49bKDqdMvLQWE2tNJqul0wocKbKoSpw==
+  dependencies:
+    "@adobe/react-spectrum" "^3.47.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-spectrum/searchfield@^3.9.0":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-spectrum/searchfield/-/searchfield-3.9.1.tgz#2484eadbc87fb48fa8db5c384933a645ab3153a1"
+  integrity sha512-h8Mf43aECw/0TE+Jq31YrGzjWmuYDdDduIdXGnCP42qlQTOw66skbwmh1TxDtY9aZAxKT7+Z80IBhipCbHCuJw==
+  dependencies:
+    "@adobe/react-spectrum" "^3.47.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-spectrum/table@^3.18.0":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@react-spectrum/table/-/table-3.18.1.tgz#cb807c0a3dc7d460a71ce18c7264acf1c7fb0d08"
+  integrity sha512-rLXJ58EYQjQt4iUZh1cXiXBX64XkDwZKIfU0mipQ3p0Us1X3ubZN5UuaPmmCLEUa+8UBpazmSVUjMFNQ8yjjCg==
+  dependencies:
+    "@adobe/react-spectrum" "^3.47.0"
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/autocomplete@3.0.0-beta.4":
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.4.tgz#113894dc39fc5da607dcf90e3421d419fe1978f9"
+  integrity sha512-K2Uy7XEdseFvgwRQ8CyrYEHMupjVKEszddOapP8deNz4hntYvT1aRm0m+sKa5Kl/4kvg9c/3NZpQcrky/vRZIg==
+  dependencies:
+    "@react-stately/utils" "^3.11.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/combobox@^3.13.0", "@react-stately/combobox@^3.14.0":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/combobox/-/combobox-3.14.1.tgz#041c8eca628fbafe46c25a7b17a2bdf4eaf3d5da"
+  integrity sha512-Sko1oHiKt07LERxUgpgmbQOYh5Yk8cU1dgRZlcE1wmmaxSVZBzBnd3fGZrEGRKSDezVOKHLibsmuYYDbxPEc+Q==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/flags@^3.1.2":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/flags/-/flags-3.2.1.tgz#32611f88b45a89cceacc1d8d14b12764b3e30175"
+  integrity sha512-WPw9z4SPYqQMuExCnBNrQyyxCWSi9CDYnVqca19bqxaHZRT/uL5nL+IGCPHHa70Y5rx39E5hYKl8Hf0QJ6XKyA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/grid@^3.12.0":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/grid/-/grid-3.12.1.tgz#9af6062bdec7de8a7ff43279c2d0cc27bf8c29e6"
+  integrity sha512-GvOXlPtzoswhyV3bZK3habHdHBGR7qdzOy2WumYiNG7DAj8J+9WvAObrPmquuI2VrZYMSNzgFb3IoL+sQsMI8A==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/layout@^4.6.0":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/layout/-/layout-4.7.1.tgz#90279bbdfe90b81a83a1599aeea23d41580afdc5"
+  integrity sha512-71fNbW2LoaRpy337wYhdANkx0E4xbqQuelW39msV//ZZ6SVEK/AuOHEKwgyympKkYXi6Ri/op0snOzH0LmXvyw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/searchfield@^3.6.0":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/searchfield/-/searchfield-3.6.1.tgz#e57da89e33fb3d333f9d7bc5623165ba8e6445c3"
+  integrity sha512-5POKE91Tc5E2nCL9CP8+cVFb1xxHI6M7RkMTbJ0kahQuBlF8EQVN9gjCH7CwnCey5T73TLouS+pdZ3OlkrlqtA==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/selection@^3.20.9":
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/selection/-/selection-3.21.1.tgz#576ade383465121ae91941003afc888670536e2b"
+  integrity sha512-Tq8UfAOG5SCxnTYivyYQH5NRpiuEJG2k20wmJ/s4Db0FnnjYg1xbKe55vu2A9ni/nUTLKUMj7MFaJytMIXPwxg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/table@^3.15.4", "@react-stately/table@^3.16.0":
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/table/-/table-3.16.1.tgz#95b8d7570792b5d7095afd6829bccbb993489a48"
+  integrity sha512-p4DriyWS05M66EkKIw5VF8H8CKs7WTafmdsrEK+zO5VngKAv9CKYLl2jxlCLxT5+u9aFgkUtdafadAhKrfH/5Q==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/utils@^3.11.0":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.12.1.tgz#1c7f3980ec00f428023a7320e8882b8449530779"
+  integrity sha512-NqKfzrknpfwiewx7R2vk1P+CneClInPDsIhw15+jOcUYSEfej0nta4cJywuKQJ2gsPwqX/ojDNixedCve9FWGw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-stately/virtualizer@^4.4.6":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/virtualizer/-/virtualizer-4.5.1.tgz#ccffc59d3bf9f6e6389f50dfa5f806c5afdcfa04"
+  integrity sha512-lNP20ZDf4GLFYe5WGeWtacjvxqtIAnDudvzW6sBRlfQcQJb4D/DAEl6zvHVUOZ9oPznPg6COxrGmncdY7Pdh8Q==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    react-stately "^3.46.0"
+
+"@react-types/autocomplete@3.0.0-alpha.38":
+  version "3.0.0-alpha.38"
+  resolved "https://registry.yarnpkg.com/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.38.tgz#fd37e5e5e40c42d8a371d871d0651cd497124e70"
+  integrity sha512-0XrlVC8drzcrCNzybbkZdLcTofXEzBsHuaFevt5awW1J0xBJ+SMLIQMDeUYrvKjjwXUBlCtjJJpOvitGt4Z+KA==
+  dependencies:
+    "@react-types/combobox" "^3.14.0"
+    "@react-types/searchfield" "^3.6.8"
+    "@react-types/shared" "^3.33.1"
+
+"@react-types/button@^3.15.1":
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/@react-types/button/-/button-3.16.0.tgz#8c6945232737e1bf07036af45c475e14f9962a11"
+  integrity sha512-Z5///n2Y1jtF0gokBq2Y1K1cpOwsWZ24HPeAm3eEmZrbBXMrxC2oEA5ZThsSHuIGsqiyNJiQ2scsDftmr+PkZw==
+  dependencies:
+    "@react-aria/button" "^3.15.0"
+    "@react-spectrum/button" "^3.18.0"
+
+"@react-types/combobox@^3.14.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@react-types/combobox/-/combobox-3.15.0.tgz#04bb3b1d34a92273538ca66351e8af697b5d5d9d"
+  integrity sha512-iWV9UfLg1P0XhEqPTbnhsVMHFwc0RnrZjHfCLwgilH0Af0z1CQ8RyWiT8cOd1eqbkOAiVgCv29Xs8PAxaQBHSg==
+  dependencies:
+    "@react-aria/combobox" "^3.16.0"
+    "@react-spectrum/combobox" "^3.17.0"
+    "@react-stately/combobox" "^3.14.0"
+
+"@react-types/form@^3.7.18":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@react-types/form/-/form-3.8.0.tgz#aa1cb4f28eb642c39f11e08e11f4a213071225ea"
+  integrity sha512-ff38E4/5xLxqVemicLw+GefRoWBJEAro+hDwFZ5sde6kslktYt2LHJ7+IkID6yQYy+T3qxXgIdfxX+O1rlpWvw==
+  dependencies:
+    "@react-spectrum/form" "^3.8.0"
+    "@react-types/shared" "^3.34.0"
+
+"@react-types/grid@^3.3.8":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@react-types/grid/-/grid-3.4.0.tgz#55e4ce6fbbd19c8b101d444bd6a7849ad7a72549"
+  integrity sha512-h+u3hKli9gVwfYx6cabkTNZrP+HQ97vAmTugGIk5IAfouE6kjhoDaDzVD0VUvIWqc12LIkrqe1LdBMZ0ofbV6A==
+  dependencies:
+    "@react-stately/grid" "^3.12.0"
+
+"@react-types/searchfield@^3.6.8":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@react-types/searchfield/-/searchfield-3.7.0.tgz#e2f80cb0bc661e3a8bd49839233e27c7d9b02df7"
+  integrity sha512-/JBVYkXLB4EozPEfgpYW7C9tzw4xUmdVmuf7g+8ip/AsFgsyW/FjdLpbaXESXR78D0nppWaNxUxcdUXcuo+eEg==
+  dependencies:
+    "@react-aria/searchfield" "^3.9.0"
+    "@react-spectrum/searchfield" "^3.9.0"
+    "@react-stately/searchfield" "^3.6.0"
+
+"@react-types/shared@^3.33.1", "@react-types/shared@^3.34.0", "@react-types/shared@^3.35.0":
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.35.0.tgz#6427fdc266c0a5980679e10ab9df5db5da234f73"
+  integrity sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==
+
+"@react-types/table@^3.13.6":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@react-types/table/-/table-3.14.0.tgz#918a7de4de7cc2408ddd10f8bb28536feae7dd5b"
+  integrity sha512-emTYu9biFFlVEN208EmYpnO3bzi0f7q+07rnerUWRRRqXQpgNW/G5Tc6ifgCUXLp+KjwzLIeoDl4hs3ZnG5NSA==
+  dependencies:
+    "@react-spectrum/table" "^3.18.0"
+    "@react-stately/table" "^3.16.0"
+    "@react-types/shared" "^3.34.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -2520,6 +3865,30 @@
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
+"@spectrum-icons/ui@^3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-icons/ui/-/ui-3.7.1.tgz#196095fba6da1952eab5d1ce2edc2f9e629f47b0"
+  integrity sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w==
+  dependencies:
+    "@adobe/react-spectrum-ui" "1.2.1"
+    "@babel/runtime" "^7.24.4"
+    "@swc/helpers" "^0.5.0"
+
+"@spectrum-icons/workflow@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-icons/workflow/-/workflow-4.3.1.tgz#c05f6aba6c3c13bc7e3c906521b3c7944dac1b23"
+  integrity sha512-kDF+/EbFVyLGytotqqdYt4uSij4j/PQmDQO5km/C6DyzKjyuic3FnSBFinR+mA6oFv1OjMcLvrrDBqK3wbqRlA==
+  dependencies:
+    "@adobe/react-spectrum-workflow" "2.3.5"
+    "@swc/helpers" "^0.5.0"
+
+"@swc/helpers@^0.5.0":
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.23.tgz#19287d0d86d962b111376039a50c792902c9a86a"
+  integrity sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==
+  dependencies:
+    tslib "^2.8.0"
 
 "@testing-library/dom@^10.4.0":
   version "10.4.0"
@@ -3491,6 +4860,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.1, aria-hidden@^1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
 
 aria-query@5.3.0, aria-query@^5.0.0, aria-query@^5.1.3:
   version "5.3.0"
@@ -4638,6 +6014,11 @@ cli@^0.9.0:
     exit "0.1.2"
     glob "^5.0.10"
 
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
@@ -4687,10 +6068,15 @@ clone-response@1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -4720,7 +6106,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4739,15 +6125,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-2.0.1.tgz#e4ed78a3c4603d0891eba5430b04b86314f4c839"
+  integrity sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
 
 colorette@^2.0.10, colorette@^2.0.14, colorette@^2.0.16:
   version "2.0.20"
@@ -5613,6 +7015,11 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
+decimal.js@^10.4.3:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
 decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
@@ -5764,6 +7171,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -5838,7 +7250,7 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
-dom-helpers@^5.1.3:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -7224,6 +8636,11 @@ get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -8141,6 +9558,16 @@ intl-messageformat@10.5.14:
     "@formatjs/icu-messageformat-parser" "2.7.8"
     tslib "^2.4.0"
 
+intl-messageformat@^10.1.0:
+  version "10.7.18"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-10.7.18.tgz#51a6f387afbca9b0f881b2ec081566db8c540b0d"
+  integrity sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.6"
+    "@formatjs/fast-memoize" "2.2.7"
+    "@formatjs/icu-messageformat-parser" "2.11.4"
+    tslib "^2.8.0"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -8204,6 +9631,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.4.tgz#1ee5553818511915685d33bb13d31bf854e5059d"
+  integrity sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -11767,6 +13199,116 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-aria-components@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/react-aria-components/-/react-aria-components-1.16.0.tgz#6a5d4c75d5e9bf2c83ef8837ac19fb0a50abb698"
+  integrity sha512-MjHbTLpMFzzD2Tv5KbeXoZwPczuUWZcRavVvQQlNHRtXHH38D+sToMEYpNeir7Wh3K/XWtzeX3EujfJW6QNkrw==
+  dependencies:
+    "@internationalized/date" "^3.12.0"
+    "@internationalized/string" "^3.2.7"
+    "@react-aria/autocomplete" "3.0.0-rc.6"
+    "@react-aria/collections" "^3.0.3"
+    "@react-aria/dnd" "^3.11.6"
+    "@react-aria/focus" "^3.21.5"
+    "@react-aria/interactions" "^3.27.1"
+    "@react-aria/live-announcer" "^3.4.4"
+    "@react-aria/overlays" "^3.31.2"
+    "@react-aria/ssr" "^3.9.10"
+    "@react-aria/textfield" "^3.18.5"
+    "@react-aria/toolbar" "3.0.0-beta.24"
+    "@react-aria/utils" "^3.33.1"
+    "@react-aria/virtualizer" "^4.1.13"
+    "@react-stately/autocomplete" "3.0.0-beta.4"
+    "@react-stately/layout" "^4.6.0"
+    "@react-stately/selection" "^3.20.9"
+    "@react-stately/table" "^3.15.4"
+    "@react-stately/utils" "^3.11.0"
+    "@react-stately/virtualizer" "^4.4.6"
+    "@react-types/form" "^3.7.18"
+    "@react-types/grid" "^3.3.8"
+    "@react-types/shared" "^3.33.1"
+    "@react-types/table" "^3.13.6"
+    "@swc/helpers" "^0.5.0"
+    client-only "^0.0.1"
+    react-aria "^3.47.0"
+    react-stately "^3.45.0"
+    use-sync-external-store "^1.6.0"
+
+react-aria-components@1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/react-aria-components/-/react-aria-components-1.18.0.tgz#05c8a93a1d8373d01885bf2e04c1099b1513c6aa"
+  integrity sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@react-types/shared" "^3.35.0"
+    "@swc/helpers" "^0.5.0"
+    client-only "^0.0.1"
+    react-aria "3.49.0"
+    react-stately "3.47.0"
+
+react-aria@3.47.0:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.47.0.tgz#f16a9f8c41dc6b2c32bd71629119e08f0e2dbe27"
+  integrity sha512-nvahimIqdByl/PXk/xPkG30LPRzcin+/Uk0uFfwbbKRRFC9aa22a6BRULZLqVHwa9GaNyKe6CDUxO1Dde4v0kA==
+  dependencies:
+    "@internationalized/string" "^3.2.7"
+    "@react-aria/breadcrumbs" "^3.5.32"
+    "@react-aria/button" "^3.14.5"
+    "@react-aria/calendar" "^3.9.5"
+    "@react-aria/checkbox" "^3.16.5"
+    "@react-aria/color" "^3.1.5"
+    "@react-aria/combobox" "^3.15.0"
+    "@react-aria/datepicker" "^3.16.1"
+    "@react-aria/dialog" "^3.5.34"
+    "@react-aria/disclosure" "^3.1.3"
+    "@react-aria/dnd" "^3.11.6"
+    "@react-aria/focus" "^3.21.5"
+    "@react-aria/gridlist" "^3.14.4"
+    "@react-aria/i18n" "^3.12.16"
+    "@react-aria/interactions" "^3.27.1"
+    "@react-aria/label" "^3.7.25"
+    "@react-aria/landmark" "^3.0.10"
+    "@react-aria/link" "^3.8.9"
+    "@react-aria/listbox" "^3.15.3"
+    "@react-aria/menu" "^3.21.0"
+    "@react-aria/meter" "^3.4.30"
+    "@react-aria/numberfield" "^3.12.5"
+    "@react-aria/overlays" "^3.31.2"
+    "@react-aria/progress" "^3.4.30"
+    "@react-aria/radio" "^3.12.5"
+    "@react-aria/searchfield" "^3.8.12"
+    "@react-aria/select" "^3.17.3"
+    "@react-aria/selection" "^3.27.2"
+    "@react-aria/separator" "^3.4.16"
+    "@react-aria/slider" "^3.8.5"
+    "@react-aria/ssr" "^3.9.10"
+    "@react-aria/switch" "^3.7.11"
+    "@react-aria/table" "^3.17.11"
+    "@react-aria/tabs" "^3.11.1"
+    "@react-aria/tag" "^3.8.1"
+    "@react-aria/textfield" "^3.18.5"
+    "@react-aria/toast" "^3.0.11"
+    "@react-aria/tooltip" "^3.9.2"
+    "@react-aria/tree" "^3.1.7"
+    "@react-aria/utils" "^3.33.1"
+    "@react-aria/visually-hidden" "^3.8.31"
+    "@react-types/shared" "^3.33.1"
+
+react-aria@3.49.0, react-aria@^3.47.0, react-aria@^3.48.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.49.0.tgz#30cfc54f283d2ef31688573e35475f8ee0e97ef8"
+  integrity sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.9"
+    "@react-types/shared" "^3.35.0"
+    "@swc/helpers" "^0.5.0"
+    aria-hidden "^1.2.3"
+    clsx "^2.0.0"
+    react-stately "3.47.0"
+    use-sync-external-store "^1.6.0"
+
 react-dom@18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -11811,6 +13353,45 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-stately@3.47.0, react-stately@^3.45.0, react-stately@^3.46.0:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.47.0.tgz#dcf68203be7160ac8af5bdaeccc6d3fde2b97d70"
+  integrity sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==
+  dependencies:
+    "@internationalized/date" "^3.12.2"
+    "@internationalized/number" "^3.6.7"
+    "@internationalized/string" "^3.2.9"
+    "@react-types/shared" "^3.35.0"
+    "@swc/helpers" "^0.5.0"
+    use-sync-external-store "^1.6.0"
+
+react-style-singleton@^2.2.1, react-style-singleton@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
+
 react-tether@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-1.0.5.tgz#6d106e0039b1aa0e14d1266925486cd9cff2d217"
@@ -11818,6 +13399,16 @@ react-tether@^1.0.5:
   dependencies:
     prop-types "^15.6.2"
     tether "^1.4.5"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@18.3.1:
   version "18.3.1"
@@ -12659,6 +14250,13 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.4.tgz#a8d11a45a11600d6a1ecdff6363329e3648c3667"
+  integrity sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sinon@^9.0.3:
   version "9.2.4"
@@ -13742,7 +15340,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -13829,6 +15427,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^3.2.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.13.1.tgz#bb744c1f0678bea7543a2d1ec24e83e68e8c8706"
+  integrity sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -14083,6 +15686,26 @@ url@^0.11.0:
   dependencies:
     punycode "^1.4.1"
     qs "^6.11.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
+
+use-sync-external-store@^1.2.0, use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,17 +1299,12 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.20.7", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
   integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
-
-"@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
-  version "7.29.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
-  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.5"
@@ -3991,9 +3986,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 box-annotations@^5.2.1-beta.0:
-  version "5.2.1-beta.14"
-  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-5.2.1-beta.14.tgz#e082637d904ad21337bb2e4537a937bd38484e7c"
-  integrity sha512-jFTQkEv/7Mz5mUmIQ8124/X9SMrCEuay3lOj3xDR6bcXvzWllVEDLBspduqQQj1EKYzSA3d1dynrJwKLMzBosw==
+  version "5.2.1-beta.0"
+  resolved "https://registry.yarnpkg.com/box-annotations/-/box-annotations-5.2.1-beta.0.tgz#09ebd0538e045797f5d0c8cc893addf8ded28351"
+  integrity sha512-M6ZqiMWkm5rYqQHBLxNtjbEaZsvtzzxdGMsrhGxL+7+sbo4NpgCqNvV875DMqh4nSvLRQbUrPrIe32iYZxKxxw==
 
 box-ui-elements@^20.0.0:
   version "20.0.0"


### PR DESCRIPTION
## Summary

Wraps the existing `src/lib/Preview.js` class as the default export of the npm package. After this lands, anyone — React, Vue, vanilla JS, Angular, jQuery — can `npm install box-content-preview` and use the existing imperative API. Full file-type coverage from day one (PDF, image, video, text, archive, 3D, etc.) backed by the production-hardened legacy code.

The CDN bundle (`yarn build:prod` → `dist/<version>/<lang>/preview.js`) is **untouched**.

## Why this approach

The original plan was to ship a from-scratch React SDK first, then publish to npm. After scoping that work, the React rewrite turned out to be a thin wrapper around pdfjs/Shaka anyway — those libraries already do the rendering. Re-implementing per-viewer in React would cost ~3000 LOC for marginal end-user value.

This PR ships the legacy class as npm now. The React API arrives in a follow-up as a thin `<ContentPreview>` wrapper around `new Preview()` rather than per-viewer rewrites.

## Usage after this lands

**React:**
```jsx
import { useEffect, useRef } from 'react';
import Preview from 'box-content-preview';
import 'box-content-preview/styles.css';

function FilePreview({ fileId, token }) {
  const containerRef = useRef(null);
  useEffect(() => {
    const preview = new Preview();
    preview.show(fileId, token, { container: containerRef.current });
    return () => preview.destroy();
  }, [fileId, token]);
  return <div ref={containerRef} />;
}
```

**Vanilla JS / any framework:**
```js
import Preview from 'box-content-preview';
import 'box-content-preview/styles.css';

const preview = new Preview();
preview.show('123456', 'TOKEN', { container: '#preview' });
preview.addListener('load', () => console.log('loaded'));
```

(A `<ContentPreview>` React component is planned as a follow-up to provide an idiomatic React API.)

## What's in here

- **`src/index.ts`** — re-exports `Preview` as default and named export. Wrapper class injects `useNpmPdfjs: true` into options for the npm path so pdfjs is always loaded from the bundled npm chunks (no CDN fallback).
- **`build/webpack.config.lib.js`** — bundles the legacy code as ESM:
  - Entry: `src/index.ts`
  - i18n loader (legacy code uses `__('key')` substitutions)
  - Externalizes `react` / `react-dom` / `box-ui-elements` / `box-annotations` / `@box/react-virtualized` / `@box/blueprint-web` / `@box/blueprint-web-assets` so consumers control versions and no duplicate copies end up in the consumer's bundle
  - SVG/HTML as `asset/source`, images/fonts as `asset/resource`
  - Suppresses pdfjs's known-noisy `Critical dependency` warning
- **Static asset copy** — a no-delete `CopyAssetsPlugin` (sister to the existing `RsyncPlugin` but supports multiple instances writing into the same dir):
  - `src/third-party/{media,text,model3d,swf}` → `dist/lib/third-party/`
  - `src/lib/exif/` → `dist/lib/exif/`
  - `node_modules/pdfjs-dist/cmaps/` → `dist/lib/cmaps/`
  - The vendored `src/third-party/doc/` is excluded — pdfjs always comes from the bundled npm chunks for npm consumers.
- **`build/lib-types/index.d.ts`** — hand-authored type declarations for the public `Preview` API (constructor, `show`, `destroy`, `reload`, `print`, `download`, `updateToken`, `addListener`, etc.). Loose typing for v1; tighten as consumer feedback comes in. Copied to `dist/lib/index.d.ts` by `build:lib:types`.
- **`package.json`**:
  - `axios` and `pdfjs-dist` declared as `dependencies` (real runtime deps).
  - `box-ui-elements`, `box-annotations`, `@box/react-virtualized`, `@box/blueprint-web`, `@box/blueprint-web-assets`, `react`, `react-dom` declared as `peerDependencies`.
  - `build:lib:types` script no longer runs `tsc` (was a no-op for the JS entry); copies the hand-authored `.d.ts` instead.

## Bundle / tarball size

| Asset | Size |
|---|---|
| `dist/lib/index.js` (legacy bundle, unminified) | 1.32 MB |
| `dist/lib/index.css` | 148 KB |
| `dist/lib/third-party/` (media + text + model3d + swf) | 20 MB (mostly model3d) |
| `dist/lib/cmaps/` | 1.6 MB |
| **Total tarball (packed)** | **11.5 MB** |
| **Total unpacked** | **25.3 MB** |

## Test plan

- [x] `yarn test` — 154 suites, 3766 tests pass (no test changes; pure build/wiring work)
- [x] `yarn lint` — passes
- [x] `yarn lint:ts` — passes
- [x] `yarn build` — CDN bundle unchanged (`preview.js` 3.6 MB)
- [x] `yarn build:lib` — emits ESM bundle + CSS + .d.ts + static assets
- [x] `npm pack --dry-run` — 339 files, 11.5 MB tarball
- [ ] Manual smoke test in scratch React/Vite app — to be done with a real Box dev token before publishing

## Known issues / follow-ups

- The bundled `index.js` still calls `globalThis.Box.Preview = Preview` from `src/lib/Preview.js`. Harmless but pollutes the consumer's global. Worth conditionalizing for the npm path in a follow-up.
- Tarball is 11.5 MB largely because of `src/third-party/model3d/` (17 MB unpacked). 3D viewer is heavy; can be code-split / made optional in a future iteration.
- No tree-shaking — the legacy bundle is monolithic. A future React API on top adds more granular surface.
- pdfjs version is hardcoded in the webpack config; should be read from `src/lib/constants.js`. ESM/CJS interop made this awkward in this PR; left as a follow-up.

## Next

- Wire `npm publish` into the Jenkins release pipeline (independent prerequisite)
- `<ContentPreview>` React wrapper around `new Preview()` (~200 LOC follow-up)
- UMD CDN bundle entry exposing `window.Box.Preview` (covers existing CDN consumers)
- Blueprint chrome migration (toolbars and thumbnails)