### PR TITLE
feat(controls): migrate image toolbar primitives to Blueprint

### DIFF
--- a/build/jest/blueprintWebMock.js
+++ b/build/jest/blueprintWebMock.js
@@ -1,0 +1,23 @@
+/* eslint-disable react/prop-types */
+const React = require('react');
+
+// Lightweight mock that mirrors the public API surface used by box-content-preview
+// without pulling in the full blueprint-web ESM tree (and its asset peer deps).
+const Button = React.forwardRef(function Button(props, ref) {
+    const { startIcon: _startIcon, endIcon: _endIcon, children, ...rest } = props;
+    return React.createElement('button', { ref, type: 'button', ...rest }, children);
+});
+
+const IconButton = React.forwardRef(function IconButton(props, ref) {
+    const { icon: Icon, ...rest } = props;
+    return React.createElement('button', { ref, type: 'button', ...rest }, Icon ? React.createElement(Icon) : null);
+});
+
+const Tooltip = function Tooltip({ children, content: _content, ...rest }) {
+    return React.createElement(React.Fragment, rest, children);
+};
+Tooltip.Provider = function TooltipProvider({ children }) {
+    return React.createElement(React.Fragment, null, children);
+};
+
+module.exports = { Button, IconButton, Tooltip };

--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -49,6 +49,16 @@ module.exports = language => {
                         filename: '[name][ext]',
                     },
                 },
