### PR TITLE
feat(image): add drop shadow and checkerboard for transparent images

### DIFF
--- a/src/lib/viewers/image/Image.scss
+++ b/src/lib/viewers/image/Image.scss
@@ -25,6 +25,17 @@
         vertical-align: middle;
     }
 
+    &.bp-image--shadow img {
+        box-shadow: 0 4px 24px rgba(0, 0, 0, .2);
+    }
+
+    &.bp-image--shadow.bp-image--transparent img {
+        background-image: repeating-conic-gradient(#e8e8e8 0% 25%, #fff 0% 50%);
+        background-size: 16px 16px;
+        box-shadow: none;
+        filter: drop-shadow(0 4px 24px rgba(0, 0, 0, .2));
+    }
+
     .pannable,
     .panning {
         cursor: move;

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -10,12 +10,15 @@ import {
     CLASS_PREFETCHED_IMAGE,
     DISCOVERABILITY_ATTRIBUTE,
     IMAGE_FTUX_CURSOR_SEEN_KEY,
+    ORIGINAL_REP_NAME,
 } from '../../constants';
 import { LOAD_METRIC, FIRST_RENDER_METRIC } from '../../events';
 import Timer from '../../Timer';
 import './Image.scss';
 
 const CSS_CLASS_IMAGE = 'bp-image';
+const CSS_CLASS_IMAGE_SHADOW = 'bp-image--shadow';
+const CSS_CLASS_IMAGE_TRANSPARENT = 'bp-image--transparent';
 const IMAGE_PADDING = 15;
 const IMAGE_ZOOM_SCALE = 1.2;
 
@@ -84,6 +87,15 @@ class ImageViewer extends ImageBaseViewer {
 
         this.wrapperEl = this.createViewer(document.createElement('div'));
         this.wrapperEl.classList.add(CSS_CLASS_IMAGE);
+
+        if (this.featureEnabled('imageDropShadow')) {
+            this.wrapperEl.classList.add(CSS_CLASS_IMAGE_SHADOW);
+
+            const { REP } = this.options.viewer;
+            if (REP === 'png' || REP === ORIGINAL_REP_NAME) {
+                this.wrapperEl.classList.add(CSS_CLASS_IMAGE_TRANSPARENT);
+            }
+        }
 
         this.imageEl = this.wrapperEl.appendChild(document.createElement('img'));
         this.imageEl.setAttribute('data-page-number', 1);

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -38,6 +38,7 @@ describe('lib/viewers/image/ImageViewer', () => {
             },
             viewer: {
                 NAME: 'Image',
+                REP: 'png',
                 ASSET: '1.png',
             },
             representation: {
@@ -110,6 +111,31 @@ describe('lib/viewers/image/ImageViewer', () => {
             expect(image.wrapperEl).toHaveClass('bp-image');
             expect(image.imageEl).toHaveClass('bp-is-invisible');
             expect(image.imageEl).toHaveAttribute('alt', 'tales.png');
+        });
+
+        test('should add shadow and transparent classes when imageDropShadow is enabled and rep is png', () => {
+            image.options.features = { imageDropShadow: true };
+            image.isSetup = false;
+            image.setup();
+            expect(image.wrapperEl).toHaveClass('bp-image--shadow');
+            expect(image.wrapperEl).toHaveClass('bp-image--transparent');
+        });
+
+        test('should add shadow class but not transparent for jpg rep', () => {
+            image.options.features = { imageDropShadow: true };
+            image.options.viewer.REP = 'jpg';
+            image.isSetup = false;
+            image.setup();
+            expect(image.wrapperEl).toHaveClass('bp-image--shadow');
+            expect(image.wrapperEl).not.toHaveClass('bp-image--transparent');
+        });
+
+        test('should not add shadow classes when imageDropShadow is disabled', () => {
+            image.options.features = { imageDropShadow: false };
+            image.isSetup = false;
+            image.setup();
+            expect(image.wrapperEl).not.toHaveClass('bp-image--shadow');
+            expect(image.wrapperEl).not.toHaveClass('bp-image--transparent');
         });
 
         test.each`


### PR DESCRIPTION
## Summary
- Adds image shadow and transparency indicator styling, fully gated behind the `imageDropShadow` feature flag
- JPEG images get a rectangular `box-shadow`
- Transparent images (PNG, SVG, GIF) get `filter: drop-shadow()` (traces visible pixels) + a checkerboard background to indicate transparency
- Nothing ships until `features.imageDropShadow` is set to `true` by the consuming app

## Usage
```js
preview.show(fileId, {
  features: { imageDropShadow: true }
});
```

## Test plan
- [ ] Without feature flag — no visual change to any image type
- [ ] With flag enabled, preview a JPEG — rectangular box-shadow
- [ ] With flag enabled, preview a transparent PNG — drop-shadow traces visible pixels + checkerboard behind transparent areas
- [ ] With flag enabled, preview an SVG — drop-shadow + checkerboard
- [ ] With flag enabled, preview a GIF — drop-shadow + checkerboard
- [ ] Zoom in/out — shadow and checkerboard remain correct
- [ ] Rotate image — no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)