### PR TITLE
feat(gallery): add gallery view with full-width page thumbnail grid

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -50,6 +50,8 @@ text_truncated=This file has been truncated due to size limits. Please download 
 toggle_findbar=Toggle findbar
 # Button tooltip to toggle Thumbnails Sidebar
 toggle_thumbnails=Toggle thumbnails
+# Button tooltip for Gallery view
+gallery_view=Gallery view
 # Message when file has inaccessible xrefs
 has_x_refs=This preview has references you cannot view. Open the file in its native application.
 # Button tooltip for finding the next instance of a phrase in the file

--- a/src/lib/viewers/controls/gallery/GalleryToggle.scss
+++ b/src/lib/viewers/controls/gallery/GalleryToggle.scss
@@ -1,0 +1,5 @@
+@import '../styles';
+
+.bp-GalleryToggle {
+    @include bp-Control;
+}

--- a/src/lib/viewers/controls/gallery/GalleryToggle.tsx
+++ b/src/lib/viewers/controls/gallery/GalleryToggle.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import IconGridView24 from '../icons/IconGridView24';
+import './GalleryToggle.scss';
+
+export type Props = {
+    isGalleryOpen?: boolean;
+    onGalleryToggle?: () => void;
+};
+
+export default function GalleryToggle({ onGalleryToggle, isGalleryOpen }: Props): JSX.Element | null {
+    if (!onGalleryToggle) {
+        return null;
+    }
+
+    return (
+        <button
+            aria-pressed={isGalleryOpen}
+            className={`bp-GalleryToggle${isGalleryOpen ? ' bp-is-active' : ''}`}
+            data-resin-target="galleryView"
+            onClick={onGalleryToggle}
+            title={__('gallery_view')}
+            type="button"
+        >
+            <IconGridView24 />
+        </button>
+    );
+}

