### PR TITLE
feat(zoom): add pinch to zoom support for txt files

### DIFF
--- a/src/lib/viewers/text/PlainText.scss
+++ b/src/lib/viewers/text/PlainText.scss
@@ -9,6 +9,7 @@
     left: 0;
     margin: 0;
     overflow: auto;
+    line-height: 1.5;
     white-space: pre-wrap;
     text-align: left;
     word-wrap: break-word;

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -9,6 +9,7 @@ const ZOOM_DEFAULT = 1.0;
 const ZOOM_MAX = 10;
 const ZOOM_MIN = 0.1;
 const ZOOM_STEP = 0.1;
+const WHEEL_ZOOM_SCALE_FACTOR = 0.01;
 
 class TextBaseViewer extends BaseViewer {
     /**
@@ -23,6 +24,7 @@ class TextBaseViewer extends BaseViewer {
         // Bind context for handlers;
         this.zoomOut = this.zoomOut.bind(this);
         this.zoomIn = this.zoomIn.bind(this);
+        this.wheelZoomHandler = this.wheelZoomHandler.bind(this);
     }
 
     /**
@@ -42,12 +44,98 @@ class TextBaseViewer extends BaseViewer {
      * @return {void}
      */
     destroy() {
+        this.unbindDOMListeners();
+
         // Destroy the controls
         if (this.controls && typeof this.controls.destroy === 'function') {
             this.controls.destroy();
         }
 
         super.destroy();
+    }
+
+    /**
+     * Binds DOM listeners for the text viewer.
+     *
+     * @protected
+     * @return {void}
+     */
+    bindDOMListeners() {
+        const textEl = this.containerEl && this.containerEl.querySelector('.bp-text');
+        if (textEl && this.featureEnabled('pinchToZoom.enabled')) {
+            textEl.addEventListener('wheel', this.wheelZoomHandler, { passive: false });
+        }
+    }
+
+    /**
+     * Unbinds DOM listeners for the text viewer.
+     *
+     * @protected
+     * @return {void}
+     */
+    unbindDOMListeners() {
+        const textEl = this.containerEl && this.containerEl.querySelector('.bp-text');
+        if (textEl) {
+            textEl.removeEventListener('wheel', this.wheelZoomHandler);
+        }
+    }
+
+    /**
+     * Handles trackpad pinch-to-zoom via wheel events with ctrlKey.
+     * On Mac trackpads, pinch gestures fire wheel events with ctrlKey set to true.
+     * Anchors zoom on the cursor position so content under the cursor stays in place.
+     *
+     * @protected
+     * @param {WheelEvent} event - wheel event object
+     * @return {void}
+     */
+    wheelZoomHandler(event) {
+        const textEl = this.containerEl && this.containerEl.querySelector('.bp-text');
+        if (!event.ctrlKey || !textEl) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const scaleDelta = -event.deltaY * WHEEL_ZOOM_SCALE_FACTOR;
+        const newScale = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, this.scale + scaleDelta));
+
+        if (newScale === this.scale) {
+            return;
+        }
+
+        // Find the text position under the cursor so we can keep it anchored
+        const range = document.caretRangeFromPoint ? document.caretRangeFromPoint(event.clientX, event.clientY) : null;
+
+        let anchorScreenY = event.clientY;
+        if (range) {
+            const rangeRect = range.getBoundingClientRect();
+            anchorScreenY = rangeRect.top;
+        }
+
+        // Record where on screen the anchor line currently sits
+        const textRect = textEl.getBoundingClientRect();
+        const anchorViewportOffset = anchorScreenY - textRect.top;
+
+        // Apply zoom via font-size
+        textEl.style.fontSize = `${Math.round(newScale * 100)}%`;
+        this.scale = newScale;
+
+        // Find where the anchor text has moved to and adjust scroll
+        if (range) {
+            const newRangeRect = range.getBoundingClientRect();
+            const newTextRect = textEl.getBoundingClientRect();
+            const newPositionInContent = newRangeRect.top - newTextRect.top + textEl.scrollTop;
+            textEl.scrollTop = newPositionInContent - anchorViewportOffset;
+        }
+
+        this.emit('zoom', {
+            canZoomIn: newScale < ZOOM_MAX,
+            canZoomOut: newScale > ZOOM_MIN,
+            zoom: newScale,
+        });
+
+        this.renderUI();
     }
 
     /**
@@ -124,6 +212,7 @@ class TextBaseViewer extends BaseViewer {
      */
     loadUI() {
         this.controls = new ControlsRoot({ containerEl: this.containerEl, fileId: this.options.file.id });
+        this.bindDOMListeners();
         this.renderUI();
     }
 

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -104,8 +104,19 @@ class TextBaseViewer extends BaseViewer {
             return;
         }
 
