### PR TITLE
fix(build): cap MultiCompiler parallelism to prevent CI OOM

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -124,4 +124,7 @@ function updateConfig(conf, language, index) {
 }
 
 const localizedConfigs = languages.map((language, index) => updateConfig(commonConfig(language), language, index));
+// MultiCompiler cap: limit concurrent language compilations so they don't all
+// enter the Terser minify phase at once and OOM the CI agent.
+localizedConfigs.parallelism = 2;
 module.exports = localizedConfigs.length > 1 ? localizedConfigs : localizedConfigs[0];


### PR DESCRIPTION
## Summary

Set `parallelism: 2` on the exported config array so webpack's MultiCompiler caps how many of the 26 per-language compilations run concurrently.

## Background

Follow-up to the previous Terser/parallelism cap. That fix bounded worker count *within* each compilation but didn't bound how many of the 26 per-language compilations run concurrently — the master CI build still `SIGKILL`'d during webpack's sealing/asset-processing phase.

The CI log clearly shows multiple language indices (`[11]`, `[16]`, `[17]`, `[18]`, `[19]`, `[23]`) all hitting `sealing asset processing TerserPlugin` at the same time. Each compilation spawns its own pool of Terser workers, so even with `parallel: 2` per compilation we still ended up with ~26 × 2 worker processes at the worst moment.

webpack 5's MultiCompiler reads a `parallelism` property from the *array* exported by the config file (not from any individual config in the array). Setting it on the array hard-caps concurrent compilations and therefore concurrent Terser worker pools.

## Test plan

- [x] Local `yarn build:prod` completes (~3m 27s on a 10-core M-series Mac)
- [x] All 26 locale directories emitted under `dist/<version>/`
- [x] Bundle output unchanged (preview.js 775 KiB, etc.)
- [ ] Master CI build completes after merge — this is the real test, since local hardware has plenty of headroom either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)