### PR TITLE
feat(video-player-v2): add comment markers to scrubber bar

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -164,6 +164,8 @@ media_guides_ultrawide=Ultrawide
 media_volume_slider=Volume Slider
 # Label for time slider in media player
 media_time_slider=Media Slider
+# Label for comment marker on video scrubber bar
+media_comment_marker=Comment marker
 # Label for Volume button in media player
 media_mute=Mute
 # Label for Volume button in media player

--- a/src/lib/viewers/controls/media/MarkerAvatar.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatar.scss
@@ -1,0 +1,44 @@
+@import '../styles';
+
+.bp-MarkerAvatar {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    overflow: hidden;
+    border: 0;
+    border-radius: 50%;
+    box-shadow: 0 0 0 0 $white;
+    transform: translate(-50%, 0);
+    transform-origin: bottom center;
+    transition: transform 150ms, box-shadow 150ms;
+
+    img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+    }
+}
+
+.bp-MarkerAvatar-initial {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    font-weight: bold;
+    font-size: 7px;
+    line-height: 1;
+    text-align: center;
+    text-transform: uppercase;
+    place-items: center;
+}
+
+.bp-MarkerAvatar-anonymousIcon {
+    width: 100%;
+    height: 100%;
+    color: #222;
+}

--- a/src/lib/viewers/controls/media/MarkerAvatar.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatar.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 import './MarkerAvatar.scss';
 
-const AVATAR_COLORS = [
-    '#7fb0ea',
-    '#003c84',
-    '#ffeb7f',
-    '#92e0c0',
-    '#fad98d',
-    '#91c2fd',
-    '#f69bab',
-    '#cf9ff6',
-    '#f8c08c',
-    '#a392e0',
+const AVATAR_PALETTE: ReadonlyArray<{ bg: string; fg: string }> = [
+    { bg: '#7fb0ea', fg: '#222' },
+    { bg: '#003c84', fg: '#fff' },
+    { bg: '#ffeb7f', fg: '#222' },
+    { bg: '#92e0c0', fg: '#222' },
+    { bg: '#fad98d', fg: '#222' },
+    { bg: '#91c2fd', fg: '#222' },
+    { bg: '#f69bab', fg: '#222' },
+    { bg: '#cf9ff6', fg: '#222' },
+    { bg: '#f8c08c', fg: '#222' },
+    { bg: '#a392e0', fg: '#222' },
 ];
-
-const DARK_COLOR_INDICES = new Set([1]);
 
 export type Props = {
     avatarUrl?: string;
@@ -34,9 +32,7 @@ function AnonymousAvatarIcon(): JSX.Element {
 }
 
 export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial }: Props): JSX.Element {
-    const index = colorIndex % AVATAR_COLORS.length;
-    const bgColor = AVATAR_COLORS[index];
-    const textColor = DARK_COLOR_INDICES.has(index) ? '#fff' : '#222';
+    const { bg: bgColor, fg: textColor } = AVATAR_PALETTE[colorIndex % AVATAR_PALETTE.length];
 
     const [imgFailed, setImgFailed] = React.useState(false);
     const showImage = Boolean(avatarUrl) && !imgFailed;

--- a/src/lib/viewers/controls/media/MarkerAvatar.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatar.tsx
@@ -32,7 +32,8 @@ function AnonymousAvatarIcon(): JSX.Element {
 }
 
 export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial }: Props): JSX.Element {
-    const { bg: bgColor, fg: textColor } = AVATAR_PALETTE[colorIndex % AVATAR_PALETTE.length];
+    const safeIndex = Number.isFinite(colorIndex) ? Math.abs(colorIndex) % AVATAR_PALETTE.length : 0;
+    const { bg: bgColor, fg: textColor } = AVATAR_PALETTE[safeIndex];
 
     const [imgFailed, setImgFailed] = React.useState(false);
     const showImage = Boolean(avatarUrl) && !imgFailed;

--- a/src/lib/viewers/controls/media/MarkerAvatar.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatar.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import './MarkerAvatar.scss';
+
+const AVATAR_COLORS = [
+    '#7fb0ea',
+    '#003c84',
+    '#ffeb7f',
+    '#92e0c0',
+    '#fad98d',
+    '#91c2fd',
+    '#f69bab',
+    '#cf9ff6',
+    '#f8c08c',
+    '#a392e0',
+];
+
+const DARK_COLOR_INDICES = new Set([1]);
+
+export type Props = {
+    avatarUrl?: string;
+    colorIndex?: number;
+    initial?: string;
+};
+
+function AnonymousAvatarIcon(): JSX.Element {
+    return (
+        <svg aria-hidden="true" className="bp-MarkerAvatar-anonymousIcon" focusable="false" viewBox="0 0 16 16">
+            <path
+                d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm0 1.5c-2.5 0-5 1.25-5 3.75V14h10v-.75c0-2.5-2.5-3.75-5-3.75Z"
+                fill="currentColor"
+            />
+        </svg>
+    );
+}
+
+export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial }: Props): JSX.Element {
+    const index = colorIndex % AVATAR_COLORS.length;
+    const bgColor = AVATAR_COLORS[index];
+    const textColor = DARK_COLOR_INDICES.has(index) ? '#fff' : '#222';
+
+    const [imgFailed, setImgFailed] = React.useState(false);
+    const showImage = Boolean(avatarUrl) && !imgFailed;
+
+    let avatar = <AnonymousAvatarIcon />;
+    if (showImage) {
+        avatar = <img alt="" onError={() => setImgFailed(true)} src={avatarUrl} />;
+    } else if (initial) {
+        avatar = (
+            <span className="bp-MarkerAvatar-initial" style={{ color: textColor }}>
+                {initial}
+            </span>
+        );
+    }
+
+    return (
+        <span className="bp-MarkerAvatar" style={!showImage ? { backgroundColor: bgColor } : undefined}>
+            {avatar}
+        </span>
+    );
+}

