### PR TITLE
fix(video): restore media container width for v1 player

### DIFF
--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -633,6 +633,10 @@ class VideoBaseViewer extends MediaBaseViewer {
             this.preloader.wrapperEl.style.top = '50%';
             this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
         }
+
+        if (!this.featureEnabled('videoPlayerV2.enabled') && this.mediaContainerEl && this.mediaEl.style.width) {
+            this.mediaContainerEl.style.width = this.mediaEl.style.width;
+        }
     }
 
     /**

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -624,18 +624,22 @@ class VideoBaseViewer extends MediaBaseViewer {
             }
         }
 
-        if (this.featureEnabled('videoPlayerV2.enabled') && this.preloader?.wrapperEl && this.mediaEl.style.width) {
-            const videoWidth = parseInt(this.mediaEl.style.width, 10);
-            const videoHeight = videoWidth / this.aspect;
-            this.preloader.wrapperEl.style.width = `${videoWidth}px`;
-            this.preloader.wrapperEl.style.height = `${videoHeight}px`;
-            this.preloader.wrapperEl.style.left = '50%';
-            this.preloader.wrapperEl.style.top = '50%';
-            this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
+        if (this.mediaContainerEl && this.mediaEl.style.width) {
+            this.mediaContainerEl.style.width = this.mediaEl.style.width;
         }
 
-        if (!this.featureEnabled('videoPlayerV2.enabled') && this.mediaContainerEl && this.mediaEl.style.width) {
-            this.mediaContainerEl.style.width = this.mediaEl.style.width;
+        if (this.featureEnabled('videoPlayerV2.enabled')) {
+            this.mediaContainerEl.style.width = '';
+
+            if (this.preloader?.wrapperEl && this.mediaEl.style.width) {
+                const videoWidth = parseInt(this.mediaEl.style.width, 10);
+                const videoHeight = videoWidth / this.aspect;
+                this.preloader.wrapperEl.style.width = `${videoWidth}px`;
+                this.preloader.wrapperEl.style.height = `${videoHeight}px`;
+                this.preloader.wrapperEl.style.left = '50%';
+                this.preloader.wrapperEl.style.top = '50%';
+                this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
+            }
         }
     }
 

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -744,6 +744,23 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaEl.style.width).toBe('325px');
             });
         });
+
+        describe('mediaContainerEl width sync', () => {
+            test('should set mediaContainerEl width to match mediaEl width when V2 is disabled', () => {
+                jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+                videoBase.aspect = 1;
+                videoBase.setVideoDimensions();
+                expect(videoBase.mediaContainerEl.style.width).toBe(videoBase.mediaEl.style.width);
+            });
+
+            test('should reset mediaContainerEl width when V2 is enabled', () => {
+                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+                videoBase.aspect = 1;
+                videoBase.mediaContainerEl.style.width = '500px';
+                videoBase.setVideoDimensions();
+                expect(videoBase.mediaContainerEl.style.width).toBe('');
+            });
+        });
     });
 
     describe('allowNavigationArrows', () => {


### PR DESCRIPTION
## Summary
- Restore `mediaContainerEl.style.width` assignment in `setVideoDimensions()`, gated to the V1 player only
- This line was inadvertently removed in #1673 without being guarded behind the `videoPlayerV2.enabled `split, which broke video sizing for the V1 player

## Test plan
- [ ] Verify V1 player (feature flag off) correctly sizes the media container to match the video width
- [ ] Verify V2 player (`videoPlayerV2.enabled`) is unaffected (no container width override)
- [ ] Test with various video aspect ratios and viewport sizes in V1 mode
