### PR TITLE
feat(media): restyle V2 settings menu and fix preload thumbnail sizing

### DIFF
--- a/src/lib/viewers/controls/settings/SettingsCheckboxItem.scss
+++ b/src/lib/viewers/controls/settings/SettingsCheckboxItem.scss
@@ -16,3 +16,22 @@ $bp-SettingsCheckboxItem-spacing: 6px;
 .bp-SettingsCheckboxItem-input {
     margin: $bp-SettingsCheckboxItem-spacing 0;
 }
+
+// V2 video player checkbox item — match the TimestampControl flyout typography
+.bp-media--v2 {
+    .bp-SettingsCheckboxItem {
+        padding: 6px 14px;
+        color: $black;
+        border-radius: 8px;
+
+        &:hover {
+            background-color: $bdl-gray-05;
+        }
+    }
+
+    .bp-SettingsCheckboxItem-label {
+        padding: 0 8px;
+        font-size: 16px;
+        line-height: 24px;
+    }
+}

--- a/src/lib/viewers/controls/settings/SettingsFlyout.scss
+++ b/src/lib/viewers/controls/settings/SettingsFlyout.scss
@@ -29,3 +29,19 @@
         overflow-y: hidden; // Hide scrollbar during menu -> submenu transition
     }
 }
+
+// V2 video player flyout — restyled to match the TimestampControl flyout
+.bp-media--v2 {
+    .bp-SettingsFlyout {
+        min-width: 250px;
+        color: $black;
+        font-size: 16px;
+        font-family: Lato, Arial, sans-serif;
+        line-height: 24px;
+        background: $white;
+        border: 0;
+        border-radius: 16px;
+        box-shadow: 0 4px 12px 0 rgba(0, 0, 0, .15);
+        backdrop-filter: none;
+    }
+}

--- a/src/lib/viewers/controls/settings/SettingsMenu.scss
+++ b/src/lib/viewers/controls/settings/SettingsMenu.scss
@@ -1,3 +1,5 @@
+@import './styles';
+
 .bp-SettingsMenu {
     display: none;
     min-width: 184px;
@@ -6,5 +8,14 @@
     &.bp-is-active {
         display: flex;
         flex-direction: column;
+    }
+}
+
+// V2 video player menu — wider min-width and more vertical padding to match
+// the TimestampControl flyout proportions.
+.bp-media--v2 {
+    .bp-SettingsMenu {
+        min-width: 234px;
+        padding: 12px 8px;
     }
 }

--- a/src/lib/viewers/controls/settings/SettingsMenuBack.scss
+++ b/src/lib/viewers/controls/settings/SettingsMenuBack.scss
@@ -27,3 +27,32 @@
 .bp-SettingsMenuBack-label {
     @include bp-SettingsRow-label;
 }
+
+// V2 video player back button — match the TimestampControl flyout typography
+.bp-media--v2 {
+    .bp-SettingsMenuBack {
+        gap: 16px;
+        padding: 6px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+
+        &:hover {
+            background-color: $bdl-gray-05;
+            border-radius: 8px;
+            box-shadow: none;
+            backdrop-filter: none;
+        }
+    }
+
+    .bp-SettingsMenuBack-label {
+        padding: 6px 14px;
+        color: $bdl-gray-62;
+        font-weight: bold;
+        font-size: 14px;
+        font-family: Lato, Arial, sans-serif;
+        line-height: 20px;
+        letter-spacing: .3px;
+        text-transform: none;
+        user-select: none;
+    }
+}

--- a/src/lib/viewers/controls/settings/SettingsMenuItem.scss
+++ b/src/lib/viewers/controls/settings/SettingsMenuItem.scss
@@ -46,3 +46,37 @@
         display: block;
     }
 }
+
+// V2 video player menu items — modern typography to match TimestampControl
+.bp-media--v2 {
+    .bp-SettingsMenuItem {
+        gap: 16px;
+        padding: 6px 14px;
+        border: 0;
+        border-radius: 8px;
+        cursor: pointer;
+
+        &:hover {
+            background-color: $bdl-gray-05;
+            border-radius: 8px;
+            box-shadow: none;
+            backdrop-filter: none;
+        }
+    }
+
+    .bp-SettingsMenuItem-label {
+        padding: 0 8px;
+        color: $black;
+        font-weight: normal;
+        font-size: 16px;
+        line-height: 24px;
+        text-transform: none;
+    }
+
+    .bp-SettingsMenuItem-value {
+        padding: 0 8px;
+        color: $bdl-gray-62;
+        font-size: 16px;
+        line-height: 24px;
+    }
+}

--- a/src/lib/viewers/controls/settings/SettingsRadioItem.scss
+++ b/src/lib/viewers/controls/settings/SettingsRadioItem.scss
@@ -47,3 +47,50 @@
 .bp-SettingsRadioItem-value {
     @include bp-SettingsRow-value;
 }