--- a/src/lib/viewers/controls/media/TimeControlsV2.scss
+++ b/src/lib/viewers/controls/media/TimeControlsV2.scss
@@ -48,12 +48,18 @@
     cursor: pointer;
     transition: transform 150ms;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         transform: translate(-50%, -50%) scale(1.7);
 
         .bp-MarkerAvatar {
             box-shadow: 0 0 0 2px $white;
             transform: translate(-50%, calc(5px / 1.7));
         }
+    }
+
+    &:focus-visible {
+        outline: 2px solid $white;
+        outline-offset: 2px;
     }
 }

--- a/src/lib/viewers/controls/media/TimeControlsV2.scss
+++ b/src/lib/viewers/controls/media/TimeControlsV2.scss
@@ -6,6 +6,10 @@
     margin-left: 10px;
 }
 
+.bp-TimeControlsV2-scrubber {
+    position: relative;
+}
+
 .bp-TimeControlsV2-slider {
     height: 20px;
 
@@ -14,6 +18,7 @@
         margin: auto 0;
         border-radius: 5px;
         backface-visibility: hidden;
+        mask-image: var(--bp-track-mask, none);
     }
 
     .bp-SliderControl-thumb {
@@ -26,5 +31,29 @@
         border-radius: 2px;
         transform: translateY(-50%);
         cursor: ew-resize;
+    }
+}
+
+.bp-TimeControlsV2-marker {
+    position: absolute;
+    top: 50%;
+    z-index: 1;
+    width: 2px;
+    height: 8px;
+    padding: 0;
+    background: $white;
+    border: 0;
+    border-radius: 2px;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    transition: transform 150ms;
+
+    &:hover {
+        transform: translate(-50%, -50%) scale(1.7);
+
+        .bp-MarkerAvatar {
+            box-shadow: 0 0 0 2px $white;
+            transform: translate(-50%, calc(5px / 1.7));
+        }
     }
 }

--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -3,17 +3,29 @@ import isFinite from 'lodash/isFinite';
 import noop from 'lodash/noop';
 import { bdlGray65, white } from 'box-ui-elements/es/styles/variables';
 import FilmstripV2 from './FilmstripV2';
+import MarkerAvatar from './MarkerAvatar';
 import SliderControl from '../slider';
 import './TimeControlsV2.scss';
 
+export type CommentMarker = {
+    avatarUrl?: string;
+    colorIndex?: number;
+    id: string;
+    initial?: string;
+    time: number;
+    type?: 'annotation' | 'comment';
+};
+
 export type Props = {
     aspectRatio?: number;
+    commentMarkers?: CommentMarker[];
     currentTime?: number;
     durationTime?: number;
     filmstripInterval?: number;
     filmstripUrl?: string;
     fps?: number;
     mediaEl?: HTMLVideoElement | null;
+    onCommentMarkerClick?: (marker: CommentMarker) => void;
     onTimeChange: (volume: number) => void;
 };
 
