### PR TITLE
feat(video): update V2 player layout and narrow viewport handling

### DIFF
--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -105,6 +105,11 @@ class VideoBaseViewer extends MediaBaseViewer {
             this.bufferingSpinnerEl.style.marginTop = `-${VIDEO_PLAYER_CONTROL_BAR_HEIGHT / 2 + SPINNER_HALF_SIZE}px`;
         }
 
+        if (this.featureEnabled('videoPlayerV2.enabled')) {
+            this.wrapperEl.classList.add('bp-media--v2');
+            this.mediaContainerEl.classList.add('bp-media-container--v2');
+        }
+
         this.lowerLights();
     }
 
@@ -388,9 +393,15 @@ class VideoBaseViewer extends MediaBaseViewer {
     loadUIReact() {
         super.loadUIReact();
 
+        // For the V2 player, mount the controls on the wrapper (above the media container)
+        // so their width is constrained by the viewport rather than the video
+        const controlsContainerEl = this.featureEnabled('videoPlayerV2.enabled')
+            ? this.wrapperEl
+            : this.mediaContainerEl;
+
         this.controls = new ControlsRoot({
             className: 'bp-VideoControlsRoot',
-            containerEl: this.mediaContainerEl,
+            containerEl: controlsContainerEl,
             fileId: this.options.file.id,
             onHide: this.handleControlsHide,
             onShow: this.handleControlsShow,
@@ -612,10 +623,6 @@ class VideoBaseViewer extends MediaBaseViewer {
                 this.mediaEl.style.width = `${viewport.height * this.aspect}px`;
             }
         }
-
-        if (this.mediaContainerEl && this.mediaEl.style.width) {
-            this.mediaContainerEl.style.width = this.mediaEl.style.width;
-        }
     }
 
     /**
@@ -627,16 +634,18 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     handleNarrowVideoUI() {
         if (this.useReactControls()) {
-            const mediaElWidthNumber = parseInt(this.mediaEl.style.width, 10);
+            const widthNumber = this.featureEnabled('videoPlayerV2.enabled')
+                ? this.wrapperEl.clientWidth
+                : parseInt(this.mediaEl.style.width, 10);
 
-            if (!Number.isNaN(mediaElWidthNumber)) {
+            if (!Number.isNaN(widthNumber)) {
                 // check if play and seek buttons exist in the dom
-                if (this.playContainerEl && mediaElWidthNumber >= SMALL_VIDEO_WIDTH_THRESHOLD) {
+                if (this.playContainerEl && widthNumber >= SMALL_VIDEO_WIDTH_THRESHOLD) {
                     this.isNarrowVideo = false;
                     this.removePlayButtonWithSeekButtons();
                     this.preloader?.showPlayOverlay();
                     this.renderUI();
-                } else if (!this.playContainerEl && mediaElWidthNumber < SMALL_VIDEO_WIDTH_THRESHOLD) {
+                } else if (!this.playContainerEl && widthNumber < SMALL_VIDEO_WIDTH_THRESHOLD) {
                     this.buildPlayButtonWithSeekButtons();
                     this.preloader?.hidePlayOverlay();
                     this.isNarrowVideo = true;

--- a/src/lib/viewers/media/VideoControlsV2.scss
+++ b/src/lib/viewers/media/VideoControlsV2.scss
@@ -15,7 +15,7 @@
 .bp-VideoControlsV2 {
     @include bp-VideoControls;
 
-    padding: 30px 20px 10px 20px;
+    padding: 30px 48px 20px 48px;
 }
 
 .bp-VideoControlsV2-bar {

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -115,24 +115,28 @@ export default function VideoControlsV2({
                     >
                         <PlayPauseIcon />
                     </MediaToggle>
-                    <div className="bp-VideoControlsV2-divider" />
-                    <MediaToggle
-                        className="bp-VideoControlsV2-skipBtn"
-                        data-resin-target="skipBackward"
-                        onClick={moveBackward}
-                        title={skipBackwardTitle}
-                    >
-                        <IconBack24 />
-                    </MediaToggle>
-                    <MediaToggle
-                        className="bp-VideoControlsV2-skipBtn"
-                        data-resin-target="skipForward"
-                        onClick={moveForward}
-                        title={skipForwardTitle}
-                    >
-                        <IconForward24 />
-                    </MediaToggle>
-                    <div className="bp-VideoControlsV2-divider" />
+                    {!isNarrowVideo && (
+                        <>
+                            <div className="bp-VideoControlsV2-divider" />
+                            <MediaToggle
+                                className="bp-VideoControlsV2-skipBtn"
+                                data-resin-target="skipBackward"
+                                onClick={moveBackward}
+                                title={skipBackwardTitle}
+                            >
+                                <IconBack24 />
+                            </MediaToggle>
+                            <MediaToggle
+                                className="bp-VideoControlsV2-skipBtn"
+                                data-resin-target="skipForward"
+                                onClick={moveForward}
+                                title={skipForwardTitle}
+                            >
+                                <IconForward24 />
+                            </MediaToggle>
+                            <div className="bp-VideoControlsV2-divider" />
+                        </>
+                    )}
                     <span className="bp-VideoControlsV2-timestamp" data-testid="bp-VideoControlsV2-timestamp">
                         {timeLabel}
                     </span>

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -115,6 +115,58 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 value: lowerLights,
             });
         });
+
+        test('should add V2 classes when videoPlayerV2 feature is enabled', () => {
+            const { lowerLights } = VideoBaseViewer.prototype;
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: jest.fn(),
+            });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: jest.fn() });
+            videoBase = new VideoBaseViewer({
+                file: {
+                    id: 1,
+                },
+                container: containerEl,
+            });
+            videoBase.useReactControls = jest.fn().mockReturnValue(false);
+            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBase.containerEl = containerEl;
+            videoBase.setup();
+
+            expect(videoBase.wrapperEl.classList.contains('bp-media--v2')).toBe(true);
+            expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(true);
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: lowerLights,
+            });
+        });
+
+        test('should not add V2 classes when videoPlayerV2 feature is disabled', () => {
+            const { lowerLights } = VideoBaseViewer.prototype;
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: jest.fn(),
+            });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: jest.fn() });
+            videoBase = new VideoBaseViewer({
+                file: {
+                    id: 1,
+                },
+                container: containerEl,
+            });
+            videoBase.useReactControls = jest.fn().mockReturnValue(false);
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            videoBase.containerEl = containerEl;
+            videoBase.setup();
+
+            expect(videoBase.wrapperEl.classList.contains('bp-media--v2')).toBe(false);
+            expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(false);
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: lowerLights,
+            });
+        });
     });
 
     describe('destroy()', () => {
@@ -218,6 +270,26 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.controls.handleHide).toEqual(videoBase.handleControlsHide);
             expect(videoBase.controls.handleShow).toEqual(videoBase.handleControlsShow);
             expect(videoBase.renderUI).toBeCalled();
+        });
+
+        test('should mount controls on wrapperEl when videoPlayerV2 is enabled', () => {
+            videoBase.mediaContainerEl = document.createElement('div');
+            videoBase.wrapperEl = document.createElement('div');
+            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBase.loadUIReact();
+
+            expect(videoBase.controls).toBeInstanceOf(ControlsRoot);
+            expect(videoBase.controls.containerEl).toEqual(videoBase.wrapperEl);
+        });
+
+        test('should mount controls on mediaContainerEl when videoPlayerV2 is disabled', () => {
+            videoBase.mediaContainerEl = document.createElement('div');
+            videoBase.wrapperEl = document.createElement('div');
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            videoBase.loadUIReact();
+
+            expect(videoBase.controls).toBeInstanceOf(ControlsRoot);
+            expect(videoBase.controls.containerEl).toEqual(videoBase.mediaContainerEl);
         });
     });
 
@@ -561,6 +633,25 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(mockBuildPlayButtonWithSeekButtons).not.toHaveBeenCalled();
             expect(mockRemovePlayButtonWithSeekButtons).not.toHaveBeenCalled();
             expect(mockRenderUI).not.toHaveBeenCalled();
+            expect(videoBaseViewer.isNarrowVideo).toBe(false);
+        });
+
+        test('should use wrapperEl.clientWidth when videoPlayerV2 is enabled', () => {
+            jest.spyOn(videoBaseViewer, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBaseViewer.wrapperEl = document.createElement('div');
+            Object.defineProperty(videoBaseViewer.wrapperEl, 'clientWidth', { value: 579 });
+            videoBaseViewer.handleNarrowVideoUI();
+            expect(mockBuildPlayButtonWithSeekButtons).toHaveBeenCalled();
+            expect(videoBaseViewer.isNarrowVideo).toBe(true);
+        });
+
+        test('should use wrapperEl.clientWidth >= threshold when videoPlayerV2 is enabled', () => {
+            jest.spyOn(videoBaseViewer, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBaseViewer.wrapperEl = document.createElement('div');
+            Object.defineProperty(videoBaseViewer.wrapperEl, 'clientWidth', { value: 580 });
+            videoBaseViewer.playContainerEl = document.createElement('div');
+            videoBaseViewer.handleNarrowVideoUI();
+            expect(mockRemovePlayButtonWithSeekButtons).toHaveBeenCalled();
             expect(videoBaseViewer.isNarrowVideo).toBe(false);
         });
     });

--- a/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
@@ -64,6 +64,12 @@ describe('VideoControlsV2', () => {
             expect(movePlayback).toHaveBeenCalledWith(false, 5);
         });
 
+        test('should not render skip buttons when isNarrowVideo is true', () => {
+            render(<VideoControlsV2 {...defaultProps} isNarrowVideo />);
+            expect(screen.queryByTitle('Skip forward')).not.toBeInTheDocument();
+            expect(screen.queryByTitle('Skip backward')).not.toBeInTheDocument();
+        });
+
         test('should not render fullscreen toggle', () => {
             render(<VideoControlsV2 {...defaultProps} />);
             expect(screen.queryByTitle('Enter fullscreen')).not.toBeInTheDocument();

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -176,6 +176,35 @@
     width: 100%;
 }
 
+.bp-media--v2 {
+    background: radial-gradient(ellipse at center, #2a2a2a 0%, #000 100%);
+}
+
+.bp-media-container--v2 {
+    padding: 48px;
+
+    video {
+        border: 1px solid rgba($white, .12);
+    }
+
+    .bp-video-preload-wrapper {
+        padding: 48px;
+
+        .bp-preload {
+            position: relative;
+            transform: none;
+        }
+
+        .bp-preload-content {
+            width: auto;
+            max-width: 100%;
+            height: auto;
+            max-height: 100%;
+            border: 1px solid rgba($white, .12);
+        }
+    }
+}
+
 .bp-video-360 {
     .bp-VideoControlsRoot {
         position: absolute;


### PR DESCRIPTION
  ## Summary
  - Mount V2 controls on the wrapper element so their width is constrained by the viewport rather than the video element
  - Add padding, radial background gradient, and subtle border styles for the V2 video container
  - Hide skip forward/backward buttons on narrow viewports to prevent controls overflow

## Known Bug

There is a known issue where the preload thumbnail of the video (i.e. the still image when user opens video but not does play the video) does not match the exact dimensions/orientation of the video when played. This will be fixed in a future PR
  
  ## Test plan
  - [ ] Verify V2 video player controls span the viewport width, not the video width
  - [ ] Verify padding and background gradient render correctly around the video
  - [ ] Resize viewport to narrow width and confirm skip buttons are hidden
  - [ ] Confirm V1 player (feature flag off) is unaffected