+
+// V2 video player radio item — match the TimestampControl flyout typography
+.bp-media--v2 {
+    .bp-SettingsRadioItem {
+        display: flex;
+        flex-direction: row-reverse;
+        gap: 16px;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+
+        &:hover {
+            background-color: $bdl-gray-05;
+            border-radius: 8px;
+            box-shadow: none;
+            backdrop-filter: none;
+
+            .bp-SettingsRadioItem-check-icon {
+                fill: $black;
+            }
+
+            .bp-SettingsRadioItem-value {
+                color: $black;
+            }
+        }
+
+        &.bp-is-selected {
+            .bp-SettingsRadioItem-value {
+                color: $black;
+            }
+
+            .bp-SettingsRadioItem-check-icon {
+                fill: $black;
+            }
+        }
+    }
+
+    .bp-SettingsRadioItem-value {
+        padding: 0;
+        color: $black;
+        font-size: 16px;
+        line-height: 24px;
+        text-align: left;
+    }
+}

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -623,6 +623,16 @@ class VideoBaseViewer extends MediaBaseViewer {
                 this.mediaEl.style.width = `${viewport.height * this.aspect}px`;
             }
         }
+
+        if (this.featureEnabled('videoPlayerV2.enabled') && this.preloader?.wrapperEl && this.mediaEl.style.width) {
+            const videoWidth = parseInt(this.mediaEl.style.width, 10);
+            const videoHeight = videoWidth / this.aspect;
+            this.preloader.wrapperEl.style.width = `${videoWidth}px`;
+            this.preloader.wrapperEl.style.height = `${videoHeight}px`;
+            this.preloader.wrapperEl.style.left = '50%';
+            this.preloader.wrapperEl.style.top = '50%';
+            this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
+        }
     }
 
     /**

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -189,18 +189,17 @@
     }
 
     .bp-video-preload-wrapper {
-        padding: 48px;
+        top: 48px;
+        right: auto;
+        bottom: 48px;
+        left: 50%;
+        transform: translateX(-50%);
 
         .bp-preload {
-            position: relative;
             transform: none;
         }
 
         .bp-preload-content {
-            width: auto;
-            max-width: 100%;
-            height: auto;
-            max-height: 100%;
             border: 1px solid rgba($white, .12);
         }
     }


### PR DESCRIPTION
## Summary
Restyle the V2 video settings menu and fix the V2 preload thumbnail sizing. Both changes are scoped under `.bp-media--v2` so V1 video, 3D viewer, and annotations menus are unchanged.

## Recording

https://github.com/user-attachments/assets/9b86b2fd-8fa0-45bc-b9c9-5225637f276f



### Settings menu restyle
- **Flyout container**: white background, 16px border-radius, clean drop shadow (no border, no backdrop-filter blur)
- **Menu items**: 16px mixed-case labels (was 11px uppercase), gray-62 values, 6px 14px padding with 8px rounded hover (gray-05 background)
- **Submenu radio items**: reversed layout (text left, checkmark right), black text, gray-05 hover, pointer cursor
- **Submenu header (back button)**: matches `TimestampControl-header` styling (14px bold gray-62, Lato, letter-spacing)
- **Checkbox items**: updated padding/font/radius to match

### Preload thumbnail fix
- Sync `preloader.wrapperEl.style.width` to match the video element width in `setVideoDimensions()` — fixes a regression from #1673 where removing the container-width sync left the thumbnail full-container-wide while the video shrinks via max-height
- Position the V2 preload wrapper at the container's content box (48px inset top/bottom, centered horizontally) so it paints into the same area as the flex-centered video

## Files changed
- `src/lib/viewers/controls/settings/SettingsFlyout.scss`
- `src/lib/viewers/controls/settings/SettingsMenu.scss`
- `src/lib/viewers/controls/settings/SettingsMenuBack.scss`
- `src/lib/viewers/controls/settings/SettingsMenuItem.scss`
- `src/lib/viewers/controls/settings/SettingsRadioItem.scss`
- `src/lib/viewers/controls/settings/SettingsCheckboxItem.scss`
- `src/lib/viewers/media/VideoBaseViewer.js`
- `src/lib/viewers/media/_mediaBase.scss`

## Test plan
- [x] V2 video: settings menu uses new style (white bg, 16px radius, mixed-case labels, gray-05 hover)
- [x] V2 video: submenu items show text on left, checkmark on right
- [x] V2 video: submenu header matches TimestampControl header style (smaller, gray, bold)
- [x] V2 video: all menu items show pointer cursor on hover
- [x] V2 video: thumbnail matches video size (no shift when video starts playing)
- [x] V1 video: settings menu unchanged
- [x] 3D viewer / annotations settings menu unchanged
- [x] Unit tests pass: `yarn jest src/lib/viewers/controls/settings/__tests__/`