@@ -27,12 +39,14 @@ export const percent = (value1: number, value2: number): number => {
 
 export default function TimeControlsV2({
     aspectRatio,
+    commentMarkers = [],
     currentTime = 0,
     durationTime = 0,
     filmstripInterval,
     filmstripUrl,
     fps,
     mediaEl,
+    onCommentMarkerClick,
     onTimeChange,
 }: Props): JSX.Element {
     const [isSliderHovered, setIsSliderHovered] = React.useState(false);
@@ -42,6 +56,25 @@ export default function TimeControlsV2({
     const currentValue = isFinite(currentTime) ? currentTime : 0;
     const durationValue = isFinite(durationTime) ? durationTime : 0;
     const currentPercentage = percent(currentValue, durationValue);
+
+    const trackMask = React.useMemo(() => {
+        if (durationValue <= 0 || commentMarkers.length === 0) return undefined;
+
+        const HALF_GAP = 2;
+        const stops: string[] = [];
+        const sorted = commentMarkers.map(m => percent(m.time, durationValue)).sort((a, b) => a - b);
+
+        stops.push('black 0%');
+        sorted.forEach(pos => {
+            stops.push(`black calc(${pos}% - ${HALF_GAP}px)`);
+            stops.push(`transparent calc(${pos}% - ${HALF_GAP}px)`);
+            stops.push(`transparent calc(${pos}% + ${HALF_GAP}px)`);
+            stops.push(`black calc(${pos}% + ${HALF_GAP}px)`);
+        });
+        stops.push('black 100%');
+
+        return `linear-gradient(to right, ${stops.join(', ')})`;
+    }, [commentMarkers, durationValue]);
 
     const handleMouseMove = (newTime: number, newPosition: number, width: number): void => {
         setHoverPosition(newPosition);
@@ -63,22 +96,48 @@ export default function TimeControlsV2({
                     time={hoverTime}
                 />
             )}
-            <SliderControl
-                className="bp-TimeControlsV2-slider"
-                data-resin-target="timeScrubber"
-                max={durationValue}
-                min={0}
-                onBlur={noop}
-                onFocus={noop}
-                onMouseOut={(): void => setIsSliderHovered(false)}
-                onMouseOver={(): void => setIsSliderHovered(true)}
-                onMove={handleMouseMove}
-                onUpdate={onTimeChange}
-                step={fps ? 1 / fps : 5}
-                title={__('media_time_slider')}
-                track={`linear-gradient(to right, ${white} calc(${currentPercentage}% - 2.5px), transparent calc(${currentPercentage}% - 2.5px), transparent calc(${currentPercentage}% + 2.5px), ${bdlGray65} calc(${currentPercentage}% + 2.5px), ${bdlGray65} 100%)`}
-                value={currentValue}
-            />
+            <div
+                className="bp-TimeControlsV2-scrubber"
+                style={trackMask ? ({ '--bp-track-mask': trackMask } as React.CSSProperties) : undefined}
+            >
+                <SliderControl
+                    className="bp-TimeControlsV2-slider"
+                    data-resin-target="timeScrubber"
+                    max={durationValue}
+                    min={0}
+                    onBlur={noop}
+                    onFocus={noop}
+                    onMouseOut={(): void => setIsSliderHovered(false)}
+                    onMouseOver={(): void => setIsSliderHovered(true)}
+                    onMove={handleMouseMove}
+                    onUpdate={onTimeChange}
+                    step={fps ? 1 / fps : 5}
+                    title={__('media_time_slider')}
+                    track={`linear-gradient(to right, ${white} calc(${currentPercentage}% - 2.5px), transparent calc(${currentPercentage}% - 2.5px), transparent calc(${currentPercentage}% + 2.5px), ${bdlGray65} calc(${currentPercentage}% + 2.5px), ${bdlGray65} 100%)`}
+                    value={currentValue}
+                />
+                {durationValue > 0 &&
+                    commentMarkers.map(marker => (
+                        <button
+                            key={marker.id}
+                            aria-label={__('media_comment_marker')}
+                            className="bp-TimeControlsV2-marker"
+                            data-testid="bp-time-controls-marker"
+                            onClick={(e): void => {
+                                e.stopPropagation();
+                                onCommentMarkerClick?.(marker);
+                            }}
+                            style={{ left: `${percent(marker.time, durationValue)}%` }}
+                            type="button"
+                        >
+                            <MarkerAvatar
+                                avatarUrl={marker.avatarUrl}
+                                colorIndex={marker.colorIndex}
+                                initial={marker.initial}
+                            />
+                        </button>
+                    ))}
+            </div>
         </div>
     );
 }

--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -57,6 +57,7 @@ export default function TimeControlsV2({
     const durationValue = isFinite(durationTime) ? durationTime : 0;
     const currentPercentage = percent(currentValue, durationValue);
 
+    const markerTimesKey = commentMarkers.map(m => m.time).join('|');
     const trackMask = React.useMemo(() => {
         if (durationValue <= 0 || commentMarkers.length === 0) return undefined;
 
@@ -74,7 +75,8 @@ export default function TimeControlsV2({
         stops.push('black 100%');
 
         return `linear-gradient(to right, ${stops.join(', ')})`;
-    }, [commentMarkers, durationValue]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [markerTimesKey, durationValue]);
 
     const handleMouseMove = (newTime: number, newPosition: number, width: number): void => {
         setHoverPosition(newPosition);

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatar-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatar-test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import MarkerAvatar from '../MarkerAvatar';
+
+describe('MarkerAvatar', () => {
+    describe('with avatarUrl', () => {
+        test('should render an image', () => {
+            const { container } = render(<MarkerAvatar avatarUrl="https://example.com/avatar.jpg" />);
+            const img = container.querySelector('img');
+            expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+        });
+
+        test('should not apply background color when image is showing', () => {
+            const { container } = render(<MarkerAvatar avatarUrl="https://example.com/avatar.jpg" colorIndex={3} />);
+            const avatar = container.querySelector('.bp-MarkerAvatar');
+            expect(avatar).not.toHaveAttribute('style');
+        });
+
+        test('should fall back to initial when image fails to load', () => {
+            const { container } = render(<MarkerAvatar avatarUrl="https://bad-url.com/broken.jpg" initial="J" />);
+            const img = container.querySelector('img')!;
+            fireEvent.error(img);
+            expect(screen.getByText('J')).toBeInTheDocument();
+            expect(container.querySelector('img')).not.toBeInTheDocument();
+        });
+
+        test('should fall back to anonymous icon when image fails and no initial', () => {
+            const { container } = render(<MarkerAvatar avatarUrl="https://bad-url.com/broken.jpg" />);
+            const img = container.querySelector('img')!;
+            fireEvent.error(img);
+            expect(container.querySelector('.bp-MarkerAvatar-anonymousIcon')).toBeInTheDocument();
+        });
+    });
+
+    describe('with initial', () => {
+        test('should render the initial letter', () => {
+            render(<MarkerAvatar initial="A" />);
+            expect(screen.getByText('A')).toBeInTheDocument();
+        });
+
+        test('should apply background color based on colorIndex', () => {
+            const { container } = render(<MarkerAvatar colorIndex={0} initial="B" />);
+            const avatar = container.querySelector('.bp-MarkerAvatar');
+            expect(avatar).toHaveStyle({ backgroundColor: '#7fb0ea' });
+        });
+
+        test('should use dark text color for light backgrounds', () => {
+            const { container } = render(<MarkerAvatar colorIndex={0} initial="C" />);
+            const initialEl = container.querySelector('.bp-MarkerAvatar-initial');
+            expect(initialEl).toHaveStyle({ color: '#222' });
+        });
+
+        test('should use white text color for dark backgrounds', () => {
+            const { container } = render(<MarkerAvatar colorIndex={1} initial="D" />);
+            const initialEl = container.querySelector('.bp-MarkerAvatar-initial');
+            expect(initialEl).toHaveStyle({ color: '#fff' });
+        });
+
+        test('should wrap colorIndex using modulo', () => {
+            const { container } = render(<MarkerAvatar colorIndex={11} initial="E" />);
+            const avatar = container.querySelector('.bp-MarkerAvatar');
+            // 11 % 10 = 1 → #003c84
+            expect(avatar).toHaveStyle({ backgroundColor: '#003c84' });
+        });
+    });
+
+    describe('without avatarUrl or initial', () => {
+        test('should render anonymous avatar icon', () => {
+            const { container } = render(<MarkerAvatar />);
+            expect(container.querySelector('.bp-MarkerAvatar-anonymousIcon')).toBeInTheDocument();
+        });
+
+        test('should apply background color', () => {
+            const { container } = render(<MarkerAvatar colorIndex={5} />);
+            const avatar = container.querySelector('.bp-MarkerAvatar');
+            expect(avatar).toHaveStyle({ backgroundColor: '#91c2fd' });
+        });
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import TimeControlsV2, { CommentMarker } from '../TimeControlsV2';
+
+describe('TimeControlsV2', () => {
+    const defaultProps = {
+        onTimeChange: jest.fn(),
+    };
+
+    describe('comment markers', () => {
+        const markers: CommentMarker[] = [
+            { id: 'marker-1', time: 10, type: 'comment' as const, initial: 'A', colorIndex: 0 },
+            { id: 'marker-2', time: 30, type: 'annotation' as const, initial: 'B', colorIndex: 1 },
+        ];
+
+        test('should not render markers when durationTime is 0', () => {
+            render(<TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={0} />);
+            expect(screen.queryAllByTestId('bp-time-controls-marker')).toHaveLength(0);
+        });
+
+        test('should render markers when durationTime is positive', () => {
+            render(<TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />);
+            expect(screen.getAllByTestId('bp-time-controls-marker')).toHaveLength(2);
+        });
+
+        test('should position markers based on time percentage', () => {
+            render(<TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />);
+            const markerEls = screen.getAllByTestId('bp-time-controls-marker');
+            // 10/60 * 100 = 16.6667%
+            expect(markerEls[0]).toHaveStyle({ left: '16.6667%' });
+            // 30/60 * 100 = 50%
+            expect(markerEls[1]).toHaveStyle({ left: '50%' });
+        });
+
+        test('should call onCommentMarkerClick when a marker is clicked', async () => {
+            const user = userEvent.setup();
+            const onCommentMarkerClick = jest.fn();
+            render(
+                <TimeControlsV2
+                    {...defaultProps}
+                    commentMarkers={markers}
+                    durationTime={60}
+                    onCommentMarkerClick={onCommentMarkerClick}
+                />,
+            );
+
+            const markerEls = screen.getAllByTestId('bp-time-controls-marker');
+            await user.click(markerEls[0]);
+            expect(onCommentMarkerClick).toHaveBeenCalledWith(markers[0]);
+        });
+
+        test('should not render markers when commentMarkers is empty', () => {
+            render(<TimeControlsV2 {...defaultProps} commentMarkers={[]} durationTime={60} />);
+            expect(screen.queryAllByTestId('bp-time-controls-marker')).toHaveLength(0);
+        });
+
+        test('should render MarkerAvatar with correct props', () => {
+            const markersWithAvatar: CommentMarker[] = [
+                { id: 'marker-img', time: 15, avatarUrl: 'https://example.com/pic.jpg', colorIndex: 2 },
+            ];
+            const { container } = render(
+                <TimeControlsV2 {...defaultProps} commentMarkers={markersWithAvatar} durationTime={60} />,
+            );
+            const img = container.querySelector('img');
+            expect(img).toHaveAttribute('src', 'https://example.com/pic.jpg');
+        });
+
+        test('should render MarkerAvatar initial when no avatarUrl', () => {
+            const markersWithInitial: CommentMarker[] = [{ id: 'marker-init', time: 20, initial: 'Z', colorIndex: 4 }];
+            render(<TimeControlsV2 {...defaultProps} commentMarkers={markersWithInitial} durationTime={60} />);
+            expect(screen.getByText('Z')).toBeInTheDocument();
+        });
+    });
+
+    describe('track mask', () => {
+        test('should not set --bp-track-mask when there are no markers', () => {
+            const { container } = render(<TimeControlsV2 {...defaultProps} durationTime={60} />);
+            const scrubber = container.querySelector('.bp-TimeControlsV2-scrubber');
+            expect(scrubber).not.toHaveAttribute('style');
+        });
+
+        test('should set --bp-track-mask CSS variable when markers are present', () => {
+            const markers: CommentMarker[] = [{ id: 'm1', time: 30 }];
+            const { container } = render(
+                <TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />,
+            );
+            const scrubber = container.querySelector('.bp-TimeControlsV2-scrubber');
+            const style = scrubber?.getAttribute('style') ?? '';
+            expect(style).toContain('--bp-track-mask');
+            expect(style).toContain('linear-gradient');
+        });
+    });
+});

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -1323,7 +1323,13 @@ class DashViewer extends VideoBaseViewer {
         }
 
         if (this.isVideoPlayerV2) {
-            this.controls.render(<VideoControlsV2 {...sharedProps} />);
+            this.controls.render(
+                <VideoControlsV2
+                    commentMarkers={this.commentMarkers}
+                    onCommentMarkerClick={this.handleCommentMarkerClick}
+                    {...sharedProps}
+                />,
+            );
             return;
         }
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -407,7 +407,7 @@ class VideoBaseViewer extends MediaBaseViewer {
             onShow: this.handleControlsShow,
         });
         this.addListener('annotator_create', () => this.renderUI());
-        this.addListener('commentmarkers', this.handleCommentMarkersUpdated);
+        this.addListener('comment_markers', this.handleCommentMarkersUpdated);
         this.renderUI();
     }
 
@@ -825,7 +825,7 @@ class VideoBaseViewer extends MediaBaseViewer {
         if (marker.type === 'annotation' && this.annotator) {
             this.annotator.emit('annotations_active_set', marker.id);
         }
-        this.emit('commentmarkerselect', { id: marker.id, time: marker.time });
+        this.emit('comment_marker_select', { id: marker.id, time: marker.time });
         this.renderUI();
     };
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -407,6 +407,7 @@ class VideoBaseViewer extends MediaBaseViewer {
             onShow: this.handleControlsShow,
         });
         this.addListener('annotator_create', () => this.renderUI());
+        this.addListener('commentmarkers', this.handleCommentMarkersUpdated);
         this.renderUI();
     }
 
@@ -776,6 +777,11 @@ class VideoBaseViewer extends MediaBaseViewer {
         }
     }
 
+    handleCommentMarkersUpdated = (markers = []) => {
+        this.commentMarkers = markers;
+        this.renderUI();
+    };
+
     scaleAnnotations(width, height) {
         if (!width && !height) {
             return;
@@ -810,6 +816,17 @@ class VideoBaseViewer extends MediaBaseViewer {
             this.annotator.emit('annotations_active_set', id);
         }
     }
+
+    handleCommentMarkerClick = marker => {
+        if (this.mediaEl) {
+            this.mediaEl.currentTime = marker.time;
+        }
+        if (marker.type === 'annotation' && this.annotator) {
+            this.annotator.emit('annotations_active_set', marker.id);
+        }
+        this.emit('commentmarkerselect', { id: marker.id, time: marker.time });
+        this.renderUI();
+    };
 
     /**
      * Handles the 'scrolltoannotation' event and calls the annotator scroll method

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -819,6 +819,7 @@ class VideoBaseViewer extends MediaBaseViewer {
 
     handleCommentMarkerClick = marker => {
         if (this.mediaEl) {
+            this.mediaEl.pause();
             this.mediaEl.currentTime = marker.time;
         }
         if (marker.type === 'annotation' && this.annotator) {

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -49,6 +49,7 @@ export default function VideoControlsV2({
     audioTrack,
     audioTracks,
     autoplay,
+    commentMarkers,
     currentTime = 0,
     durationTime = 0,
     experiences,
@@ -65,6 +66,7 @@ export default function VideoControlsV2({
     isPlaying,
     mediaEl,
     movePlayback,
+    onCommentMarkerClick,
     onFullscreenToggle,
     onAnnotationColorChange,
     onAnnotationModeClick,
@@ -106,12 +108,14 @@ export default function VideoControlsV2({
                 <VideoFullscreenButton mediaEl={mediaEl} onFullscreenToggle={onFullscreenToggle} />
                 <TimeControlsV2
                     aspectRatio={aspectRatio}
+                    commentMarkers={commentMarkers}
                     currentTime={currentTime}
                     durationTime={durationTime}
                     filmstripInterval={filmstripInterval}
                     filmstripUrl={filmstripUrl}
                     fps={fps}
                     mediaEl={mediaEl}
+                    onCommentMarkerClick={onCommentMarkerClick}
                     onTimeChange={onTimeChange}
                 />
                 <div className="bp-VideoControlsV2-bar">

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1665,6 +1665,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         beforeEach(() => {
             videoBase.mediaEl = {
                 currentTime: 0,
+                pause: jest.fn(),
                 removeEventListener: jest.fn(),
             };
             videoBase.annotator = {
@@ -1674,9 +1675,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             jest.spyOn(videoBase, 'emit');
         });
 
-        test('should seek video to marker time', () => {
+        test('should pause and seek video to marker time', () => {
             videoBase.handleCommentMarkerClick({ id: '1', time: 42, type: 'comment' });
 
+            expect(videoBase.mediaEl.pause).toHaveBeenCalled();
             expect(videoBase.mediaEl.currentTime).toBe(42);
         });
 

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1636,4 +1636,99 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(URL.revokeObjectURL).not.toHaveBeenCalled();
         });
     });
+
+    describe('handleCommentMarkersUpdated', () => {
+        beforeEach(() => {
+            videoBase.renderUI = jest.fn();
+        });
+
+        test('should set commentMarkers and call renderUI', () => {
+            const markers = [
+                { id: '1', time: 5 },
+                { id: '2', time: 10 },
+            ];
+            videoBase.handleCommentMarkersUpdated(markers);
+
+            expect(videoBase.commentMarkers).toBe(markers);
+            expect(videoBase.renderUI).toHaveBeenCalled();
+        });
+
+        test('should default to empty array when called with no argument', () => {
+            videoBase.handleCommentMarkersUpdated();
+
+            expect(videoBase.commentMarkers).toEqual([]);
+            expect(videoBase.renderUI).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleCommentMarkerClick', () => {
+        beforeEach(() => {
+            videoBase.mediaEl = {
+                currentTime: 0,
+                removeEventListener: jest.fn(),
+            };
+            videoBase.annotator = {
+                emit: jest.fn(),
+            };
+            videoBase.renderUI = jest.fn();
+            jest.spyOn(videoBase, 'emit');
+        });
+
+        test('should seek video to marker time', () => {
+            videoBase.handleCommentMarkerClick({ id: '1', time: 42, type: 'comment' });
+
+            expect(videoBase.mediaEl.currentTime).toBe(42);
+        });
+
+        test('should emit commentmarkerselect event', () => {
+            videoBase.handleCommentMarkerClick({ id: '1', time: 42, type: 'comment' });
+
+            expect(videoBase.emit).toHaveBeenCalledWith('commentmarkerselect', { id: '1', time: 42 });
+        });
+
+        test('should call renderUI', () => {
+            videoBase.handleCommentMarkerClick({ id: '1', time: 42, type: 'comment' });
+
+            expect(videoBase.renderUI).toHaveBeenCalled();
+        });
+
+        test('should activate annotation when marker type is annotation', () => {
+            videoBase.handleCommentMarkerClick({ id: 'ann-1', time: 15, type: 'annotation' });
+
+            expect(videoBase.annotator.emit).toHaveBeenCalledWith('annotations_active_set', 'ann-1');
+        });
+
+        test('should not activate annotation when marker type is comment', () => {
+            videoBase.handleCommentMarkerClick({ id: '1', time: 15, type: 'comment' });
+
+            expect(videoBase.annotator.emit).not.toHaveBeenCalled();
+        });
+
+        test('should not fail if annotator is missing for annotation type', () => {
+            videoBase.annotator = null;
+
+            expect(() =>
+                videoBase.handleCommentMarkerClick({ id: 'ann-1', time: 15, type: 'annotation' }),
+            ).not.toThrow();
+        });
+
+        test('should not fail if mediaEl is missing', () => {
+            videoBase.mediaEl = null;
+
+            expect(() => videoBase.handleCommentMarkerClick({ id: '1', time: 10, type: 'comment' })).not.toThrow();
+            expect(videoBase.emit).toHaveBeenCalledWith('commentmarkerselect', { id: '1', time: 10 });
+        });
+    });
+
+    describe('commentmarkers event listener', () => {
+        test('should register commentmarkers listener during loadUIReact', () => {
+            videoBase.addListener = jest.fn();
+            videoBase.featureEnabled = jest.fn().mockReturnValue(false);
+            videoBase.mediaContainerEl = document.createElement('div');
+
+            videoBase.loadUIReact();
+
+            expect(videoBase.addListener).toHaveBeenCalledWith('commentmarkers', videoBase.handleCommentMarkersUpdated);
+        });
+    });
 });

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1682,10 +1682,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.mediaEl.currentTime).toBe(42);
         });
 
-        test('should emit commentmarkerselect event', () => {
+        test('should emit comment_marker_select event', () => {
             videoBase.handleCommentMarkerClick({ id: '1', time: 42, type: 'comment' });
 
-            expect(videoBase.emit).toHaveBeenCalledWith('commentmarkerselect', { id: '1', time: 42 });
+            expect(videoBase.emit).toHaveBeenCalledWith('comment_marker_select', { id: '1', time: 42 });
         });
 
         test('should call renderUI', () => {
@@ -1718,19 +1718,22 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.mediaEl = null;
 
             expect(() => videoBase.handleCommentMarkerClick({ id: '1', time: 10, type: 'comment' })).not.toThrow();
-            expect(videoBase.emit).toHaveBeenCalledWith('commentmarkerselect', { id: '1', time: 10 });
+            expect(videoBase.emit).toHaveBeenCalledWith('comment_marker_select', { id: '1', time: 10 });
         });
     });
 
-    describe('commentmarkers event listener', () => {
-        test('should register commentmarkers listener during loadUIReact', () => {
+    describe('comment_markers event listener', () => {
+        test('should register comment_markers listener during loadUIReact', () => {
             videoBase.addListener = jest.fn();
             videoBase.featureEnabled = jest.fn().mockReturnValue(false);
             videoBase.mediaContainerEl = document.createElement('div');
 
             videoBase.loadUIReact();
 
-            expect(videoBase.addListener).toHaveBeenCalledWith('commentmarkers', videoBase.handleCommentMarkersUpdated);
+            expect(videoBase.addListener).toHaveBeenCalledWith(
+                'comment_markers',
+                videoBase.handleCommentMarkersUpdated,
+            );
         });
     });
 });


### PR DESCRIPTION
## Summary
- Adds comment markers to the V2 video scrubber bar that display timestamped comments and annotations as interactive markers
- Each marker shows the author's avatar (with profile picture or color-coded initial fallback) positioned above a white tick on the scrubber bar
  - Clicking a marker seeks the video to that timestamp, activates the annotation overlay (for annotation-type markers), and emits a `commentmarkerselect` event so the sidebar can scroll
  to the corresponding item
- The scrubber track uses a CSS mask to punch transparent gaps around each marker for a clean visual separation
- Introduces a `commentmarkers` inbound event on the viewer that the host app (BUIE) emits whenever feed items change

## New files
- `MarkerAvatar.tsx` / `MarkerAvatar.scss` — Avatar component for markers with image, color-coded initial, or anonymous icon fallback
- `TimeControlsV2-test.tsx` — Unit tests for marker rendering, positioning, and click behavior
- `MarkerAvatar-test.tsx` — Unit tests for avatar states and color logic

## Modified files
- `TimeControlsV2.tsx` — Added `CommentMarker` type, marker rendering, track mask computation
- `TimeControlsV2.scss` — Marker styles, track mask application, hover effects
- `VideoControlsV2.tsx` — Threads `commentMarkers` and `onCommentMarkerClick` props
- `VideoBaseViewer.js` — `commentmarkers` event listener, `handleCommentMarkerClick` with annotator activation
- `DashViewer.js` — Passes marker props to V2 controls
- `VideoBaseViewer-test.js` — Tests for new handler methods

  ## Test plan
  - [ ] Load a video with timestamped comments and annotations in the activity sidebar
  - [ ] Verify markers appear at correct positions on the scrubber bar
  - [ ] Verify each marker shows the correct avatar (image or initial with matching color)
  - [ ] Click a comment marker — video seeks to timestamp, sidebar scrolls to comment
  - [ ] Click an annotation marker — video seeks, annotation overlay appears, sidebar scrolls
  - [ ] Create a new timestamped comment — verify a new marker appears
  - [ ] Delete a comment/annotation — verify the marker disappears
  - [ ] Hover over markers — verify tick scales and avatar expands with white border
  - [ ] Verify markers don't appear for non-video files
