### PR TITLE
fix(build): repair npm package consumer compatibility

### DIFF
--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -49,7 +49,12 @@ module.exports = {
         filename: '[name].js',
         library: { type: 'module' },
         module: true,
-        environment: { module: true, dynamicImport: true },
+        // chunkLoading: false suppresses webpack's chunk-loading runtime. Without this,
+        // webpack emits an `import("./" + chunkId)` line that downstream webpack builds
+        // re-parse as a context module — sweeping in every file under dist/lib/, including
+        // .bin/.d.ts, and failing the consumer build.
+        environment: { module: true, dynamicImport: false },
+        chunkLoading: false,
         clean: true,
     },
     experiments: {
@@ -107,6 +112,10 @@ module.exports = {
     },
     optimization: {
         minimize: false,
+        // Inline all dynamic imports into the single lib bundle. Combined with
+        // chunkLoading: false above, this guarantees no chunk-loading runtime is emitted.
+        splitChunks: false,
+        runtimeChunk: false,
     },
     ignoreWarnings: [
         // pdfjs-dist contains an internal dynamic require that webpack flags as a critical

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -70,6 +70,10 @@ module.exports = {
         /^@box\/blueprint-web(\/.*)?$/,
         /^@box\/blueprint-web-assets(\/.*)?$/,
         /^@box\/react-virtualized(\/.*)?$/,
+        // Externalize pdfjs JS entry points. Consumers install pdfjs-dist (peerDependency)
+        // and their webpack code-splits it. The CSS import (pdfjs-dist/web/pdf_viewer.css)
+        // is intentionally NOT externalized — it stays inlined into dist/lib/index.css.
+        /^pdfjs-dist\/.*\.m?js$/,
     ],
     externalsType: 'module',
     module: {

--- a/package.json
+++ b/package.json
@@ -19,19 +19,13 @@
         "./styles.css": "./dist/lib/index.css",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },
     "dependencies": {
-        "axios": "^0.24.0",
-        "pdfjs-dist": "6.0.227"
+        "axios": "^0.24.0"
     },
     "peerDependencies": {
         "@box/blueprint-web": "^14.32.1",
@@ -39,6 +33,7 @@
         "@box/react-virtualized": "9.22.3-rc-box.2",
         "box-annotations": "^5.2.1-beta.0",
         "box-ui-elements": "^20.0.0",
+        "pdfjs-dist": "^6.0.227",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
     },
@@ -111,6 +106,7 @@
         "mock-local-storage": "^1.1.15",
         "mojito-rb-gen": "^0.0.1",
         "npm-run-all": "^4.1.5",
+        "pdfjs-dist": "6.0.227",
         "postcss": "^8.5.3",
         "postcss-loader": "^8.1.1",
         "prettier": "^1.19.1",


### PR DESCRIPTION
## Summary

The npm-published lib bundle (`dist/lib/index.js` from 3.40 onward) emits webpack's chunk-loading runtime, including a literal `import("./" + __webpack_require__.u(chunkId))`. Downstream webpack builds re-parse that as a `require.context` over `dist/lib/`, sweeping in `.bin` (3D viewer assets) and `.d.ts` (the hand-authored types) and failing with `Module parse failed: Unexpected character` errors. No webpack-based consumer can build against the package as shipped.

This PR fixes the lib build with two related changes:

1. **Suppress the chunk-loading runtime.** `output.chunkLoading: false`, `output.environment.dynamicImport: false`, plus `optimization.{splitChunks, runtimeChunk}: false`. All dynamic imports inline into the single bundle. The consumer's webpack still code-splits at the `import('box-content-preview')` boundary in box-ui-elements.

2. **Externalize `pdfjs-dist`.** Move `pdfjs-dist` from `dependencies` to `peerDependencies` (kept in `devDependencies` for the lib build). Add `/^pdfjs-dist\/.*\.m?js$/` to externals so consumers code-split it themselves. The `pdf_viewer.css` import is intentionally not externalized — it stays inlined into `dist/lib/index.css`.

Bundle drops from 2.15 MB → 1.32 MB. Consumer-side benefits include dedup if the host app already uses pdfjs (e.g., for thumbnails), version control for CVE patches, and natural code splitting per route.

## Verification

- ✅ `dist/lib/index.js` contains no `import("./" + ...)` or `__webpack_require__.u()` runtime.
- ✅ `dist/lib/index.js` references pdfjs as static external imports (`import * as ... from "pdfjs-dist/build/pdf.min.mjs"`).
- ✅ CDN build (`build/webpack.config.js`) is untouched and still compiles cleanly.
- ✅ Full Jest suite: 3824 tests pass, 11 skipped, 0 failures.

## Consumer impact

**npm consumers (e.g., EUA, preview-client via box-ui-elements):**
- Must add `pdfjs-dist` to their dependencies. Yarn/npm warns at install time via the peerDependencies declaration.
- First-preview wire bytes are roughly equivalent to the prior intended npm shape, with one fewer round-trip than the CDN path.

**CDN consumers:**
- No change. The CDN bundle (`webpack.config.js`) is untouched. `pdfjs-dist` remains available via devDependencies for the build.

## Test plan

- [ ] CI passes (full Jest, lint, lib build, CDN build)
- [ ] Smoke test in a webpack 5 consumer: `yarn add box-content-preview pdfjs-dist`, `import` it, verify the build no longer errors on `.bin` / `.d.ts` files
- [ ] No regression in the CDN bundle output

🤖 Generated with [Claude Code](https://claude.com/claude-code)