### PR TITLE
feat(video): add timeline markers on V2 scrubber

### DIFF
--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -3,7 +3,7 @@ import isFinite from 'lodash/isFinite';
 import noop from 'lodash/noop';
 import { bdlGray65, white } from 'box-ui-elements/es/styles/variables';
 import FilmstripV2 from './FilmstripV2';
-import SliderControl from '../slider';
+import SliderControl, { Marker } from '../slider';
 import './TimeControlsV2.scss';
 
 export type Props = {
@@ -13,7 +13,9 @@ export type Props = {
     filmstripInterval?: number;
     filmstripUrl?: string;
     fps?: number;
+    markers?: Marker[];
     mediaEl?: HTMLVideoElement | null;
+    onMarkerClick?: (id: string) => void;
     onTimeChange: (volume: number) => void;
 };
 
@@ -32,7 +34,9 @@ export default function TimeControlsV2({
     filmstripInterval,
     filmstripUrl,
     fps,
+    markers,
     mediaEl,
+    onMarkerClick,
     onTimeChange,
 }: Props): JSX.Element {
     const [isSliderHovered, setIsSliderHovered] = React.useState(false);
@@ -66,10 +70,12 @@ export default function TimeControlsV2({
             <SliderControl
                 className="bp-TimeControlsV2-slider"
                 data-resin-target="timeScrubber"
+                markers={markers}
                 max={durationValue}
                 min={0}
                 onBlur={noop}
                 onFocus={noop}
+                onMarkerClick={onMarkerClick}
                 onMouseOut={(): void => setIsSliderHovered(false)}
                 onMouseOver={(): void => setIsSliderHovered(true)}
                 onMove={handleMouseMove}

--- a/src/lib/viewers/controls/slider/SliderControl.scss
+++ b/src/lib/viewers/controls/slider/SliderControl.scss
@@ -30,3 +30,39 @@
     margin: auto $bp-SliderControl-track-space; // Center and allow the thumb to fully dock to edge of the track
     background: transparent linear-gradient($white, $white) no-repeat center border-box;
 }
+
+.bp-SliderControl-markers {
+    position: absolute;
+    top: 0;
+    right: $bp-SliderControl-track-space;
+    bottom: 0;
+    left: $bp-SliderControl-track-space;
+    pointer-events: none;
+}
+
+.bp-SliderControl-marker {
+    position: absolute;
+    top: calc(50% - #{$bp-SliderControl-marker-height / 2});
+    width: $bp-SliderControl-marker-width;
+    height: $bp-SliderControl-marker-height;
+    margin-left: -#{$bp-SliderControl-marker-width / 2};
+    background: $white;
+    cursor: pointer;
+    transition: transform 100ms ease-out;
+    pointer-events: auto;
+
+    // Expand the hit target without changing the visible 2px line
+    &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: $bp-SliderControl-marker-hit-width;
+        height: $bp-SliderControl-marker-hit-height;
+        transform: translate(-50%, -50%);
+        content: '';
+    }
+
+    &:hover {
+        transform: scaleX(2);
+    }
+}

--- a/src/lib/viewers/controls/slider/SliderControl.tsx
+++ b/src/lib/viewers/controls/slider/SliderControl.tsx
@@ -6,10 +6,17 @@ import './SliderControl.scss';
 
 export type Ref = HTMLDivElement;
 
+export type Marker = {
+    id: string;
+    value: number;
+};
+
 export type Props = React.HTMLAttributes<Ref> & {
     className?: string;
+    markers?: Marker[];
     max?: number;
     min?: number;
+    onMarkerClick?: (id: string) => void;
     onMove?: (value: number, position: number, width: number) => void;
     onUpdate?: (value: number) => void;
     step?: number;
@@ -20,8 +27,10 @@ export type Props = React.HTMLAttributes<Ref> & {
 
 export default function SliderControl({
     className,
+    markers,
     max = 100,
     min = 0,
+    onMarkerClick,
     onMove = noop,
     onUpdate = noop,
     step = 1,
@@ -139,6 +148,26 @@ export default function SliderControl({
                 data-testid="bp-slider-control-track"
                 style={{ backgroundImage: track }}
             />
+            {markers && max > 0 && (
+                <div className="bp-SliderControl-markers" data-testid="bp-slider-control-markers">
+                    {markers
+                        .filter(({ value: markerValue }) => markerValue >= min && markerValue <= max)
+                        .map(({ id, value: markerValue }) => (
+                            <div
+                                key={id}
+                                className="bp-SliderControl-marker"
+                                data-testid="bp-slider-control-marker"
+                                onClick={(event): void => {
+                                    event.stopPropagation();
+                                    if (onMarkerClick) onMarkerClick(id);
+                                }}
+                                onMouseDown={(event): void => event.stopPropagation()}
+                                role="presentation"
+                                style={{ left: `${(markerValue / max) * 100}%` }}
+                            />
+                        ))}
+                </div>
+            )}
             <div
                 className="bp-SliderControl-thumb"
                 data-testid="bp-slider-control-thumb"

--- a/src/lib/viewers/controls/slider/variables.scss
+++ b/src/lib/viewers/controls/slider/variables.scss
@@ -2,3 +2,7 @@ $bp-SliderControl-thumb-size: 12px;
 $bp-SliderControl-thumb-radius: #{$bp-SliderControl-thumb-size / 2};
 $bp-SliderControl-track-size: 3px;
 $bp-SliderControl-track-space: 3px;
+$bp-SliderControl-marker-width: 2px;
+$bp-SliderControl-marker-height: 9px;
+$bp-SliderControl-marker-hit-width: 12px;
+$bp-SliderControl-marker-hit-height: 16px;

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -1272,6 +1272,9 @@ class DashViewer extends VideoBaseViewer {
             this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission() && this.videoAnnotationsEnabled;
 
         const annotationsEnabled = !!this.annotator && this.videoAnnotationsEnabled;
+        const markers = this.isVideoPlayerV2
+            ? this.timelineMarkers.map(({ id, timestampMs }) => ({ id, value: timestampMs / 1000 }))
+            : undefined;
         const sharedProps = {
             annotationColor: this.annotationModule.getColor(),
             annotationMode: this.annotationControlsFSM.getMode(),
@@ -1292,6 +1295,7 @@ class DashViewer extends VideoBaseViewer {
             isHDSupported: this.hdVideoId !== -1,
             isNarrowVideo: this.isNarrowVideo,
             isPlaying: !this.mediaEl.paused,
+            markers,
             mediaEl: this.mediaEl,
             movePlayback: this.movePlayback,
             onAnnotationColorChange: this.handleAnnotationColorChange,
@@ -1300,6 +1304,7 @@ class DashViewer extends VideoBaseViewer {
             onAudioTrackChange: this.setAudioTrack,
             onAutoplayChange: this.setAutoplay,
             onGuideChange: this.setGuide,
+            onMarkerClick: this.handleTimelineMarkerClick,
             onMuteChange: this.toggleMute,
             onPlayPause: this.handlePlayRequest,
             onQualityChange: this.setQuality,

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -39,6 +39,15 @@ class VideoBaseViewer extends MediaBaseViewer {
     preloader;
 
     /**
+     * Markers shown on the timeline. Hosts (e.g. box-ui-elements) push the list
+     * via a window-level CustomEvent rather than via a method call so the SDK
+     * does not have to expose a viewer reference.
+     *
+     * @property {Array<{id: string, timestampMs: number, type?: string}>}
+     */
+    timelineMarkers = [];
+
+    /**
      * @inheritdoc
      */
     constructor(options) {
@@ -48,6 +57,8 @@ class VideoBaseViewer extends MediaBaseViewer {
         this.handleControlsHide = this.handleControlsHide.bind(this);
         this.handleControlsShow = this.handleControlsShow.bind(this);
         this.handlePlayRequest = this.handlePlayRequest.bind(this);
+        this.handleTimelineMarkerClick = this.handleTimelineMarkerClick.bind(this);
+        this.handleTimelineMarkersUpdateEvent = this.handleTimelineMarkersUpdateEvent.bind(this);
         this.loadeddataHandler = this.loadeddataHandler.bind(this);
         this.pointerHandler = this.pointerHandler.bind(this);
         this.waitingHandler = this.waitingHandler.bind(this);
@@ -63,6 +74,32 @@ class VideoBaseViewer extends MediaBaseViewer {
         this.updateDiscoverabilityResinTag = this.updateDiscoverabilityResinTag.bind(this);
         this.annotationControlsFSM.subscribe(this.applyCursorFtux);
         this.annotationControlsFSM.subscribe(this.updateDiscoverabilityResinTag);
+    }
+
+    /**
+     * Receives marker pushes from any host listening on the window. Stores the
+     * list and re-renders the controls so the scrubber overlay matches.
+     *
+     * @private
+     * @param {CustomEvent} event - { detail: marker[] }
+     * @return {void}
+     */
+    handleTimelineMarkersUpdateEvent(event) {
+        const markers = event && event.detail;
+        this.timelineMarkers = Array.isArray(markers) ? markers : [];
+        this.renderUI();
+    }
+
+    handleTimelineMarkerClick(id) {
+        const marker = this.timelineMarkers.find(m => m.id === id);
+        const detail = {
+            id,
+            timestampMs: marker ? marker.timestampMs : undefined,
+            type: marker ? marker.type : undefined,
+        };
+        if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
+            window.dispatchEvent(new window.CustomEvent('bp:timeline_marker_click', { detail }));
+        }
     }
 
     /**
@@ -108,6 +145,17 @@ class VideoBaseViewer extends MediaBaseViewer {
         if (this.featureEnabled('videoPlayerV2.enabled')) {
             this.wrapperEl.classList.add('bp-media--v2');
             this.mediaContainerEl.classList.add('bp-media-container--v2');
+        }
+
+        // Listen for host-pushed timeline markers. The host (e.g. box-ui-elements)
+        // dispatches `bp:timeline_markers_update` whenever the derived list
+        // changes; we re-broadcast a `bp:timeline_markers_ready` so the host can
+        // replay its current list now that the viewer is ready to receive it.
+        if (typeof window !== 'undefined') {
+            window.addEventListener('bp:timeline_markers_update', this.handleTimelineMarkersUpdateEvent);
+            if (typeof window.CustomEvent === 'function') {
+                window.dispatchEvent(new window.CustomEvent('bp:timeline_markers_ready'));
+            }
         }
 
         this.lowerLights();
@@ -342,6 +390,10 @@ class VideoBaseViewer extends MediaBaseViewer {
         }
 
         this.bufferingSpinnerEl = null;
+
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('bp:timeline_markers_update', this.handleTimelineMarkersUpdateEvent);
+        }
 
         super.destroy();
     }

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -57,6 +57,7 @@ export default function VideoControlsV2({
     isHDSupported,
     isNarrowVideo,
     isPlaying,
+    markers,
     mediaEl,
     movePlayback,
     onAnnotationColorChange,
@@ -65,6 +66,7 @@ export default function VideoControlsV2({
     onAudioTrackChange,
     onAutoplayChange,
     onGuideChange,
+    onMarkerClick,
     onMuteChange,
     onPlayPause,
     onQualityChange,
@@ -102,7 +104,9 @@ export default function VideoControlsV2({
                 filmstripInterval={filmstripInterval}
                 filmstripUrl={filmstripUrl}
                 fps={fps}
+                markers={markers}
                 mediaEl={mediaEl}
+                onMarkerClick={onMarkerClick}
                 onTimeChange={onTimeChange}
             />
             <div className="bp-VideoControlsV2-bar">


### PR DESCRIPTION
## Summary
- Adds host-driven timeline markers on the V2 video scrubber
- Hosts push the marker list via a `bp:timeline_markers_update` window CustomEvent; clicks dispatch `bp:timeline_marker_click` for the host to route
- Viewer is display-only — no fetch, no parsing, no host reference
- Markers render as 2px white lines on the scrubber with a hover hit-target expansion (visual treatment is placeholder; final design TBD)

## Test plan
- [ ] Open a video file with `videoPlayerV2.enabled` on
- [ ] Dispatch `bp:timeline_markers_update` with `{ detail: [{ id, timestampMs, type }, ...] }` from a host or devtools; confirm white lines render at the right scrubber positions
- [ ] Click a marker; confirm `bp:timeline_marker_click` fires with the matching `{ id, timestampMs, type }` payload
- [ ] On viewer setup, confirm `bp:timeline_markers_ready` is dispatched so hosts can replay their cached list
- [ ] Hover a marker; confirm the hit-target expansion makes the click more forgiving without changing the visible 2px line
- [ ] V1 viewers (`videoPlayerV2.enabled` off) — confirm no markers render, no events listened for

🤖 Generated with [Claude Code](https://claude.com/claude-code)