--- a/src/lib/viewers/controls/gallery/__tests__/GalleryToggle-test.tsx
+++ b/src/lib/viewers/controls/gallery/__tests__/GalleryToggle-test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GalleryToggle from '../GalleryToggle';
+
+describe('GalleryToggle', () => {
+    const getWrapper = (props = {}) => render(<GalleryToggle {...props} />);
+
+    describe('render', () => {
+        test('should return null if no callback is defined', () => {
+            getWrapper();
+            expect(screen.queryByRole('button')).toBeNull();
+        });
+
+        test('should render a button when onGalleryToggle is provided', () => {
+            getWrapper({ onGalleryToggle: jest.fn() });
+            expect(screen.getByRole('button')).toBeInTheDocument();
+        });
+
+        test('should render the GridView icon', () => {
+            getWrapper({ onGalleryToggle: jest.fn() });
+            expect(screen.getByTestId('IconGridView24')).toBeVisible();
+        });
+    });
+
+    describe('aria', () => {
+        test.each([true, false])('should set aria-pressed to %s', async isGalleryOpen => {
+            getWrapper({ onGalleryToggle: jest.fn(), isGalleryOpen });
+            const button = screen.getByRole('button');
+            expect(button).toHaveAttribute('aria-pressed', isGalleryOpen.toString());
+        });
+    });
+
+    describe('active state', () => {
+        test('should have bp-is-active class when isGalleryOpen is true', () => {
+            getWrapper({ onGalleryToggle: jest.fn(), isGalleryOpen: true });
+            expect(screen.getByRole('button')).toHaveClass('bp-is-active');
+        });
+
+        test('should not have bp-is-active class when isGalleryOpen is false', () => {
+            getWrapper({ onGalleryToggle: jest.fn(), isGalleryOpen: false });
+            expect(screen.getByRole('button')).not.toHaveClass('bp-is-active');
+        });
+    });
+
+    describe('event handlers', () => {
+        test('should call onGalleryToggle on click', async () => {
+            const onToggle = jest.fn();
+            getWrapper({ onGalleryToggle: onToggle });
+            await userEvent.click(screen.getByRole('button'));
+            expect(onToggle).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/lib/viewers/controls/gallery/index.ts
+++ b/src/lib/viewers/controls/gallery/index.ts
@@ -1,0 +1,2 @@
+export * from './GalleryToggle';
+export { default } from './GalleryToggle';

--- a/src/lib/viewers/controls/icons/IconGridView24.tsx
+++ b/src/lib/viewers/controls/icons/IconGridView24.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+function IconGridView24(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            data-testid="IconGridView24"
+            focusable="false"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            {...props}
+        >
+            <path
+                d="M8 13a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-2a3 3 0 0 1 3-3h2Zm10 0a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3v-2a3 3 0 0 1 3-3h2ZM6 15a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1H6Zm10 0a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1h-2ZM8 3a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3h2Zm10 0a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3h2ZM6 5a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H6Zm10 0a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2Z"
+                fill="#fff"
+                fillRule="evenodd"
+            />
+        </svg>
+    );
+}
+
+export default IconGridView24;

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import { createRoot } from 'react-dom/client';
 import throttle from 'lodash/throttle';
 import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
 import ControlsRoot from '../controls/controls-root';
 import DocControls from './DocControls';
 import DocFindBar from './DocFindBar';
+import GalleryGrid from '../gallery/GalleryGrid';
 import PageTracker from '../../PageTracker';
 import Popup from '../../Popup';
 import PreviewError from '../../PreviewError';
@@ -121,6 +123,18 @@ class DocBaseViewer extends BaseViewer {
     /** @property {Thumbnail} - Thumbnail reference */
     advancedInsightsThumbs;
 
+    /** @property {number} - Page focused in gallery via Tab */
+    galleryFocusedPage = null;
+
+    /** @property {Thumbnail} - Dedicated gallery thumbnail instance (persists between opens) */
+    galleryThumbnail;
+
+    /** @property {boolean} - Whether gallery mode is active */
+    isGalleryOpen = false;
+
+    /** @property {boolean} - Whether sidebar was open before entering gallery */
+    sidebarWasOpen = false;
+
     /** @property {PageTracker} - PageTracker instance */
     pageTracker;
 
@@ -153,6 +167,7 @@ class DocBaseViewer extends BaseViewer {
         this.handleAnnotationCreateEvent = this.handleAnnotationCreateEvent.bind(this);
         this.handleAnnotationCreatorChangeEvent = this.handleAnnotationCreatorChangeEvent.bind(this);
         this.handleDocElKeydown = this.handleDocElKeydown.bind(this);
+        this.handleGalleryNavigate = this.handleGalleryNavigate.bind(this);
         this.handlePageSubmit = this.handlePageSubmit.bind(this);
         this.onThumbnailSelectHandler = this.onThumbnailSelectHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
@@ -167,6 +182,7 @@ class DocBaseViewer extends BaseViewer {
         this.setPage = this.setPage.bind(this);
         this.throttledScrollHandler = this.getScrollHandler().bind(this);
         this.toggleFindBar = this.toggleFindBar.bind(this);
+        this.toggleGallery = this.toggleGallery.bind(this);
         this.toggleThumbnails = this.toggleThumbnails.bind(this);
         this.updateExperiences = this.updateExperiences.bind(this);
         this.updateDiscoverabilityResinTag = this.updateDiscoverabilityResinTag.bind(this);
@@ -273,6 +289,21 @@ class DocBaseViewer extends BaseViewer {
 
         if (this.printPopup) {
             this.printPopup.destroy();
+        }
+
+        if (this.galleryRoot) {
+            this.galleryRoot.unmount();
+            this.galleryRoot = null;
+        }
+
+        if (this.galleryEl) {
+            this.galleryEl.remove();
+            this.galleryEl = null;
+        }
+
+        if (this.galleryThumbnail) {
+            this.galleryThumbnail.destroy();
+            this.galleryThumbnail = null;
         }
 
         if (this.thumbnailsSidebar) {
@@ -881,6 +912,11 @@ class DocBaseViewer extends BaseViewer {
             this.thumbnailsSidebar.refresh();
         }
 
+        if (this.galleryThumbnail) {
+            this.galleryThumbnail.destroy();
+            this.galleryThumbnail = null;
+        }
+
         this.renderUI();
 
         // Emit scale with rotation angle so annotations transform to match rotated content
@@ -1449,6 +1485,11 @@ class DocBaseViewer extends BaseViewer {
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
         const canRotate = this.featureEnabled('rotate.enabled');
+        const canGallery =
+            isFeatureEnabled(this.options.features, 'galleryView.enabled') &&
+            enableThumbnailsSidebar &&
+            this.pdfViewer.pagesCount > 1 &&
+            this.pdfViewer.pagesCount <= 200;
 
         this.controls.render(
             <DocControls
@@ -1458,6 +1499,7 @@ class DocBaseViewer extends BaseViewer {
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
                 hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
                 hasRegion={canAnnotate && isAnnotationsMode}
+                isGalleryOpen={this.isGalleryOpen}
                 isThumbnailsOpen={this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen}
                 maxScale={MAX_SCALE}
                 minScale={MIN_SCALE}
@@ -1466,6 +1508,7 @@ class DocBaseViewer extends BaseViewer {
                 onAnnotationModeEscape={this.handleAnnotationControlsEscape}
                 onFindBarToggle={!this.isFindDisabled() ? this.toggleFindBar : undefined}
                 onFullscreenToggle={this.toggleFullscreen}
+                onGalleryToggle={canGallery ? this.toggleGallery : undefined}
                 onPageChange={this.setPage}
                 onPageSubmit={this.handlePageSubmit}
                 onRotateLeft={canRotate ? this.rotateLeft : undefined}
@@ -1700,6 +1743,11 @@ class DocBaseViewer extends BaseViewer {
      */
     handleDocElKeydown(event) {
         const key = decodeKeydown(event);
+
+        if (key === 'Escape' && this.isGalleryOpen) {
+            this.toggleGallery();
+            return;
+        }
 
         if (event.altKey && key.includes('Arrow')) {
             event.stopPropagation(); // Prevent collection/page navigation for caret navigation users
@@ -2007,6 +2055,88 @@ class DocBaseViewer extends BaseViewer {
             this.rootEl.classList.remove(CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE_ACTIVE);
             this.rootEl.classList.remove(CLASS_BOX_PREVIEW_THUMBNAILS_OPEN_ACTIVE);
         }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+    }
+
+    mountGalleryGrid() {
+        if (!this.galleryThumbnail) {
+            this.galleryThumbnail = new Thumbnail(this.pdfViewer, this.preloader);
+        }
+
+        this.galleryEl = document.createElement('div');
+        this.containerEl.appendChild(this.galleryEl);
+        this.galleryRoot = createRoot(this.galleryEl);
+        this.galleryFocusedPage = this.pdfViewer.currentPageNumber;
+        this.galleryRoot.render(
+            <GalleryGrid
+                currentPage={this.pdfViewer.currentPageNumber}
+                onClose={this.toggleGallery}
+                onFocusChange={pageNum => {
+                    this.galleryFocusedPage = pageNum;
+                }}
+                onPageNavigate={this.handleGalleryNavigate}
+                pageCount={this.pdfViewer.pagesCount}
+                thumbnail={this.galleryThumbnail}
+            />,
+        );
+    }
+
+    toggleGallery() {
+        this.isGalleryOpen = !this.isGalleryOpen;
+
+        if (this.isGalleryOpen) {
+            this.sidebarWasOpen = !!(this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen);
+
+            if (this.sidebarWasOpen) {
+                this.toggleThumbnails();
+                setTimeout(() => this.mountGalleryGrid(), THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
+            } else {
+                this.mountGalleryGrid();
+            }
+        } else {
+            const navigateToPage =
+                this.galleryFocusedPage && this.galleryFocusedPage !== this.pdfViewer.currentPageNumber
+                    ? this.galleryFocusedPage
+                    : null;
+
+            if (this.galleryRoot) {
+                this.galleryRoot.unmount();
+                this.galleryRoot = null;
+            }
+
+            if (this.galleryEl) {
+                this.galleryEl.remove();
+                this.galleryEl = null;
+            }
+
+            this.galleryFocusedPage = null;
+
+            if (this.sidebarWasOpen && this.thumbnailsSidebar && !this.thumbnailsSidebar.isOpen) {
+                this.toggleThumbnails();
+            }
+
+            if (navigateToPage) {
+                this.setPage(navigateToPage);
+
+                if (this.sidebarWasOpen && this.thumbnailsSidebar) {
+                    setTimeout(() => {
+                        this.thumbnailsSidebar.setCurrentPage(navigateToPage);
+                    }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+                }
+            }
+        }
+
+        this.renderUI();
+    }
+
+    handleGalleryNavigate(pageNum) {
+        this.toggleGallery();
+        this.setPage(pageNum);
+
+        if (this.sidebarWasOpen && this.thumbnailsSidebar) {
+            setTimeout(() => {
+                this.thumbnailsSidebar.setCurrentPage(pageNum);
+            }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1487,7 +1487,6 @@ class DocBaseViewer extends BaseViewer {
         const canRotate = this.featureEnabled('rotate.enabled');
         const canGallery =
             isFeatureEnabled(this.options.features, 'galleryView.enabled') &&
-            enableThumbnailsSidebar &&
             this.pdfViewer.pagesCount > 1 &&
             this.pdfViewer.pagesCount <= 200;
 
@@ -2129,14 +2128,8 @@ class DocBaseViewer extends BaseViewer {
     }
 
     handleGalleryNavigate(pageNum) {
+        this.galleryFocusedPage = pageNum;
         this.toggleGallery();
-        this.setPage(pageNum);
-
-        if (this.sidebarWasOpen && this.thumbnailsSidebar) {
-            setTimeout(() => {
-                this.thumbnailsSidebar.setCurrentPage(pageNum);
-            }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
-        }
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -98,6 +98,7 @@ const RANGE_CHUNK_SIZE_US = 1048576; // 1MB
 const RANGE_REQUEST_MINIMUM_SIZE = 26214400; // 25MB
 const SAFARI_PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
 const SCROLL_EVENT_THROTTLE_INTERVAL = 200;
+const GALLERY_MAX_PAGES = 200; // Hide gallery toggle for files above this page count, will increase in V2
 const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // 301ms
 const THUMBNAILS_SIDEBAR_TOGGLED_MAP_KEY = 'doc-thumbnails-toggled-map';
 
@@ -125,6 +126,12 @@ class DocBaseViewer extends BaseViewer {
 
     /** @property {number} - Page focused in gallery via Tab */
     galleryFocusedPage = null;
+
+    /** @property {number} - Pending setTimeout ID for delayed gallery mount */
+    galleryMountTimeoutId = null;
+
+    /** @property {number} - Pending setTimeout ID for delayed sidebar setCurrentPage after gallery exit */
+    gallerySidebarTimeoutId = null;
 
     /** @property {Thumbnail} - Dedicated gallery thumbnail instance (persists between opens) */
     galleryThumbnail;
@@ -273,6 +280,31 @@ class DocBaseViewer extends BaseViewer {
             this.findBar.destroy();
         }
 
+        // Cancel any pending gallery setTimeouts so they don't fire after teardown
+        if (this.galleryMountTimeoutId !== null) {
+            clearTimeout(this.galleryMountTimeoutId);
+            this.galleryMountTimeoutId = null;
+        }
+        if (this.gallerySidebarTimeoutId !== null) {
+            clearTimeout(this.gallerySidebarTimeoutId);
+            this.gallerySidebarTimeoutId = null;
+        }
+
+        if (this.galleryRoot) {
+            this.galleryRoot.unmount();
+            this.galleryRoot = null;
+        }
+
+        if (this.galleryEl) {
+            this.galleryEl.remove();
+            this.galleryEl = null;
+        }
+
+        if (this.galleryThumbnail) {
+            this.galleryThumbnail.destroy();
+            this.galleryThumbnail = null;
+        }
+
         // Clean up PDF network requests
         if (this.pdfLoadingTask) {
             try {
@@ -289,21 +321,6 @@ class DocBaseViewer extends BaseViewer {
 
         if (this.printPopup) {
             this.printPopup.destroy();
-        }
-
-        if (this.galleryRoot) {
-            this.galleryRoot.unmount();
-            this.galleryRoot = null;
-        }
-
-        if (this.galleryEl) {
-            this.galleryEl.remove();
-            this.galleryEl = null;
-        }
-
-        if (this.galleryThumbnail) {
-            this.galleryThumbnail.destroy();
-            this.galleryThumbnail = null;
         }
 
         if (this.thumbnailsSidebar) {
@@ -1488,7 +1505,7 @@ class DocBaseViewer extends BaseViewer {
         const canGallery =
             isFeatureEnabled(this.options.features, 'galleryView.enabled') &&
             this.pdfViewer.pagesCount > 1 &&
-            this.pdfViewer.pagesCount <= 200;
+            this.pdfViewer.pagesCount <= GALLERY_MAX_PAGES;
 
         this.controls.render(
             <DocControls
@@ -2057,6 +2074,10 @@ class DocBaseViewer extends BaseViewer {
     }
 
     mountGalleryGrid() {
+        if (this.galleryRoot) {
+            return;
+        }
+
         if (!this.galleryThumbnail) {
             this.galleryThumbnail = new Thumbnail(this.pdfViewer, this.preloader);
         }
@@ -2083,15 +2104,28 @@ class DocBaseViewer extends BaseViewer {
         this.isGalleryOpen = !this.isGalleryOpen;
 
         if (this.isGalleryOpen) {
+            if (this.gallerySidebarTimeoutId !== null) {
+                clearTimeout(this.gallerySidebarTimeoutId);
+                this.gallerySidebarTimeoutId = null;
+            }
+
             this.sidebarWasOpen = !!(this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen);
 
             if (this.sidebarWasOpen) {
                 this.toggleThumbnails();
-                setTimeout(() => this.mountGalleryGrid(), THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
+                this.galleryMountTimeoutId = setTimeout(() => {
+                    this.galleryMountTimeoutId = null;
+                    this.mountGalleryGrid();
+                }, THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
             } else {
                 this.mountGalleryGrid();
             }
         } else {
+            if (this.galleryMountTimeoutId !== null) {
+                clearTimeout(this.galleryMountTimeoutId);
+                this.galleryMountTimeoutId = null;
+            }
+
             const navigateToPage =
                 this.galleryFocusedPage && this.galleryFocusedPage !== this.pdfViewer.currentPageNumber
                     ? this.galleryFocusedPage
@@ -2117,7 +2151,8 @@ class DocBaseViewer extends BaseViewer {
                 this.setPage(navigateToPage);
 
                 if (this.sidebarWasOpen && this.thumbnailsSidebar) {
-                    setTimeout(() => {
+                    this.gallerySidebarTimeoutId = setTimeout(() => {
+                        this.gallerySidebarTimeoutId = null;
                         this.thumbnailsSidebar.setCurrentPage(navigateToPage);
                     }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
                 }

--- a/src/lib/viewers/doc/DocControls.tsx
+++ b/src/lib/viewers/doc/DocControls.tsx
@@ -5,6 +5,7 @@ import DrawingControls, { Props as DrawingControlsProps } from '../controls/anno
 import ExperiencesProvider, { Props as ExperiencesProviderProps } from '../controls/experiences';
 import FindBarToggle, { Props as FindBarToggleProps } from '../controls/findbar';
 import FullscreenToggle, { Props as FullscreenToggleProps } from '../controls/fullscreen';
+import GalleryToggle, { Props as GalleryToggleProps } from '../controls/gallery';
 import PageControls, { Props as PageControlsProps } from '../controls/page';
 import RotateControl, { Props as RotateControlProps } from '../controls/rotate/RotateControl';
 import ThumbnailsToggle, { Props as ThumbnailsToggleProps } from '../controls/sidebar';
@@ -15,6 +16,7 @@ export type Props = AnnotationsControlsProps &
     ExperiencesProviderProps &
     FindBarToggleProps &
     FullscreenToggleProps &
+    GalleryToggleProps &
     PageControlsProps &
     Partial<RotateControlProps> &
     ThumbnailsToggleProps &
@@ -27,6 +29,7 @@ export default function DocControls({
     hasDrawing,
     hasHighlight,
     hasRegion,
+    isGalleryOpen,
     isThumbnailsOpen,
     maxScale,
     minScale,
@@ -35,6 +38,7 @@ export default function DocControls({
     onAnnotationModeEscape,
     onFindBarToggle,
     onFullscreenToggle,
+    onGalleryToggle,
     onPageChange,
     onPageSubmit,
     onRotateLeft,
@@ -45,6 +49,19 @@ export default function DocControls({
     pageNumber,
     scale,
 }: Props): JSX.Element {
+    if (isGalleryOpen) {
+        return (
+            <ExperiencesProvider experiences={experiences}>
+                <ControlsBar>
+                    <ControlsBarGroup>
+                        <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
+                        <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
+                    </ControlsBarGroup>
+                </ControlsBar>
+            </ExperiencesProvider>
+        );
+    }
+
     return (
         <ExperiencesProvider experiences={experiences}>
             <ControlsBar>
@@ -75,6 +92,7 @@ export default function DocControls({
                     </ControlsBarGroup>
                 )}
                 <ControlsBarGroup>
+                    <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
                     <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
                     <AnnotationsControls
                         annotationColor={annotationColor}

--- a/src/lib/viewers/doc/DocControls.tsx
+++ b/src/lib/viewers/doc/DocControls.tsx
@@ -49,69 +49,70 @@ export default function DocControls({
     pageNumber,
     scale,
 }: Props): JSX.Element {
-    if (isGalleryOpen) {
-        return (
-            <ExperiencesProvider experiences={experiences}>
+    return (
+        <ExperiencesProvider experiences={experiences}>
+            {isGalleryOpen ? (
                 <ControlsBar>
                     <ControlsBarGroup>
                         <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
                         <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
                     </ControlsBarGroup>
                 </ControlsBar>
-            </ExperiencesProvider>
-        );
-    }
-
-    return (
-        <ExperiencesProvider experiences={experiences}>
-            <ControlsBar>
-                <ControlsBarGroup>
-                    <ThumbnailsToggle isThumbnailsOpen={isThumbnailsOpen} onThumbnailsToggle={onThumbnailsToggle} />
-                    <FindBarToggle onFindBarToggle={onFindBarToggle} />
-                </ControlsBarGroup>
-                <ControlsBarGroup isDistinct>
-                    <PageControls
-                        onPageChange={onPageChange}
-                        onPageSubmit={onPageSubmit}
-                        pageCount={pageCount}
-                        pageNumber={pageNumber}
-                    />
-                </ControlsBarGroup>
-                <ControlsBarGroup isDistinct>
-                    <ZoomControls
-                        maxScale={maxScale}
-                        minScale={minScale}
-                        onZoomIn={onZoomIn}
-                        onZoomOut={onZoomOut}
-                        scale={scale}
-                    />
-                </ControlsBarGroup>
-                {onRotateLeft && (
-                    <ControlsBarGroup>
-                        <RotateControl onRotateLeft={onRotateLeft} />
-                    </ControlsBarGroup>
-                )}
-                <ControlsBarGroup>
-                    <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
-                    <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
-                    <AnnotationsControls
-                        annotationColor={annotationColor}
-                        annotationMode={annotationMode}
-                        hasDrawing={hasDrawing}
-                        hasHighlight={hasHighlight}
-                        hasRegion={hasRegion}
-                        onAnnotationModeClick={onAnnotationModeClick}
-                        onAnnotationModeEscape={onAnnotationModeEscape}
-                    />
-                </ControlsBarGroup>
-            </ControlsBar>
-            <ControlsBar>
-                <DrawingControls
-                    annotationColor={annotationColor}
-                    annotationMode={annotationMode}
-                    onAnnotationColorChange={onAnnotationColorChange}
-                />
-            </ControlsBar>
+            ) : (
+                <>
+                    <ControlsBar>
+                        <ControlsBarGroup>
+                            <ThumbnailsToggle
+                                isThumbnailsOpen={isThumbnailsOpen}
+                                onThumbnailsToggle={onThumbnailsToggle}
+                            />
+                            <FindBarToggle onFindBarToggle={onFindBarToggle} />
+                        </ControlsBarGroup>
+                        <ControlsBarGroup isDistinct>
+                            <PageControls
+                                onPageChange={onPageChange}
+                                onPageSubmit={onPageSubmit}
+                                pageCount={pageCount}
+                                pageNumber={pageNumber}
+                            />
+                        </ControlsBarGroup>
+                        <ControlsBarGroup isDistinct>
+                            <ZoomControls
+                                maxScale={maxScale}
+                                minScale={minScale}
+                                onZoomIn={onZoomIn}
+                                onZoomOut={onZoomOut}
+                                scale={scale}
+                            />
+                        </ControlsBarGroup>
+                        {onRotateLeft && (
+                            <ControlsBarGroup>
+                                <RotateControl onRotateLeft={onRotateLeft} />
+                            </ControlsBarGroup>
+                        )}
+                        <ControlsBarGroup>
+                            <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
+                            <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
+                            <AnnotationsControls
+                                annotationColor={annotationColor}
+                                annotationMode={annotationMode}
+                                hasDrawing={hasDrawing}
+                                hasHighlight={hasHighlight}
+                                hasRegion={hasRegion}
+                                onAnnotationModeClick={onAnnotationModeClick}
+                                onAnnotationModeEscape={onAnnotationModeEscape}
+                            />
+                        </ControlsBarGroup>
+                    </ControlsBar>
+                    <ControlsBar>
+                        <DrawingControls
+                            annotationColor={annotationColor}
+                            annotationMode={annotationMode}
+                            onAnnotationColorChange={onAnnotationColorChange}
+                        />
+                    </ControlsBar>
+                </>
+            )}
         </ExperiencesProvider>
     );
 }

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -1,0 +1,88 @@
+@import '../../boxuiVariables';
+
+.bp-gallery-grid {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+    align-items: start;
+    padding: 40px;
+    padding-bottom: 100px;
+    overflow-y: auto;
+    background-color: $white;
+}
+
+.bp-gallery-tile {
+    position: relative;
+    padding: 0;
+    background: $ffive;
+    border: none;
+    border-radius: 12px;
+    box-shadow: 0 0 0 1px $off-white;
+    cursor: pointer;
+    transition: box-shadow .2s ease-in-out;
+
+    &:hover {
+        box-shadow: 0 0 0 3px $seventy-sixers, 0 4px 5px 0 rgba(0, 0, 0, .15);
+
+        .bp-gallery-tile-badge {
+            opacity: 1;
+        }
+    }
+
+    &:focus {
+        outline: none;
+    }
+
+    img {
+        display: block;
+        width: 100%;
+        height: auto;
+        border-radius: 12px;
+    }
+}
+
+.bp-gallery-tile--selected {
+    box-shadow: 0 0 0 3px $box-blue, 0 4px 5px 0 rgba(0, 0, 0, .08);
+
+    &:hover,
+    &:focus {
+        box-shadow: 0 0 0 3px $box-blue, 0 4px 5px 0 rgba(0, 0, 0, .08);
+    }
+
+    .bp-gallery-tile-badge {
+        background: $box-blue;
+        opacity: 1;
+    }
+}
+
+.bp-gallery-tile-badge {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 24px;
+    padding: 0 4px;
+    color: $white;
+    font-size: 13px;
+    line-height: 1;
+    background: $seventy-sixers;
+    border-radius: 12px 0 12px 0;
+    opacity: 0;
+    transition: opacity .15s;
+}
+
+.bp-gallery-tile-placeholder {
+    display: block;
+    width: 100%;
+    padding-top: 129%;
+}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -38,11 +38,12 @@ export default function GalleryGrid({
     const gridRef = useRef<HTMLDivElement>(null);
     const queueRef = useRef<number[]>([]);
     const isProcessingRef = useRef(false);
+    const isMountedRef = useRef(true);
     const initialLoadDoneRef = useRef(false);
     const initialLoadCountRef = useRef(0);
 
     function processQueue() {
-        if (!thumbnail || queueRef.current.length === 0) {
+        if (!isMountedRef.current || !thumbnail || queueRef.current.length === 0) {
             isProcessingRef.current = false;
             return;
         }
@@ -52,7 +53,7 @@ export default function GalleryGrid({
         queueRef.current = queueRef.current.slice(batchSize);
 
         requestAnimationFrame(() => {
-            if (!thumbnail) {
+            if (!isMountedRef.current || !thumbnail) {
                 isProcessingRef.current = false;
                 return;
             }
@@ -62,6 +63,11 @@ export default function GalleryGrid({
             const onComplete = () => {
                 completed += 1;
                 if (completed < batch.length) return;
+
+                if (!isMountedRef.current) {
+                    isProcessingRef.current = false;
+                    return;
+                }
 
                 if (!initialLoadDoneRef.current) {
                     initialLoadCountRef.current += batch.length;
@@ -78,7 +84,7 @@ export default function GalleryGrid({
                 thumbnail
                     .createThumbnailImage(pageNum - 1, { createImgTag: true, thumbMaxWidth: GALLERY_THUMB_MAX_WIDTH })
                     .then((imageEl: HTMLImageElement | null) => {
-                        if (imageEl && imageEl.src) {
+                        if (isMountedRef.current && imageEl && imageEl.src) {
                             setLoadedImages(prev => ({ ...prev, [pageNum]: imageEl.src }));
                         }
                         onComplete();
@@ -111,7 +117,8 @@ export default function GalleryGrid({
 
         tiles.forEach(tile => {
             const el = tile as HTMLElement;
-            const pageNum = parseInt(el.dataset.page || '0', 10);
+            if (!el.dataset.page) return;
+            const pageNum = parseInt(el.dataset.page, 10);
             const tileTop = el.offsetTop;
             const tileBottom = tileTop + el.offsetHeight;
 
@@ -136,6 +143,8 @@ export default function GalleryGrid({
     );
 
     useEffect(() => {
+        const throttledScroll = handleScrollRef.current;
+
         if (gridRef.current) {
             const tile = gridRef.current.querySelector(`[data-page="${currentPage}"]`) as HTMLElement;
             if (tile) {
@@ -165,13 +174,16 @@ export default function GalleryGrid({
         queueRef.current = uncachedPages;
 
         thumbnail.init().then(() => {
+            if (!isMountedRef.current) return;
             isProcessingRef.current = true;
             processQueue();
         });
 
         return () => {
+            isMountedRef.current = false;
             queueRef.current = [];
             isProcessingRef.current = false;
+            throttledScroll.cancel();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -7,14 +7,22 @@ const INITIAL_LOAD_BUFFER = 40;
 const CONCURRENT_LOADS = 4;
 const SCROLL_THROTTLE_MS = 200;
 
+interface GalleryThumbnail {
+    init: () => Promise<unknown>;
+    getImageFromCache: (itemIndex: number) => { image?: HTMLImageElement; inProgress: boolean } | null | undefined;
+    createThumbnailImage: (
+        itemIndex: number,
+        options: { createImgTag: boolean; thumbMaxWidth: number },
+    ) => Promise<HTMLImageElement | null>;
+}
+
 export type Props = {
     pageCount: number;
     currentPage: number;
     onFocusChange?: (pageNum: number) => void;
     onPageNavigate: (n: number) => void;
     onClose: () => void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    thumbnail: any;
+    thumbnail: GalleryThumbnail;
 };
 
 export default function GalleryGrid({

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -1,0 +1,266 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import throttle from 'lodash/throttle';
+import './GalleryGrid.scss';
+
+const GALLERY_THUMB_MAX_WIDTH = 440;
+const INITIAL_LOAD_BUFFER = 40;
+const CONCURRENT_LOADS = 4;
+const SCROLL_THROTTLE_MS = 200;
+
+export type Props = {
+    pageCount: number;
+    currentPage: number;
+    onFocusChange?: (pageNum: number) => void;
+    onPageNavigate: (n: number) => void;
+    onClose: () => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    thumbnail: any;
+};
+
+export default function GalleryGrid({
+    pageCount,
+    currentPage,
+    onClose,
+    onFocusChange,
+    onPageNavigate,
+    thumbnail,
+}: Props): JSX.Element {
+    const [loadedImages, setLoadedImages] = useState<Record<number, string>>({});
+    const [focusedPage, setFocusedPage] = useState(currentPage);
+    const gridRef = useRef<HTMLDivElement>(null);
+    const queueRef = useRef<number[]>([]);
+    const isProcessingRef = useRef(false);
+    const initialLoadDoneRef = useRef(false);
+    const initialLoadCountRef = useRef(0);
+
+    function processQueue() {
+        if (!thumbnail || queueRef.current.length === 0) {
+            isProcessingRef.current = false;
+            return;
+        }
+
+        const batchSize = initialLoadDoneRef.current ? CONCURRENT_LOADS : 1;
+        const batch = queueRef.current.slice(0, batchSize);
+        queueRef.current = queueRef.current.slice(batchSize);
+
+        requestAnimationFrame(() => {
+            if (!thumbnail) {
+                isProcessingRef.current = false;
+                return;
+            }
+
+            let completed = 0;
+
+            const onComplete = () => {
+                completed += 1;
+                if (completed < batch.length) return;
+
+                if (!initialLoadDoneRef.current) {
+                    initialLoadCountRef.current += batch.length;
+                    if (initialLoadCountRef.current >= INITIAL_LOAD_BUFFER) {
+                        initialLoadDoneRef.current = true;
+                        isProcessingRef.current = false;
+                        return;
+                    }
+                }
+                processQueue();
+            };
+
+            batch.forEach(pageNum => {
+                thumbnail
+                    .createThumbnailImage(pageNum - 1, { createImgTag: true, thumbMaxWidth: GALLERY_THUMB_MAX_WIDTH })
+                    .then((imageEl: HTMLImageElement | null) => {
+                        if (imageEl && imageEl.src) {
+                            setLoadedImages(prev => ({ ...prev, [pageNum]: imageEl.src }));
+                        }
+                        onComplete();
+                    })
+                    .catch(() => {
+                        onComplete();
+                    });
+            });
+        });
+    }
+
+    function startProcessing() {
+        if (!isProcessingRef.current && queueRef.current.length > 0) {
+            isProcessingRef.current = true;
+            processQueue();
+        }
+    }
+
+    function getUnloadedNearViewport(): number[] {
+        const grid = gridRef.current;
+        if (!grid) return [];
+
+        const { scrollTop, clientHeight } = grid;
+        const bufferZone = clientHeight * 3;
+        const viewportTop = scrollTop - bufferZone;
+        const viewportBottom = scrollTop + clientHeight + bufferZone;
+
+        const nearbyUnloaded: number[] = [];
+        const tiles = grid.querySelectorAll('[data-page]');
+
+        tiles.forEach(tile => {
+            const el = tile as HTMLElement;
+            const pageNum = parseInt(el.dataset.page || '0', 10);
+            const tileTop = el.offsetTop;
+            const tileBottom = tileTop + el.offsetHeight;
+
+            if (tileBottom > viewportTop && tileTop < viewportBottom && !el.querySelector('img')) {
+                nearbyUnloaded.push(pageNum);
+            }
+        });
+
+        return nearbyUnloaded;
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const handleScroll = useCallback(
+        throttle(() => {
+            const nearbyUnloaded = getUnloadedNearViewport();
+            if (nearbyUnloaded.length > 0) {
+                const currentQueue = queueRef.current;
+                const toAdd = nearbyUnloaded.filter(p => !currentQueue.includes(p));
+                queueRef.current = [...toAdd, ...currentQueue];
+                startProcessing();
+            }
+        }, SCROLL_THROTTLE_MS),
+        [],
+    );
+
+    useEffect(() => {
+        if (gridRef.current) {
+            const tile = gridRef.current.querySelector(`[data-page="${currentPage}"]`) as HTMLElement;
+            if (tile) {
+                tile.scrollIntoView({ block: 'center' });
+                tile.focus();
+            }
+        }
+
+        const initialImages: Record<number, string> = {};
+        const uncachedPages: number[] = [];
+
+        for (let i = 1; i <= pageCount; i += 1) {
+            const cached = thumbnail.getImageFromCache(i - 1);
+            if (cached && cached.image && cached.image.src) {
+                initialImages[i] = cached.image.src;
+                initialLoadCountRef.current += 1;
+            } else {
+                uncachedPages.push(i);
+            }
+        }
+
+        if (Object.keys(initialImages).length > 0) {
+            setLoadedImages(initialImages);
+        }
+
+        uncachedPages.sort((a, b) => Math.abs(a - currentPage) - Math.abs(b - currentPage));
+        queueRef.current = uncachedPages;
+
+        thumbnail.init().then(() => {
+            isProcessingRef.current = true;
+            processQueue();
+        });
+
+        return () => {
+            queueRef.current = [];
+            isProcessingRef.current = false;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleTileFocus = useCallback(
+        (pageNum: number) => {
+            setFocusedPage(pageNum);
+            if (onFocusChange) {
+                onFocusChange(pageNum);
+            }
+        },
+        [onFocusChange],
+    );
+
+    const handleGridFocus = useCallback(
+        (event: React.FocusEvent) => {
+            if (event.target === gridRef.current && gridRef.current) {
+                const tile = gridRef.current.querySelector(`[data-page="${focusedPage}"]`) as HTMLElement;
+                if (tile) {
+                    tile.focus();
+                }
+            }
+        },
+        [focusedPage],
+    );
+
+    const handleGridKeyDown = useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                event.stopPropagation();
+                onClose();
+                return;
+            }
+
+            if (event.key === ' ') {
+                event.preventDefault();
+                const activePage = (document.activeElement as HTMLElement)?.dataset?.page;
+                if (activePage) {
+                    onPageNavigate(parseInt(activePage, 10));
+                }
+                return;
+            }
+
+            if (event.key === 'Tab' && gridRef.current) {
+                const buttons = gridRef.current.querySelectorAll('button');
+                const first = buttons[0];
+                const last = buttons[buttons.length - 1];
+
+                if (event.shiftKey && document.activeElement === first) {
+                    event.preventDefault();
+                    last.focus();
+                } else if (!event.shiftKey && document.activeElement === last) {
+                    event.preventDefault();
+                    first.focus();
+                }
+            }
+        },
+        [onClose, onPageNavigate],
+    );
+
+    const tiles = [];
+    for (let i = 1; i <= pageCount; i += 1) {
+        const isFocused = i === focusedPage;
+        tiles.push(
+            <button
+                key={i}
+                aria-label={`Page ${i}${isFocused ? ', current page' : ''}`}
+                className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
+                data-page={i}
+                onClick={() => onPageNavigate(i)}
+                onFocus={() => handleTileFocus(i)}
+                type="button"
+            >
+                <span className="bp-gallery-tile-badge">{i}</span>
+                {loadedImages[i] ? (
+                    <img alt={`Page ${i}`} src={loadedImages[i]} />
+                ) : (
+                    <span className="bp-gallery-tile-placeholder" />
+                )}
+            </button>,
+        );
+    }
+
+    return (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+            ref={gridRef}
+            className="bp-gallery-grid"
+            onFocus={handleGridFocus}
+            onKeyDown={handleGridKeyDown}
+            onScroll={handleScroll}
+            tabIndex={-1}
+        >
+            {tiles}
+        </div>
+    );
+}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -115,8 +115,7 @@ export default function GalleryGrid({
         return nearbyUnloaded;
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const handleScroll = useCallback(
+    const handleScrollRef = useRef(
         throttle(() => {
             const nearbyUnloaded = getUnloadedNearViewport();
             if (nearbyUnloaded.length > 0) {
@@ -126,7 +125,6 @@ export default function GalleryGrid({
                 startProcessing();
             }
         }, SCROLL_THROTTLE_MS),
-        [],
     );
 
     useEffect(() => {
@@ -201,15 +199,6 @@ export default function GalleryGrid({
                 return;
             }
 
-            if (event.key === ' ') {
-                event.preventDefault();
-                const activePage = (document.activeElement as HTMLElement)?.dataset?.page;
-                if (activePage) {
-                    onPageNavigate(parseInt(activePage, 10));
-                }
-                return;
-            }
-
             if (event.key === 'Tab' && gridRef.current) {
                 const buttons = gridRef.current.querySelectorAll('button');
                 const first = buttons[0];
@@ -224,7 +213,7 @@ export default function GalleryGrid({
                 }
             }
         },
-        [onClose, onPageNavigate],
+        [onClose],
     );
 
     const tiles = [];
@@ -257,7 +246,7 @@ export default function GalleryGrid({
             className="bp-gallery-grid"
             onFocus={handleGridFocus}
             onKeyDown={handleGridKeyDown}
-            onScroll={handleScroll}
+            onScroll={handleScrollRef.current}
             tabIndex={-1}
         >
             {tiles}

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GalleryGrid from '../GalleryGrid';
+
+describe('GalleryGrid', () => {
+    const mockThumbnail = {
+        init: jest.fn().mockResolvedValue(100),
+        getImageFromCache: jest.fn().mockReturnValue(null),
+        createThumbnailImage: jest.fn().mockResolvedValue(null),
+        destroy: jest.fn(),
+    };
+
+    const defaultProps = {
+        pageCount: 10,
+        currentPage: 3,
+        onPageNavigate: jest.fn(),
+        onClose: jest.fn(),
+        thumbnail: mockThumbnail,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Mock scrollIntoView
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    const getWrapper = (props = {}) => render(<GalleryGrid {...defaultProps} {...props} />);
+
+    describe('render', () => {
+        test('should render the gallery grid container', () => {
+            getWrapper();
+            expect(document.querySelector('.bp-gallery-grid')).toBeInTheDocument();
+        });
+
+        test('should render a button for each page', () => {
+            getWrapper();
+            const buttons = screen.getAllByRole('button');
+            expect(buttons).toHaveLength(10);
+        });
+
+        test('should set aria-label on each tile', () => {
+            getWrapper();
+            expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
+            expect(screen.getByLabelText('Page 3, current page')).toBeInTheDocument();
+            expect(screen.getByLabelText('Page 10')).toBeInTheDocument();
+        });
+    });
+
+    describe('current page highlight', () => {
+        test('should apply selected class to current page tile', () => {
+            getWrapper();
+            const tile = screen.getByLabelText('Page 3, current page');
+            expect(tile).toHaveClass('bp-gallery-tile--selected');
+        });
+
+        test('should not apply selected class to other tiles', () => {
+            getWrapper();
+            const tile = screen.getByLabelText('Page 1');
+            expect(tile).not.toHaveClass('bp-gallery-tile--selected');
+        });
+
+        test('should render badge on every tile', () => {
+            getWrapper();
+            const allTiles = screen.getAllByRole('button');
+            allTiles.forEach(tile => {
+                expect(tile.querySelector('.bp-gallery-tile-badge')).toBeInTheDocument();
+            });
+        });
+
+        test('should scroll current page tile into view on mount', () => {
+            getWrapper();
+            expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+        });
+    });
+
+    describe('navigation', () => {
+        test('should call onPageNavigate on tile click', async () => {
+            const onPageNavigate = jest.fn();
+            getWrapper({ onPageNavigate });
+            await userEvent.click(screen.getByLabelText('Page 5'));
+            expect(onPageNavigate).toHaveBeenCalledWith(5);
+        });
+    });
+
+    describe('keyboard', () => {
+        test('should call onClose on Escape', async () => {
+            const onClose = jest.fn();
+            getWrapper({ onClose });
+            const grid = document.querySelector('.bp-gallery-grid') as HTMLElement;
+            grid.focus();
+            await userEvent.keyboard('{Escape}');
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        test('should wrap focus from last tile to first on Tab', async () => {
+            getWrapper();
+            const buttons = screen.getAllByRole('button');
+            const lastButton = buttons[buttons.length - 1];
+            lastButton.focus();
+            await userEvent.tab();
+            expect(buttons[0]).toHaveFocus();
+        });
+
+        test('should wrap focus from first tile to last on Shift+Tab', async () => {
+            getWrapper();
+            const buttons = screen.getAllByRole('button');
+            buttons[0].focus();
+            await userEvent.tab({ shift: true });
+            expect(buttons[buttons.length - 1]).toHaveFocus();
+        });
+    });
+
+    describe('focus management', () => {
+        test('should focus current page tile on mount', () => {
+            getWrapper();
+            const tile = screen.getByLabelText('Page 3, current page');
+            expect(tile).toHaveFocus();
+        });
+
+        test('should move selected class when tile receives focus', async () => {
+            getWrapper();
+            const tile5 = screen.getByLabelText('Page 5');
+            tile5.focus();
+
+            await waitFor(() => {
+                expect(tile5).toHaveClass('bp-gallery-tile--selected');
+            });
+
+            const tile3 = screen.getByLabelText('Page 3');
+            expect(tile3).not.toHaveClass('bp-gallery-tile--selected');
+        });
+
+        test('should call onFocusChange when tile receives focus', () => {
+            const onFocusChange = jest.fn();
+            getWrapper({ onFocusChange });
+            const tile5 = screen.getByLabelText('Page 5');
+            tile5.focus();
+            expect(onFocusChange).toHaveBeenCalledWith(5);
+        });
+
+        test('should redirect focus to focused tile when grid container is clicked', async () => {
+            getWrapper();
+            const grid = document.querySelector('.bp-gallery-grid') as HTMLElement;
+            // Simulate clicking empty area — focus goes to grid container
+            grid.focus();
+
+            await waitFor(() => {
+                // Focus should redirect to the focused page tile
+                const focusedTile = screen.getByLabelText('Page 3, current page');
+                expect(focusedTile).toHaveFocus();
+            });
+        });
+    });
+
+    describe('thumbnail loading', () => {
+        test('should call thumbnail.init on mount', async () => {
+            getWrapper();
+            await waitFor(() => {
+                expect(mockThumbnail.init).toHaveBeenCalled();
+            });
+        });
+
+        test('should check cache for each page on mount', () => {
+            getWrapper();
+            expect(mockThumbnail.getImageFromCache).toHaveBeenCalledTimes(10);
+        });
+
+        test('should use cached images when available', () => {
+            const cachedThumbnail = {
+                ...mockThumbnail,
+                getImageFromCache: jest.fn(pageIndex => {
+                    if (pageIndex === 2) {
+                        return { image: { src: 'data:image/png;cached-page-3' }, inProgress: false };
+                    }
+                    return null;
+                }),
+            };
+            getWrapper({ thumbnail: cachedThumbnail });
+
+            const tile3 = screen.getByLabelText('Page 3, current page');
+            const img = tile3.querySelector('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', 'data:image/png;cached-page-3');
+        });
+
+        test('should show placeholder for uncached pages', () => {
+            getWrapper();
+            const tile1 = screen.getByLabelText('Page 1');
+            expect(tile1.querySelector('.bp-gallery-tile-placeholder')).toBeInTheDocument();
+            expect(tile1.querySelector('img')).not.toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
**Summary**

Adds a gallery view mode to document preview — a full-width, responsive grid of page thumbnails. Users toggle a GridView toolbar icon to enter an overlay showing all pages, single-click to navigate, and return to the document viewer.

The gallery renders thumbnails progressively outward from the current page, with lazy scroll-triggered loading for pages beyond the initial buffer. A persistent thumbnail cache means re-opening gallery is instant. The toolbar collapses to just the gallery toggle + fullscreen when gallery is open (will also later have pinch to zoom), and sidebar state is preserved across open/close.

**Feature flag**
  
Gallery toggle visibility is gated on features.galleryView.enabled (consumed via isFeatureEnabled). BCP never contacts Split — EUA evaluates preview_gallery_view and passes the boolean. Additionally requires page count between 2–200.

**Other changes**
  
  - New GalleryToggle toolbar button with bp-is-active highlight state and aria-pressed
  - New GalleryGrid React component mounted directly by DocBaseViewer via createRoot
  - Dedicated Thumbnail instance for gallery (not shared with sidebar or ACI - in a future version will be shared with sidebar thumbnails) — destroyed on rotation
  - Keyboard: Tab/Shift-Tab cycles tiles with focus wrap, Escape exits, Enter/Space navigates
  - Focused page tracked via onFocusChange callback — exiting via toggle navigates to the focused tile
  - Sidebar scroll synced after gallery exit via delayed setCurrentPage
  - New i18n string: gallery_view (more later in a11y pr)

**Screenshots**
<img width="591" height="103" alt="Screenshot 2026-06-17 at 10 22 38 AM" src="https://github.com/user-attachments/assets/43a71abd-94fb-4872-b934-8ff83a1f7f2f" />

<img width="1248" height="776" alt="Screenshot 2026-06-17 at 10 23 00 AM" src="https://github.com/user-attachments/assets/3eec31a8-72a4-4be6-84b9-e1b31344e66e" />

<img width="1728" height="1083" alt="Screenshot 2026-06-17 at 10 24 38 AM" src="https://github.com/user-attachments/assets/3d1ce70a-02a1-46ca-bd78-f4b0baed455f" />


**Test plan**

  - [x] 27 unit tests (8 GalleryToggle, 19 GalleryGrid) — all passing
  - [x] Lint and type check clean
  - [x] Manual: flag ON + multi-page PDF → grid icon appears, click opens grid, thumbnails load outward from current page
  - [x] Manual: single-click tile → navigates, gallery closes, sidebar restores
  - [x] Manual: Tab between tiles → highlight moves, exit navigates to focused page
  - [x] Manual: Escape exits without navigation
  - [x] Manual: rotate PDF → re-open gallery → fresh thumbnails at new rotation
  - [x] Manual: close + re-open → instant from cache
  - [x] Manual: flag OFF / single-page / 200+ pages → no grid icon

**Known bugs**

- Markup, comment on region, and highlight and comment have some issues after clicking gallery view - will be fixed in next PR
- Scrolling hard up at top or bottom will show document under gallery view for a little bit
