### PR TITLE
fix(file): cache-bust authenticated content URL per request

### DIFF
--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -239,7 +239,6 @@ describe('lib/file', () => {
 
             cacheFile(cache, file);
 
-            // Stamp is unconditional; createContentUrl() re-resolves it per request only when the flag is on.
             expect(file.representations.entries[0].content.url_template).toContain('_cache_buster=');
         });
 

--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -239,8 +239,7 @@ describe('lib/file', () => {
 
             cacheFile(cache, file);
 
-            // The value here is a fallback that createContentUrl() re-resolves to a fresh
-            // timestamp at request time; we only assert the _cache_buster param is present.
+            // Stamp is unconditional; createContentUrl() re-resolves it per request only when the flag is on.
             expect(file.representations.entries[0].content.url_template).toContain('_cache_buster=');
         });
 

--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -228,7 +228,7 @@ describe('lib/file', () => {
             expect(file.representations.entries[0].content.url_template).toContain('version=123');
         });
 
-        test('should tag the original rep content URL with a _bcs cache-buster param', () => {
+        test('should tag the original rep content URL with a _cache_buster param', () => {
             const file = {
                 id: '0',
                 authenticated_download_url: 'https://dl.boxcloud.com/content',
@@ -240,8 +240,8 @@ describe('lib/file', () => {
             cacheFile(cache, file);
 
             // The value here is a fallback that createContentUrl() re-resolves to a fresh
-            // timestamp at request time; we only assert the _bcs param is present.
-            expect(file.representations.entries[0].content.url_template).toContain('_bcs=');
+            // timestamp at request time; we only assert the _cache_buster param is present.
+            expect(file.representations.entries[0].content.url_template).toContain('_cache_buster=');
         });
 
         test('should additionally cache file by file version ID if file version exists on file', () => {

--- a/src/lib/__tests__/file-test.js
+++ b/src/lib/__tests__/file-test.js
@@ -228,6 +228,22 @@ describe('lib/file', () => {
             expect(file.representations.entries[0].content.url_template).toContain('version=123');
         });
 
+        test('should tag the original rep content URL with a _bcs cache-buster param', () => {
+            const file = {
+                id: '0',
+                authenticated_download_url: 'https://dl.boxcloud.com/content',
+                representations: {
+                    entries: [],
+                },
+            };
+
+            cacheFile(cache, file);
+
+            // The value here is a fallback that createContentUrl() re-resolves to a fresh
+            // timestamp at request time; we only assert the _bcs param is present.
+            expect(file.representations.entries[0].content.url_template).toContain('_bcs=');
+        });
+
         test('should additionally cache file by file version ID if file version exists on file', () => {
             const file = {
                 id: '123',

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -242,15 +242,23 @@ describe('lib/util', () => {
             expect(util.createContentUrl('https://dl6.boxcloud.com', 'bar')).toBe('https://dl.boxcloud.com');
         });
 
-        test('should resolve the _cache_buster marker to a fresh value at request time', () => {
+        test('should resolve the _cache_buster marker to a fresh value at request time when enabled', () => {
             jest.spyOn(Date, 'now').mockReturnValue(0);
             expect(
-                util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9'),
+                util.createContentUrl(
+                    'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9',
+                    null,
+                    true,
+                ),
             ).toBe('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9');
 
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
             expect(
-                util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9'),
+                util.createContentUrl(
+                    'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9',
+                    null,
+                    true,
+                ),
             ).toBe('https://dl.boxcloud.com/content?preview=true&_cache_buster=zzz&version=9');
         });
 
@@ -260,22 +268,29 @@ describe('lib/util', () => {
             jest.spyOn(Date, 'now')
                 .mockReturnValueOnce(1)
                 .mockReturnValueOnce(2);
-            const first = util.createContentUrl(template);
-            const second = util.createContentUrl(template);
+            const first = util.createContentUrl(template, null, true);
+            const second = util.createContentUrl(template, null, true);
 
             expect(first).not.toBe(second);
         });
 
+        test('should leave the _cache_buster marker frozen when resolveCacheBuster is not set', () => {
+            jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
+            const template = 'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9';
+            // Flag off: the in-URL rotating token is the cache-buster, so the marker stays frozen.
+            expect(util.createContentUrl(template)).toBe(template);
+        });
+
         test('should leave urls without a _cache_buster marker untouched', () => {
             const url = 'https://dl.boxcloud.com/content?preview=true&version=9';
-            expect(util.createContentUrl(url)).toBe(url);
+            expect(util.createContentUrl(url, null, true)).toBe(url);
         });
 
         test('should resolve _cache_buster when it is the first query param', () => {
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('abc', 36));
-            expect(util.createContentUrl('https://dl.boxcloud.com/content?_cache_buster=0&preview=true')).toBe(
-                'https://dl.boxcloud.com/content?_cache_buster=abc&preview=true',
-            );
+            expect(
+                util.createContentUrl('https://dl.boxcloud.com/content?_cache_buster=0&preview=true', null, true),
+            ).toBe('https://dl.boxcloud.com/content?_cache_buster=abc&preview=true');
         });
     });
 

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -243,15 +243,6 @@ describe('lib/util', () => {
         });
 
         test('should resolve the _cache_buster marker to a fresh value at request time when enabled', () => {
-            jest.spyOn(Date, 'now').mockReturnValue(0);
-            expect(
-                util.createContentUrl(
-                    'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9',
-                    null,
-                    true,
-                ),
-            ).toBe('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9');
-
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
             expect(
                 util.createContentUrl(
@@ -274,7 +265,7 @@ describe('lib/util', () => {
             expect(first).not.toBe(second);
         });
 
-        test('should leave the _cache_buster marker frozen when resolveCacheBuster is not set', () => {
+        test('should leave the _cache_buster marker frozen when disabled', () => {
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
             const template = 'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9';
             // Flag off: the in-URL rotating token is the cache-buster, so the marker stays frozen.

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -268,7 +268,6 @@ describe('lib/util', () => {
         test('should leave the _cache_buster marker frozen when disabled', () => {
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
             const template = 'https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9';
-            // Flag off: the in-URL rotating token is the cache-buster, so the marker stays frozen.
             expect(util.createContentUrl(template)).toBe(template);
         });
 

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -241,6 +241,42 @@ describe('lib/util', () => {
             DownloadReachability.isDownloadHostBlocked.mockReturnValue(true);
             expect(util.createContentUrl('https://dl6.boxcloud.com', 'bar')).toBe('https://dl.boxcloud.com');
         });
+
+        test('should resolve the _bcs cache-buster marker to a fresh value at request time', () => {
+            jest.spyOn(Date, 'now').mockReturnValue(0);
+            expect(util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9')).toBe(
+                'https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9',
+            );
+
+            jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
+            expect(util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9')).toBe(
+                'https://dl.boxcloud.com/content?preview=true&_bcs=zzz&version=9',
+            );
+        });
+
+        test('should produce a different _bcs on each call so every request is a unique cache key', () => {
+            const template = 'https://dl.boxcloud.com/content?preview=true&_bcs=0';
+
+            jest.spyOn(Date, 'now')
+                .mockReturnValueOnce(1)
+                .mockReturnValueOnce(2);
+            const first = util.createContentUrl(template);
+            const second = util.createContentUrl(template);
+
+            expect(first).not.toBe(second);
+        });
+
+        test('should leave urls without a _bcs marker untouched', () => {
+            const url = 'https://dl.boxcloud.com/content?preview=true&version=9';
+            expect(util.createContentUrl(url)).toBe(url);
+        });
+
+        test('should resolve _bcs when it is the first query param', () => {
+            jest.spyOn(Date, 'now').mockReturnValue(parseInt('abc', 36));
+            expect(util.createContentUrl('https://dl.boxcloud.com/content?_bcs=0&preview=true')).toBe(
+                'https://dl.boxcloud.com/content?_bcs=abc&preview=true',
+            );
+        });
     });
 
     describe('createAssetUrlCreator()', () => {

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -242,20 +242,20 @@ describe('lib/util', () => {
             expect(util.createContentUrl('https://dl6.boxcloud.com', 'bar')).toBe('https://dl.boxcloud.com');
         });
 
-        test('should resolve the _bcs cache-buster marker to a fresh value at request time', () => {
+        test('should resolve the _cache_buster marker to a fresh value at request time', () => {
             jest.spyOn(Date, 'now').mockReturnValue(0);
-            expect(util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9')).toBe(
-                'https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9',
-            );
+            expect(
+                util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9'),
+            ).toBe('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9');
 
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('zzz', 36));
-            expect(util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_bcs=0&version=9')).toBe(
-                'https://dl.boxcloud.com/content?preview=true&_bcs=zzz&version=9',
-            );
+            expect(
+                util.createContentUrl('https://dl.boxcloud.com/content?preview=true&_cache_buster=0&version=9'),
+            ).toBe('https://dl.boxcloud.com/content?preview=true&_cache_buster=zzz&version=9');
         });
 
-        test('should produce a different _bcs on each call so every request is a unique cache key', () => {
-            const template = 'https://dl.boxcloud.com/content?preview=true&_bcs=0';
+        test('should produce a different _cache_buster on each call so every request is a unique cache key', () => {
+            const template = 'https://dl.boxcloud.com/content?preview=true&_cache_buster=0';
 
             jest.spyOn(Date, 'now')
                 .mockReturnValueOnce(1)
@@ -266,15 +266,15 @@ describe('lib/util', () => {
             expect(first).not.toBe(second);
         });
 
-        test('should leave urls without a _bcs marker untouched', () => {
+        test('should leave urls without a _cache_buster marker untouched', () => {
             const url = 'https://dl.boxcloud.com/content?preview=true&version=9';
             expect(util.createContentUrl(url)).toBe(url);
         });
 
-        test('should resolve _bcs when it is the first query param', () => {
+        test('should resolve _cache_buster when it is the first query param', () => {
             jest.spyOn(Date, 'now').mockReturnValue(parseInt('abc', 36));
-            expect(util.createContentUrl('https://dl.boxcloud.com/content?_bcs=0&preview=true')).toBe(
-                'https://dl.boxcloud.com/content?_bcs=abc&preview=true',
+            expect(util.createContentUrl('https://dl.boxcloud.com/content?_cache_buster=0&preview=true')).toBe(
+                'https://dl.boxcloud.com/content?_cache_buster=abc&preview=true',
             );
         });
     });

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -149,11 +149,9 @@ function addOriginalRepresentation(file) {
 
     const queryParams = {
         preview: 'true',
-        // The /content?preview=true response is a 302 with a long-lived Cache-Control
-        // and a short-lived signed URL in the Location header. Once the signed URL
-        // expires, the browser can still replay the cached redirect on re-open and
-        // follow it to a dead URL. A unique query param per call forces the browser
-        // disk cache to miss, so each open fetches a fresh redirect with a fresh URL.
+        // Cache-buster so a cached 302 redirect isn't replayed after its signed URL
+        // expires. Re-resolved to a fresh value per request in createContentUrl(); the
+        // value here is a fallback for any path that skips createContentUrl().
         _bcs: Date.now().toString(36),
     };
 

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -149,6 +149,12 @@ function addOriginalRepresentation(file) {
 
     const queryParams = {
         preview: 'true',
+        // The /content?preview=true response is a 302 with a long-lived Cache-Control
+        // and a short-lived signed URL in the Location header. Once the signed URL
+        // expires, the browser can still replay the cached redirect on re-open and
+        // follow it to a dead URL. A unique query param per call forces the browser
+        // disk cache to miss, so each open fetches a fresh redirect with a fresh URL.
+        _bcs: Date.now().toString(36),
     };
 
     if (file.file_version) {

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -152,7 +152,7 @@ function addOriginalRepresentation(file) {
         // Cache-buster so a cached 302 redirect isn't replayed after its signed URL
         // expires. Re-resolved to a fresh value per request in createContentUrl(); the
         // value here is a fallback for any path that skips createContentUrl().
-        _bcs: Date.now().toString(36),
+        _cache_buster: Date.now().toString(36),
     };
 
     if (file.file_version) {

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -149,9 +149,8 @@ function addOriginalRepresentation(file) {
 
     const queryParams = {
         preview: 'true',
-        // Cache-buster so a cached 302 redirect isn't replayed after its signed URL
-        // expires. Re-resolved to a fresh value per request in createContentUrl(); the
-        // value here is a fallback for any path that skips createContentUrl().
+        // Cache-buster marker; createContentUrl() re-resolves it per request when auth is
+        // header-based. Stamped unconditionally since the file is cached before that flag is known.
         _cache_buster: Date.now().toString(36),
     };
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -293,7 +293,6 @@ export function createContentUrl(template, asset, resolveCacheBuster = false) {
         return url;
     }
 
-    // Fresh value per request so a cached file object can't replay a stale URL key.
     return url.replace(/([?&]_cache_buster=)[^&]*/, `$1${Date.now().toString(36)}`);
 }
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -284,9 +284,11 @@ export function createContentUrl(template, asset) {
         // eslint-disable-next-line
         template = DownloadReachability.replaceDownloadHostWithDefault(template);
     }
-    // Re-resolve the _bcs cache-buster per request so a cached file object can't reuse
-    // a stale URL key, keeping every content fetch a unique disk-cache key.
-    return template.replace('{+asset_path}', asset || '').replace(/([?&]_bcs=)[^&]*/, `$1${Date.now().toString(36)}`);
+    // Re-resolve the _cache_buster per request so a cached file object can't reuse a
+    // stale URL key, keeping every content fetch a unique disk-cache key.
+    return template
+        .replace('{+asset_path}', asset || '')
+        .replace(/([?&]_cache_buster=)[^&]*/, `$1${Date.now().toString(36)}`);
 }
 
 /**

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -284,7 +284,9 @@ export function createContentUrl(template, asset) {
         // eslint-disable-next-line
         template = DownloadReachability.replaceDownloadHostWithDefault(template);
     }
-    return template.replace('{+asset_path}', asset || '');
+    // Re-resolve the _bcs cache-buster per request so a cached file object can't reuse
+    // a stale URL key, keeping every content fetch a unique disk-cache key.
+    return template.replace('{+asset_path}', asset || '').replace(/([?&]_bcs=)[^&]*/, `$1${Date.now().toString(36)}`);
 }
 
 /**

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -277,18 +277,24 @@ export function appendAuthParamsV2(url, sharedLink = '', password = '') {
  * @public
  * @param {string} template - URL template to attach param to
  * @param {string|void} [asset] - Optional asset name needed to access file
+ * @param {boolean} [resolveCacheBuster] - Re-resolve the _cache_buster marker per request
+ * (needed only when auth is header-based; the in-URL token otherwise varies the cache key).
  * @return {string} Content url
  */
-export function createContentUrl(template, asset) {
+export function createContentUrl(template, asset, resolveCacheBuster = false) {
     if (DownloadReachability.isDownloadHostBlocked()) {
         // eslint-disable-next-line
         template = DownloadReachability.replaceDownloadHostWithDefault(template);
     }
-    // Re-resolve the _cache_buster per request so a cached file object can't reuse a
-    // stale URL key, keeping every content fetch a unique disk-cache key.
-    return template
-        .replace('{+asset_path}', asset || '')
-        .replace(/([?&]_cache_buster=)[^&]*/, `$1${Date.now().toString(36)}`);
+
+    const url = template.replace('{+asset_path}', asset || '');
+
+    if (!resolveCacheBuster) {
+        return url;
+    }
+
+    // Fresh value per request so a cached file object can't replay a stale URL key.
+    return url.replace(/([?&]_cache_buster=)[^&]*/, `$1${Date.now().toString(36)}`);
 }
 
 /**

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -474,9 +474,13 @@ class BaseViewer extends EventEmitter {
             template = this.api.reachability.constructor.replaceDownloadHostWithDefault(template);
         }
 
+        // Cache-buster only needed when auth is header-based; the in-URL token otherwise
+        // varies the cache key on its own.
+        const resolveCacheBuster = this.featureEnabled('migrateAccessTokenToHeader');
+
         // Append optional query params
         const { queryParams } = this.options;
-        return appendQueryParams(createContentUrl(template, asset), queryParams);
+        return appendQueryParams(createContentUrl(template, asset, resolveCacheBuster), queryParams);
     }
 
     /**

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -358,7 +358,20 @@ describe('lib/viewers/BaseViewer', () => {
 
             const result = base.createContentUrl(url, '');
             expect(result).toBe('url');
-            expect(util.createContentUrl).toBeCalledWith(url, '');
+            expect(util.createContentUrl).toBeCalledWith(url, '', false);
+        });
+
+        test('should resolve the cache-buster only when migrateAccessTokenToHeader is enabled', () => {
+            const url = 'url{+asset_path}';
+            jest.spyOn(util, 'createContentUrl');
+
+            base.options.features = {};
+            base.createContentUrl(url, '');
+            expect(util.createContentUrl).toBeCalledWith(url, '', false);
+
+            base.options.features = { migrateAccessTokenToHeader: true };
+            base.createContentUrl(url, '');
+            expect(util.createContentUrl).toBeCalledWith(url, '', true);
         });
 
         test('should return content url with asset path from args', () => {
@@ -375,7 +388,7 @@ describe('lib/viewers/BaseViewer', () => {
             jest.spyOn(util, 'createContentUrl');
             const result = base.createContentUrl(url, 'bar');
             expect(result).toBe('urlbar');
-            expect(util.createContentUrl).toBeCalledWith(url, 'bar');
+            expect(util.createContentUrl).toBeCalledWith(url, 'bar', false);
         });
 
         test('should fallback to the default host if we have retried', () => {
@@ -394,7 +407,7 @@ describe('lib/viewers/BaseViewer', () => {
             jest.spyOn(base, 'appendAuthParams').mockReturnValue('bar');
             const result = base.createContentUrlWithAuthParams('boo', 'hoo');
             expect(result).toBe('bar');
-            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo');
+            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo', false);
             expect(base.appendAuthParams).toBeCalledWith('foo');
         });
     });
@@ -407,7 +420,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.options.sharedLinkPassword = 'pass';
             const result = base.createContentUrlV2('boo', 'hoo');
             expect(result).toBe('bar');
-            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo');
+            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo', false);
             expect(util.appendAuthParamsV2).toBeCalledWith('foo', 'https://app.box.com/s/HASH', 'pass');
         });
     });


### PR DESCRIPTION
### Description

Browser disk cache can replay a cached 302 redirect long after the signed URL inside the `Location` header expires. When a viewer re-fetches the authenticated content URL, the cached redirect points at a dead signed URL and the preview fails to load.

The fix gives content fetches a unique disk-cache key via a `_cache_buster` query parameter, resolved **at request time** rather than stamped once:

- `addOriginalRepresentation` (`file.js`) tags the synthesized `authenticated_download_url` with a `_cache_buster` marker. It's stamped unconditionally because the file object is cached before the viewer (and its feature flags) is known.
- `createContentUrl` (`util.js`) re-resolves `_cache_buster` to a fresh value per request, but only when its caller asks for it.
- `BaseViewer.createContentUrl` asks for re-resolution only when `migrateAccessTokenToHeader` is enabled.

The gate matters because the rotating in-URL `access_token` already varies the disk-cache key on its own. When `migrateAccessTokenToHeader` is off, the token stays in the URL and does that job, so the marker is left frozen. When the flag is on, the token moves to the `Authorization` header and the URL loses its only varying component — that's the configuration where the stale-302 replay was actually observed, and where `_cache_buster` takes over.

Resolving at request time (rather than freezing one value into the cached file object) is what makes this hold across in-SPA navigation: a value stamped once gets replayed unchanged on file -> folder -> same-file reopen, so the key never changes and the stale 302 comes back. Re-resolving in `createContentUrl` keeps every actual fetch a unique key regardless of how the file object is cached or reused.

The fix lives at the URL-construction chokepoint (`createContentUrl`), so it covers all viewers that build content URLs through it (PDF, SVG, GIF, MP3, SWF, HTML, XML), including native-tag viewers where request-header workarounds aren't an option.

### Verification

Captured customer HAR files for this incident show every failing `/content?preview=true` request carried `access_token=false` in the URL — i.e. `migrateAccessTokenToHeader` was on in 100% of observed failures, which is what scopes the fix to that flag.

Verified on devpod against the previously-failing in-SPA navigation flow with the flag on:

- Each `/content?preview=true` request carries a distinct `_cache_buster` value across reopens of the same file.
- After idling past the signed-URL TTL, reopening a file (gif, mp3, pdf) issues a fresh `302` and renders correctly.

### Test plan

- [ ] With `migrateAccessTokenToHeader` enabled, open a file in a viewer that uses the original representation (e.g., PDF, SVG)
- [ ] Confirm the `/content` request URL includes a `_cache_buster=` query parameter and no `access_token`
- [ ] Navigate away within the app and reopen the same file; confirm `_cache_buster` changes between opens
- [ ] Leave the tab idle past the signed-URL TTL, reopen the file, confirm it renders
- [ ] With the flag off, confirm the `access_token` stays in the URL and `_cache_buster` does not rotate

### Changes

code 22% · tests 78%
