### PR TITLE
fix(build): cap minify parallelism to prevent CI OOM

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -46,9 +46,15 @@ function updateConfig(conf, language, index) {
             archive: [`${lib}/viewers/archive/BoxArchive.js`],
         },
         mode: isProd ? 'production' : 'development',
+        // Cap webpack's per-compilation parallelism so the 26 per-language
+        // configs don't all enter the minify phase at once on CI.
+        parallelism: 1,
         optimization: {
             minimizer: [
                 new TerserPlugin({
+                    // Default is os.cpus().length, which combined with 26 parallel
+                    // language compilations OOMs the Jenkins agent.
+                    parallel: 2,
                     terserOptions: {
                         compress: {
                             drop_console: true,


### PR DESCRIPTION
## Summary

- Cap `TerserPlugin` to `parallel: 2` (was `os.cpus().length` default)
- Cap webpack's per-config `parallelism: 1` so the 26 per-language compilations don't all enter the minify phase at once

## Background

The master pipeline `yarn build:prod` was being killed with `SIGKILL` during webpack's sealing/asset-processing phase. The kill is the kernel OOM killer — total RSS exceeds the Jenkins agent's memory limit.

Root cause is the webpack 4→5 upgrade (#1651). webpack 5 builds all 26 per-language configs concurrently, each spawning `os.cpus().length` Terser worker processes. On a multi-core CI agent that's `26 × N` Terser workers running simultaneously, each at ~512MB defaults — easily blows past agent RAM. `--max_old_space_size=4096` only applies to the parent Node process; the Terser children don't inherit it.

These caps put a deterministic upper bound on concurrent worker count regardless of agent CPU/RAM, at the cost of a slower (but reliably completing) minify phase. No change to emitted bundles — Terser parallelism is purely a worker-count knob.

## Test plan

- [x] Local `yarn build:prod` completes without OOM
- [x] Local timing: ~3m 39s wall on a 10-core M-series Mac, all 26 locales emitted
- [x] Bundle output unchanged (preview.js 775 KiB, annotations.js 783 KiB, etc)
- [ ] Master CI build completes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)