### PR TITLE
feat(video): show timestamped comment markers on the V2 scrubber

### DIFF
--- a/src/lib/__tests__/timestampedCommentsAPI-test.js
+++ b/src/lib/__tests__/timestampedCommentsAPI-test.js
@@ -1,0 +1,158 @@
+/* eslint-disable no-unused-expressions */
+import TimestampedCommentsAPI from '../timestampedCommentsAPI';
+import Api from '../api';
+
+let stubs = {};
+
+describe('timestampedCommentsAPI', () => {
+    beforeEach(() => {
+        stubs = {};
+        stubs.timestampedCommentsAPI = new TimestampedCommentsAPI(new Api());
+        stubs.get = jest.spyOn(Api.prototype, 'get').mockImplementation();
+    });
+
+    describe('getURL()', () => {
+        test('Should build a file_activities URL with the expected query params', () => {
+            const url = TimestampedCommentsAPI.getURL('123', 'https://api.box.com');
+            expect(url).toContain('https://api.box.com/2.0/file_activities');
+            expect(url).toContain('file_id=123');
+            expect(url).toContain('activity_types=enhanced_annotation,enhanced_comment,task,versions');
+            expect(url).toContain('enable_replies=true');
+            expect(url).toContain('reply_limit=1000');
+        });
+    });
+
+    describe('parseResponse()', () => {
+        test('Should return an empty array when response is missing or has no entries', () => {
+            expect(TimestampedCommentsAPI.parseResponse(undefined)).toEqual([]);
+            expect(TimestampedCommentsAPI.parseResponse({})).toEqual([]);
+            expect(TimestampedCommentsAPI.parseResponse({ entries: [] })).toEqual([]);
+        });
+
+        test('Should keep enhanced_comment entries with a timestamp prefix and strip the prefix', () => {
+            const response = {
+                entries: [
+                    {
+                        activity_type: 'enhanced_comment',
+                        source: {
+                            enhanced_comment: {
+                                created_at: '2026-06-17T15:48:11-07:00',
+                                created_by: { avatar_url: 'https://example.com/a.png', name: 'Alex Park' },
+                                id: '490977',
+                                message: '#[timestamp:24600,versionId:40815299067] hello',
+                            },
+                        },
+                    },
+                ],
+            };
+
+            const result = TimestampedCommentsAPI.parseResponse(response);
+
+            expect(result).toEqual([
+                {
+                    createdAt: '2026-06-17T15:48:11-07:00',
+                    id: '490977',
+                    message: 'hello',
+                    time: 24.6,
+                    user: { avatarUrl: 'https://example.com/a.png', name: 'Alex Park' },
+                },
+            ]);
+        });
+
+        test('Should accept comment entries without a versionId in the prefix', () => {
+            const response = {
+                entries: [
+                    {
+                        activity_type: 'comment',
+                        source: {
+                            comment: {
+                                created_at: '2026-06-17T15:48:11-07:00',
+                                created_by: { name: 'Alex Park' },
+                                id: '1',
+                                message: '#[timestamp:5000] body',
+                            },
+                        },
+                    },
+                ],
+            };
+
+            expect(TimestampedCommentsAPI.parseResponse(response)).toEqual([
+                {
+                    createdAt: '2026-06-17T15:48:11-07:00',
+                    id: '1',
+                    message: 'body',
+                    time: 5,
+                    user: { avatarUrl: undefined, name: 'Alex Park' },
+                },
+            ]);
+        });
+
+        test('Should drop entries that are not comments or that lack a timestamp prefix', () => {
+            const response = {
+                entries: [
+                    { activity_type: 'task', source: {} },
+                    {
+                        activity_type: 'enhanced_comment',
+                        source: { enhanced_comment: { id: '2', message: 'no prefix here' } },
+                    },
+                    {
+                        activity_type: 'enhanced_comment',
+                        source: null,
+                    },
+                ],
+            };
+
+            expect(TimestampedCommentsAPI.parseResponse(response)).toEqual([]);
+        });
+    });
+
+    describe('getTimestampedComments()', () => {
+        test('Should call api.get with the file_activities URL + auth headers and return the parsed list', () => {
+            const apiResponse = {
+                entries: [
+                    {
+                        activity_type: 'enhanced_comment',
+                        source: {
+                            enhanced_comment: {
+                                created_at: 'now',
+                                created_by: { name: 'Alex Park' },
+                                id: '1',
+                                message: '#[timestamp:1000] x',
+                            },
+                        },
+                    },
+                ],
+            };
+            stubs.get.mockResolvedValueOnce(apiResponse);
+
+            return stubs.timestampedCommentsAPI
+                .getTimestampedComments('123', { apiHost: 'https://api.box.com', token: 'tok' })
+                .then(result => {
+                    expect(stubs.get).toBeCalledWith(
+                        expect.stringContaining('/2.0/file_activities?file_id=123'),
+                        expect.objectContaining({ headers: expect.any(Object) }),
+                    );
+                    expect(result).toEqual([
+                        {
+                            createdAt: 'now',
+                            id: '1',
+                            message: 'x',
+                            time: 1,
+                            user: { avatarUrl: undefined, name: 'Alex Park' },
+                        },
+                    ]);
+                });
+        });
+
+        test('Should reject when api.get rejects', () => {
+            const apiError = new Error('boom');
+            stubs.get.mockRejectedValueOnce(apiError);
+
+            return stubs.timestampedCommentsAPI
+                .getTimestampedComments('123', { apiHost: 'https://api.box.com', token: 'tok' })
+                .catch(err => {
+                    expect(err).toBe(apiError);
+                });
+        });
+    });
+});