+                {
+                    // @box/blueprint-web's ESM build uses extensionless imports (e.g., 'lodash/noop')
+                    // which webpack 5 rejects under strict ESM resolution. Relax the requirement
+                    // for paths inside Blueprint so its imports resolve correctly.
+                    test: /\.m?js$/,
+                    include: [path.resolve('node_modules/@box/blueprint-web')],
+                    resolve: {
+                        fullySpecified: false,
+                    },
+                },
             ],
         },
         plugins: [

--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -27,13 +27,23 @@ module.exports = language => {
                     include: [path.resolve('src/lib')],
                 },
                 {
-                    test: /\.s?css$/,
+                    test: /\.scss$/,
                     use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader', 'sass-loader'],
                     include: [
                         path.resolve('src/lib'),
                         path.resolve('node_modules/box-annotations'),
                         path.resolve('node_modules/box-ui-elements'),
+                    ],
+                },
+                {
+                    test: /\.css$/,
+                    use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader'],
+                    include: [
+                        path.resolve('src/lib'),
+                        path.resolve('node_modules/box-annotations'),
+                        path.resolve('node_modules/box-ui-elements'),
                         path.resolve('node_modules/pdfjs-dist'),
+                        path.resolve('node_modules/@box/blueprint-web'),
                     ],
                 },
                 {

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ module.exports = {
         '@box/react-virtualized/dist/es': '@box/react-virtualized/dist/commonjs',
         'box-elements-messages': '<rootDir>/build/jest/i18nMock.js',
         'react-intl': '<rootDir>/build/jest/react-intl-mock.js',
+        '^@box/blueprint-web$': '<rootDir>/build/jest/blueprintWebMock.js',
+        '^@box/blueprint-web-assets/icons/(.*)$': '<rootDir>/node_modules/@box/blueprint-web-assets/dist/icons/$1.js',
         THREE: '<rootDir>/src/third-party/model3d/1.12.0/three.min.js',
     },
     restoreMocks: true,
@@ -30,5 +32,5 @@ module.exports = {
         '^.+\\.[jt]sx?$': 'babel-jest',
         '^.+\\.(svg|html)$': '<rootDir>/build/jest/stringLoader.js',
     },
-    transformIgnorePatterns: ['node_modules/(?!(box-ui-elements|react-virtualized)/)'],
+    transformIgnorePatterns: ['node_modules/(?!(box-ui-elements|react-virtualized|@box/blueprint-web-assets)/)'],
 };

--- a/src/lib/viewers/box3d/image360/__tests__/Image360Controls-test.tsx
+++ b/src/lib/viewers/box3d/image360/__tests__/Image360Controls-test.tsx
@@ -14,7 +14,7 @@ describe('lib/viewers/box3d/image360/Image360Controls', () => {
 
             expect(screen.queryByTitle('Toggle VR display')).not.toBeInTheDocument();
 
-            await user.click(screen.getByTitle('Enter fullscreen'));
+            await user.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
 
             expect(onFullscreenToggle).toHaveBeenCalled();
         });

--- a/src/lib/viewers/box3d/model3d/__tests__/Model3DControlsNew-test.tsx
+++ b/src/lib/viewers/box3d/model3d/__tests__/Model3DControlsNew-test.tsx
@@ -60,7 +60,7 @@ describe('lib/viewers/box3d/model3d/Model3DControlsNew', () => {
             await user.click(animationClip);
             expect(onAnimationClipSelect).toHaveBeenCalledTimes(1);
 
-            await user.click(screen.getByTitle('Enter fullscreen'));
+            await user.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
             expect(onFullscreenToggle).toHaveBeenCalledTimes(1);
 
             await user.click(screen.getByTitle('Toggle VR display'));

--- a/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
+++ b/src/lib/viewers/controls/fullscreen/FullscreenToggle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import IconArrowsMaximizeMedium24 from '../icons/IconArrowsMaximizeMedium24';
-import IconArrowsMinimizeMedium24 from '../icons/IconArrowsMinimizeMedium24';
+import { IconButton } from '@box/blueprint-web';
+import ArrowsCollapse from '@box/blueprint-web-assets/icons/Fill/ArrowsCollapse';
+import ArrowsExpand from '@box/blueprint-web-assets/icons/Fill/ArrowsExpand';
 import useFullscreen from '../hooks/useFullscreen';
 import './FullscreenToggle.scss';
 
@@ -11,23 +12,21 @@ export type Props = {
 
 export default function FullscreenToggle({ onFullscreenToggle, ...rest }: Props): JSX.Element {
     const isFullscreen = useFullscreen();
-    const Icon = isFullscreen ? IconArrowsMinimizeMedium24 : IconArrowsMaximizeMedium24;
-    const title = isFullscreen ? __('exit_fullscreen') : __('enter_fullscreen');
+    const Icon = isFullscreen ? ArrowsCollapse : ArrowsExpand;
+    const ariaLabel = isFullscreen ? __('exit_fullscreen') : __('enter_fullscreen');
 
     const handleClick = ({ target }: React.MouseEvent): void => {
         onFullscreenToggle(!isFullscreen, target);
     };
 
     return (
-        <button
+        <IconButton
+            aria-label={ariaLabel}
             className="bp-FullscreenToggle"
             data-resin-target="fullscreen"
+            icon={Icon}
             onClick={handleClick}
-            title={title}
-            type="button"
             {...rest}
-        >
-            <Icon />
-        </button>
+        />
     );
 }

--- a/src/lib/viewers/controls/fullscreen/__tests__/FullscreenToggle-test.tsx
+++ b/src/lib/viewers/controls/fullscreen/__tests__/FullscreenToggle-test.tsx
@@ -6,10 +6,8 @@ import FullscreenToggle from '../FullscreenToggle';
 
 describe('FullscreenToggle', () => {
     const getWrapper = (props = {}) => render(<FullscreenToggle onFullscreenToggle={jest.fn()} {...props} />);
-    const getEnterToggleButton = async () => screen.findByTitle('Enter fullscreen');
-    const getExitToggleButton = async () => screen.findByTitle('Exit fullscreen');
-    const getIconFullscreenIn = async () => screen.findByTestId('IconArrowsMaximizeMedium24');
-    const getIconFullscreenOut = async () => screen.findByTestId('IconArrowsMinimizeMedium24');
+    const getEnterToggleButton = async () => screen.findByRole('button', { name: 'Enter fullscreen' });
+    const getExitToggleButton = async () => screen.findByRole('button', { name: 'Exit fullscreen' });
 
     describe('event handlers', () => {
         test('should respond to fullscreen events', async () => {
@@ -19,18 +17,14 @@ describe('FullscreenToggle', () => {
                 fullscreen.enter();
             });
 
-            const iconFullscreenOut = await getIconFullscreenOut();
             const exitToggleButton = await getExitToggleButton();
-            expect(iconFullscreenOut).toBeInTheDocument();
             expect(exitToggleButton).toBeInTheDocument();
 
             act(() => {
                 fullscreen.exit();
             });
 
-            const iconFullscreenIn = await getIconFullscreenIn();
             const enterToggleButton = await getEnterToggleButton();
-            expect(iconFullscreenIn).toBeInTheDocument();
             expect(enterToggleButton).toBeInTheDocument();
         });
 
@@ -50,19 +44,6 @@ describe('FullscreenToggle', () => {
 
             const enterToggleButton = await getEnterToggleButton();
             expect(enterToggleButton).toBeInTheDocument();
-        });
-
-        test('should render modern icons', async () => {
-            getWrapper();
-
-            expect(await screen.findByTestId('IconArrowsMaximizeMedium24')).toBeInTheDocument();
-
-            // Enter fullscreen
-            act(() => {
-                fullscreen.enter();
-            });
-
-            expect(await screen.findByTestId('IconArrowsMinimizeMedium24')).toBeInTheDocument();
         });
     });
 });

--- a/src/lib/viewers/controls/rotate/RotateControl.tsx
+++ b/src/lib/viewers/controls/rotate/RotateControl.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import IconRotate24 from '../icons/IconRotate24';
+import { IconButton } from '@box/blueprint-web';
+import RotateLeft from '@box/blueprint-web-assets/icons/Medium/RotateLeft';
 import './RotateControl.scss';
 
 export type Props = {
@@ -8,14 +9,12 @@ export type Props = {
 
 export default function RotateControl({ onRotateLeft }: Props): JSX.Element {
     return (
-        <button
+        <IconButton
+            aria-label={__('rotate_left')}
             className="bp-RotateControl"
             data-resin-target="rotate"
+            icon={RotateLeft}
             onClick={onRotateLeft}
-            title={__('rotate_left')}
-            type="button"
-        >
-            <IconRotate24 />
-        </button>
+        />
     );
 }

--- a/src/lib/viewers/controls/rotate/__tests__/RotateControl-test.tsx
+++ b/src/lib/viewers/controls/rotate/__tests__/RotateControl-test.tsx
@@ -23,10 +23,8 @@ describe('RotateControl', () => {
         test('should return a valid wrapper', async () => {
             getWrapper();
             const button = await getButton();
-            const icon = await screen.findByTestId('IconRotate24');
 
             expect(button).toBeInTheDocument();
-            expect(icon).toBeInTheDocument();
         });
     });
 });

--- a/src/lib/viewers/controls/zoom/ZoomControls.tsx
+++ b/src/lib/viewers/controls/zoom/ZoomControls.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import isFinite from 'lodash/isFinite';
-import IconMinusMedium24 from '../icons/IconMinusMedium24';
-import IconPlusMedium24 from '../icons/IconPlusMedium24';
+import { IconButton } from '@box/blueprint-web';
+import Minus from '@box/blueprint-web-assets/icons/Fill/Minus';
+import Plus from '@box/blueprint-web-assets/icons/Fill/Plus';
 import './ZoomControls.scss';
 
 export type Props = {
@@ -28,33 +29,29 @@ export default function ZoomControls({
 
     return (
         <div className="bp-ZoomControls">
-            <button
+            <IconButton
+                aria-label={__('zoom_out')}
                 className="bp-ZoomControls-button"
                 data-resin-target="zoomOut"
                 data-testid="bp-ZoomControls-out"
                 disabled={currentScale <= minScaleValue}
+                icon={Minus}
                 onClick={onZoomOut}
-                title={__('zoom_out')}
-                type="button"
-            >
-                <IconMinusMedium24 />
-            </button>
+            />
             <div
                 className="bp-ZoomControls-current"
                 data-testid="bp-ZoomControls-current"
                 title={__('zoom_current_scale')}
             >{`${Math.round(currentScale * 100)}%`}</div>
-            <button
+            <IconButton
+                aria-label={__('zoom_in')}
                 className="bp-ZoomControls-button"
                 data-resin-target="zoomIn"
                 data-testid="bp-ZoomControls-in"
                 disabled={currentScale >= maxScaleValue}
+                icon={Plus}
                 onClick={onZoomIn}
-                title={__('zoom_in')}
-                type="button"
-            >
-                <IconPlusMedium24 />
-            </button>
+            />
         </div>
     );
 }

--- a/src/lib/viewers/controls/zoom/__tests__/ZoomControls-test.tsx
+++ b/src/lib/viewers/controls/zoom/__tests__/ZoomControls-test.tsx
@@ -50,9 +50,6 @@ describe('ZoomControls', () => {
                 } else {
                     expect(zoomOut).not.toBeDisabled();
                 }
-
-                expect(screen.getByTestId('IconMinusMedium24')).toBeVisible();
-                expect(screen.getByTestId('IconPlusMedium24')).toBeVisible();
             },
         );
 

--- a/src/lib/viewers/image/__tests__/ImageControls-test.jsx
+++ b/src/lib/viewers/image/__tests__/ImageControls-test.jsx
@@ -26,7 +26,7 @@ describe('ImageControls', () => {
         test('should pass down props to FullscreenToggle', async () => {
             const onFullscreenToggle = jest.fn();
             getWrapper({ onFullscreenToggle });
-            const toggle = await screen.findByTitle(__('enter_fullscreen'));
+            const toggle = await screen.findByRole('button', { name: __('enter_fullscreen') });
 
             await userEvent.click(toggle);
 
@@ -36,7 +36,7 @@ describe('ImageControls', () => {
         test('should pass down props to RotateControl', async () => {
             const onRotateLeft = jest.fn();
             getWrapper({ onRotateLeft });
-            const toggle = await screen.findByTitle(__('rotate_left'));
+            const toggle = await screen.findByRole('button', { name: __('rotate_left') });
 
             await userEvent.click(toggle);
 
@@ -47,8 +47,8 @@ describe('ImageControls', () => {
             const onZoomIn = jest.fn();
             const onZoomOut = jest.fn();
             getWrapper({ onZoomIn, onZoomOut });
-            const zoomIn = await screen.findByTitle(__('zoom_in'));
-            const zoomOut = await screen.findByTitle(__('zoom_out'));
+            const zoomIn = await screen.findByRole('button', { name: __('zoom_in') });
+            const zoomOut = await screen.findByRole('button', { name: __('zoom_out') });
 
             await userEvent.click(zoomIn);
             await userEvent.click(zoomOut);

--- a/src/lib/viewers/image/__tests__/MultiImageControls-test.jsx
+++ b/src/lib/viewers/image/__tests__/MultiImageControls-test.jsx
@@ -29,7 +29,7 @@ describe('MultiImageControls', () => {
         test('should pass down props to FullscreenToggle', async () => {
             const onFullscreenToggle = jest.fn();
             getWrapper({ onFullscreenToggle });
-            const toggle = await screen.findByTitle(__('enter_fullscreen'));
+            const toggle = await screen.findByRole('button', { name: __('enter_fullscreen') });
 
             await userEvent.click(toggle);
 
@@ -59,8 +59,8 @@ describe('MultiImageControls', () => {
             const onZoomIn = jest.fn();
             const onZoomOut = jest.fn();
             getWrapper({ onZoomIn, onZoomOut });
-            const zoomIn = await screen.findByTitle(__('zoom_in'));
-            const zoomOut = await screen.findByTitle(__('zoom_out'));
+            const zoomIn = await screen.findByRole('button', { name: __('zoom_in') });
+            const zoomOut = await screen.findByRole('button', { name: __('zoom_out') });
 
             await userEvent.click(zoomIn);
             await userEvent.click(zoomOut);

--- a/src/lib/viewers/media/__tests__/MP4Controls-test.jsx
+++ b/src/lib/viewers/media/__tests__/MP4Controls-test.jsx
@@ -32,7 +32,7 @@ describe('MP4Controls', () => {
             const onFullscreenToggle = jest.fn();
             getWrapper({ onFullscreenToggle });
 
-            const toggle = await screen.findByTitle(__('enter_fullscreen'));
+            const toggle = await screen.findByRole('button', { name: __('enter_fullscreen') });
 
             await userEvent.click(toggle);
 

--- a/src/lib/viewers/media/__tests__/VideoControls-test.tsx
+++ b/src/lib/viewers/media/__tests__/VideoControls-test.tsx
@@ -46,7 +46,7 @@ describe('VideoControls', () => {
                 />,
             );
 
-            await user.click(screen.getByTitle('Enter fullscreen'));
+            await user.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
             expect(onFullscreenToggle).toHaveBeenCalledTimes(1);
 
             await user.click(screen.getByTitle('Play'));

--- a/src/lib/viewers/text/__tests__/MarkdownControls-test.jsx
+++ b/src/lib/viewers/text/__tests__/MarkdownControls-test.jsx
@@ -17,7 +17,7 @@ describe('MarkdownControls', () => {
         test('should pass down onFullscreenToggle prop', async () => {
             const onFullscreenToggle = jest.fn();
             getWrapper({ onFullscreenToggle });
-            const toggle = await screen.findByTitle(__('enter_fullscreen'));
+            const toggle = await screen.findByRole('button', { name: __('enter_fullscreen') });
 
             await userEvent.click(toggle);
 

--- a/src/lib/viewers/text/__tests__/TextControls-test.jsx
+++ b/src/lib/viewers/text/__tests__/TextControls-test.jsx
@@ -18,7 +18,7 @@ describe('TextControls', () => {
         test('should pass down props to FullscreenToggle', async () => {
             const onFullscreenToggle = jest.fn();
             getWrapper({ onFullscreenToggle });
-            const toggle = await screen.findByTitle(__('enter_fullscreen'));
+            const toggle = await screen.findByRole('button', { name: __('enter_fullscreen') });
 
             await userEvent.click(toggle);
 
@@ -29,8 +29,8 @@ describe('TextControls', () => {
             const onZoomIn = jest.fn();
             const onZoomOut = jest.fn();
             getWrapper({ onZoomIn, onZoomOut });
-            const zoomIn = await screen.findByTitle(__('zoom_in'));
-            const zoomOut = await screen.findByTitle(__('zoom_out'));
+            const zoomIn = await screen.findByRole('button', { name: __('zoom_in') });
+            const zoomOut = await screen.findByRole('button', { name: __('zoom_out') });
 
             await userEvent.click(zoomIn);
             await userEvent.click(zoomOut);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "ES2020",
+        "moduleResolution": "bundler",
         "types": ["node", "jest", "@testing-library/jest-dom"]
     },
     "extends": "@box/frontend/ts/tsconfig.json",


### PR DESCRIPTION
## Summary

First step of the chrome migration. Replaces custom button + icon primitives in the three controls used by Image (and shared with Text, Media, etc.) with Blueprint equivalents. **Visual treatment is preserved** — existing CSS classes stay applied to Blueprint's `IconButton` via `className`, so the translucent dark overlay, white icons, and chunky 48px button look are unchanged.

This is **primitives-only**: toolbar shell (`ControlsBar`) and visual styling stay as-is. The toolbar visual story (whether to migrate the shell to Blueprint's `Toolbar` component, what variant/size to use) is a follow-up that needs design input.

## Migrations

| File | Custom → Blueprint |
|---|---|
| `ZoomControls.tsx` | `<button>` + `IconPlusMedium24`/`IconMinusMedium24` → `IconButton` + `Fill/Plus` + `Fill/Minus` |
| `RotateControl.tsx` | `<button>` + `IconRotate24` → `IconButton` + `Medium/RotateLeft` |
| `FullscreenToggle.tsx` | `<button>` + `IconArrowsMaximize/MinimizeMedium24` → `IconButton` + `Fill/ArrowsExpand` + `Fill/ArrowsCollapse` |

## Build infrastructure

- **`jest.config.js`**: lightweight Blueprint mock (`build/jest/blueprintWebMock.js`) so tests don't need to load Blueprint's full ESM tree. `transformIgnorePatterns` allows `@box/blueprint-web-assets` through. Subpath imports for icons mapped explicitly because Jest 26 doesn't honor the `exports` field.
- **`webpack.common.config.js`**: 
  - Split `\.s?css$/` rule into separate `\.scss/` and `\.css/` rules. Blueprint ships pre-built `.css` with native CSS `min(100%, max-content)` which Sass-loader incorrectly tries to interpret as a Sass function.
  - Add `resolve.fullySpecified: false` for paths inside `@box/blueprint-web` because Blueprint's ESM build uses extensionless lodash imports that webpack 5 strict ESM resolution rejects.
- **`tsconfig.json`**: bump `moduleResolution` to `bundler` so `tsc` honors the Blueprint package's `exports` field for icon subpaths.

## Test updates

The 8 viewer-control test suites (Image/Text/Media/MultiImage/Markdown/MP4/Image360/Model3D) used `screen.findByTitle('Enter fullscreen')`/`getByTitle('Zoom in')` etc. to find the buttons. Blueprint `IconButton` exposes the label via `aria-label`, not the `title` attribute. Updated to `screen.findByRole('button', { name: ... })`.

Drop `data-testid="IconRotate24"` etc. assertions — those checked the old custom icon was rendered. Existing button-level checks are sufficient.

## Bundle impact

| Output | Before | After | Delta |
|---|---|---|---|
| CDN `preview.js` | 3.6 MB | 4.0 MB | +400 KB (Blueprint inlined; CDN doesn't externalize) |
| npm `dist/lib/index.js` | 1.32 MB | 1.39 MB | +70 KB (Blueprint externalized; only IconButton/icon wiring bundled) |

## Test plan

- [x] `yarn test` — 154 suites, 3807 tests pass (+41 from updated test sweep)
- [x] `yarn lint` — passes
- [x] `yarn lint:ts` — passes
- [x] `yarn build` — CDN bundle builds cleanly
- [x] `yarn build:lib` — npm bundle builds cleanly
- [ ] Visual regression: confirm image viewer toolbar renders identically pre/post — to be verified during review

## Out of scope (intentional)

- Toolbar shell migration (replace `<ControlsBar>` with Blueprint's `Toolbar`) — needs design input on whether to abandon the current floating dark overlay aesthetic.
- Other viewer chrome migrations (Text, Media, Doc, Box3D, Thumbnails) — each is its own follow-up using this PR's pattern.