### PR TITLE
feat(video): expose time format via data attributes on media container

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -186,8 +186,6 @@ media_time_format_standard=Standard time
 media_time_format_timecode=Timecode
 # Label for the frame numbers format option (e.g. Frame 1997) in media player
 media_time_format_frames=Frame numbers
-# Displays the current frame number in media player, where {1} is the frame number
-media_frame_number=Frame {1}
 # Used in ARIA label for volume
 volume=Volume
 # Used in ARIA label for timescrubber progress

--- a/src/lib/viewers/controls/media/TimestampControl.tsx
+++ b/src/lib/viewers/controls/media/TimestampControl.tsx
@@ -6,7 +6,7 @@ import IconChevronDownMedium24 from '../icons/IconChevronDownMedium24';
 import IconChevronUpMedium24 from '../icons/IconChevronUpMedium24';
 import useClickOutside from '../hooks/useClickOutside';
 import { DEFAULT_FPS } from '../../media/videoFps';
-import { decodeKeydown, replacePlaceholders } from '../../../util';
+import { decodeKeydown } from '../../../util';
 import { formatTime } from './DurationLabels';
 import './TimestampControl.scss';
 
@@ -29,7 +29,7 @@ export function formatLabel(time: number, format: TimeFormat, fps: number): stri
         case TimeFormat.TIMECODE:
             return formatTimecode(time, fps);
         case TimeFormat.FRAMES:
-            return replacePlaceholders(__('media_frame_number'), [Math.floor(time * fps).toString()]);
+            return Math.floor(time * fps).toString();
         case TimeFormat.STANDARD:
         default:
             return formatTime(time);

