### PR TITLE
feat(viewers): forward loadViewers options to viewer loadViewerAssets

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -798,9 +798,10 @@ class Preview extends EventEmitter {
      *
      * @public
      * @param {string[]} [viewerNames] - Names of viewers to load assets for, defaults to none
+     * @param {Object} [options] - Options forwarded to the viewer's loadViewerAssets
      * @return {void}
      */
-    loadViewers(viewerNames = []) {
+    loadViewers(viewerNames = [], options = {}) {
         this.getViewers()
             .filter(viewer => viewerNames.includes(viewer.NAME))
             .forEach(viewer => {
@@ -811,7 +812,7 @@ class Preview extends EventEmitter {
                 );
 
                 if (typeof viewerInstance.loadViewerAssets === 'function') {
-                    viewerInstance.loadViewerAssets();
+                    viewerInstance.loadViewerAssets(options);
                 }
             });
     }

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -946,7 +946,7 @@ describe('lib/Preview', () => {
         });
 
         test('forwards options to each viewer instance loadViewerAssets', () => {
-            const options = { useNpmPdfjs: true };
+            const options = { isUseNpmPdfjsEnabled: true };
             preview.loadViewers(['Document', 'MP4', 'IMAGE'], options);
             expect(loadViewerAssetsStub).toHaveBeenCalledWith(options);
         });

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -944,6 +944,12 @@ describe('lib/Preview', () => {
             expect(loadViewerAssetsStub).toHaveBeenCalledTimes(1);
             expect(prefetchStub).not.toHaveBeenCalled();
         });
+
+        test('forwards options to each viewer instance loadViewerAssets', () => {
+            const options = { useNpmPdfjs: true };
+            preview.loadViewers(['Document', 'MP4', 'IMAGE'], options);
+            expect(loadViewerAssetsStub).toHaveBeenCalledWith(options);
+        });
     });
 
     describe('disableViewers()', () => {

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -511,9 +511,21 @@ class DocBaseViewer extends BaseViewer {
      * Loads the viewer assets as opposed to just prefetching them as a performance optimization. This means that the libraries will be loaded
      * into memory eliminating the need to load them when a preview is clicked.
      *
+     * @param {Object} [options]
+     * @param {boolean} [options.useNpmPdfjs] - Warm up the npm-bundled pdfjs
+     *   chunks instead of the legacy CDN scripts so this matches what `load()`
+     *   will use when the flag is on.
      * @return {void}
      */
-    loadViewerAssets() {
+    loadViewerAssets({ useNpmPdfjs = false } = {}) {
+        if (useNpmPdfjs) {
+            this.loadAssets(EXIF_READER, []);
+            // Kick off the dynamic imports so the pdfjs chunks land in cache
+            // before per-file load() awaits them. Errors are swallowed; load()
+            // will surface them later.
+            this.loadPdfjsFromNpm().catch(() => {});
+            return;
+        }
         const ASSETS = [...JS_NO_EXIF, ...EXIF_READER];
         this.loadAssets(ASSETS, CSS);
         this.loadAssets(PRELOAD_JS, []);

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -512,13 +512,13 @@ class DocBaseViewer extends BaseViewer {
      * into memory eliminating the need to load them when a preview is clicked.
      *
      * @param {Object} [options]
-     * @param {boolean} [options.useNpmPdfjs] - Warm up the npm-bundled pdfjs
-     *   chunks instead of the legacy CDN scripts so this matches what `load()`
-     *   will use when the flag is on.
+     * @param {boolean} [options.isUseNpmPdfjsEnabled] - Warm up the npm-bundled
+     *   pdfjs chunks instead of the legacy CDN scripts so this matches what
+     *   `load()` will use when the flag is on.
      * @return {void}
      */
-    loadViewerAssets({ useNpmPdfjs = false } = {}) {
-        if (useNpmPdfjs) {
+    loadViewerAssets({ isUseNpmPdfjsEnabled = false } = {}) {
+        if (isUseNpmPdfjsEnabled) {
             this.loadAssets(EXIF_READER, []);
             // Kick off the dynamic imports so the pdfjs chunks land in cache
             // before per-file load() awaits them. Errors are swallowed; load()

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1218,6 +1218,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(1, [...JS_NO_EXIF, ...EXIF_READER], CSS);
                 expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(2, PRELOAD_JS, []);
             });
+
+            test('warms the npm pdfjs chunks instead of CDN scripts when useNpmPdfjs is true', () => {
+                const loadPdfjsFromNpmStub = jest.spyOn(testDocBase, 'loadPdfjsFromNpm').mockResolvedValue(undefined);
+
+                testDocBase.loadViewerAssets({ useNpmPdfjs: true });
+
+                expect(testDocBase.loadAssets).toHaveBeenCalledTimes(1);
+                expect(testDocBase.loadAssets).toHaveBeenCalledWith(EXIF_READER, []);
+                expect(loadPdfjsFromNpmStub).toHaveBeenCalledTimes(1);
+            });
         });
 
         describe('handleAssetAndRepLoad', () => {

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1219,10 +1219,10 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(testDocBase.loadAssets).toHaveBeenNthCalledWith(2, PRELOAD_JS, []);
             });
 
-            test('warms the npm pdfjs chunks instead of CDN scripts when useNpmPdfjs is true', () => {
+            test('warms the npm pdfjs chunks instead of CDN scripts when isUseNpmPdfjsEnabled is true', () => {
                 const loadPdfjsFromNpmStub = jest.spyOn(testDocBase, 'loadPdfjsFromNpm').mockResolvedValue(undefined);
 
-                testDocBase.loadViewerAssets({ useNpmPdfjs: true });
+                testDocBase.loadViewerAssets({ isUseNpmPdfjsEnabled: true });
 
                 expect(testDocBase.loadAssets).toHaveBeenCalledTimes(1);
                 expect(testDocBase.loadAssets).toHaveBeenCalledWith(EXIF_READER, []);


### PR DESCRIPTION
### Summary

Make `Preview.loadViewers` accept an `options` object and forward it to each viewer's `loadViewerAssets`. In `DocBaseViewer.loadViewerAssets`, honor `{ useNpmPdfjs: true }` by warming the npm-bundled pdfjs chunks via `loadPdfjsFromNpm()` instead of the legacy CDN asset list — matching what `load()` will use when the flag is on.

### Why

Consumers drive the `useNpmPdfjs` feature flag and call `previewInstance.loadViewers(viewers)` during cache warmup. Today `loadViewers` swallows any caller options and `loadViewerAssets` unconditionally loads the legacy CDN bundle, so warmup pulls CDN scripts even when the actual preview will pull npm chunks — defeating the warmup. Forwarding options closes that gap.

### Changes

- `src/lib/Preview.js`: `loadViewers(viewerNames = [], options = {})` — pass `options` into `viewerInstance.loadViewerAssets(options)`.
- `src/lib/viewers/doc/DocBaseViewer.js`: `loadViewerAssets({ useNpmPdfjs = false } = {})` — when on, load only `EXIF_READER` and call `this.loadPdfjsFromNpm().catch(() => {})` so chunks land in cache before per-file `load()` awaits them.
- Unit tests added for both branches (`Preview-test.js`, `DocBaseViewer-test.js`).

### Test plan

- [x] `yarn jest src/lib/__tests__/Preview-test.js -t loadViewers` passes
- [x] `yarn jest src/lib/viewers/doc/__tests__/DocBaseViewer-test.js -t loadViewerAssets` passes
- [ ] Verify in consumer that warmup pulls npm chunks when flag is on, CDN scripts when off

🤖 Generated with [Claude Code](https://claude.com/claude-code)