### PR TITLE
feat(video-player-v2): add clustering for comment markers in scrubber bar

### DIFF
--- a/src/lib/viewers/controls/media/MarkerAvatar.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatar.scss
@@ -9,10 +9,11 @@
     overflow: hidden;
     border: 0;
     border-radius: 50%;
+    outline: 2px solid rgba(0, 0, 0, .5);
     box-shadow: 0 0 0 0 $white;
     transform: translate(-50%, 0);
     transform-origin: bottom center;
-    transition: transform 150ms, box-shadow 150ms;
+    transition: transform 150ms, box-shadow 150ms, outline 150ms;
 
     img {
         position: absolute;

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.scss
@@ -12,6 +12,9 @@
 .bp-MarkerAvatarStack-item {
     position: relative;
     flex-shrink: 0;
+    padding: 0;
+    background: none;
+    border: 0;
     cursor: pointer;
     transition: margin 150ms;
 

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.scss
@@ -1,0 +1,57 @@
+@import '../styles';
+
+.bp-MarkerAvatarStack {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    display: flex;
+    align-items: center;
+    transform: translateX(-50%);
+}
+
+.bp-MarkerAvatarStack-item {
+    position: relative;
+    flex-shrink: 0;
+    cursor: pointer;
+    transition: margin 150ms;
+
+    &:not(:first-child) {
+        margin-left: -6px;
+    }
+
+    .bp-MarkerAvatar {
+        position: relative;
+        bottom: auto;
+        left: auto;
+        display: block;
+        transform: none;
+    }
+
+    &:hover,
+    &:focus-visible {
+        z-index: 1;
+
+        .bp-MarkerAvatar {
+            outline: 0 solid transparent;
+            box-shadow: 0 0 0 2px $white;
+        }
+    }
+}
+
+// Expand avatars when parent container is hovered or focused
+.bp-TimeControlsV2-marker--group:hover,
+.bp-TimeControlsV2-marker--group:focus-visible,
+.bp-MarkerCluster:hover,
+.bp-MarkerCluster:focus-within {
+    .bp-MarkerAvatarStack-item:not(:first-child) {
+        margin-left: 2px;
+    }
+}
+
+.bp-MarkerAvatarStack-overflow {
+    cursor: pointer;
+}
+
+.bp-MarkerAvatarStack-overflowBadge {
+    background-color: $bdl-gray-65;
+}

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MarkerAvatar from './MarkerAvatar';
-import { CommentMarker } from './TimeControlsV2';
+import { CommentMarker } from './types';
 import './MarkerAvatarStack.scss';
 
 const MAX_VISIBLE_AVATARS = 4;

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import MarkerAvatar from './MarkerAvatar';
+import { CommentMarker } from './TimeControlsV2';
+import './MarkerAvatarStack.scss';
+
+const MAX_VISIBLE_AVATARS = 4;
+
+export type Props = {
+    markers: CommentMarker[];
+    onMarkerClick?: (marker: CommentMarker) => void;
+};
+
+export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JSX.Element {
+    const hasOverflow = markers.length > MAX_VISIBLE_AVATARS;
+    const visibleMarkers = hasOverflow ? markers.slice(0, MAX_VISIBLE_AVATARS - 1) : markers;
+
+    return (
+        <span className="bp-MarkerAvatarStack">
+            {visibleMarkers.map(marker => (
+                <button
+                    key={marker.id}
+                    className="bp-MarkerAvatarStack-item"
+                    onClick={(e): void => {
+                        e.stopPropagation();
+                        onMarkerClick?.(marker);
+                    }}
+                    type="button"
+                >
+                    <MarkerAvatar
+                        avatarUrl={marker.avatarUrl}
+                        colorIndex={marker.colorIndex}
+                        initial={marker.initial}
+                    />
+                </button>
+            ))}
+            {hasOverflow && (
+                <button
+                    className="bp-MarkerAvatarStack-item bp-MarkerAvatarStack-overflow"
+                    onClick={(e): void => {
+                        e.stopPropagation();
+                        onMarkerClick?.(markers[MAX_VISIBLE_AVATARS - 1]);
+                    }}
+                    type="button"
+                >
+                    <span className="bp-MarkerAvatar bp-MarkerAvatarStack-overflowBadge">
+                        <span className="bp-MarkerAvatar-initial">+{markers.length - (MAX_VISIBLE_AVATARS - 1)}</span>
+                    </span>
+                </button>
+            )}
+        </span>
+    );
+}

--- a/src/lib/viewers/controls/media/MarkerCluster.scss
+++ b/src/lib/viewers/controls/media/MarkerCluster.scss
@@ -1,0 +1,32 @@
+@import '../styles';
+
+.bp-MarkerCluster {
+    position: absolute;
+    top: 50%;
+    z-index: 1;
+    height: 8px;
+    transform: translate(-2px, -50%);
+    transition: transform 150ms;
+
+    &:hover,
+    &:focus-within {
+        z-index: 2;
+        transform: translate(-2px, -50%) scale(1.5);
+
+        .bp-MarkerCluster-tick {
+            transform: none;
+        }
+    }
+}
+
+.bp-MarkerCluster-tick {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    background: $bdl-gray-65;
+    border: 1px solid $white;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: transform 150ms;
+}

--- a/src/lib/viewers/controls/media/MarkerCluster.tsx
+++ b/src/lib/viewers/controls/media/MarkerCluster.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import MarkerAvatarStack from './MarkerAvatarStack';
+import { CommentMarker } from './TimeControlsV2';
+import './MarkerCluster.scss';
+
+export type ClusterData = {
+    id: string;
+    isSinglePoint: boolean;
+    leftPercent: number;
+    markers: CommentMarker[];
+    rightPercent: number;
+};
+
+export type Props = {
+    cluster: ClusterData;
+    onMarkerClick?: (marker: CommentMarker) => void;
+};
+
+export default function MarkerCluster({ cluster, onMarkerClick }: Props): JSX.Element {
+    const { markers, leftPercent, rightPercent } = cluster;
+
+    const style: React.CSSProperties = {
+        left: `${leftPercent}%`,
+        width: `calc(${rightPercent - leftPercent}% + 4px)`,
+    };
+
+    return (
+        <div className="bp-MarkerCluster" data-testid="bp-marker-cluster" style={style}>
+            <button
+                aria-label={__('media_comment_marker')}
+                className="bp-MarkerCluster-tick"
+                onClick={(e): void => {
+                    e.stopPropagation();
+                    onMarkerClick?.(markers[0]);
+                }}
+                type="button"
+            />
+            <MarkerAvatarStack markers={markers} onMarkerClick={onMarkerClick} />
+        </div>
+    );
+}

--- a/src/lib/viewers/controls/media/MarkerCluster.tsx
+++ b/src/lib/viewers/controls/media/MarkerCluster.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import MarkerAvatarStack from './MarkerAvatarStack';
-import { CommentMarker } from './TimeControlsV2';
+import { ClusterData, CommentMarker } from './types';
 import './MarkerCluster.scss';
-
-export type ClusterData = {
-    id: string;
-    isSinglePoint: boolean;
-    leftPercent: number;
-    markers: CommentMarker[];
-    rightPercent: number;
-};
 
 export type Props = {
     cluster: ClusterData;

--- a/src/lib/viewers/controls/media/MarkerTick.tsx
+++ b/src/lib/viewers/controls/media/MarkerTick.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import MarkerAvatar from './MarkerAvatar';
+import MarkerAvatarStack from './MarkerAvatarStack';
+import { CommentMarker } from './TimeControlsV2';
+
+export type Props = {
+    markers: CommentMarker[];
+    onMarkerClick?: (marker: CommentMarker) => void;
+    position: number;
+};
+
+export default function MarkerTick({ markers, onMarkerClick, position }: Props): JSX.Element {
+    const isGroup = markers.length > 1;
+
+    return (
+        <button
+            aria-label={__('media_comment_marker')}
+            className={`bp-TimeControlsV2-marker${isGroup ? ' bp-TimeControlsV2-marker--group' : ''}`}
+            data-testid="bp-time-controls-marker"
+            onClick={(e): void => {
+                e.stopPropagation();
+                onMarkerClick?.(markers[0]);
+            }}
+            style={{ left: `${position}%` }}
+            type="button"
+        >
+            {isGroup ? (
+                <MarkerAvatarStack markers={markers} onMarkerClick={onMarkerClick} />
+            ) : (
+                <MarkerAvatar
+                    avatarUrl={markers[0].avatarUrl}
+                    colorIndex={markers[0].colorIndex}
+                    initial={markers[0].initial}
+                />
+            )}
+        </button>
+    );
+}

--- a/src/lib/viewers/controls/media/MarkerTick.tsx
+++ b/src/lib/viewers/controls/media/MarkerTick.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MarkerAvatar from './MarkerAvatar';
 import MarkerAvatarStack from './MarkerAvatarStack';
-import { CommentMarker } from './TimeControlsV2';
+import { CommentMarker } from './types';
 
 export type Props = {
     markers: CommentMarker[];

--- a/src/lib/viewers/controls/media/TimeControlsV2.scss
+++ b/src/lib/viewers/controls/media/TimeControlsV2.scss
@@ -50,9 +50,11 @@
 
     &:hover,
     &:focus-visible {
+        z-index: 2;
         transform: translate(-50%, -50%) scale(1.7);
 
-        .bp-MarkerAvatar {
+        > .bp-MarkerAvatar {
+            outline: 0 solid transparent;
             box-shadow: 0 0 0 2px $white;
             transform: translate(-50%, calc(5px / 1.7));
         }
@@ -61,5 +63,12 @@
     &:focus-visible {
         outline: 2px solid $white;
         outline-offset: 2px;
+    }
+
+    &--group {
+        &:hover,
+        &:focus-visible {
+            transform: translate(-50%, -50%) scale(1.5);
+        }
     }
 }

--- a/src/lib/viewers/controls/media/TimeControlsV2.scss
+++ b/src/lib/viewers/controls/media/TimeControlsV2.scss
@@ -23,6 +23,7 @@
 
     .bp-SliderControl-thumb {
         top: 50%;
+        z-index: 3;
         width: 3px;
         height: 16px;
         margin-left: -1.5px;

--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import isFinite from 'lodash/isFinite';
 import noop from 'lodash/noop';
 import { bdlGray65, white } from 'box-ui-elements/es/styles/variables';
+import buildClusters from './buildClusters';
 import FilmstripV2 from './FilmstripV2';
-import MarkerAvatar from './MarkerAvatar';
+import MarkerCluster from './MarkerCluster';
+import MarkerTick from './MarkerTick';
 import SliderControl from '../slider';
 import './TimeControlsV2.scss';
 
@@ -53,30 +55,53 @@ export default function TimeControlsV2({
     const [hoverPosition, setHoverPosition] = React.useState(0);
     const [hoverPositionMax, setHoverPositionMax] = React.useState(0);
     const [hoverTime, setHoverTime] = React.useState(0);
+    const [trackWidth, setTrackWidth] = React.useState(0);
+    const scrubberRef = React.useRef<HTMLDivElement>(null);
     const currentValue = isFinite(currentTime) ? currentTime : 0;
     const durationValue = isFinite(durationTime) ? durationTime : 0;
     const currentPercentage = percent(currentValue, durationValue);
 
-    const markerTimesKey = commentMarkers.map(m => m.time).join('|');
+    React.useLayoutEffect(() => {
+        const el = scrubberRef.current;
+        if (!el) return undefined;
+
+        setTrackWidth(el.clientWidth);
+
+        const observer = new ResizeObserver(entries => {
+            entries.forEach(entry => {
+                setTrackWidth(entry.contentRect.width);
+            });
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    const clusters = React.useMemo(() => buildClusters(commentMarkers, durationValue, trackWidth), [
+        commentMarkers,
+        durationValue,
+        trackWidth,
+    ]);
+
     const trackMask = React.useMemo(() => {
-        if (durationValue <= 0 || commentMarkers.length === 0) return undefined;
+        if (durationValue <= 0 || clusters.length === 0) return undefined;
 
         const HALF_GAP = 2;
         const stops: string[] = [];
-        const sorted = commentMarkers.map(m => percent(m.time, durationValue)).sort((a, b) => a - b);
 
         stops.push('black 0%');
-        sorted.forEach(pos => {
-            stops.push(`black calc(${pos}% - ${HALF_GAP}px)`);
-            stops.push(`transparent calc(${pos}% - ${HALF_GAP}px)`);
-            stops.push(`transparent calc(${pos}% + ${HALF_GAP}px)`);
-            stops.push(`black calc(${pos}% + ${HALF_GAP}px)`);
+        clusters.forEach(({ leftPercent, rightPercent }) => {
+            const isRange = leftPercent !== rightPercent;
+            const leftPad = isRange ? HALF_GAP + 1 : HALF_GAP;
+            const rightPad = isRange ? HALF_GAP + 1 : HALF_GAP;
+            stops.push(`black calc(${leftPercent}% - ${leftPad}px)`);
+            stops.push(`transparent calc(${leftPercent}% - ${leftPad}px)`);
+            stops.push(`transparent calc(${rightPercent}% + ${rightPad}px)`);
+            stops.push(`black calc(${rightPercent}% + ${rightPad}px)`);
         });
         stops.push('black 100%');
 
         return `linear-gradient(to right, ${stops.join(', ')})`;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [markerTimesKey, durationValue]);
+    }, [durationValue, clusters]);
 
     const handleMouseMove = (newTime: number, newPosition: number, width: number): void => {
         setHoverPosition(newPosition);
@@ -99,6 +124,7 @@ export default function TimeControlsV2({
                 />
             )}
             <div
+                ref={scrubberRef}
                 className="bp-TimeControlsV2-scrubber"
                 style={trackMask ? ({ '--bp-track-mask': trackMask } as React.CSSProperties) : undefined}
             >
@@ -119,26 +145,18 @@ export default function TimeControlsV2({
                     value={currentValue}
                 />
                 {durationValue > 0 &&
-                    commentMarkers.map(marker => (
-                        <button
-                            key={marker.id}
-                            aria-label={__('media_comment_marker')}
-                            className="bp-TimeControlsV2-marker"
-                            data-testid="bp-time-controls-marker"
-                            onClick={(e): void => {
-                                e.stopPropagation();
-                                onCommentMarkerClick?.(marker);
-                            }}
-                            style={{ left: `${percent(marker.time, durationValue)}%` }}
-                            type="button"
-                        >
-                            <MarkerAvatar
-                                avatarUrl={marker.avatarUrl}
-                                colorIndex={marker.colorIndex}
-                                initial={marker.initial}
+                    clusters.map(cluster =>
+                        cluster.isSinglePoint ? (
+                            <MarkerTick
+                                key={cluster.id}
+                                markers={cluster.markers}
+                                onMarkerClick={onCommentMarkerClick}
+                                position={cluster.leftPercent}
                             />
-                        </button>
-                    ))}
+                        ) : (
+                            <MarkerCluster key={cluster.id} cluster={cluster} onMarkerClick={onCommentMarkerClick} />
+                        ),
+                    )}
             </div>
         </div>
     );

--- a/src/lib/viewers/controls/media/TimeControlsV2.tsx
+++ b/src/lib/viewers/controls/media/TimeControlsV2.tsx
@@ -7,16 +7,9 @@ import FilmstripV2 from './FilmstripV2';
 import MarkerCluster from './MarkerCluster';
 import MarkerTick from './MarkerTick';
 import SliderControl from '../slider';
+import { CommentMarker } from './types';
+import { percent } from './utils';
 import './TimeControlsV2.scss';
-
-export type CommentMarker = {
-    avatarUrl?: string;
-    colorIndex?: number;
-    id: string;
-    initial?: string;
-    time: number;
-    type?: 'annotation' | 'comment';
-};
 
 export type Props = {
     aspectRatio?: number;
@@ -26,17 +19,8 @@ export type Props = {
     filmstripInterval?: number;
     filmstripUrl?: string;
     fps?: number;
-    mediaEl?: HTMLVideoElement | null;
     onCommentMarkerClick?: (marker: CommentMarker) => void;
     onTimeChange: (volume: number) => void;
-};
-
-export const round = (value: number): number => {
-    return +value.toFixed(4);
-};
-
-export const percent = (value1: number, value2: number): number => {
-    return round((value1 / value2) * 100);
 };
 
 export default function TimeControlsV2({
@@ -47,7 +31,6 @@ export default function TimeControlsV2({
     filmstripInterval,
     filmstripUrl,
     fps,
-    mediaEl,
     onCommentMarkerClick,
     onTimeChange,
 }: Props): JSX.Element {

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import FilmstripV2 from '../FilmstripV2';
+
+describe('FilmstripV2', () => {
+    describe('visibility', () => {
+        test('should have bp-is-shown class when isShown is true', () => {
+            render(<FilmstripV2 isShown />);
+            expect(screen.getByTestId('bp-FilmstripV2')).toHaveClass('bp-is-shown');
+        });
+
+        test('should not have bp-is-shown class when isShown is false', () => {
+            render(<FilmstripV2 isShown={false} />);
+            expect(screen.getByTestId('bp-FilmstripV2')).not.toHaveClass('bp-is-shown');
+        });
+    });
+
+    describe('positioning', () => {
+        test('should position based on position prop', () => {
+            render(<FilmstripV2 position={200} positionMax={800} />);
+            const el = screen.getByTestId('bp-FilmstripV2');
+            expect(el.style.left).toBeDefined();
+        });
+
+        test('should clamp position to not overflow left edge', () => {
+            render(<FilmstripV2 position={0} positionMax={800} />);
+            const el = screen.getByTestId('bp-FilmstripV2');
+            expect(el.style.left).toBe('0px');
+        });
+    });
+
+    describe('frame display', () => {
+        test('should set background image when imageUrl is provided', () => {
+            render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" interval={1} time={5} />);
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            expect(frame.style.backgroundImage).toContain('https://example.com/filmstrip.jpg');
+        });
+
+        test('should not set background image when imageUrl is empty', () => {
+            render(<FilmstripV2 interval={1} time={5} />);
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            expect(frame.style.backgroundImage).toBe('');
+        });
+
+        test('should set frame height to 135px', () => {
+            render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" interval={1} time={5} />);
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            expect(frame.style.height).toBe('135px');
+        });
+
+        test('should calculate background position based on time and interval', () => {
+            render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" interval={1} time={10} />);
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            expect(frame.style.backgroundPositionX).toBeDefined();
+        });
+    });
+
+    describe('timecode', () => {
+        test('should display formatted time', () => {
+            render(<FilmstripV2 time={65} />);
+            const timeEl = screen.getByTestId('bp-FilmstripV2-time');
+            expect(timeEl).toHaveTextContent('1:05');
+        });
+
+        test('should display 0:00 for time 0', () => {
+            render(<FilmstripV2 time={0} />);
+            const timeEl = screen.getByTestId('bp-FilmstripV2-time');
+            expect(timeEl).toHaveTextContent('0:00');
+        });
+    });
+
+    describe('loading state', () => {
+        test('should show crawler when image has not loaded', () => {
+            render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" />);
+            expect(screen.getByTestId('bp-FilmstripV2-crawler')).toBeInTheDocument();
+        });
+
+        test('should hide crawler after image loads', () => {
+            let capturedImg: HTMLImageElement | null = null;
+            const originalCreateElement = document.createElement.bind(document);
+            jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+                const el = originalCreateElement(tag);
+                if (tag === 'img') capturedImg = el as HTMLImageElement;
+                return el;
+            });
+
+            render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" />);
+            expect(screen.getByTestId('bp-FilmstripV2-crawler')).toBeInTheDocument();
+
+            act(() => {
+                if (capturedImg?.onload) {
+                    Object.defineProperty(capturedImg, 'naturalWidth', { value: 24000 });
+                    (capturedImg.onload as (this: GlobalEventHandlers, ev: Event) => void).call(
+                        capturedImg,
+                        new Event('load'),
+                    );
+                }
+            });
+
+            expect(screen.queryByTestId('bp-FilmstripV2-crawler')).not.toBeInTheDocument();
+
+            (document.createElement as jest.Mock).mockRestore();
+        });
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import MarkerAvatarStack from '../MarkerAvatarStack';
+import { CommentMarker } from '../TimeControlsV2';
+
+describe('MarkerAvatarStack', () => {
+    const markers: CommentMarker[] = [
+        { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+        { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+        { id: 'm3', time: 10, initial: 'C', colorIndex: 2 },
+    ];
+
+    test('should render all markers when count is within limit', () => {
+        render(<MarkerAvatarStack markers={markers} />);
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+        expect(screen.getByText('C')).toBeInTheDocument();
+    });
+
+    test('should not show overflow badge when markers are within limit', () => {
+        const { container } = render(<MarkerAvatarStack markers={markers} />);
+        expect(container.querySelector('.bp-MarkerAvatarStack-overflow')).not.toBeInTheDocument();
+    });
+
+    test('should show exactly 4 markers without overflow', () => {
+        const fourMarkers: CommentMarker[] = [
+            { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+            { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+            { id: 'm3', time: 10, initial: 'C', colorIndex: 2 },
+            { id: 'm4', time: 10, initial: 'D', colorIndex: 3 },
+        ];
+        const { container } = render(<MarkerAvatarStack markers={fourMarkers} />);
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+        expect(screen.getByText('C')).toBeInTheDocument();
+        expect(screen.getByText('D')).toBeInTheDocument();
+        expect(container.querySelector('.bp-MarkerAvatarStack-overflow')).not.toBeInTheDocument();
+    });
+
+    describe('overflow', () => {
+        const manyMarkers: CommentMarker[] = [
+            { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+            { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+            { id: 'm3', time: 10, initial: 'C', colorIndex: 2 },
+            { id: 'm4', time: 10, initial: 'D', colorIndex: 3 },
+            { id: 'm5', time: 10, initial: 'E', colorIndex: 4 },
+            { id: 'm6', time: 10, initial: 'F', colorIndex: 5 },
+        ];
+
+        test('should show first 3 avatars and overflow badge when more than 4', () => {
+            render(<MarkerAvatarStack markers={manyMarkers} />);
+            expect(screen.getByText('A')).toBeInTheDocument();
+            expect(screen.getByText('B')).toBeInTheDocument();
+            expect(screen.getByText('C')).toBeInTheDocument();
+            expect(screen.queryByText('D')).not.toBeInTheDocument();
+            expect(screen.queryByText('E')).not.toBeInTheDocument();
+            expect(screen.queryByText('F')).not.toBeInTheDocument();
+        });
+
+        test('should display correct overflow count', () => {
+            render(<MarkerAvatarStack markers={manyMarkers} />);
+            // 6 markers - 3 visible = +3
+            expect(screen.getByText('+3')).toBeInTheDocument();
+        });
+
+        test('should call onMarkerClick with first hidden marker when overflow is clicked', async () => {
+            const user = userEvent.setup();
+            const onMarkerClick = jest.fn();
+            const { container } = render(<MarkerAvatarStack markers={manyMarkers} onMarkerClick={onMarkerClick} />);
+            const overflow = container.querySelector('.bp-MarkerAvatarStack-overflow') as HTMLElement;
+            await user.click(overflow);
+            expect(onMarkerClick).toHaveBeenCalledWith(manyMarkers[3]);
+        });
+    });
+
+    test('should call onMarkerClick with correct marker when individual avatar is clicked', async () => {
+        const user = userEvent.setup();
+        const onMarkerClick = jest.fn();
+        const { container } = render(<MarkerAvatarStack markers={markers} onMarkerClick={onMarkerClick} />);
+        const items = container.querySelectorAll('.bp-MarkerAvatarStack-item');
+        await user.click(items[1] as HTMLElement);
+        expect(onMarkerClick).toHaveBeenCalledWith(markers[1]);
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import MarkerAvatarStack from '../MarkerAvatarStack';
-import { CommentMarker } from '../TimeControlsV2';
+import { CommentMarker } from '../types';
 
 describe('MarkerAvatarStack', () => {
     const markers: CommentMarker[] = [

--- a/src/lib/viewers/controls/media/__tests__/MarkerCluster-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerCluster-test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import MarkerCluster, { ClusterData } from '../MarkerCluster';
-import { CommentMarker } from '../TimeControlsV2';
+import MarkerCluster from '../MarkerCluster';
+import { ClusterData, CommentMarker } from '../types';
 
 describe('MarkerCluster', () => {
     const markers: CommentMarker[] = [

--- a/src/lib/viewers/controls/media/__tests__/MarkerCluster-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerCluster-test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import MarkerCluster, { ClusterData } from '../MarkerCluster';
+import { CommentMarker } from '../TimeControlsV2';
+
+describe('MarkerCluster', () => {
+    const markers: CommentMarker[] = [
+        { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+        { id: 'm2', time: 10.1, initial: 'B', colorIndex: 1 },
+        { id: 'm3', time: 10.2, initial: 'C', colorIndex: 2 },
+    ];
+
+    const rangeCluster: ClusterData = {
+        id: 'm1|m2|m3',
+        isSinglePoint: false,
+        leftPercent: 10,
+        markers,
+        rightPercent: 15,
+    };
+
+    test('should render with correct positioning and width', () => {
+        render(<MarkerCluster cluster={rangeCluster} />);
+        const el = screen.getByTestId('bp-marker-cluster');
+        expect(el).toHaveStyle({ left: '10%', width: 'calc(5% + 4px)' });
+    });
+
+    test('should render the grey tick element', () => {
+        const { container } = render(<MarkerCluster cluster={rangeCluster} />);
+        expect(container.querySelector('.bp-MarkerCluster-tick')).toBeInTheDocument();
+    });
+
+    test('should render avatars via MarkerAvatarStack', () => {
+        render(<MarkerCluster cluster={rangeCluster} />);
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+        expect(screen.getByText('C')).toBeInTheDocument();
+    });
+
+    test('should show overflow indicator when more than 4 markers', () => {
+        const manyMarkers: CommentMarker[] = [
+            { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+            { id: 'm2', time: 10.1, initial: 'B', colorIndex: 1 },
+            { id: 'm3', time: 10.2, initial: 'C', colorIndex: 2 },
+            { id: 'm4', time: 10.3, initial: 'D', colorIndex: 3 },
+            { id: 'm5', time: 10.4, initial: 'E', colorIndex: 4 },
+        ];
+        const cluster: ClusterData = {
+            id: 'm1|m2|m3|m4|m5',
+            isSinglePoint: false,
+            leftPercent: 10,
+            markers: manyMarkers,
+            rightPercent: 15,
+        };
+        render(<MarkerCluster cluster={cluster} />);
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+        expect(screen.getByText('C')).toBeInTheDocument();
+        expect(screen.queryByText('D')).not.toBeInTheDocument();
+        expect(screen.queryByText('E')).not.toBeInTheDocument();
+        expect(screen.getByText('+2')).toBeInTheDocument();
+    });
+
+    test('should call onMarkerClick with first marker when tick is clicked', async () => {
+        const user = userEvent.setup();
+        const onMarkerClick = jest.fn();
+        const { container } = render(<MarkerCluster cluster={rangeCluster} onMarkerClick={onMarkerClick} />);
+        const tick = container.querySelector('.bp-MarkerCluster-tick') as HTMLElement;
+        await user.click(tick);
+        expect(onMarkerClick).toHaveBeenCalledWith(markers[0]);
+    });
+
+    test('should call onMarkerClick with specific marker when avatar is clicked', async () => {
+        const user = userEvent.setup();
+        const onMarkerClick = jest.fn();
+        const { container } = render(<MarkerCluster cluster={rangeCluster} onMarkerClick={onMarkerClick} />);
+        const avatarItems = container.querySelectorAll('.bp-MarkerAvatarStack-item');
+        await user.click(avatarItems[1] as HTMLElement);
+        expect(onMarkerClick).toHaveBeenCalledWith(markers[1]);
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/MarkerTick-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerTick-test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import MarkerTick from '../MarkerTick';
-import { CommentMarker } from '../TimeControlsV2';
+import { CommentMarker } from '../types';
 
 describe('MarkerTick', () => {
     const singleMarker: CommentMarker[] = [{ id: 'm1', time: 10, initial: 'A', colorIndex: 0 }];

--- a/src/lib/viewers/controls/media/__tests__/MarkerTick-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerTick-test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import MarkerTick from '../MarkerTick';
+import { CommentMarker } from '../TimeControlsV2';
+
+describe('MarkerTick', () => {
+    const singleMarker: CommentMarker[] = [{ id: 'm1', time: 10, initial: 'A', colorIndex: 0 }];
+
+    const groupMarkers: CommentMarker[] = [
+        { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+        { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+        { id: 'm3', time: 10, initial: 'C', colorIndex: 2 },
+    ];
+
+    describe('single marker', () => {
+        test('should render with correct position', () => {
+            render(<MarkerTick markers={singleMarker} position={16.6667} />);
+            const el = screen.getByTestId('bp-time-controls-marker');
+            expect(el).toHaveStyle({ left: '16.6667%' });
+        });
+
+        test('should not have group modifier class', () => {
+            render(<MarkerTick markers={singleMarker} position={16.6667} />);
+            const el = screen.getByTestId('bp-time-controls-marker');
+            expect(el).toHaveClass('bp-TimeControlsV2-marker');
+            expect(el).not.toHaveClass('bp-TimeControlsV2-marker--group');
+        });
+
+        test('should render a single MarkerAvatar', () => {
+            render(<MarkerTick markers={singleMarker} position={16.6667} />);
+            expect(screen.getByText('A')).toBeInTheDocument();
+        });
+
+        test('should call onMarkerClick when clicked', async () => {
+            const user = userEvent.setup();
+            const onMarkerClick = jest.fn();
+            render(<MarkerTick markers={singleMarker} onMarkerClick={onMarkerClick} position={16.6667} />);
+            await user.click(screen.getByTestId('bp-time-controls-marker'));
+            expect(onMarkerClick).toHaveBeenCalledWith(singleMarker[0]);
+        });
+    });
+
+    describe('group markers', () => {
+        test('should have group modifier class', () => {
+            render(<MarkerTick markers={groupMarkers} position={16.6667} />);
+            const el = screen.getByTestId('bp-time-controls-marker');
+            expect(el).toHaveClass('bp-TimeControlsV2-marker--group');
+        });
+
+        test('should render MarkerAvatarStack instead of single avatar', () => {
+            const { container } = render(<MarkerTick markers={groupMarkers} position={16.6667} />);
+            expect(container.querySelector('.bp-MarkerAvatarStack')).toBeInTheDocument();
+        });
+
+        test('should render all marker avatars', () => {
+            render(<MarkerTick markers={groupMarkers} position={16.6667} />);
+            expect(screen.getByText('A')).toBeInTheDocument();
+            expect(screen.getByText('B')).toBeInTheDocument();
+            expect(screen.getByText('C')).toBeInTheDocument();
+        });
+
+        test('should call onMarkerClick with first marker when tick button is clicked', async () => {
+            const user = userEvent.setup();
+            const onMarkerClick = jest.fn();
+            render(<MarkerTick markers={groupMarkers} onMarkerClick={onMarkerClick} position={16.6667} />);
+            await user.click(screen.getByTestId('bp-time-controls-marker'));
+            expect(onMarkerClick).toHaveBeenCalledWith(groupMarkers[0]);
+        });
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
@@ -3,6 +3,21 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import TimeControlsV2, { CommentMarker } from '../TimeControlsV2';
 
+const mockResizeObserver = jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+}));
+((global as unknown) as { ResizeObserver: jest.Mock }).ResizeObserver = mockResizeObserver;
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 600 });
+});
+
+afterAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 });
+});
+
 describe('TimeControlsV2', () => {
     const defaultProps = {
         onTimeChange: jest.fn(),
@@ -70,6 +85,65 @@ describe('TimeControlsV2', () => {
             const markersWithInitial: CommentMarker[] = [{ id: 'marker-init', time: 20, initial: 'Z', colorIndex: 4 }];
             render(<TimeControlsV2 {...defaultProps} commentMarkers={markersWithInitial} durationTime={60} />);
             expect(screen.getByText('Z')).toBeInTheDocument();
+        });
+    });
+
+    describe('clustering', () => {
+        test('should render MarkerCluster for markers within 2px of each other', () => {
+            // trackWidth=600, duration=60 => 10px/s. Markers at 10s and 10.1s => 1px apart
+            const markers: CommentMarker[] = [
+                { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+                { id: 'm2', time: 10.1, initial: 'B', colorIndex: 1 },
+            ];
+            const { container } = render(
+                <TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />,
+            );
+            expect(container.querySelector('.bp-MarkerCluster')).toBeInTheDocument();
+        });
+
+        test('should render grouped MarkerTick for markers at the same timestamp', () => {
+            const markers: CommentMarker[] = [
+                { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+                { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+            ];
+            const { container } = render(
+                <TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />,
+            );
+            expect(container.querySelector('.bp-TimeControlsV2-marker--group')).toBeInTheDocument();
+            expect(container.querySelector('.bp-MarkerAvatarStack')).toBeInTheDocument();
+        });
+
+        test('should render individual MarkerTicks for markers far apart', () => {
+            const markers: CommentMarker[] = [
+                { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+                { id: 'm2', time: 30, initial: 'B', colorIndex: 1 },
+            ];
+            const { container } = render(
+                <TimeControlsV2 {...defaultProps} commentMarkers={markers} durationTime={60} />,
+            );
+            expect(screen.getAllByTestId('bp-time-controls-marker')).toHaveLength(2);
+            expect(container.querySelector('.bp-MarkerCluster')).not.toBeInTheDocument();
+            expect(container.querySelector('.bp-TimeControlsV2-marker--group')).not.toBeInTheDocument();
+        });
+
+        test('should call onCommentMarkerClick when a grouped marker tick is clicked', async () => {
+            const user = userEvent.setup();
+            const onCommentMarkerClick = jest.fn();
+            const markers: CommentMarker[] = [
+                { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+                { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+            ];
+            const { container } = render(
+                <TimeControlsV2
+                    {...defaultProps}
+                    commentMarkers={markers}
+                    durationTime={60}
+                    onCommentMarkerClick={onCommentMarkerClick}
+                />,
+            );
+            const groupTick = container.querySelector('.bp-TimeControlsV2-marker--group') as HTMLElement;
+            await user.click(groupTick);
+            expect(onCommentMarkerClick).toHaveBeenCalledWith(markers[0]);
         });
     });
 

--- a/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimeControlsV2-test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import TimeControlsV2, { CommentMarker } from '../TimeControlsV2';
+import TimeControlsV2 from '../TimeControlsV2';
+import { CommentMarker } from '../types';
 
 const mockResizeObserver = jest.fn().mockImplementation(() => ({
     disconnect: jest.fn(),

--- a/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
+++ b/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
@@ -1,5 +1,5 @@
 import buildClusters from '../buildClusters';
-import { CommentMarker } from '../TimeControlsV2';
+import { CommentMarker } from '../types';
 
 describe('buildClusters', () => {
     test('should return empty array when markers is empty', () => {

--- a/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
+++ b/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
@@ -1,0 +1,120 @@
+import buildClusters from '../buildClusters';
+import { CommentMarker } from '../TimeControlsV2';
+
+describe('buildClusters', () => {
+    test('should return empty array when markers is empty', () => {
+        expect(buildClusters([], 60, 600)).toHaveLength(0);
+    });
+
+    test('should return empty array when trackWidth is 0', () => {
+        const markers: CommentMarker[] = [{ id: 'm1', time: 10 }];
+        expect(buildClusters(markers, 60, 0)).toHaveLength(0);
+    });
+
+    test('should return empty array when durationValue is 0', () => {
+        const markers: CommentMarker[] = [{ id: 'm1', time: 10 }];
+        expect(buildClusters(markers, 0, 500)).toHaveLength(0);
+    });
+
+    test('should return a single cluster for a single marker', () => {
+        const markers: CommentMarker[] = [{ id: 'm1', time: 10 }];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].markers).toHaveLength(1);
+        expect(clusters[0].isSinglePoint).toBe(true);
+    });
+
+    test('should not cluster markers that are far apart', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 30 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].markers).toHaveLength(1);
+        expect(clusters[1].markers).toHaveLength(1);
+    });
+
+    test('should cluster markers at the same timestamp', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 10 },
+            { id: 'm3', time: 10 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].markers).toHaveLength(3);
+        expect(clusters[0].isSinglePoint).toBe(true);
+    });
+
+    test('should cluster markers within threshold px of each other', () => {
+        // trackWidth=600, duration=60 => 10px per second
+        // markers at 10s and 10.1s => 100px and 101px => 1px apart => cluster
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 10.1 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].markers).toHaveLength(2);
+        expect(clusters[0].isSinglePoint).toBe(false);
+    });
+
+    test('should not cluster markers that are more than threshold px apart', () => {
+        // trackWidth=600, duration=60 => 10px per second
+        // markers at 10s and 10.5s => 100px and 105px => 5px apart => no cluster
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 10.5 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(2);
+    });
+
+    test('should sort markers by time before clustering', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 30 },
+            { id: 'm2', time: 10 },
+            { id: 'm3', time: 10 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].markers[0].id).toBe('m2');
+        expect(clusters[0].markers[1].id).toBe('m3');
+        expect(clusters[1].markers[0].id).toBe('m1');
+    });
+
+    test('should chain nearby markers into a single cluster', () => {
+        // trackWidth=1000, duration=100 => 10px per second
+        // A=10s(100px), C=10.1s(101px), B=10.2s(102px) — each 1px apart
+        const markers: CommentMarker[] = [
+            { id: 'A', time: 10 },
+            { id: 'B', time: 10.2 },
+            { id: 'C', time: 10.1 },
+        ];
+        const clusters = buildClusters(markers, 100, 1000);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].markers).toHaveLength(3);
+        expect(clusters[0].markers.map(m => m.id)).toEqual(['A', 'C', 'B']);
+    });
+
+    test('should compute correct leftPercent and rightPercent', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 6 },
+            { id: 'm2', time: 6.1 },
+        ];
+        // 6/60 * 100 = 10%, 6.1/60 * 100 = 10.1667%
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters[0].leftPercent).toBeCloseTo(10, 2);
+        expect(clusters[0].rightPercent).toBeCloseTo(10.1667, 2);
+    });
+
+    test('should generate id by joining marker ids', () => {
+        const markers: CommentMarker[] = [
+            { id: 'a', time: 10 },
+            { id: 'b', time: 10 },
+        ];
+        const clusters = buildClusters(markers, 60, 600);
+        expect(clusters[0].id).toBe('a|b');
+    });
+});

--- a/src/lib/viewers/controls/media/__tests__/utils-test.ts
+++ b/src/lib/viewers/controls/media/__tests__/utils-test.ts
@@ -1,0 +1,35 @@
+import { round, percent } from '../utils';
+
+describe('utils', () => {
+    describe('round', () => {
+        test('should round to 4 decimal places', () => {
+            expect(round(1.23456789)).toBe(1.2346);
+        });
+
+        test('should not add unnecessary decimals', () => {
+            expect(round(5)).toBe(5);
+        });
+
+        test('should handle 0', () => {
+            expect(round(0)).toBe(0);
+        });
+    });
+
+    describe('percent', () => {
+        test('should calculate percentage correctly', () => {
+            expect(percent(10, 60)).toBeCloseTo(16.6667, 4);
+        });
+
+        test('should return 100 for equal values', () => {
+            expect(percent(60, 60)).toBe(100);
+        });
+
+        test('should return 50 for half', () => {
+            expect(percent(30, 60)).toBe(50);
+        });
+
+        test('should return 0 for zero numerator', () => {
+            expect(percent(0, 60)).toBe(0);
+        });
+    });
+});

--- a/src/lib/viewers/controls/media/buildClusters.ts
+++ b/src/lib/viewers/controls/media/buildClusters.ts
@@ -1,0 +1,53 @@
+import { ClusterData } from './MarkerCluster';
+import { CommentMarker, percent } from './TimeControlsV2';
+
+/** Max pixel distance between adjacent markers (sorted by time) for them to be grouped into a single cluster. */
+const CLUSTER_THRESHOLD_PX = 2;
+
+/** Converts a group of markers into a ClusterData object with computed positions and metadata. */
+function finalizeCluster(group: CommentMarker[], durationValue: number): ClusterData {
+    const leftPercent = percent(group[0].time, durationValue);
+    const rightPercent = percent(group[group.length - 1].time, durationValue);
+    const isSinglePoint = leftPercent === rightPercent;
+
+    return {
+        id: group.map(m => m.id).join('|'),
+        isSinglePoint,
+        leftPercent,
+        markers: group,
+        rightPercent,
+    };
+}
+
+/**
+ * Groups comment markers into clusters based on their pixel proximity on the scrubber track.
+ * Markers are sorted by time, then chained: each marker that is within CLUSTER_THRESHOLD_PX
+ * of its neighbor joins the same cluster. This means distant markers can end up in one cluster
+ * if intermediate markers bridge the gap.
+ */
+export default function buildClusters(
+    markers: CommentMarker[],
+    durationValue: number,
+    trackWidth: number,
+): ClusterData[] {
+    if (durationValue <= 0 || markers.length === 0 || trackWidth <= 0) return [];
+
+    const sorted = [...markers].sort((a, b) => a.time - b.time);
+    const clusters: ClusterData[] = [];
+    let currentGroup: CommentMarker[] = [sorted[0]];
+
+    for (let i = 1; i < sorted.length; i += 1) {
+        const prevPx = (sorted[i - 1].time / durationValue) * trackWidth;
+        const currPx = (sorted[i].time / durationValue) * trackWidth;
+
+        if (currPx - prevPx <= CLUSTER_THRESHOLD_PX) {
+            currentGroup.push(sorted[i]);
+        } else {
+            clusters.push(finalizeCluster(currentGroup, durationValue));
+            currentGroup = [sorted[i]];
+        }
+    }
+    clusters.push(finalizeCluster(currentGroup, durationValue));
+
+    return clusters;
+}

--- a/src/lib/viewers/controls/media/buildClusters.ts
+++ b/src/lib/viewers/controls/media/buildClusters.ts
@@ -1,5 +1,5 @@
-import { ClusterData } from './MarkerCluster';
-import { CommentMarker, percent } from './TimeControlsV2';
+import { ClusterData, CommentMarker } from './types';
+import { percent } from './utils';
 
 /** Max pixel distance between adjacent markers (sorted by time) for them to be grouped into a single cluster. */
 const CLUSTER_THRESHOLD_PX = 2;

--- a/src/lib/viewers/controls/media/types.ts
+++ b/src/lib/viewers/controls/media/types.ts
@@ -1,0 +1,16 @@
+export type CommentMarker = {
+    avatarUrl?: string;
+    colorIndex?: number;
+    id: string;
+    initial?: string;
+    time: number;
+    type?: 'annotation' | 'comment';
+};
+
+export type ClusterData = {
+    id: string;
+    isSinglePoint: boolean;
+    leftPercent: number;
+    markers: CommentMarker[];
+    rightPercent: number;
+};

--- a/src/lib/viewers/controls/media/utils.ts
+++ b/src/lib/viewers/controls/media/utils.ts
@@ -1,0 +1,7 @@
+export const round = (value: number): number => {
+    return +value.toFixed(4);
+};
+
+export const percent = (value1: number, value2: number): number => {
+    return round((value1 / value2) * 100);
+};

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -114,7 +114,6 @@ export default function VideoControlsV2({
                     filmstripInterval={filmstripInterval}
                     filmstripUrl={filmstripUrl}
                     fps={fps}
-                    mediaEl={mediaEl}
                     onCommentMarkerClick={onCommentMarkerClick}
                     onTimeChange={onTimeChange}
                 />

--- a/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
@@ -6,6 +6,12 @@ import subtitles from '../../controls/media/__mocks__/subtitles';
 import { Quality } from '../../controls/media/MediaSettingsMenuQuality';
 import { SUBTITLES_OFF } from '../../../constants';
 
+((global as unknown) as { ResizeObserver: jest.Mock }).ResizeObserver = jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+}));
+
 const defaultProps = {
     audioTrack: 1,
     audioTracks: [],


### PR DESCRIPTION
## Summary
  - Add marker clustering to the V2 video player scrubber bar. Markers that are within 2px of each other on the track are combined into clusters, and markers at the exact same timestamp are grouped into a single tick with a
   stacked avatar display.
  - Clusters render as grey rectangles spanning the marker range; same-timestamp groups render as standard white 2px ticks with multiple avatars stacked above.
  - Avatar stacks show up to 4 avatars with half-overlap; overflow shows a "+N" badge that is clickable. On hover of a cluster or group tick, the element scales up and avatars expand apart so users can individually hover
  and click each avatar to seek to its comment.

  ## New Components
  | Component | Purpose |
  |-----------|---------|
  | `buildClusters.ts` | Groups markers by pixel proximity using a chain-based algorithm |
  | `MarkerTick.tsx` | White 2px marker button — renders single avatar or avatar stack |
  | `MarkerAvatarStack.tsx` | Horizontal overlapping avatar row with overflow badge (shared by `MarkerTick` and `MarkerCluster`) |
  | `MarkerCluster.tsx` | Grey rectangle for range clusters (markers close but not at same timestamp) |

  ## Behavior
  | Scenario | Scrubber element | Click action |
  |----------|-----------------|--------------|
  | Single comment | White 2px tick + single avatar | Seek to comment |
  | Multiple comments, same timestamp | White 2px tick + avatar stack | Tick click: seek to first comment. Avatar click: seek to that comment |
  | Multiple comments, within 2px | Grey rectangle + avatar stack | Tick click: seek to first comment. Avatar click: seek to that comment |

  ## Hover interactions
  - **Individual markers**: Tick scales up (1.7x), avatar gains white border
  - **Group ticks & cluster rectangles**: Element scales up, avatar stack expands apart (animated), individual avatars gain white border on hover with elevated z-index

  ## Test plan
  - [x] `buildClusters-test.ts` — 10 tests covering edge cases, chaining, sorting, and output shape
  - [x] `MarkerTick-test.tsx` — 7 tests for single/group rendering and click behavior
  - [x] `MarkerAvatarStack-test.tsx` — 7 tests for avatar display, overflow count/click, and individual avatar clicks
  - [x] `MarkerCluster-test.tsx` — 6 tests for range cluster rendering and interactions
  - [x] `TimeControlsV2-test.tsx` — 13 tests including 4 new clustering integration tests
  - [ ] Manually verify hover animations render smoothly in browser
  - [ ] Verify clicking individual avatars in expanded stack correctly seeks to the corresponding comment
  - [ ] Verify overflow "+N" badge shows correct count and seeks correctly