-        // Find the text position under the cursor so we can keep it anchored
-        const range = document.caretRangeFromPoint ? document.caretRangeFromPoint(event.clientX, event.clientY) : null;
+        // Find the text position under the cursor so we can keep it anchored.
+        // Chrome/Safari use caretRangeFromPoint; Firefox uses caretPositionFromPoint.
+        let range = null;
+        if (document.caretRangeFromPoint) {
+            range = document.caretRangeFromPoint(event.clientX, event.clientY);
+        } else if (document.caretPositionFromPoint) {
+            const pos = document.caretPositionFromPoint(event.clientX, event.clientY);
+            if (pos) {
+                range = document.createRange();
+                range.setStart(pos.offsetNode, pos.offset);
+                range.collapse(true);
+            }
+        }
 
         let anchorScreenY = event.clientY;
         if (range) {

--- a/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
+++ b/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
@@ -47,6 +47,17 @@ describe('lib/viewers/text/TextBaseViewer', () => {
             textBase.destroy();
             expect(textBase.controls.destroy).toBeCalled();
         });
+
+        test('should unbind DOM listeners', () => {
+            const textEl = document.createElement('div');
+            textEl.className = 'bp-text';
+            textBase.containerEl.appendChild(textEl);
+            jest.spyOn(textEl, 'removeEventListener');
+
+            textBase.destroy();
+
+            expect(textEl.removeEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler);
+        });
     });
 
     describe('zoom()', () => {
@@ -207,28 +218,6 @@ describe('lib/viewers/text/TextBaseViewer', () => {
         });
     });
 
-    describe('unbindDOMListeners()', () => {
-        let textEl;
-
-        beforeEach(() => {
-            textEl = document.createElement('div');
-            textEl.className = 'bp-text';
-            textBase.containerEl.appendChild(textEl);
-        });
-
-        afterEach(() => {
-            textBase.containerEl.removeChild(textEl);
-        });
-
-        test('should remove wheel event listener', () => {
-            jest.spyOn(textEl, 'removeEventListener');
-
-            textBase.unbindDOMListeners();
-
-            expect(textEl.removeEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler);
-        });
-    });
-
     describe('wheelZoomHandler()', () => {
         let textEl;
 
@@ -321,28 +310,96 @@ describe('lib/viewers/text/TextBaseViewer', () => {
             expect(textBase.scale).toBe(0.1);
         });
 
-        test('should use caretRangeFromPoint to anchor scroll to the line under cursor', () => {
-            const mockRange = {
-                getBoundingClientRect: jest
-                    .fn()
-                    .mockReturnValueOnce({ top: 200 })
-                    .mockReturnValueOnce({ top: 220 }),
-            };
-            document.caretRangeFromPoint = jest.fn().mockReturnValue(mockRange);
+        describe('caret-based scroll anchoring', () => {
+            let originalCaretRangeFromPoint;
+            let originalCaretPositionFromPoint;
 
-            const event = new WheelEvent('wheel', {
-                deltaY: -10,
-                ctrlKey: true,
-                clientX: 400,
-                clientY: 200,
+            beforeEach(() => {
+                originalCaretRangeFromPoint = document.caretRangeFromPoint;
+                originalCaretPositionFromPoint = document.caretPositionFromPoint;
             });
 
-            textBase.wheelZoomHandler(event);
+            afterEach(() => {
+                if (originalCaretRangeFromPoint) {
+                    document.caretRangeFromPoint = originalCaretRangeFromPoint;
+                } else {
+                    delete document.caretRangeFromPoint;
+                }
+                if (originalCaretPositionFromPoint) {
+                    document.caretPositionFromPoint = originalCaretPositionFromPoint;
+                } else {
+                    delete document.caretPositionFromPoint;
+                }
+            });
 
-            expect(document.caretRangeFromPoint).toBeCalledWith(400, 200);
-            expect(textBase.scale).toBeGreaterThan(1.0);
+            test('should use caretRangeFromPoint to anchor scroll to the line under cursor', () => {
+                const mockRange = {
+                    getBoundingClientRect: jest
+                        .fn()
+                        .mockReturnValueOnce({ top: 200 })
+                        .mockReturnValueOnce({ top: 220 }),
+                };
+                document.caretRangeFromPoint = jest.fn().mockReturnValue(mockRange);
 
-            delete document.caretRangeFromPoint;
+                const event = new WheelEvent('wheel', {
+                    deltaY: -10,
+                    ctrlKey: true,
+                    clientX: 400,
+                    clientY: 200,
+                });
+
+                textBase.wheelZoomHandler(event);
+
+                expect(document.caretRangeFromPoint).toBeCalledWith(400, 200);
+                expect(textBase.scale).toBeGreaterThan(1.0);
+            });
+
+            test('should fall back to caretPositionFromPoint for Firefox', () => {
+                delete document.caretRangeFromPoint;
+
+                const mockRange = {
+                    getBoundingClientRect: jest
+                        .fn()
+                        .mockReturnValueOnce({ top: 200 })
+                        .mockReturnValueOnce({ top: 220 }),
+                    setStart: jest.fn(),
+                    collapse: jest.fn(),
+                };
+                jest.spyOn(document, 'createRange').mockReturnValue(mockRange);
+                document.caretPositionFromPoint = jest.fn().mockReturnValue({
+                    offsetNode: document.createTextNode('test'),
+                    offset: 0,
+                });
+
+                const event = new WheelEvent('wheel', {
+                    deltaY: -10,
+                    ctrlKey: true,
+                    clientX: 400,
+                    clientY: 200,
+                });
+
+                textBase.wheelZoomHandler(event);
+
+                expect(document.caretPositionFromPoint).toBeCalledWith(400, 200);
+                expect(textBase.scale).toBeGreaterThan(1.0);
+            });
+
+            test('should still zoom when neither caret API is available', () => {
+                delete document.caretRangeFromPoint;
+                delete document.caretPositionFromPoint;
+
+                const event = new WheelEvent('wheel', {
+                    deltaY: -10,
+                    ctrlKey: true,
+                    clientX: 400,
+                    clientY: 200,
+                });
+
+                textBase.wheelZoomHandler(event);
+
+                expect(textBase.scale).toBeGreaterThan(1.0);
+                expect(textEl.style.fontSize).toBe(`${Math.round(textBase.scale * 100)}%`);
+            });
         });
     });
 });

--- a/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
+++ b/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
@@ -174,4 +174,175 @@ describe('lib/viewers/text/TextBaseViewer', () => {
             expect(textBase.onKeydown('blah')).toBe(false);
         });
     });
