### PR TITLE
fix(zoom): bug fixes for pinch to zoom images

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -74,6 +74,8 @@ import { getClientLogDetails, getISOTime } from './logUtils';
 import { isFeatureEnabled } from './featureChecking';
 import './Preview.scss';
 
+console.log('LOCAL PREVIEW LOADED 237');
+
 const DEFAULT_DISABLED_VIEWERS = ['Office']; // viewers disabled by default
 const PREFETCH_COUNT = 4; // number of files to prefetch
 const MOUSEMOVE_THROTTLE_MS = 1500; // for showing or hiding the navigation icons

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -74,8 +74,6 @@ import { getClientLogDetails, getISOTime } from './logUtils';
 import { isFeatureEnabled } from './featureChecking';
 import './Preview.scss';
 
-console.log('LOCAL PREVIEW LOADED 237');
-
 const DEFAULT_DISABLED_VIEWERS = ['Office']; // viewers disabled by default
 const PREFETCH_COUNT = 4; // number of files to prefetch
 const MOUSEMOVE_THROTTLE_MS = 1500; // for showing or hiding the navigation icons

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -388,75 +388,73 @@ class ImageBaseViewer extends BaseViewer {
         }
 
         const baseWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10) || currentWidth;
-        const minWidth = this.initialWidth || baseWidth * WHEEL_ZOOM_MIN_SCALE;
+        const minWidth = baseWidth * WHEEL_ZOOM_MIN_SCALE;
         const maxWidth = baseWidth * WHEEL_ZOOM_MAX_SCALE;
 
         const delta = -event.deltaY * MIN_PINCH_SCALE_DELTA;
         const newWidth = Math.min(maxWidth, Math.max(minWidth, currentWidth * (1 + delta)));
         const ratio = newWidth / currentWidth;
 
-        // Record where the cursor sits within the image (in image-local coords).
-        // This is what we'll keep anchored to the cursor through the zoom.
+        const belowInitialWidth = this.initialWidth && newWidth <= this.initialWidth;
+
+        // Capture cursor position in image-local coords before resizing.
         const oldImageRect = this.imageEl.getBoundingClientRect();
         const pointInImageX = event.clientX - oldImageRect.left;
         const pointInImageY = event.clientY - oldImageRect.top;
 
-        // Resize the image. This grows/shrinks from the top-left corner, so the exact
-        // pixel that was under the cursor is now at a different screen position.
         this.imageEl.style.width = `${newWidth}px`;
         this.imageEl.style.height = '';
 