--- a/src/lib/__tests__/timestampedCommentsAPI-test.js
+++ b/src/lib/__tests__/timestampedCommentsAPI-test.js
@@ -16,7 +16,7 @@ describe('timestampedCommentsAPI', () => {
             const url = TimestampedCommentsAPI.getURL('123', 'https://api.box.com');
             expect(url).toContain('https://api.box.com/2.0/file_activities');
             expect(url).toContain('file_id=123');
-            expect(url).toContain('activity_types=enhanced_annotation,enhanced_comment,task,versions');
+            expect(url).toContain('activity_types=enhanced_comment,task,versions');
             expect(url).toContain('enable_replies=true');
             expect(url).toContain('reply_limit=1000');
         });
@@ -57,6 +57,26 @@ describe('timestampedCommentsAPI', () => {
                     user: { avatarUrl: 'https://example.com/a.png', name: 'Alex Park' },
                 },
             ]);
+        });
+
+        test('Should drop resolved comments to mirror the sidebar filtered view', () => {
+            const response = {
+                entries: [
+                    {
+                        activity_type: 'enhanced_comment',
+                        source: {
+                            enhanced_comment: {
+                                created_by: { name: 'Alex Park' },
+                                id: '1',
+                                message: '#[timestamp:5000] body',
+                                status: 'resolved',
+                            },
+                        },
+                    },
+                ],
+            };
+
+            expect(TimestampedCommentsAPI.parseResponse(response)).toEqual([]);
         });
 
         test('Should accept comment entries without a versionId in the prefix', () => {

--- a/src/lib/timestampedCommentsAPI.js
+++ b/src/lib/timestampedCommentsAPI.js
@@ -1,6 +1,6 @@
 import { getHeaders } from './util';
 
-const ACTIVITY_TYPES = ['enhanced_annotation', 'enhanced_comment', 'task', 'versions'];
+const ACTIVITY_TYPES = ['enhanced_comment', 'task', 'versions'];
 const REPLY_LIMIT = 1000;
 
 const TIMESTAMP_PREFIX_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
@@ -25,7 +25,8 @@ export default class TimestampedCommentsAPI {
 
     /**
      * Filters the file_activities response down to comments with a timestamp
-     * prefix and reshapes them for the scrubber-marker overlay.
+     * prefix and reshapes them for the scrubber-marker overlay. Resolved
+     * comments are dropped to mirror the sidebar's filtered view.
      *
      * @param {Object} response - file_activities response payload
      * @return {Array<{id: string, time: number, message: string, createdAt: string, user: {name: string, avatarUrl?: string}}>}
@@ -41,6 +42,12 @@ export default class TimestampedCommentsAPI {
 
             const comment = entry.source.enhanced_comment || entry.source.comment;
             if (!comment) {
+                return acc;
+            }
+
+            // Resolved comments are hidden in the sidebar; mirror that on
+            // the scrubber so both views stay in sync.
+            if (comment.status === 'resolved') {
                 return acc;
             }
 

--- a/src/lib/timestampedCommentsAPI.js
+++ b/src/lib/timestampedCommentsAPI.js
@@ -1,0 +1,98 @@
+import { getHeaders } from './util';
+
+const ACTIVITY_TYPES = ['enhanced_annotation', 'enhanced_comment', 'task', 'versions'];
+const REPLY_LIMIT = 1000;
+
+const TIMESTAMP_PREFIX_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
+
+export default class TimestampedCommentsAPI {
+    /**
+     * Builds the file_activities URL for a given file.
+     *
+     * @param {string} fileId - File id
+     * @param {string} apiHost - API host
+     * @return {string} The file activities URL
+     */
+    static getURL(fileId, apiHost) {
+        return (
+            `${apiHost}/2.0/file_activities` +
+            `?file_id=${fileId}` +
+            `&activity_types=${ACTIVITY_TYPES.join(',')}` +
+            `&enable_replies=true` +
+            `&reply_limit=${REPLY_LIMIT}`
+        );
+    }
+
+    /**
+     * Filters the file_activities response down to comments with a timestamp
+     * prefix and reshapes them for the scrubber-marker overlay.
+     *
+     * @param {Object} response - file_activities response payload
+     * @return {Array<{id: string, time: number, message: string, createdAt: string, user: {name: string, avatarUrl?: string}}>}
+     */
+    static parseResponse(response) {
+        const entries = (response && response.entries) || [];
+
+        return entries.reduce((acc, entry) => {
+            const isComment = entry.activity_type === 'enhanced_comment' || entry.activity_type === 'comment';
+            if (!isComment || !entry.source) {
+                return acc;
+            }
+
+            const comment = entry.source.enhanced_comment || entry.source.comment;
+            if (!comment) {
+                return acc;
+            }
+
+            const message = (comment.message || '').toString();
+            const match = message.match(TIMESTAMP_PREFIX_REGEX);
+            if (!match) {
+                return acc;
+            }
+
+            const createdBy = comment.created_by || {};
+            acc.push({
+                createdAt: comment.created_at,
+                id: comment.id,
+                message: message.replace(TIMESTAMP_PREFIX_REGEX, ''),
+                time: parseInt(match[1], 10) / 1000,
+                user: {
+                    avatarUrl: createdBy.avatar_url,
+                    name: createdBy.name || '',
+                },
+            });
+            return acc;
+        }, []);
+    }
+
+    /** @property {Api} Preview's instance of the api for XHR calls */
+    api;
+
+    /**
+     * @param {Api} client - Preview's instance of the api.
+     */
+    constructor(client) {
+        this.api = client;
+    }
+
+    /**
+     * Fetches the file's activity feed and returns just the timestamped
+     * comments, in scrubber-marker shape.
+     *
+     * @param {string} fileId - File id
+     * @param {Object} options - options object
+     * @param {string} options.apiHost - api host
+     * @param {string} options.token - authentication token
+     * @param {string} [options.sharedLink] - shared link
+     * @param {string} [options.sharedLinkPassword] - shared link password
+     * @return {Promise<Array>} Resolves with the parsed timestamped-comment list
+     */
+    getTimestampedComments(fileId, { apiHost, token, sharedLink, sharedLinkPassword }) {
+        const url = TimestampedCommentsAPI.getURL(fileId, apiHost);
+        return this.api
+            .get(url, {
+                headers: getHeaders({}, token, sharedLink, sharedLinkPassword),
+            })
+            .then(TimestampedCommentsAPI.parseResponse);
+    }
+}

--- a/src/lib/viewers/controls/avatar/BPAvatar.scss
+++ b/src/lib/viewers/controls/avatar/BPAvatar.scss
@@ -1,0 +1,68 @@
+.bp-BPAvatar {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    font-family: Lato, -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+    line-height: 1;
+    background-color: #e8e8e8;
+    border-radius: 50%;
+}
+
+.bp-BPAvatar-image {
+    object-fit: cover;
+}
+
+.bp-BPAvatar--anonymous {
+    color: #6f6f6f;
+    background-color: #e8e8e8;
+}
+
+.bp-BPAvatar-anonymousIcon {
+    width: 75%;
+    height: 75%;
+}
+
+.bp-BPAvatar-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: #fff;
+    font-size: .375rem;
+    background-color: #0061d5;
+    border-radius: 50%;
+}
+
+.bp-BPAvatar--xsmall {
+    width: 1.25rem;
+    height: 1.25rem;
+
+    .bp-BPAvatar-text.bp-BPAvatar-length-1,
+    .bp-BPAvatar-text.bp-BPAvatar-length-2 {
+        font-weight: bold;
+        font-size: .625rem;
+        line-height: 1;
+        letter-spacing: .0375rem;
+    }
+}
+
+.bp-BPAvatar--small {
+    width: 1.5rem;
+    height: 1.5rem;
+
+    .bp-BPAvatar-text {
+        font-size: .5rem;
+    }
+
+    .bp-BPAvatar-text.bp-BPAvatar-length-1,
+    .bp-BPAvatar-text.bp-BPAvatar-length-2 {
+        font-weight: bold;
+        font-size: .625rem;
+        line-height: 1;
+        letter-spacing: .0375rem;
+    }
+}

--- a/src/lib/viewers/controls/avatar/BPAvatar.tsx
+++ b/src/lib/viewers/controls/avatar/BPAvatar.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import classNames from 'classnames';
+import './BPAvatar.scss';
+
+export type AvatarSize = 'xsmall' | 'small';
+
+export type Props = {
+    avatarUrl?: string;
+    text?: string;
+    /**
+     * `alt` for the image variant, `aria-label` for the text/silhouette variants.
+     * Pass `''` to mark the avatar as decorative (suppresses `role="img"` and the
+     * `aria-label`); use this when the parent already exposes the accessible name.
+     */
+    name?: string;
+    size?: AvatarSize;
+    className?: string;
+};
+
+const SIZE_CLASS: Record<AvatarSize, string> = {
+    xsmall: 'bp-BPAvatar--xsmall',
+    small: 'bp-BPAvatar--small',
+};
+
+function AnonymousAvatarIcon(): JSX.Element {
+    return (
+        <svg aria-hidden="true" className="bp-BPAvatar-anonymousIcon" focusable="false" viewBox="0 0 16 16">
+            <path
+                d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm0 1.5c-2.5 0-5 1.25-5 3.75V14h10v-.75c0-2.5-2.5-3.75-5-3.75Z"
+                fill="currentColor"
+            />
+        </svg>
+    );
+}
+
+export default function BPAvatar({ avatarUrl, text, name, size = 'small', className }: Props): JSX.Element {
+    const root = classNames('bp-BPAvatar', SIZE_CLASS[size], className);
+    const isDecorative = name === '';
+    const initial = (text || '').trim();
+
+    if (avatarUrl) {
+        return <img alt={name || ''} className={classNames(root, 'bp-BPAvatar-image')} src={avatarUrl} />;
+    }
+
+    if (!initial) {
+        return (
+            <span
+                aria-label={isDecorative ? undefined : name}
+                className={classNames(root, 'bp-BPAvatar--anonymous')}
+                role={isDecorative ? undefined : 'img'}
+            >
+                <AnonymousAvatarIcon />
+            </span>
+        );
+    }
+
+    const lengthClass = initial.length === 2 ? 'bp-BPAvatar-length-2' : 'bp-BPAvatar-length-1';
+
+    return (
+        <span aria-label={isDecorative ? undefined : name} className={root} role={isDecorative ? undefined : 'img'}>
+            <span className={classNames('bp-BPAvatar-text', lengthClass)}>{initial}</span>
+        </span>
+    );
+}

--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -4,6 +4,7 @@ import noop from 'lodash/noop';
 import { bdlGray65, white } from 'box-ui-elements/es/styles/variables';
 import FilmstripV2 from './FilmstripV2';
 import SliderControl from '../slider';
+import TimelineMarkers, { TimestampedComment } from './TimelineMarkers';
 import './TimeControlsV2.scss';
 
 export type Props = {
@@ -15,6 +16,8 @@ export type Props = {
     fps?: number;
     mediaEl?: HTMLVideoElement | null;
     onTimeChange: (volume: number) => void;
+    onTimestampedCommentClick?: (comment: TimestampedComment) => void;
+    timestampedComments?: Array<TimestampedComment>;
 };
 
 export const round = (value: number): number => {
@@ -34,6 +37,8 @@ export default function TimeControlsV2({
     fps,
     mediaEl,
     onTimeChange,
+    onTimestampedCommentClick,
+    timestampedComments,
 }: Props): JSX.Element {
     const [isSliderHovered, setIsSliderHovered] = React.useState(false);
     const [hoverPosition, setHoverPosition] = React.useState(0);
@@ -61,6 +66,13 @@ export default function TimeControlsV2({
                     position={hoverPosition}
                     positionMax={hoverPositionMax}
                     time={hoverTime}
+                />
+            )}
+            {timestampedComments && timestampedComments.length > 0 && (
+                <TimelineMarkers
+                    comments={timestampedComments}
+                    durationTime={durationValue}
+                    onMarkerClick={onTimestampedCommentClick}
                 />
             )}
             <SliderControl

--- a/src/lib/viewers/controls/media/TimelineMarker.scss
+++ b/src/lib/viewers/controls/media/TimelineMarker.scss
@@ -1,0 +1,104 @@
+@import '../styles';
+
+// Anchor the bottom of the tick at the slider's vertical midpoint and grow the
+// stack upward so the tick straddles the track and the avatar floats above.
+// 5px = half the tick height.
+.bp-TimelineMarker {
+    position: absolute;
+    bottom: calc(50% - 5px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transform: translateX(-50%);
+    cursor: pointer;
+    pointer-events: auto;
+
+    > .bp-BPAvatar {
+        margin-bottom: 2px;
+        border: 1px solid $white;
+        transform-origin: center bottom;
+        transition: transform 150ms ease-out;
+    }
+
+    &:hover > .bp-BPAvatar {
+        transform: scale(1.5);
+    }
+}
+
+// White core with a dark border so the tick stays legible over both the
+// played (white) and unplayed (gray) regions of the track.
+.bp-TimelineMarker-tick {
+    box-sizing: content-box;
+    width: 4px;
+    height: 10px;
+    background-color: $white;
+    border: 1px solid $twos;
+    border-radius: 2px;
+}
+
+.bp-TimelineMarker-bubble {
+    position: absolute;
+    bottom: calc(100% + 16px);
+    left: 50%;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    box-sizing: border-box;
+    width: 280px;
+    padding: 12px;
+    color: $twos;
+    text-align: left;
+    background-color: $white;
+    border-radius: 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, .25);
+    transform: translateX(-50%);
+    pointer-events: auto;
+}
+
+// Invisible bridge across the gap between the avatar and the bubble so the
+// cursor can transit upward without leaving the marker's hover region.
+.bp-TimelineMarker-bubble::before {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    width: 100%;
+    height: 16px;
+    content: '';
+}
+
+.bp-TimelineMarker-bubbleHeader {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.bp-TimelineMarker-bubbleAuthor {
+    font-weight: bold;
+    font-size: 13px;
+    line-height: 16px;
+}
+
+.bp-TimelineMarker-bubbleBody {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 13px;
+    line-height: 18px;
+    word-break: break-word;
+}
+
+.bp-TimelineMarker-bubbleTimestamp {
+    color: $box-blue;
+    font-weight: bold;
+}
+
+.bp-TimelineMarker-bubbleMessage {
+    white-space: pre-wrap;
+}
+
+.bp-TimelineMarker-bubbleFooter {
+    color: $sunset-grey;
+    font-size: 11px;
+    line-height: 14px;
+}

--- a/src/lib/viewers/controls/media/TimelineMarker.tsx
+++ b/src/lib/viewers/controls/media/TimelineMarker.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import BPAvatar, { AvatarSize } from '../avatar/BPAvatar';
+import { formatTime } from './DurationLabels';
+import './TimelineMarker.scss';
+
+export type TimestampedComment = {
+    createdAt?: string;
+    id: string;
+    /** Body with the timestamp prefix already stripped. */
+    message?: string;
+    /** Video position in seconds. */
+    time: number;
+    user: { avatarUrl?: string; name: string };
+};
+
+// Grace period (ms) so the cursor can transit from avatar/tick → bubble
+// without the bubble closing underneath.
+const HOVER_CLOSE_DELAY_MS = 50;
+
+// Strips bracketed prefixes/suffixes before taking the first letter so they
+// don't become the visible initial. Returns '' when no usable letter remains.
+const getInitials = (name: string): string => {
+    const cleaned = name.replace(/[[({<]+.*[\])}>]+/g, '').trim();
+    if (!cleaned) return '';
+    return cleaned.charAt(0).toUpperCase();
+};
+
+const MarkerAvatar = ({
+    user,
+    size,
+    decorative = false,
+}: {
+    decorative?: boolean;
+    size: AvatarSize;
+    user: TimestampedComment['user'];
+}): JSX.Element => (
+    <BPAvatar avatarUrl={user.avatarUrl} name={decorative ? '' : user.name} size={size} text={getInitials(user.name)} />
+);
+
+const formatRelativeTime = (iso?: string): string => {
+    if (!iso) return '';
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+    if (diffSec < 60) return `${diffSec}s ago`;
+    const diffMin = Math.round(diffSec / 60);
+    if (diffMin < 60) return `${diffMin} min ago`;
+    const diffHr = Math.round(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDay = Math.round(diffHr / 24);
+    if (diffDay < 30) return `${diffDay}d ago`;
+    const diffMo = Math.round(diffDay / 30);
+    if (diffMo < 12) return `${diffMo}mo ago`;
+    return `${Math.round(diffMo / 12)}y ago`;
+};
+
+export type Props = {
+    comment: TimestampedComment;
+    durationTime: number;
+    onMarkerClick?: (comment: TimestampedComment) => void;
+    /** Stacking order; higher values paint on top of lower ones. */
+    zIndex?: number;
+};
+
+export default function TimelineMarker({ comment, durationTime, onMarkerClick, zIndex }: Props): JSX.Element {
+    const { createdAt, message, time, user } = comment;
+    const left = `${Math.max(0, Math.min((time / durationTime) * 100, 100))}%`;
+
+    const [isOpen, setIsOpen] = React.useState(false);
+    const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const cancelScheduledClose = React.useCallback(() => {
+        if (closeTimerRef.current) {
+            clearTimeout(closeTimerRef.current);
+            closeTimerRef.current = null;
+        }
+    }, []);
+
+    const scheduleClose = React.useCallback(() => {
+        cancelScheduledClose();
+        closeTimerRef.current = setTimeout(() => setIsOpen(false), HOVER_CLOSE_DELAY_MS);
+    }, [cancelScheduledClose]);
+
+    const handleHoverOpen = React.useCallback(() => {
+        cancelScheduledClose();
+        setIsOpen(true);
+    }, [cancelScheduledClose]);
+
+    React.useEffect(() => () => cancelScheduledClose(), [cancelScheduledClose]);
+
+    const activate = (): void => {
+        if (onMarkerClick) {
+            onMarkerClick(comment);
+        }
+    };
+    const handleClick = (event: React.MouseEvent<HTMLSpanElement>): void => {
+        event.stopPropagation(); // don't let the click bubble to the slider's seek handler
+        event.currentTarget.focus(); // keep the native focus ring on the clicked marker
+        activate();
+    };
+    const handleKeyDown = (event: React.KeyboardEvent): void => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            activate();
+        }
+    };
+
+    return (
+        <span
+            className="bp-TimelineMarker"
+            data-testid="bp-TimelineMarker"
+            onBlur={scheduleClose}
+            onClick={handleClick}
+            onFocus={handleHoverOpen}
+            onKeyDown={handleKeyDown}
+            onMouseDown={event => event.stopPropagation()} // SliderControl reacts to mousedown
+            onMouseEnter={handleHoverOpen}
+            onMouseLeave={scheduleClose}
+            role="button"
+            style={zIndex !== undefined ? { left, zIndex } : { left }}
+            tabIndex={0}
+        >
+            <MarkerAvatar size="xsmall" user={user} />
+            <span className="bp-TimelineMarker-tick" data-testid="bp-TimelineMarker-tick" />
+            {isOpen ? (
+                <span
+                    className="bp-TimelineMarker-bubble"
+                    data-testid="bp-TimelineMarker-bubble"
+                    onMouseEnter={cancelScheduledClose}
+                    onMouseLeave={scheduleClose}
+                >
+                    <span className="bp-TimelineMarker-bubbleHeader">
+                        <MarkerAvatar decorative size="small" user={user} />
+                        <span className="bp-TimelineMarker-bubbleAuthor">{user.name}</span>
+                    </span>
+                    <span className="bp-TimelineMarker-bubbleBody">
+                        <span className="bp-TimelineMarker-bubbleTimestamp">▶ {formatTime(time)}</span>
+                        {message ? <span className="bp-TimelineMarker-bubbleMessage">{message}</span> : null}
+                    </span>
+                    {createdAt ? (
+                        <span className="bp-TimelineMarker-bubbleFooter">{formatRelativeTime(createdAt)}</span>
+                    ) : null}
+                </span>
+            ) : null}
+        </span>
+    );
+}

--- a/src/lib/viewers/controls/media/TimelineMarkers.scss
+++ b/src/lib/viewers/controls/media/TimelineMarkers.scss
@@ -1,0 +1,17 @@
+@import '../styles';
+
+// Keep the controls visible while markers are mounted so they stay readable.
+// Scoped to videos that actually have timestamped comments.
+.bp-ControlsLayer:has(.bp-TimelineMarkers) {
+    opacity: 1;
+}
+
+.bp-TimelineMarkers {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1; // paint above the slider track
+    height: 100%;
+    pointer-events: none;
+}

--- a/src/lib/viewers/controls/media/TimelineMarkers.tsx
+++ b/src/lib/viewers/controls/media/TimelineMarkers.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import TimelineMarker, { TimestampedComment } from './TimelineMarker';
+import './TimelineMarkers.scss';
+
+export { TimestampedComment };
+
+export type Props = {
+    comments: Array<TimestampedComment>;
+    durationTime?: number;
+    onMarkerClick?: (comment: TimestampedComment) => void;
+};
+
+export default function TimelineMarkers({ comments, durationTime = 0, onMarkerClick }: Props): JSX.Element | null {
+    if (!durationTime || !comments.length) {
+        return null;
+    }
+
+    // Earliest first → later markers paint on top so same-time stacks cascade
+    // newest-frontmost.
+    const ordered = [...comments].sort((a, b) => a.time - b.time);
+
+    return (
+        <div className="bp-TimelineMarkers" data-testid="bp-TimelineMarkers">
+            {ordered.map((comment, index) => (
+                <TimelineMarker
+                    key={comment.id}
+                    comment={comment}
+                    durationTime={durationTime}
+                    onMarkerClick={onMarkerClick}
+                    zIndex={index + 1}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -7,6 +7,7 @@ import getLanguageName from '../../lang';
 import PreviewError from '../../PreviewError';
 
 import Timer from '../../Timer';
+import TimestampedCommentsAPI from '../../timestampedCommentsAPI';
 import { appendQueryParams, getProp } from '../../util';
 import './Dash.scss';
 import { getVideoFps, isFpsAvailable } from './videoFps';
@@ -78,6 +79,20 @@ class DashViewer extends VideoBaseViewer {
         this.frameStep = this.frameStep.bind(this);
         this.movePlayback = this.movePlayback.bind(this);
         this.updateExperiences = this.updateExperiences.bind(this);
+        this.handleTimestampedCommentClick = this.handleTimestampedCommentClick.bind(this);
+    }
+
+    /**
+     * Pauses the video and forwards the click to host listeners so they can
+     * focus the matching comment in their UI.
+     *
+     * @private
+     * @param {Object} comment - The clicked comment
+     * @return {void}
+     */
+    handleTimestampedCommentClick(comment) {
+        this.pause(undefined, true);
+        this.emit('timestamped_comment_click', comment);
     }
 
     /**
@@ -105,6 +120,11 @@ class DashViewer extends VideoBaseViewer {
         this.wrapperEl.classList.add(CSS_CLASS_DASH);
 
         this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled');
+
+        // Refresh the scrubber's timestamped-comment markers when the host
+        // reports a sidebar-side CRUD change. Refetch returns the canonical
+        // filtered list, so deletes + edit-and-strip-prefix handle themselves.
+        this.addListener('timestamped_comment_changed', () => this.fetchTimestampedComments());
     }
 
     /**
@@ -854,6 +874,8 @@ class DashViewer extends VideoBaseViewer {
             this.loadUI();
         }
 
+        this.fetchTimestampedComments();
+
         if (this.isAutoplayEnabled()) {
             this.autoplay();
         }
@@ -933,6 +955,40 @@ class DashViewer extends VideoBaseViewer {
         this.emit('guide_selected', { guide });
         this.renderUI();
     };
+
+    /**
+     * Fetches the file's timestamped comments and stores them on the viewer
+     * for the scrubber-marker overlay. Fire-and-forget; failures are
+     * swallowed so they never block playback.
+     *
+     * @private
+     * @return {void}
+     */
+    fetchTimestampedComments() {
+        if (!this.isVideoPlayerV2) {
+            return;
+        }
+        const { apiHost, token, sharedLink, sharedLinkPassword } = this.options;
+        const fileId = this.options.file && this.options.file.id;
+        if (!fileId || !token || !apiHost) {
+            return;
+        }
+        const client = new TimestampedCommentsAPI(this.api);
+        client
+            .getTimestampedComments(fileId, { apiHost, token, sharedLink, sharedLinkPassword })
+            .then(timestampedComments => {
+                if (this.isDestroyed()) {
+                    return;
+                }
+                this.timestampedComments = timestampedComments;
+                if (this.useReactControls()) {
+                    this.renderUI();
+                }
+            })
+            .catch(() => {
+                // Swallow — markers are an enhancement, not a hard requirement.
+            });
+    }
 
     /**
      * Loads the film strip
@@ -1321,7 +1377,13 @@ class DashViewer extends VideoBaseViewer {
         }
 
         if (this.isVideoPlayerV2) {
-            this.controls.render(<VideoControlsV2 {...sharedProps} />);
+            this.controls.render(
+                <VideoControlsV2
+                    {...sharedProps}
+                    onTimestampedCommentClick={this.handleTimestampedCommentClick}
+                    timestampedComments={this.timestampedComments}
+                />,
+            );
             return;
         }
 

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -72,11 +72,13 @@ export default function VideoControlsV2({
     onSubtitleChange,
     onSubtitlesToggle,
     onTimeChange,
+    onTimestampedCommentClick,
     onVolumeChange,
     quality,
     rate,
     subtitle,
     subtitles = [],
+    timestampedComments,
     videoAnnotationsEnabled = false,
     volume,
 }: Props): JSX.Element {
@@ -104,6 +106,8 @@ export default function VideoControlsV2({
                 fps={fps}
                 mediaEl={mediaEl}
                 onTimeChange={onTimeChange}
+                onTimestampedCommentClick={onTimestampedCommentClick}
+                timestampedComments={timestampedComments}
             />
             <div className="bp-VideoControlsV2-bar">
                 <div className="bp-VideoControlsV2-group bp-VideoControlsV2-group--left">

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -135,6 +135,13 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.setup();
             expect(dash.videoAnnotationsEnabled).toBe(true);
         });
+
+        test('should refetch timestamped comments when timestamped_comment_changed is emitted', () => {
+            jest.spyOn(dash, 'fetchTimestampedComments').mockImplementation();
+            dash.setup();
+            dash.emit('timestamped_comment_changed', { op: 'created' });
+            expect(dash.fetchTimestampedComments).toBeCalled();
+        });
     });
 
     describe('destroy()', () => {

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -144,6 +144,22 @@ describe('lib/viewers/media/DashViewer', () => {
         });
     });
 
+    describe('handleTimestampedCommentClick()', () => {
+        beforeEach(() => {
+            jest.spyOn(dash, 'pause').mockImplementation();
+            jest.spyOn(dash, 'emit').mockImplementation();
+        });
+
+        test('should pause and emit timestamped_comment_click', () => {
+            const comment = { id: '1' };
+
+            dash.handleTimestampedCommentClick(comment);
+
+            expect(dash.pause).toBeCalledWith(undefined, true);
+            expect(dash.emit).toBeCalledWith('timestamped_comment_click', comment);
+        });
+    });
+
     describe('destroy()', () => {
         test('should remove event listeners on the dash', () => {
             stubs.removeStats = jest.spyOn(dash, 'removeStats');


### PR DESCRIPTION
### Description

Renders avatar markers on the V2 video scrubber for every timestamped comment on the file. Hovering a marker shows a bubble with author, timecode, message body, and relative time. Clicking a marker pauses playback and emits a `timestamped_comment_click` viewer event so the host app can route its sidebar to the matching comment.

The viewer self-fetches its data via a new `TimestampedCommentsAPI` backed by `/2.0/file_activities`. Resolved comments are dropped from the parsed result so the bar mirrors the activity sidebar's filtered view. The viewer also self-listens for a host-emitted `timestamped_comment_changed` event and refetches when fired — letting any sidebar-side create / resolve / delete refresh the markers without the host reaching into BCP internals.

Gated behind the existing `videoPlayerV2.enabled` viewer option.

### Test plan

- [ ] Open a video file that has timestamped comments. Confirm an avatar + tick mark renders on the scrubber at each comment's timestamp; users without an avatar image fall back to initials.
- [ ] Hover a marker. Confirm the bubble shows author, timecode, message, and relative time.
- [ ] Click a marker. Confirm the video pauses and the host-side `timestamped_comment_click` event fires with the matching comment payload.
- [ ] With `videoPlayerV2.enabled` off, confirm no markers render and no extra `/2.0/file_activities` request is made.
- [ ] Emit `timestamped_comment_changed` on the viewer after a sidebar-side create / resolve / delete. Confirm the bar refreshes within one refetch round-trip and a resolved comment's marker disappears.

### Semantic release type

- [x] `feat` - New feature
