### PR TITLE
feat(zoom): add resin tracking for pinch-to-zoom events 

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1120,6 +1120,9 @@ class Preview extends EventEmitter {
         this.options.preloadStatus = options.preloadStatus;
         this.options.clientName = options.clientName;
 
+        // Optional resin analytics instance for tracking user interactions
+        this.options.resin = options.resin;
+
         // Options that are applicable to certain file ids
         this.options.fileOptions = options.fileOptions || {};
 

--- a/src/lib/viewers/controls/controls-root/ControlsRoot.tsx
+++ b/src/lib/viewers/controls/controls-root/ControlsRoot.tsx
@@ -8,6 +8,7 @@ import './ControlsRoot.scss';
 export type Options = {
     className?: string;
     containerEl: HTMLElement;
+    fileExtension?: string;
     fileId: string;
     onHide?: () => void;
     onShow?: () => void;
@@ -30,12 +31,20 @@ export default class ControlsRoot {
 
     root: Root;
 
-    constructor({ className = 'bp-ControlsRoot', containerEl, fileId, onHide = noop, onShow = noop }: Options) {
+    constructor({
+        className = 'bp-ControlsRoot',
+        containerEl,
+        fileExtension,
+        fileId,
+        onHide = noop,
+        onShow = noop,
+    }: Options) {
         this.controlsEl = document.createElement('div');
         this.controlsEl.setAttribute('class', className);
         this.controlsEl.setAttribute('data-testid', 'bp-controls');
         this.controlsEl.setAttribute('data-resin-component', 'toolbar');
         this.controlsEl.setAttribute('data-resin-fileid', fileId);
+        this.controlsEl.setAttribute('data-resin-fileextension', fileExtension || '');
 
         this.containerEl = containerEl;
         this.containerEl.addEventListener('mousemove', this.handleMouseMove);

--- a/src/lib/viewers/controls/controls-root/__tests__/ControlsRoot-test.tsx
+++ b/src/lib/viewers/controls/controls-root/__tests__/ControlsRoot-test.tsx
@@ -30,6 +30,13 @@ describe('ControlsRoot', () => {
             expect(instance.controlsEl).toHaveClass('bp-ControlsRoot');
             expect(instance.controlsEl).toHaveAttribute('data-resin-component', 'toolbar');
             expect(instance.controlsEl).toHaveAttribute('data-resin-fileid', '1');
+            expect(instance.controlsEl).toHaveAttribute('data-resin-fileextension', '');
+        });
+
+        test('should set data-resin-fileextension when fileExtension is provided', () => {
+            const instance = getInstance({ fileExtension: 'pdf' });
+
+            expect(instance.controlsEl).toHaveAttribute('data-resin-fileextension', 'pdf');
         });
 
         test('should attach event handlers to the container element', () => {

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1415,7 +1415,11 @@ class DocBaseViewer extends BaseViewer {
      * @return {void}
      */
     loadUI() {
-        this.controls = new ControlsRoot({ containerEl: this.containerEl, fileId: this.options.file.id });
+        this.controls = new ControlsRoot({
+            containerEl: this.containerEl,
+            fileExtension: this.options.file.extension,
+            fileId: this.options.file.id,
+        });
         this.annotationControlsFSM.subscribe(() => this.renderUI());
         this.renderUI();
     }
@@ -1890,8 +1894,25 @@ class DocBaseViewer extends BaseViewer {
 
     trackpadPinchToZoomHandler(event) {
         if (!event.ctrlKey) {
+            this.isTrackpadPinching = false;
             return;
         }
+
+        if (!this.isTrackpadPinching) {
+            this.isTrackpadPinching = true;
+            this.options.resin?.recordAction({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: event.deltaY > 0 ? 'zoomOut' : 'zoomIn',
+                fileId: this.options.file.id,
+                fileExtension: this.options.file.extension,
+            });
+        }
+
+        clearTimeout(this.trackpadPinchIdleTimer);
+        this.trackpadPinchIdleTimer = setTimeout(() => {
+            this.isTrackpadPinching = false;
+        }, 200);
 
         event.preventDefault();
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -3680,6 +3680,50 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 expect(docBase.updateScale).toBeCalled();
             });
+
+            test('should call resin.recordAction on pinch start with zoomIn target', () => {
+                docBase.options.resin = { recordAction: jest.fn() };
+                docBase.options.file = { id: '0', extension: 'pdf' };
+                docBase.isTrackpadPinching = false;
+
+                event.deltaY = -50; // zoom in
+                docBase.trackpadPinchToZoomHandler(event);
+
+                expect(docBase.options.resin.recordAction).toBeCalledWith({
+                    action: 'programmatic',
+                    component: 'toolbar',
+                    target: 'zoomIn',
+                    fileId: '0',
+                    fileExtension: 'pdf',
+                });
+            });
+
+            test('should call resin.recordAction on pinch start with zoomOut target', () => {
+                docBase.options.resin = { recordAction: jest.fn() };
+                docBase.options.file = { id: '0', extension: 'pdf' };
+                docBase.isTrackpadPinching = false;
+                docBase.pdfViewer.currentScale = 2;
+
+                event.deltaY = 50; // zoom out
+                docBase.trackpadPinchToZoomHandler(event);
+
+                expect(docBase.options.resin.recordAction).toBeCalledWith({
+                    action: 'programmatic',
+                    component: 'toolbar',
+                    target: 'zoomOut',
+                    fileId: '0',
+                    fileExtension: 'pdf',
+                });
+            });
+
+            test('should not call resin.recordAction if already pinching', () => {
+                docBase.options.resin = { recordAction: jest.fn() };
+                docBase.isTrackpadPinching = true;
+
+                docBase.trackpadPinchToZoomHandler(event);
+
+                expect(docBase.options.resin.recordAction).not.toBeCalled();
+            });
         });
 
         describe('getStartPage()', () => {

--- a/src/lib/viewers/image/ImageBaseViewer.js
+++ b/src/lib/viewers/image/ImageBaseViewer.js
@@ -219,7 +219,11 @@ class ImageBaseViewer extends BaseViewer {
      * @return {void}
      */
     loadUI() {
-        this.controls = new ControlsRoot({ containerEl: this.containerEl, fileId: this.options.file.id });
+        this.controls = new ControlsRoot({
+            containerEl: this.containerEl,
+            fileExtension: this.options.file.extension,
+            fileId: this.options.file.id,
+        });
     }
 
     /**
@@ -372,6 +376,13 @@ class ImageBaseViewer extends BaseViewer {
                 return;
             }
             this.isPinching = true;
+            this.options.resin?.recordAction({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: event.deltaY > 0 ? 'zoomOut' : 'zoomIn',
+                fileId: this.options.file.id,
+                fileExtension: this.options.file.extension,
+            });
         }
 
         // Reset pinch session after a brief idle (no explicit "pinch end" event exists)

--- a/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageBaseViewer-test.js
@@ -631,6 +631,58 @@ describe('lib/viewers/image/ImageBaseViewer', () => {
             expect(imageBase.isPinching).toBe(true);
         });
 
+        test('should call resin.recordAction on pinch start with zoomIn target', () => {
+            imageBase.isPinching = false;
+            imageBase.options.resin = { recordAction: jest.fn() };
+            imageBase.options.file = { id: '1234', extension: 'png' };
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 })
+                .mockReturnValue({ left: 0, top: 0, right: 105, bottom: 105, width: 105, height: 105 });
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+
+            expect(imageBase.options.resin.recordAction).toBeCalledWith({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: 'zoomIn',
+                fileId: '1234',
+                fileExtension: 'png',
+            });
+        });
+
+        test('should call resin.recordAction on pinch start with zoomOut target', () => {
+            imageBase.isPinching = false;
+            imageBase.options.resin = { recordAction: jest.fn() };
+            imageBase.options.file = { id: '1234', extension: 'png' };
+            imageBase.imageEl.getBoundingClientRect = jest
+                .fn()
+                .mockReturnValueOnce({ left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 })
+                .mockReturnValue({ left: 0, top: 0, right: 95, bottom: 95, width: 95, height: 95 });
+            const event = { clientX: 50, clientY: 50, ctrlKey: true, deltaY: 5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+
+            expect(imageBase.options.resin.recordAction).toBeCalledWith({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: 'zoomOut',
+                fileId: '1234',
+                fileExtension: 'png',
+            });
+        });
+
+        test('should not call resin.recordAction if already pinching', () => {
+            imageBase.isPinching = true;
+            imageBase.options.resin = { recordAction: jest.fn() };
+            const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
+
+            imageBase.wheelZoomHandler(event);
+
+            expect(imageBase.options.resin.recordAction).not.toBeCalled();
+        });
+
         test('should preventDefault and apply proportional zoom on pinch in', () => {
             const event = { clientX: 0, clientY: 0, ctrlKey: true, deltaY: -5, preventDefault: jest.fn() };
 

--- a/src/lib/viewers/text/TextBaseViewer.js
+++ b/src/lib/viewers/text/TextBaseViewer.js
@@ -92,8 +92,25 @@ class TextBaseViewer extends BaseViewer {
     wheelZoomHandler(event) {
         const textEl = this.containerEl && this.containerEl.querySelector('.bp-text');
         if (!event.ctrlKey || !textEl) {
+            this.isPinching = false;
             return;
         }
+
+        if (!this.isPinching) {
+            this.isPinching = true;
+            this.options.resin?.recordAction({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: event.deltaY > 0 ? 'zoomOut' : 'zoomIn',
+                fileId: this.options.file.id,
+                fileExtension: this.options.file.extension,
+            });
+        }
+
+        clearTimeout(this.pinchIdleTimer);
+        this.pinchIdleTimer = setTimeout(() => {
+            this.isPinching = false;
+        }, 200);
 
         event.preventDefault();
 
@@ -222,7 +239,11 @@ class TextBaseViewer extends BaseViewer {
      * @protected
      */
     loadUI() {
-        this.controls = new ControlsRoot({ containerEl: this.containerEl, fileId: this.options.file.id });
+        this.controls = new ControlsRoot({
+            containerEl: this.containerEl,
+            fileExtension: this.options.file.extension,
+            fileId: this.options.file.id,
+        });
         this.bindDOMListeners();
         this.renderUI();
     }

--- a/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
+++ b/src/lib/viewers/text/__tests__/TextBaseViewer-test.js
@@ -310,6 +310,66 @@ describe('lib/viewers/text/TextBaseViewer', () => {
             expect(textBase.scale).toBe(0.1);
         });
 
+        test('should call resin.recordAction on pinch start with zoomIn target', () => {
+            textBase.isPinching = false;
+            textBase.options.resin = { recordAction: jest.fn() };
+            textBase.options.file = { id: '0', extension: 'txt' };
+            const event = new WheelEvent('wheel', {
+                deltaY: -10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.options.resin.recordAction).toBeCalledWith({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: 'zoomIn',
+                fileId: '0',
+                fileExtension: 'txt',
+            });
+        });
+
+        test('should call resin.recordAction on pinch start with zoomOut target', () => {
+            textBase.isPinching = false;
+            textBase.options.resin = { recordAction: jest.fn() };
+            textBase.options.file = { id: '0', extension: 'txt' };
+            const event = new WheelEvent('wheel', {
+                deltaY: 10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.options.resin.recordAction).toBeCalledWith({
+                action: 'programmatic',
+                component: 'toolbar',
+                target: 'zoomOut',
+                fileId: '0',
+                fileExtension: 'txt',
+            });
+        });
+
+        test('should not call resin.recordAction if already pinching', () => {
+            textBase.isPinching = true;
+            textBase.options.resin = { recordAction: jest.fn() };
+            textBase.options.file = { id: '0', extension: 'txt' };
+            const event = new WheelEvent('wheel', {
+                deltaY: -10,
+                ctrlKey: true,
+                clientX: 400,
+                clientY: 300,
+            });
+
+            textBase.wheelZoomHandler(event);
+
+            expect(textBase.options.resin.recordAction).not.toBeCalled();
+        });
+
         describe('caret-based scroll anchoring', () => {
             let originalCaretRangeFromPoint;
             let originalCaretPositionFromPoint;


### PR DESCRIPTION
**Summary**
- Add programmatic resin analytics tracking for pinch-to-zoom gestures on image, doc, and text file viewers
- Pass `fileExtension` to `ControlsRoot` so toolbar click events include file extension data via `data-resin-fileextension` attribute
- Accept resin option from consuming applications to enable recordAction calls for non-click interactions

**Details**
- Pinch-to-zoom (trackpad) events are not captured by resin's DOM-based click delegation since they are wheel events, not clicks. This adds programmatic `resin.recordAction()` calls that fire once per pinch session (debounced with a 200ms idle timeout) with the same shape as toolbar zoom click events:

`{ action: 'programmatic', component: 'toolbar', target: 'zoomIn'|'zoomOut', fileId, fileExtension }`

The resin object is injected by the consuming app via preview options.

**Screenshots**
<img width="1145" height="706" alt="Screenshot 2026-06-05 at 2 25 04 PM" src="https://github.com/user-attachments/assets/fef690d4-1ca3-427a-a45f-41ce04e0801f" />

**Test plan**
  - [x] Unit tests for ControlsRoot data-resin-fileextension attribute
  - [x] Unit tests for resin.recordAction calls in ImageBaseViewer, DocBaseViewer, and TextBaseViewer pinch handlers
  - [ ] Manual: pinch-to-zoom on an image/doc/text file and verify resin event fires in network tab
  - [ ] Manual: click toolbar zoom buttons and verify fileExtension is present in resin payload