-        // Compute how far the image pixel drifted from the cursor after resizing.
-        const newImageRect = this.imageEl.getBoundingClientRect();
-        const wrapperRect = this.wrapperEl.getBoundingClientRect();
-        let dx = newImageRect.left + pointInImageX * ratio - event.clientX;
-        let dy = newImageRect.top + pointInImageY * ratio - event.clientY;
+        if (belowInitialWidth) {
+            // Below fit-to-viewport size: zoom from center, same as toolbar zoom controls
+            if (typeof this.adjustImageZoomPadding === 'function') {
+                this.adjustImageZoomPadding();
+            }
+        } else {
+            // Compute how far the image pixel drifted from the cursor after resizing.
+            const newImageRect = this.imageEl.getBoundingClientRect();
+            const wrapperRect = this.wrapperEl.getBoundingClientRect();
+            let dx = newImageRect.left + pointInImageX * ratio - event.clientX;
+            let dy = newImageRect.top + pointInImageY * ratio - event.clientY;
 
-        // When zooming out, clamp so edges don't retreat past the initial rect.
-        // This guides the image back to its initial position as it shrinks.
-        if (newWidth < currentWidth && this.initialRect) {
-            // Where the image would end up after full cursor-anchor correction
-            let targetLeft = newImageRect.left - wrapperRect.left - dx;
-            let targetTop = newImageRect.top - wrapperRect.top - dy;
-            const targetRight = targetLeft + newImageRect.width;
-            const targetBottom = targetTop + newImageRect.height;
+            // When zooming out, clamp so edges don't retreat past the initial rect.
+            // This guides the image back to its initial position as it shrinks.
+            if (newWidth < currentWidth && this.initialRect) {
+                let targetLeft = newImageRect.left - wrapperRect.left - dx;
+                let targetTop = newImageRect.top - wrapperRect.top - dy;
+                const targetRight = targetLeft + newImageRect.width;
+                const targetBottom = targetTop + newImageRect.height;
 
-            // Clamp: don't let an edge retreat past its initial boundary
-            if (targetLeft > this.initialRect.left) {
-                targetLeft = this.initialRect.left;
-            } else if (targetRight < this.initialRect.right) {
-                targetLeft = this.initialRect.right - newImageRect.width;
+                if (targetLeft > this.initialRect.left) {
+                    targetLeft = this.initialRect.left;
+                } else if (targetRight < this.initialRect.right) {
+                    targetLeft = this.initialRect.right - newImageRect.width;
+                }
+
+                if (targetTop > this.initialRect.top) {
+                    targetTop = this.initialRect.top;
+                } else if (targetBottom < this.initialRect.bottom) {
+                    targetTop = this.initialRect.bottom - newImageRect.height;
+                }
+
+                dx = newImageRect.left - wrapperRect.left - targetLeft;
+                dy = newImageRect.top - wrapperRect.top - targetTop;
             }
 
-            if (targetTop > this.initialRect.top) {
-                targetTop = this.initialRect.top;
-            } else if (targetBottom < this.initialRect.bottom) {
-                targetTop = this.initialRect.bottom - newImageRect.height;
+            // Apply correction: scroll first, then CSS offset for any remainder.
+            const prevScrollLeft = this.wrapperEl.scrollLeft;
+            const prevScrollTop = this.wrapperEl.scrollTop;
+            this.wrapperEl.scrollLeft += dx;
+            this.wrapperEl.scrollTop += dy;
+
+            const remainderX = dx - (this.wrapperEl.scrollLeft - prevScrollLeft);
+            const remainderY = dy - (this.wrapperEl.scrollTop - prevScrollTop);
+            if (remainderX !== 0 || remainderY !== 0) {
+                const currentLeft = parseFloat(this.imageEl.style.left) || 0;
+                const currentTop = parseFloat(this.imageEl.style.top) || 0;
+                this.imageEl.style.left = `${currentLeft - remainderX}px`;
+                this.imageEl.style.top = `${currentTop - remainderY}px`;
             }
-
-            dx = newImageRect.left - wrapperRect.left - targetLeft;
-            dy = newImageRect.top - wrapperRect.top - targetTop;
-        }
-
-        // Apply correction: scroll first, then CSS offset for any remainder.
-        const prevScrollLeft = this.wrapperEl.scrollLeft;
-        const prevScrollTop = this.wrapperEl.scrollTop;
-        this.wrapperEl.scrollLeft += dx;
-        this.wrapperEl.scrollTop += dy;
-
-        const remainderX = dx - (this.wrapperEl.scrollLeft - prevScrollLeft);
-        const remainderY = dy - (this.wrapperEl.scrollTop - prevScrollTop);
-        if (remainderX !== 0 || remainderY !== 0) {
-            const currentLeft = parseFloat(this.imageEl.style.left) || 0;
-            const currentTop = parseFloat(this.imageEl.style.top) || 0;
-            this.imageEl.style.left = `${currentLeft - remainderX}px`;
-            this.imageEl.style.top = `${currentTop - remainderY}px`;
-        }
-
-        // When we've reached the minimum width, snap to the correct centered position
-        // via adjustImageZoomPadding. This handles rotation where the initial rect is stale.
-        if (newWidth <= minWidth && typeof this.adjustImageZoomPadding === 'function') {
-            this.adjustImageZoomPadding();
         }
 
         // setScale emits 'scale', which triggers annotation re-render. Call it AFTER

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -402,6 +402,8 @@ class ImageBaseViewer extends BaseViewer {
         const pointInImageX = event.clientX - oldImageRect.left;
         const pointInImageY = event.clientY - oldImageRect.top;
 
+        // Resize the image. This grows/shrinks from the top-left corner, so the exact
+        // pixel that was under the cursor is now at a different screen position.
         this.imageEl.style.width = `${newWidth}px`;
         this.imageEl.style.height = '';
 

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -597,6 +597,7 @@ class ImageViewer extends ImageBaseViewer {
      */
     handleOrientationChange() {
         this.adjustImageZoomPadding();
+        this.recalculateInitialRect();
 
         this.scale = this.imageEl.clientWidth / this.imageEl.getAttribute('originalWidth');
         this.rotationAngle = (this.currentRotationAngle % 3600) % 360;
@@ -604,6 +605,64 @@ class ImageViewer extends ImageBaseViewer {
             scale: this.scale,
             rotationAngle: this.rotationAngle,
         });
+    }
+
+    /**
+     * Recomputes initialWidth and initialRect for the current rotation by
+     * temporarily sizing the image to its fit-to-viewport dimensions.
+     *
+     * @private
+     * @return {void}
+     */
+    recalculateInitialRect() {
+        const savedWidth = this.imageEl.style.width;
+        const savedHeight = this.imageEl.style.height;
+        const savedLeft = this.imageEl.style.left;
+        const savedTop = this.imageEl.style.top;
+        const savedScrollLeft = this.wrapperEl.scrollLeft;
+        const savedScrollTop = this.wrapperEl.scrollTop;
+
+        const isRotated = this.isRotated();
+        const origHeight = parseInt(this.imageEl.getAttribute('originalHeight'), 10);
+        const origWidth = parseInt(this.imageEl.getAttribute('originalWidth'), 10);
+        const { width, height } = this.getTransformWidthAndHeight(origWidth, origHeight, isRotated);
+        const modifyWidthInsteadOfHeight = width >= height;
+        const viewport = this.getViewportDimensions();
+
+        let resetWidth;
+        let resetHeight;
+        if (width > viewport.width || height > viewport.height) {
+            const ratio = Math.min(viewport.width / width, viewport.height / height);
+            if (modifyWidthInsteadOfHeight) {
+                resetWidth = width * ratio;
+            } else {
+                resetHeight = height * ratio;
+            }
+        } else if (modifyWidthInsteadOfHeight) {
+            resetWidth = Math.min(viewport.width, origWidth);
+        } else {
+            resetHeight = Math.min(viewport.height, origHeight);
+        }
+
+        if (isRotated) {
+            const temp = resetWidth;
+            resetWidth = resetHeight;
+            resetHeight = temp;
+        }
+
+        this.imageEl.style.width = resetWidth ? `${resetWidth}px` : '';
+        this.imageEl.style.height = resetHeight ? `${resetHeight}px` : '';
+        this.adjustImageZoomPadding();
+
+        this.initialWidth = this.imageEl.offsetWidth;
+        this.initialRect = this.getInitialImageRect();
+
+        this.imageEl.style.width = savedWidth;
+        this.imageEl.style.height = savedHeight;
+        this.imageEl.style.left = savedLeft;
+        this.imageEl.style.top = savedTop;
+        this.wrapperEl.scrollLeft = savedScrollLeft;
+        this.wrapperEl.scrollTop = savedScrollTop;
     }
 
     handleAnnotationColorChange(color) {


### PR DESCRIPTION
## Summary
This PR includes two bug fixes for pinch to zoom functionality for images:
- Fix pinch-to-zoom out with rotated images: `initialRect` and `initialWidth` (used for zoom-out edge clamping) were captured at load time and never updated on rotation. After rotating, the clamping would guide the image toward a stale pre-rotation position, causing it to jump when snapping back to center. Added `recalculateInitialRect()` which temporarily sizes the image to its fit-to-viewport dimensions for the current rotation, captures the correct initialRect/initialWidth, then restores the actual dimensions without visual flicker.
- Allow pinch-to-zoom out past fit-to-viewport size: Previously, pinch zoom was clamped at initialWidth (the fit-to-viewport size). Removed that floor so users can continue zooming out. When below initialWidth, uses simple center-based zoom via adjustImageZoomPadding() (matching toolbar zoom-out behavior) instead of cursor-anchored positioning with edge clamping.

## Test plan
  - Pinch to zoom in on an unrotated image, then pinch to zoom out — image should smoothly return to center
  - Rotate an image, then pinch to zoom out — image should smoothly return to center (no jumping)
  - Zoom in, rotate, then pinch to zoom out — image should smoothly return to center (no jumping)
  - Pinch to zoom out past the fit-to-viewport size — image should shrink centered in the viewport
  - Verify toolbar zoom in/out buttons still work correctly
  - Verify pinch-to-zoom in still anchors to cursor position correctly