--- a/src/lib/viewers/controls/media/TimestampControl.tsx
+++ b/src/lib/viewers/controls/media/TimestampControl.tsx
@@ -59,6 +59,14 @@ export default function TimestampControl({
     useClickOutside(containerElRef, () => setIsOpen(false));
 
     React.useEffect(() => {
+        const container = mediaEl?.closest('.bp-media-container');
+        if (container) {
+            container.setAttribute('data-time-format', format);
+            container.setAttribute('data-fps', String(fps));
+        }
+    }, [format, fps, mediaEl]);
+
+    React.useEffect(() => {
         // Re-render via timeupdate events is too slow (~4Hz) for frame-accurate
         // formats, so update the current time text on animation frames instead
         if (format === TimeFormat.STANDARD || !mediaEl || !currentElRef.current) {

--- a/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
@@ -4,8 +4,23 @@ import { userEvent } from '@testing-library/user-event';
 import TimestampControl from '../TimestampControl';
 
 describe('TimestampControl', () => {
+    let mediaContainer: HTMLDivElement;
+    let videoEl: HTMLVideoElement;
+
+    beforeEach(() => {
+        mediaContainer = document.createElement('div');
+        mediaContainer.className = 'bp-media-container';
+        videoEl = document.createElement('video');
+        mediaContainer.appendChild(videoEl);
+        document.body.appendChild(mediaContainer);
+    });
+
+    afterEach(() => {
+        mediaContainer.remove();
+    });
+
     const getWrapper = (props = {}) =>
-        render(<TimestampControl currentTime={65} durationTime={120} fps={24} {...props} />);
+        render(<TimestampControl currentTime={65} durationTime={120} fps={24} mediaEl={videoEl} {...props} />);
 
     const getButton = () => screen.getByTestId('bp-TimestampControl-button');
 
@@ -124,6 +139,40 @@ describe('TimestampControl', () => {
             await user.click(screen.getByRole('option', { name: 'Frame numbers' }));
 
             expect(getButton()).toHaveTextContent('Frame 120/600');
+        });
+    });
+
+    describe('data attributes', () => {
+        test('should set data-time-format on the media container when format changes', async () => {
+            const user = userEvent.setup();
+            getWrapper();
+
+            expect(mediaContainer.getAttribute('data-time-format')).toBe('standard');
+
+            await user.click(getButton());
+            await user.click(screen.getByRole('option', { name: 'Timecode' }));
+
+            expect(mediaContainer.getAttribute('data-time-format')).toBe('timecode');
+        });
+
+        test('should set data-fps on the media container', () => {
+            getWrapper({ fps: 30 });
+            expect(mediaContainer.getAttribute('data-fps')).toBe('30');
+        });
+
+        test('should update data-time-format to frames when selected', async () => {
+            const user = userEvent.setup();
+            getWrapper();
+
+            await user.click(getButton());
+            await user.click(screen.getByRole('option', { name: 'Frame numbers' }));
+
+            expect(mediaContainer.getAttribute('data-time-format')).toBe('frames');
+        });
+
+        test('should not set data attributes when mediaEl is not provided', () => {
+            render(<TimestampControl currentTime={65} durationTime={120} fps={24} />);
+            expect(mediaContainer.hasAttribute('data-time-format')).toBe(false);
         });
     });
 });

--- a/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
@@ -116,7 +116,7 @@ describe('TimestampControl', () => {
             await user.click(getButton());
             await user.click(screen.getByRole('option', { name: 'Frame numbers' }));
 
-            expect(getButton()).toHaveTextContent('Frame 240/2880');
+            expect(getButton()).toHaveTextContent('240/2880');
         });
 
         test('should return to standard time format when selected', async () => {
@@ -138,7 +138,7 @@ describe('TimestampControl', () => {
             await user.click(getButton());
             await user.click(screen.getByRole('option', { name: 'Frame numbers' }));
 
-            expect(getButton()).toHaveTextContent('Frame 120/600');
+            expect(getButton()).toHaveTextContent('120/600');
         });
     });
 

--- a/src/lib/viewers/media/__tests__/formatTimecode-test.ts
+++ b/src/lib/viewers/media/__tests__/formatTimecode-test.ts
@@ -33,16 +33,23 @@ describe('formatTimecode', () => {
     });
 
     describe('edge cases', () => {
-        test('should handle NaN', () => {
+        test('should handle NaN seconds', () => {
             expect(formatTimecode(NaN, 30)).toBe('00:00:00:00');
         });
 
-        test('should handle Infinity', () => {
+        test('should handle Infinity seconds', () => {
             expect(formatTimecode(Infinity, 30)).toBe('00:00:00:00');
         });
 
-        test('should handle negative values', () => {
+        test('should handle negative seconds', () => {
             expect(formatTimecode(-5, 30)).toBe('00:00:00:00');
+        });
+
+        test('should fall back to 24fps when fps is invalid', () => {
+            expect(formatTimecode(1, 0)).toBe('00:00:01:00');
+            expect(formatTimecode(1, -1)).toBe('00:00:01:00');
+            expect(formatTimecode(1, NaN)).toBe('00:00:01:00');
+            expect(formatTimecode(1, Infinity)).toBe('00:00:01:00');
         });
     });
 });

--- a/src/lib/viewers/media/formatTimecode.ts
+++ b/src/lib/viewers/media/formatTimecode.ts
@@ -1,16 +1,19 @@
 import isFinite from 'lodash/isFinite';
+import { DEFAULT_FPS } from './videoFps';
 
 /**
  * Formats seconds into professional timecode: HH:MM:SS:FF
  */
 export default function formatTimecode(seconds: number, fps: number): string {
-    const val = isFinite(seconds) ? Math.max(0, seconds) : 0;
-    const totalFrames = Math.floor(val * fps);
+    const validSeconds = isFinite(seconds) && seconds > 0 ? seconds : 0;
+    const validFps = isFinite(fps) && fps > 0 ? fps : DEFAULT_FPS;
+    const totalFrames = Math.floor(validSeconds * validFps);
+    const frameBase = Math.round(validFps);
 
-    const hours = Math.floor(totalFrames / (fps * 3600));
-    const minutes = Math.floor((totalFrames % (fps * 3600)) / (fps * 60));
-    const secs = Math.floor((totalFrames % (fps * 60)) / fps);
-    const frames = totalFrames % Math.round(fps);
+    const hours = Math.floor(totalFrames / (frameBase * 3600));
+    const minutes = Math.floor((totalFrames % (frameBase * 3600)) / (frameBase * 60));
+    const secs = Math.floor((totalFrames % (frameBase * 60)) / frameBase);
+    const frames = totalFrames % frameBase;
 
     const hh = hours.toString().padStart(2, '0');
     const mm = minutes.toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
  - Sets `data-time-format` and `data-fps` attributes on `.bp-media-container` when the user selects a time format in TimestampControl
- Enables external consumers (e.g. BUIE sidebar) to observe the selected format via `MutationObserver` and render timestamps consistently
- Refactors `formatTimecode` to use `Math.round(fps)` consistently for all time components (non-drop-frame timecode convention) and adds fps validation with fallback to DEFAULT_FPS
- Associated BUIE PR: https://github.com/box/box-ui-elements/pull/4636 
- Also added a small polish change to the displayed string when user selects "Frame numbers" view, it now displays e.g. `0/1506` instead of `Frame 0/1506`
  
  ## Test plan
  - [x] Existing TimestampControl tests pass (12 tests)
  - [x] New data attribute tests added (4 tests) — verify attributes are set on format change, fps prop, and no-op when mediaEl is absent
  - [ ] Manual: open video, change time format in dropdown, verify `data-time-format` attribute updates on `.bp-media-container` via DevTools