### PR TITLE
refactor(gallery): extract GalleryController from DocBaseViewer

### DIFF
--- a/src/lib/featureChecking.ts
+++ b/src/lib/featureChecking.ts
@@ -1,10 +1,10 @@
 import get from 'lodash/get';
 
-type FeatureOptions = {
+export type FeatureOptions = {
     [key: string]: NonNullable<unknown>;
 };
 
-type FeatureConfig = {
+export type FeatureConfig = {
     [key: string]: FeatureOptions;
 };
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { createRoot } from 'react-dom/client';
 import throttle from 'lodash/throttle';
 import BaseViewer from '../BaseViewer';
 import Browser from '../../Browser';
 import ControlsRoot from '../controls/controls-root';
 import DocControls from './DocControls';
 import DocFindBar from './DocFindBar';
-import GalleryGrid from '../gallery/GalleryGrid';
+import GalleryController from '../gallery/GalleryController';
 import PageTracker from '../../PageTracker';
 import Popup from '../../Popup';
 import PreviewError from '../../PreviewError';
@@ -98,7 +97,6 @@ const RANGE_CHUNK_SIZE_US = 1048576; // 1MB
 const RANGE_REQUEST_MINIMUM_SIZE = 26214400; // 25MB
 const SAFARI_PRINT_TIMEOUT_MS = 1000; // Wait 1s before trying to print
 const SCROLL_EVENT_THROTTLE_INTERVAL = 200;
-const GALLERY_MAX_PAGES = 200; // Hide gallery toggle for files above this page count, will increase in V2
 const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // 301ms
 const THUMBNAILS_SIDEBAR_TOGGLED_MAP_KEY = 'doc-thumbnails-toggled-map';
 
@@ -124,23 +122,8 @@ class DocBaseViewer extends BaseViewer {
     /** @property {Thumbnail} - Thumbnail reference */
     advancedInsightsThumbs;
 
-    /** @property {number} - Page focused in gallery via Tab */
-    galleryFocusedPage = null;
-
-    /** @property {number} - Pending setTimeout ID for delayed gallery mount */
-    galleryMountTimeoutId = null;
-
-    /** @property {number} - Pending setTimeout ID for delayed sidebar setCurrentPage after gallery exit */
-    gallerySidebarTimeoutId = null;
-
-    /** @property {Thumbnail} - Dedicated gallery thumbnail instance (persists between opens) */
-    galleryThumbnail;
-
-    /** @property {boolean} - Whether gallery mode is active */
-    isGalleryOpen = false;
-
-    /** @property {boolean} - Whether sidebar was open before entering gallery */
-    sidebarWasOpen = false;
+    /** @property {GalleryController} - Owns gallery-view state, lifecycle, and toolbar gating */
+    galleryController;
 
     /** @property {PageTracker} - PageTracker instance */
     pageTracker;
@@ -174,7 +157,6 @@ class DocBaseViewer extends BaseViewer {
         this.handleAnnotationCreateEvent = this.handleAnnotationCreateEvent.bind(this);
         this.handleAnnotationCreatorChangeEvent = this.handleAnnotationCreatorChangeEvent.bind(this);
         this.handleDocElKeydown = this.handleDocElKeydown.bind(this);
-        this.handleGalleryNavigate = this.handleGalleryNavigate.bind(this);
         this.handlePageSubmit = this.handlePageSubmit.bind(this);
         this.onThumbnailSelectHandler = this.onThumbnailSelectHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
@@ -189,7 +171,6 @@ class DocBaseViewer extends BaseViewer {
         this.setPage = this.setPage.bind(this);
         this.throttledScrollHandler = this.getScrollHandler().bind(this);
         this.toggleFindBar = this.toggleFindBar.bind(this);
-        this.toggleGallery = this.toggleGallery.bind(this);
         this.toggleThumbnails = this.toggleThumbnails.bind(this);
         this.updateExperiences = this.updateExperiences.bind(this);
         this.updateDiscoverabilityResinTag = this.updateDiscoverabilityResinTag.bind(this);
@@ -253,6 +234,17 @@ class DocBaseViewer extends BaseViewer {
         if (isFeatureEnabled(this.options.features, 'advancedContentInsights.enabled')) {
             this.pageTracker = new PageTracker(advancedContentInsightsConfig, this.options.file);
         }
+
+        this.galleryController = new GalleryController({
+            containerEl: this.containerEl,
+            features: this.options.features,
+            getPdfViewer: () => this.pdfViewer,
+            getPreloader: () => this.preloader,
+            getThumbnailsSidebar: () => this.thumbnailsSidebar,
+            setPage: n => this.setPage(n),
+            toggleThumbnails: () => this.toggleThumbnails(),
+            requestUiUpdate: () => this.renderUI(),
+        });
     }
 
     /**
@@ -280,29 +272,9 @@ class DocBaseViewer extends BaseViewer {
             this.findBar.destroy();
         }
 
-        // Cancel any pending gallery setTimeouts so they don't fire after teardown
-        if (this.galleryMountTimeoutId !== null) {
-            clearTimeout(this.galleryMountTimeoutId);
-            this.galleryMountTimeoutId = null;
-        }
-        if (this.gallerySidebarTimeoutId !== null) {
-            clearTimeout(this.gallerySidebarTimeoutId);
-            this.gallerySidebarTimeoutId = null;
-        }
-
-        if (this.galleryRoot) {
-            this.galleryRoot.unmount();
-            this.galleryRoot = null;
-        }
-
-        if (this.galleryEl) {
-            this.galleryEl.remove();
-            this.galleryEl = null;
-        }
-
-        if (this.galleryThumbnail) {
-            this.galleryThumbnail.destroy();
-            this.galleryThumbnail = null;
+        // Must run before pdfViewer teardown — galleryController holds Thumbnail render promises against pdfViewer
+        if (this.galleryController) {
+            this.galleryController.destroy();
         }
 
         // Clean up PDF network requests
@@ -929,9 +901,8 @@ class DocBaseViewer extends BaseViewer {
             this.thumbnailsSidebar.refresh();
         }
 
-        if (this.galleryThumbnail) {
-            this.galleryThumbnail.destroy();
-            this.galleryThumbnail = null;
+        if (this.galleryController) {
+            this.galleryController.handleRotate();
         }
 
         this.renderUI();
@@ -1502,10 +1473,7 @@ class DocBaseViewer extends BaseViewer {
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
         const canRotate = this.featureEnabled('rotate.enabled');
-        const canGallery =
-            isFeatureEnabled(this.options.features, 'galleryView.enabled') &&
-            this.pdfViewer.pagesCount > 1 &&
-            this.pdfViewer.pagesCount <= GALLERY_MAX_PAGES;
+        const canGallery = this.galleryController.canRender(this.pdfViewer.pagesCount);
 
         this.controls.render(
             <DocControls
@@ -1515,7 +1483,7 @@ class DocBaseViewer extends BaseViewer {
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
                 hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
                 hasRegion={canAnnotate && isAnnotationsMode}
-                isGalleryOpen={this.isGalleryOpen}
+                isGalleryOpen={this.galleryController.isOpen}
                 isThumbnailsOpen={this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen}
                 maxScale={MAX_SCALE}
                 minScale={MIN_SCALE}
@@ -1524,7 +1492,7 @@ class DocBaseViewer extends BaseViewer {
                 onAnnotationModeEscape={this.handleAnnotationControlsEscape}
                 onFindBarToggle={!this.isFindDisabled() ? this.toggleFindBar : undefined}
                 onFullscreenToggle={this.toggleFullscreen}
-                onGalleryToggle={canGallery ? this.toggleGallery : undefined}
+                onGalleryToggle={canGallery ? this.galleryController.toggle : undefined}
                 onPageChange={this.setPage}
                 onPageSubmit={this.handlePageSubmit}
                 onRotateLeft={canRotate ? this.rotateLeft : undefined}
@@ -1760,8 +1728,7 @@ class DocBaseViewer extends BaseViewer {
     handleDocElKeydown(event) {
         const key = decodeKeydown(event);
 
-        if (key === 'Escape' && this.isGalleryOpen) {
-            this.toggleGallery();
+        if (key === 'Escape' && this.galleryController.handleEscape()) {
             return;
         }
 
@@ -2071,100 +2038,6 @@ class DocBaseViewer extends BaseViewer {
             this.rootEl.classList.remove(CLASS_BOX_PREVIEW_THUMBNAILS_CLOSE_ACTIVE);
             this.rootEl.classList.remove(CLASS_BOX_PREVIEW_THUMBNAILS_OPEN_ACTIVE);
         }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
-    }
-
-    mountGalleryGrid() {
-        if (this.galleryRoot) {
-            return;
-        }
-
-        if (!this.galleryThumbnail) {
-            this.galleryThumbnail = new Thumbnail(this.pdfViewer, this.preloader);
-        }
-
-        this.galleryEl = document.createElement('div');
-        this.containerEl.appendChild(this.galleryEl);
-        this.galleryRoot = createRoot(this.galleryEl);
-        this.galleryFocusedPage = this.pdfViewer.currentPageNumber;
-        this.galleryRoot.render(
-            <GalleryGrid
-                currentPage={this.pdfViewer.currentPageNumber}
-                onClose={this.toggleGallery}
-                onFocusChange={pageNum => {
-                    this.galleryFocusedPage = pageNum;
-                }}
-                onPageNavigate={this.handleGalleryNavigate}
-                pageCount={this.pdfViewer.pagesCount}
-                thumbnail={this.galleryThumbnail}
-            />,
-        );
-    }
-
-    toggleGallery() {
-        this.isGalleryOpen = !this.isGalleryOpen;
-
-        if (this.isGalleryOpen) {
-            if (this.gallerySidebarTimeoutId !== null) {
-                clearTimeout(this.gallerySidebarTimeoutId);
-                this.gallerySidebarTimeoutId = null;
-            }
-
-            this.sidebarWasOpen = !!(this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen);
-
-            if (this.sidebarWasOpen) {
-                this.toggleThumbnails();
-                this.galleryMountTimeoutId = setTimeout(() => {
-                    this.galleryMountTimeoutId = null;
-                    this.mountGalleryGrid();
-                }, THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
-            } else {
-                this.mountGalleryGrid();
-            }
-        } else {
-            if (this.galleryMountTimeoutId !== null) {
-                clearTimeout(this.galleryMountTimeoutId);
-                this.galleryMountTimeoutId = null;
-            }
-
-            const navigateToPage =
-                this.galleryFocusedPage && this.galleryFocusedPage !== this.pdfViewer.currentPageNumber
-                    ? this.galleryFocusedPage
-                    : null;
-
-            if (this.galleryRoot) {
-                this.galleryRoot.unmount();
-                this.galleryRoot = null;
-            }
-
-            if (this.galleryEl) {
-                this.galleryEl.remove();
-                this.galleryEl = null;
-            }
-
-            this.galleryFocusedPage = null;
-
-            if (this.sidebarWasOpen && this.thumbnailsSidebar && !this.thumbnailsSidebar.isOpen) {
-                this.toggleThumbnails();
-            }
-
-            if (navigateToPage) {
-                this.setPage(navigateToPage);
-
-                if (this.sidebarWasOpen && this.thumbnailsSidebar) {
-                    this.gallerySidebarTimeoutId = setTimeout(() => {
-                        this.gallerySidebarTimeoutId = null;
-                        this.thumbnailsSidebar.setCurrentPage(navigateToPage);
-                    }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
-                }
-            }
-        }
-
-        this.renderUI();
-    }
-
-    handleGalleryNavigate(pageNum) {
-        this.galleryFocusedPage = pageNum;
-        this.toggleGallery();
     }
 
     /**

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -1,0 +1,248 @@
+// Doc-viewer-bound: this controller talks to PDF.js (pdfViewer, Thumbnail) and
+// the doc-specific ThumbnailsSidebar. If a non-doc viewer ever needs gallery,
+// the dependencies below must be abstracted first.
+
+import React from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import Thumbnail from '../../Thumbnail';
+import { FeatureConfig, isFeatureEnabled } from '../../featureChecking';
+import GalleryGrid, { GalleryThumbnail } from './GalleryGrid';
+
+// Controller-owned shape: GalleryGrid only sees the read surface (GalleryThumbnail),
+// but the controller also needs destroy() to invalidate the cache on rotate/teardown.
+type ManagedGalleryThumbnail = GalleryThumbnail & { destroy: () => void };
+
+const GALLERY_MAX_PAGES = 200; // Hide gallery toggle for files above this page count, will increase in V2
+const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // ms
+
+// Minimal local shapes for untyped peer modules (pdfjs is JS-only, sidebar is JS-only).
+// Only the members the controller actually uses are declared — extend as needed.
+interface PdfViewerLike {
+    currentPageNumber: number;
+    pagesCount: number;
+}
+
+interface ThumbnailsSidebarLike {
+    isOpen: boolean;
+    setCurrentPage: (n: number) => void;
+}
+
+// The preloader is opaque to the controller; we only forward it into Thumbnail's constructor.
+// Type-alias what the Thumbnail constructor expects so the two sides stay in sync.
+type PreloaderLike = ConstructorParameters<typeof Thumbnail>[1];
+
+export type GalleryControllerOptions = {
+    containerEl: HTMLElement;
+    features: FeatureConfig;
+    getPdfViewer: () => PdfViewerLike;
+    getPreloader: () => PreloaderLike;
+    getThumbnailsSidebar: () => ThumbnailsSidebarLike | null;
+    setPage: (n: number) => void;
+    toggleThumbnails: () => void;
+    requestUiUpdate: () => void;
+};
+
+export default class GalleryController {
+    private containerEl: HTMLElement;
+
+    private features: FeatureConfig;
+
+    private getPdfViewer: () => PdfViewerLike;
+
+    private getPreloader: () => PreloaderLike;
+
+    private getThumbnailsSidebar: () => ThumbnailsSidebarLike | null;
+
+    private setPage: (n: number) => void;
+
+    private toggleThumbnails: () => void;
+
+    private requestUiUpdate: () => void;
+
+    private galleryRoot: Root | null = null;
+
+    private galleryEl: HTMLDivElement | null = null;
+
+    private galleryThumbnail: ManagedGalleryThumbnail | null = null;
+
+    private galleryFocusedPage: number | null = null;
+
+    private galleryMountTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    private gallerySidebarTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    private sidebarWasOpen = false;
+
+    private isGalleryOpen = false;
+
+    constructor(opts: GalleryControllerOptions) {
+        this.containerEl = opts.containerEl;
+        this.features = opts.features;
+        this.getPdfViewer = opts.getPdfViewer;
+        this.getPreloader = opts.getPreloader;
+        this.getThumbnailsSidebar = opts.getThumbnailsSidebar;
+        this.setPage = opts.setPage;
+        this.toggleThumbnails = opts.toggleThumbnails;
+        this.requestUiUpdate = opts.requestUiUpdate;
+    }
+
+    get isOpen(): boolean {
+        return this.isGalleryOpen;
+    }
+
+    canRender(pageCount: number): boolean {
+        return (
+            isFeatureEnabled(this.features, 'galleryView.enabled') && pageCount > 1 && pageCount <= GALLERY_MAX_PAGES
+        );
+    }
+
+    toggle = (): void => {
+        this.isGalleryOpen = !this.isGalleryOpen;
+
+        if (this.isGalleryOpen) {
+            if (this.gallerySidebarTimeoutId !== null) {
+                clearTimeout(this.gallerySidebarTimeoutId);
+                this.gallerySidebarTimeoutId = null;
+            }
+
+            const sidebar = this.getThumbnailsSidebar();
+            this.sidebarWasOpen = !!(sidebar && sidebar.isOpen);
+
+            if (this.sidebarWasOpen) {
+                this.toggleThumbnails();
+                this.galleryMountTimeoutId = setTimeout(() => {
+                    this.galleryMountTimeoutId = null;
+                    this.mountGrid();
+                }, THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
+            } else {
+                this.mountGrid();
+            }
+        } else {
+            if (this.galleryMountTimeoutId !== null) {
+                clearTimeout(this.galleryMountTimeoutId);
+                this.galleryMountTimeoutId = null;
+            }
+
+            const pdfViewer = this.getPdfViewer();
+            const navigateToPage =
+                this.galleryFocusedPage && this.galleryFocusedPage !== pdfViewer.currentPageNumber
+                    ? this.galleryFocusedPage
+                    : null;
+
+            if (this.galleryRoot) {
+                this.galleryRoot.unmount();
+                this.galleryRoot = null;
+            }
+
+            if (this.galleryEl) {
+                this.galleryEl.remove();
+                this.galleryEl = null;
+            }
+
+            this.galleryFocusedPage = null;
+
+            const sidebar = this.getThumbnailsSidebar();
+            if (this.sidebarWasOpen && sidebar && !sidebar.isOpen) {
+                this.toggleThumbnails();
+            }
+
+            if (navigateToPage) {
+                this.setPage(navigateToPage);
+
+                if (this.sidebarWasOpen && sidebar) {
+                    this.gallerySidebarTimeoutId = setTimeout(() => {
+                        this.gallerySidebarTimeoutId = null;
+                        sidebar.setCurrentPage(navigateToPage);
+                    }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+                }
+            }
+        }
+
+        this.requestUiUpdate();
+    };
+
+    handleEscape(): boolean {
+        if (!this.isGalleryOpen) return false;
+        this.toggle();
+        return true;
+    }
+
+    handleRotate(): void {
+        if (this.galleryThumbnail) {
+            this.galleryThumbnail.destroy();
+            this.galleryThumbnail = null;
+        }
+    }
+
+    destroy(): void {
+        if (this.galleryMountTimeoutId !== null) {
+            clearTimeout(this.galleryMountTimeoutId);
+            this.galleryMountTimeoutId = null;
+        }
+        if (this.gallerySidebarTimeoutId !== null) {
+            clearTimeout(this.gallerySidebarTimeoutId);
+            this.gallerySidebarTimeoutId = null;
+        }
+
+        if (this.galleryRoot) {
+            this.galleryRoot.unmount();
+            this.galleryRoot = null;
+        }
+
+        if (this.galleryEl) {
+            this.galleryEl.remove();
+            this.galleryEl = null;
+        }
+
+        if (this.galleryThumbnail) {
+            this.galleryThumbnail.destroy();
+            this.galleryThumbnail = null;
+        }
+
+        // Reset state so isOpen is honest even after teardown.
+        this.isGalleryOpen = false;
+        this.sidebarWasOpen = false;
+        this.galleryFocusedPage = null;
+    }
+
+    private handleGalleryNavigate = (pageNum: number): void => {
+        this.galleryFocusedPage = pageNum;
+        this.toggle();
+    };
+
+    private handleFocusChange = (pageNum: number): void => {
+        this.galleryFocusedPage = pageNum;
+    };
+
+    private mountGrid(): void {
+        if (this.galleryRoot) {
+            return;
+        }
+
+        const pdfViewer = this.getPdfViewer();
+
+        if (!this.galleryThumbnail) {
+            // Thumbnail is a JS class; cast to the typed interface used by the controller + grid.
+            this.galleryThumbnail = (new Thumbnail(
+                pdfViewer,
+                this.getPreloader(),
+            ) as unknown) as ManagedGalleryThumbnail;
+        }
+
+        const thumbnail = this.galleryThumbnail;
+        this.galleryEl = document.createElement('div');
+        this.containerEl.appendChild(this.galleryEl);
+        this.galleryRoot = createRoot(this.galleryEl);
+        this.galleryFocusedPage = pdfViewer.currentPageNumber;
+        this.galleryRoot.render(
+            <GalleryGrid
+                currentPage={pdfViewer.currentPageNumber}
+                onClose={this.toggle}
+                onFocusChange={this.handleFocusChange}
+                onPageNavigate={this.handleGalleryNavigate}
+                pageCount={pdfViewer.pagesCount}
+                thumbnail={thumbnail}
+            />,
+        );
+    }
+}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -7,7 +7,7 @@ const INITIAL_LOAD_BUFFER = 40;
 const CONCURRENT_LOADS = 4;
 const SCROLL_THROTTLE_MS = 200;
 
-interface GalleryThumbnail {
+export interface GalleryThumbnail {
     init: () => Promise<unknown>;
     getImageFromCache: (itemIndex: number) => { image?: HTMLImageElement; inProgress: boolean } | null | undefined;
     createThumbnailImage: (

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -91,14 +91,6 @@ describe('GalleryController', () => {
     });
 
     describe('destroy', () => {
-        test('should be idempotent on a never-opened controller', () => {
-            const { controller } = makeController();
-            expect(() => {
-                controller.destroy();
-                controller.destroy();
-            }).not.toThrow();
-        });
-
         test('should cancel a deferred mount scheduled while sidebar was open', () => {
             const { controller, containerEl } = makeController({ sidebarOpen: true });
             controller.toggle();
@@ -172,8 +164,9 @@ describe('GalleryController', () => {
         test('should navigate to focused page when it differs from the current page on close', () => {
             const { controller, setPage } = makeController({ currentPage: 1, sidebarOpen: false });
             controller.toggle();
-            // Simulate user focusing page 5 in the grid
-            ((controller as unknown) as { galleryFocusedPage: number }).galleryFocusedPage = 5;
+            // Simulate the grid reporting focus on page 5 via its onFocusChange callback
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onFocusChange(5);
             controller.toggle();
             expect(setPage).toHaveBeenCalledWith(5);
         });
@@ -190,7 +183,8 @@ describe('GalleryController', () => {
             controller.toggle();
             jest.advanceTimersByTime(THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
 
-            ((controller as unknown) as { galleryFocusedPage: number }).galleryFocusedPage = 7;
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onFocusChange(7);
             controller.toggle();
 
             expect(toggleThumbnails).toHaveBeenCalledTimes(2);
@@ -209,16 +203,6 @@ describe('GalleryController', () => {
 
             expect(setPage).toHaveBeenCalledWith(8);
             expect(controller.isOpen).toBe(false);
-        });
-
-        test('should not double-mount when toggle is called twice without close', () => {
-            const { controller, containerEl } = makeController({ sidebarOpen: false });
-            controller.toggle();
-            const firstEl = containerEl.firstChild;
-            // Reach private mountGrid to verify the re-entry guard.
-            ((controller as unknown) as { mountGrid: () => void }).mountGrid();
-            expect(containerEl.children).toHaveLength(1);
-            expect(containerEl.firstChild).toBe(firstEl);
         });
     });
 
@@ -246,11 +230,11 @@ describe('GalleryController', () => {
         test('should destroy the cached thumbnail instance after the gallery has been opened', () => {
             const { controller } = makeController({ sidebarOpen: false });
             controller.toggle();
-            // Reach into the private field to grab the cached Thumbnail mock
-            const cached = ((controller as unknown) as { galleryThumbnail: { destroy: jest.Mock } }).galleryThumbnail;
+            // The thumbnail prop the grid received is the cached instance the controller owns
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            const cached = grid.props.thumbnail as { destroy: jest.Mock };
             controller.handleRotate();
             expect(cached.destroy).toHaveBeenCalled();
-            expect(((controller as unknown) as { galleryThumbnail: unknown }).galleryThumbnail).toBeNull();
         });
     });
 });

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -1,0 +1,256 @@
+import GalleryController, { GalleryControllerOptions } from '../GalleryController';
+
+jest.mock('../../../Thumbnail', () => {
+    return jest.fn().mockImplementation(() => ({
+        init: jest.fn().mockResolvedValue(undefined),
+        getImageFromCache: jest.fn().mockReturnValue(null),
+        createThumbnailImage: jest.fn().mockResolvedValue(null),
+        destroy: jest.fn(),
+    }));
+});
+
+// Stub react-dom/client so tests focus on controller behavior, not React reconciliation.
+// (createRoot's async commit interacts badly with afterEach DOM teardown under fake timers.)
+// The render/unmount mocks are accessible via mockLastRoot so tests can assert on grid props.
+let mockLastRoot: { render: jest.Mock; unmount: jest.Mock };
+jest.mock('react-dom/client', () => ({
+    createRoot: jest.fn(() => {
+        mockLastRoot = { render: jest.fn(), unmount: jest.fn() };
+        return mockLastRoot;
+    }),
+}));
+
+const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301;
+
+type Sidebar = { isOpen: boolean; setCurrentPage: jest.Mock };
+
+interface Harness {
+    controller: GalleryController;
+    containerEl: HTMLElement;
+    pdfViewer: { currentPageNumber: number; pagesCount: number };
+    sidebar: Sidebar | null;
+    setPage: jest.Mock;
+    toggleThumbnails: jest.Mock;
+    requestUiUpdate: jest.Mock;
+}
+
+function makeController(
+    overrides: {
+        sidebarOpen?: boolean;
+        sidebarPresent?: boolean;
+        pageCount?: number;
+        currentPage?: number;
+        flagOn?: boolean;
+    } = {},
+): Harness {
+    const { sidebarOpen = false, sidebarPresent = true, pageCount = 10, currentPage = 1, flagOn = true } = overrides;
+
+    const containerEl = document.createElement('div');
+    document.body.appendChild(containerEl);
+
+    const pdfViewer = { currentPageNumber: currentPage, pagesCount: pageCount };
+    const sidebar: Sidebar | null = sidebarPresent ? { isOpen: sidebarOpen, setCurrentPage: jest.fn() } : null;
+    const setPage = jest.fn((n: number) => {
+        pdfViewer.currentPageNumber = n;
+    });
+    const toggleThumbnails = jest.fn(() => {
+        if (sidebar) sidebar.isOpen = !sidebar.isOpen;
+    });
+    const requestUiUpdate = jest.fn();
+
+    const opts: GalleryControllerOptions = {
+        containerEl,
+        features: { galleryView: { enabled: flagOn } },
+        getPdfViewer: () => pdfViewer,
+        getPreloader: () => null,
+        getThumbnailsSidebar: () => sidebar,
+        setPage,
+        toggleThumbnails,
+        requestUiUpdate,
+    };
+
+    return {
+        controller: new GalleryController(opts),
+        containerEl,
+        pdfViewer,
+        sidebar,
+        setPage,
+        toggleThumbnails,
+        requestUiUpdate,
+    };
+}
+
+describe('GalleryController', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    describe('destroy', () => {
+        test('should be idempotent on a never-opened controller', () => {
+            const { controller } = makeController();
+            expect(() => {
+                controller.destroy();
+                controller.destroy();
+            }).not.toThrow();
+        });
+
+        test('should cancel a deferred mount scheduled while sidebar was open', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: true });
+            controller.toggle();
+            expect(containerEl.children).toHaveLength(0);
+
+            controller.destroy();
+            jest.advanceTimersByTime(THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+            expect(containerEl.children).toHaveLength(0);
+        });
+
+        test('should tear down DOM and reset isOpen when destroyed while gallery is open', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(controller.isOpen).toBe(true);
+            expect(containerEl.children).toHaveLength(1);
+
+            controller.destroy();
+
+            expect(controller.isOpen).toBe(false);
+            expect(containerEl.children).toHaveLength(0);
+        });
+    });
+
+    describe('canRender', () => {
+        test.each`
+            pages  | flag     | expected
+            ${1}   | ${true}  | ${false}
+            ${2}   | ${true}  | ${true}
+            ${200} | ${true}  | ${true}
+            ${201} | ${true}  | ${false}
+            ${50}  | ${false} | ${false}
+        `('should return $expected when pages=$pages and flag=$flag', ({ pages, flag, expected }) => {
+            const { controller } = makeController({ flagOn: flag });
+            expect(controller.canRender(pages)).toBe(expected);
+        });
+    });
+
+    describe('toggle', () => {
+        test('should mount grid synchronously and update UI when sidebar is closed', () => {
+            const { controller, containerEl, requestUiUpdate } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(controller.isOpen).toBe(true);
+            expect(containerEl.children).toHaveLength(1);
+            expect(requestUiUpdate).toHaveBeenCalledTimes(1);
+        });
+
+        test('should wire the correct props into GalleryGrid', () => {
+            const { controller } = makeController({ currentPage: 3, pageCount: 25, sidebarOpen: false });
+            controller.toggle();
+
+            expect(mockLastRoot.render).toHaveBeenCalledTimes(1);
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            expect(grid.props.currentPage).toBe(3);
+            expect(grid.props.pageCount).toBe(25);
+            expect(grid.props.thumbnail).toBeDefined();
+            expect(grid.props.onClose).toBe(controller.toggle);
+            expect(typeof grid.props.onPageNavigate).toBe('function');
+            expect(typeof grid.props.onFocusChange).toBe('function');
+        });
+
+        test('should close sidebar first and defer grid mount by half the transition time when sidebar is open', () => {
+            const { controller, containerEl, toggleThumbnails } = makeController({ sidebarOpen: true });
+            controller.toggle();
+            expect(toggleThumbnails).toHaveBeenCalledTimes(1);
+            expect(containerEl.children).toHaveLength(0);
+
+            jest.advanceTimersByTime(THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
+            expect(containerEl.children).toHaveLength(1);
+        });
+
+        test('should navigate to focused page when it differs from the current page on close', () => {
+            const { controller, setPage } = makeController({ currentPage: 1, sidebarOpen: false });
+            controller.toggle();
+            // Simulate user focusing page 5 in the grid
+            ((controller as unknown) as { galleryFocusedPage: number }).galleryFocusedPage = 5;
+            controller.toggle();
+            expect(setPage).toHaveBeenCalledWith(5);
+        });
+
+        test('should not navigate when focused page matches current page on close', () => {
+            const { controller, setPage } = makeController({ currentPage: 3, sidebarOpen: false });
+            controller.toggle();
+            controller.toggle();
+            expect(setPage).not.toHaveBeenCalled();
+        });
+
+        test('should restore sidebar and schedule setCurrentPage when sidebar was open before', () => {
+            const { controller, sidebar, toggleThumbnails } = makeController({ sidebarOpen: true });
+            controller.toggle();
+            jest.advanceTimersByTime(THUMBNAILS_SIDEBAR_TRANSITION_TIME / 2);
+
+            ((controller as unknown) as { galleryFocusedPage: number }).galleryFocusedPage = 7;
+            controller.toggle();
+
+            expect(toggleThumbnails).toHaveBeenCalledTimes(2);
+
+            jest.advanceTimersByTime(THUMBNAILS_SIDEBAR_TRANSITION_TIME);
+            expect(sidebar!.setCurrentPage).toHaveBeenCalledWith(7);
+        });
+
+        test('should close gallery and navigate when onPageNavigate fires from the grid', () => {
+            const { controller, setPage } = makeController({ currentPage: 1, sidebarOpen: false });
+            controller.toggle();
+            expect(controller.isOpen).toBe(true);
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onPageNavigate(8);
+
+            expect(setPage).toHaveBeenCalledWith(8);
+            expect(controller.isOpen).toBe(false);
+        });
+
+        test('should not double-mount when toggle is called twice without close', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            const firstEl = containerEl.firstChild;
+            // Reach private mountGrid to verify the re-entry guard.
+            ((controller as unknown) as { mountGrid: () => void }).mountGrid();
+            expect(containerEl.children).toHaveLength(1);
+            expect(containerEl.firstChild).toBe(firstEl);
+        });
+    });
+
+    describe('handleEscape', () => {
+        test('should return false when gallery is closed', () => {
+            const { controller } = makeController();
+            expect(controller.handleEscape()).toBe(false);
+            expect(controller.isOpen).toBe(false);
+        });
+
+        test('should return true and close the gallery when open', () => {
+            const { controller } = makeController();
+            controller.toggle();
+            expect(controller.handleEscape()).toBe(true);
+            expect(controller.isOpen).toBe(false);
+        });
+    });
+
+    describe('handleRotate', () => {
+        test('should be a no-op when gallery has never been opened', () => {
+            const { controller } = makeController();
+            expect(() => controller.handleRotate()).not.toThrow();
+        });
+
+        test('should destroy the cached thumbnail instance after the gallery has been opened', () => {
+            const { controller } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            // Reach into the private field to grab the cached Thumbnail mock
+            const cached = ((controller as unknown) as { galleryThumbnail: { destroy: jest.Mock } }).galleryThumbnail;
+            controller.handleRotate();
+            expect(cached.destroy).toHaveBeenCalled();
+            expect(((controller as unknown) as { galleryThumbnail: unknown }).galleryThumbnail).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
**Summary**

  - Moves gallery state and lifecycle off DocBaseViewer.js (8 instance properties, 3 methods, 2 constructor bindings, feature gating in renderUI, cleanup in destroy / rotateLeft) into a new GalleryController class that mirrors the ControlsRoot pattern.
  - The controller owns the React root for GalleryGrid, the dedicated Thumbnail cache, sidebar snapshot/restore on enter/exit, deferred mount when the sidebar was open, and focused-page navigation on close.
  - DocBaseViewer keeps one galleryController field and delegates through a small public surface: isOpen, canRender, toggle, handleEscape, handleRotate, destroy. Viewer dependencies are passed via explicit getter callbacks so the controller stays testable without a full viewer harness.
  - Pure refactor — zero behavior change. DocBaseViewer.js net: -173 lines.

  **New files**

  - src/lib/viewers/gallery/GalleryController.tsx — typed class encapsulating gallery state, React-root lifecycle, sidebar
  coordination, thumbnail cache, and feature gating
  - src/lib/viewers/gallery/__tests__/GalleryController-test.tsx — 18 unit tests for controller lifecycle, sidebar coordination, prop wiring into the grid, destroy-while-open, and canRender gating

  **Modifies**

  - src/lib/viewers/doc/DocBaseViewer.js — remove gallery state/methods/bindings/constant/imports; replace 5 call sites with thin delegations to galleryController.
  - src/lib/featureChecking.ts — export FeatureConfig and FeatureOptions for controller typing
  - src/lib/viewers/gallery/GalleryGrid.tsx — export GalleryThumbnail interface for controller typing

  **Test plan**

  - [ ] Open a multi-page PDF with preview_gallery_view on — gallery toggle appears in the toolbar
  - [ ] Click the toggle — gallery opens, current page is selected and focused
  - [ ] Open with sidebar previously open — sidebar collapses, grid mounts after the transition
  - [ ] Click a tile — document navigates to that page, gallery closes, sidebar restores to prior state
  - [ ] Press Escape inside gallery — gallery closes on same page
  - [ ] Toggle gallery off without clicking a tile — exits on same page, sidebar restores
  - [ ] Open gallery, rotate document via toolbar (if reachable) — thumbnail cache invalidates without error
  - [ ] Open gallery, navigate away from preview — viewer destroys cleanly (no console errors, no leaked timeouts)
  - [ ] Verify gallery toggle is hidden for single-page docs, >200-page docs, and when the flag is off
  - [ ] No regression in non-gallery preview flows (zoom, find bar, annotations, thumbnails sidebar toggle)