+
+    describe('bindDOMListeners()', () => {
+        let textEl;
+
+        beforeEach(() => {
+            textEl = document.createElement('div');
+            textEl.className = 'bp-text';
+            textBase.containerEl.appendChild(textEl);
+        });
+
+        afterEach(() => {
+            textBase.containerEl.removeChild(textEl);
+        });
+
+        test('should add wheel event listener when pinchToZoom is enabled', () => {
+            jest.spyOn(textBase, 'featureEnabled').mockReturnValue(true);
+            jest.spyOn(textEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textEl.addEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler, { passive: false });
+        });
+
+        test('should not add wheel event listener when pinchToZoom is disabled', () => {
+            jest.spyOn(textBase, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(textEl, 'addEventListener');
+
+            textBase.bindDOMListeners();
+
+            expect(textEl.addEventListener).not.toBeCalled();
+        });
+    });
+
+    describe('unbindDOMListeners()', () => {
+        let textEl;
+
+        beforeEach(() => {
+            textEl = document.createElement('div');
+            textEl.className = 'bp-text';
+            textBase.containerEl.appendChild(textEl);
+        });
+
+        afterEach(() => {
+            textBase.containerEl.removeChild(textEl);
+        });
+
+        test('should remove wheel event listener', () => {
+            jest.spyOn(textEl, 'removeEventListener');
+
+            textBase.unbindDOMListeners();
+
+            expect(textEl.removeEventListener).toBeCalledWith('wheel', textBase.wheelZoomHandler);
+        });
+    });
+
+    describe('wheelZoomHandler()', () => {
+        let textEl;
+
+        beforeEach(() => {
+            textEl = document.createElement('div');
+            textEl.className = 'bp-text';
+            textBase.containerEl.appendChild(textEl);
+            textBase.renderUI = jest.fn();
+            Object.defineProperty(textEl, 'scrollLeft', { value: 0, writable: true });
+            Object.defineProperty(textEl, 'scrollTop', { value: 0, writable: true });
+            textEl.getBoundingClientRect = jest.fn().mockReturnValue({
+                left: 0,
+                top: 0,
+                width: 800,
+                height: 600,
+            });
+        });
+
+        afterEach(() => {
+            textBase.containerEl.removeChild(textEl);
+        });
+
+        test('should do nothing if ctrlKey is not pressed', () => {
+            const event = new WheelEvent('wheel', { deltaY: -10, ctrlKey: false });
+            jest.spyOn(event, 'preventDefault');
+
+            textBase.wheelZoomHandler(event);
+
+            expect(event.preventDefault).not.toBeCalled();
+            expect(textBase.scale).toBe(1.0);
+        });
+
+        test('should prevent default and zoom in on negative deltaY', () => {
+            jest.spyOn(textBase, 'emit');
+            const event = new WheelEvent('wheel', {
+                deltaY: -10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+            jest.spyOn(event, 'preventDefault');
+
+            textBase.wheelZoomHandler(event);
+
+            expect(event.preventDefault).toBeCalled();
+            expect(textBase.scale).toBeGreaterThan(1.0);
+            expect(textEl.style.fontSize).toBe(`${Math.round(textBase.scale * 100)}%`);
+            expect(textBase.emit).toBeCalledWith('zoom', expect.objectContaining({ zoom: textBase.scale }));
+            expect(textBase.renderUI).toBeCalled();
+        });
+
+        test('should zoom out on positive deltaY', () => {
+            const event = new WheelEvent('wheel', {
+                deltaY: 10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.scale).toBeLessThan(1.0);
+        });
+
+        test('should not exceed max scale', () => {
+            textBase.scale = 10;
+            const event = new WheelEvent('wheel', {
+                deltaY: -10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.scale).toBe(10);
+        });
+
+        test('should not go below min scale', () => {
+            textBase.scale = 0.1;
+            const event = new WheelEvent('wheel', {
+                deltaY: 10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.scale).toBe(0.1);
+        });
+
+        test('should use caretRangeFromPoint to anchor scroll to the line under cursor', () => {
+            const mockRange = {
+                getBoundingClientRect: jest
+                    .fn()
+                    .mockReturnValueOnce({ top: 200 })
+                    .mockReturnValueOnce({ top: 220 }),
+            };
+            document.caretRangeFromPoint = jest.fn().mockReturnValue(mockRange);
+
+            const event = new WheelEvent('wheel', {
+                deltaY: -10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 200,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(document.caretRangeFromPoint).toBeCalledWith(400, 200);
+            expect(textBase.scale).toBeGreaterThan(1.0);
+
+            delete document.caretRangeFromPoint;
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Add trackpad pinch-to-zoom support for text file viewers (.txt, .json, .csv etc.), matching the existing behavior in image and document viewers
- Zoom is anchored to the line of text under the cursor using document.caretRangeFromPoint, so the line you're looking at stays in place as you zoom
- Gated behind the existing `pinchToZoom.enabled` feature flag

## Implementation

On Mac trackpads, pinch gestures fire wheel events with `ctrlKey=true`. We listen for these on the `.bp-text` element and:
1. Identify the anchor text (text where we want zoom to my anchored on): Call `document.caretRangeFromPoint(clientX, clientY)` to get a DOM `Range` pointing at the exact character under the cursor. This gives us a stable handle to a piece of text content, not a pixel position.
2. Record its screen position: Call `range.getBoundingClientRect()` to get where that line currently sits on screen, then compute its offset from the top of the scrollable container.
3. Apply zoom: Change `font-size` on the text element as a percentage (e.g. 110%). The browser reflows text — lines may wrap differently, content height changes.
4. Re-anchor: The `Range` still references the same text node + character offset (the DOM didn't change, only layout). Call `range.getBoundingClientRect()` again to find where that text moved to after reflow. Adjust `scrollTop` so it appears at the same vertical offset from the container top as before.

**Why line-level anchoring (not pixel/word-level)**

For images and PDFs, we can anchor zoom to the exact pixel under the cursor because content scales uniformly in both dimensions. Text is different — when font-size increases, lines reflow: a word that fit on one line may shift horizontally and wrap to the next line in an unpredictable way. Since the text container doesn't scroll horizontally (`white-space: pre-wrap` with `word-wrap: break-word`), there's no way to compensate for that horizontal drift.

Instead, we anchor to the line the cursor is on. After zoom, we adjust `scrollTop` so that the same line of text remains at the same vertical screen position. This keeps the user's reading context stable through the zoom — the text they were focused on doesn't jump off screen.

## Test plan
  - Enable pinchToZoom.enabled feature flag
  - Open a text file (.js, .py, .csv, etc.) in preview
  - Trackpad pinch to zoom in — verify font size increases and the line under cursor stays in place
  - Trackpad pinch to zoom out — verify font size decreases and line stays anchored
  - Verify zoom does not exceed min (0.1) or max (10) scale
  - Verify zoom controls (buttons, keyboard shortcuts) still work independently
  - Verify no effect when pinchToZoom.enabled is disabled
  - Verify no regression in image and document pinch-to-zoom