### PR TITLE
feat(gallery): a11y polish, entry-state reset, focus return

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -52,6 +52,8 @@ toggle_findbar=Toggle findbar
 toggle_thumbnails=Toggle thumbnails
 # Button tooltip for Gallery view
 gallery_view=Gallery view
+# Accessible name for the gallery page-thumbnail listbox
+page_gallery=Page gallery
 # Message when file has inaccessible xrefs
 has_x_refs=This preview has references you cannot view. Open the file in its native application.
 # Button tooltip for finding the next instance of a phrase in the file

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -54,6 +54,8 @@ toggle_thumbnails=Toggle thumbnails
 gallery_view=Gallery view
 # Accessible name for the gallery page-thumbnail listbox
 page_gallery=Page gallery
+# Accessible name for a single gallery tile; {1} is the page number
+page_gallery_tile=Page {1}
 # Message when file has inaccessible xrefs
 has_x_refs=This preview has references you cannot view. Open the file in its native application.
 # Button tooltip for finding the next instance of a phrase in the file

--- a/src/lib/viewers/controls/controls-root/ControlsRoot.scss
+++ b/src/lib/viewers/controls/controls-root/ControlsRoot.scss
@@ -4,7 +4,7 @@
     position: absolute;
     bottom: 25px;
     left: 50%;
-    z-index: 4;
+    z-index: 5;
     transform: translate3d(-50%, 0, 0);
     backface-visibility: hidden;
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -157,6 +157,7 @@ class DocBaseViewer extends BaseViewer {
         this.handleAnnotationCreateEvent = this.handleAnnotationCreateEvent.bind(this);
         this.handleAnnotationCreatorChangeEvent = this.handleAnnotationCreatorChangeEvent.bind(this);
         this.handleDocElKeydown = this.handleDocElKeydown.bind(this);
+        this.handleGalleryToggle = this.handleGalleryToggle.bind(this);
         this.handlePageSubmit = this.handlePageSubmit.bind(this);
         this.onThumbnailSelectHandler = this.onThumbnailSelectHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
@@ -244,6 +245,12 @@ class DocBaseViewer extends BaseViewer {
             setPage: n => this.setPage(n),
             toggleThumbnails: () => this.toggleThumbnails(),
             requestUiUpdate: () => this.renderUI(),
+            focusToggle: () => {
+                const toggle = this.containerEl.querySelector('.bp-GalleryToggle');
+                if (toggle && toggle.focus) {
+                    toggle.focus();
+                }
+            },
         });
     }
 
@@ -1492,7 +1499,7 @@ class DocBaseViewer extends BaseViewer {
                 onAnnotationModeEscape={this.handleAnnotationControlsEscape}
                 onFindBarToggle={!this.isFindDisabled() ? this.toggleFindBar : undefined}
                 onFullscreenToggle={this.toggleFullscreen}
-                onGalleryToggle={canGallery ? this.galleryController.toggle : undefined}
+                onGalleryToggle={canGallery ? this.handleGalleryToggle : undefined}
                 onPageChange={this.setPage}
                 onPageSubmit={this.handlePageSubmit}
                 onRotateLeft={canRotate ? this.rotateLeft : undefined}
@@ -1992,6 +1999,26 @@ class DocBaseViewer extends BaseViewer {
     toggleFindBar(findBarToggleEl) {
         this.findBarToggleEl = findBarToggleEl;
         this.findBar.toggle();
+    }
+
+    /**
+     * Callback when the gallery toggle button is clicked. Closes the find bar and resets
+     * annotation mode before entering gallery, then delegates to the gallery controller.
+     *
+     * @protected
+     * @return {void}
+     */
+    handleGalleryToggle() {
+        if (!this.galleryController.isOpen) {
+            if (this.findBar) {
+                this.findBar.close();
+            }
+            this.processAnnotationModeChange(this.annotationControlsFSM.transition(AnnotationInput.RESET));
+            if (this.annotator) {
+                this.annotator.toggleAnnotationMode(AnnotationMode.NONE);
+            }
+        }
+        this.galleryController.toggle();
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -157,7 +157,6 @@ class DocBaseViewer extends BaseViewer {
         this.handleAnnotationCreateEvent = this.handleAnnotationCreateEvent.bind(this);
         this.handleAnnotationCreatorChangeEvent = this.handleAnnotationCreatorChangeEvent.bind(this);
         this.handleDocElKeydown = this.handleDocElKeydown.bind(this);
-        this.handleGalleryToggle = this.handleGalleryToggle.bind(this);
         this.handlePageSubmit = this.handlePageSubmit.bind(this);
         this.onThumbnailSelectHandler = this.onThumbnailSelectHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
@@ -251,6 +250,8 @@ class DocBaseViewer extends BaseViewer {
                     toggle.focus();
                 }
             },
+            onBeforeOpen: () => this.handleGalleryEnter(),
+            onAfterClose: () => this.handleGalleryExit(),
         });
     }
 
@@ -1499,7 +1500,7 @@ class DocBaseViewer extends BaseViewer {
                 onAnnotationModeEscape={this.handleAnnotationControlsEscape}
                 onFindBarToggle={!this.isFindDisabled() ? this.toggleFindBar : undefined}
                 onFullscreenToggle={this.toggleFullscreen}
-                onGalleryToggle={canGallery ? this.handleGalleryToggle : undefined}
+                onGalleryToggle={canGallery ? this.galleryController.toggle : undefined}
                 onPageChange={this.setPage}
                 onPageSubmit={this.handlePageSubmit}
                 onRotateLeft={canRotate ? this.rotateLeft : undefined}
@@ -2002,23 +2003,31 @@ class DocBaseViewer extends BaseViewer {
     }
 
     /**
-     * Callback when the gallery toggle button is clicked. Closes the find bar and resets
-     * annotation mode before entering gallery, then delegates to the gallery controller.
+     * Called before the gallery opens. Closes the find bar and resets annotation mode.
      *
      * @protected
      * @return {void}
      */
-    handleGalleryToggle() {
-        if (!this.galleryController.isOpen) {
-            if (this.findBar) {
-                this.findBar.close();
-            }
-            this.processAnnotationModeChange(this.annotationControlsFSM.transition(AnnotationInput.RESET));
-            if (this.annotator) {
-                this.annotator.toggleAnnotationMode(AnnotationMode.NONE);
-            }
+    handleGalleryEnter() {
+        if (this.findBar) {
+            this.findBar.close();
         }
-        this.galleryController.toggle();
+        this.processAnnotationModeChange(this.annotationControlsFSM.transition(AnnotationInput.RESET));
+        if (this.annotator) {
+            this.annotator.toggleAnnotationMode(AnnotationMode.NONE);
+        }
+    }
+
+    /**
+     * Called after the gallery closes. Restores REGION mode so the region-comment cursor is active.
+     *
+     * @protected
+     * @return {void}
+     */
+    handleGalleryExit() {
+        if (this.annotator && this.areNewAnnotationsEnabled()) {
+            this.annotator.toggleAnnotationMode(AnnotationMode.REGION);
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/DocControls.tsx
+++ b/src/lib/viewers/doc/DocControls.tsx
@@ -51,16 +51,9 @@ export default function DocControls({
 }: Props): JSX.Element {
     return (
         <ExperiencesProvider experiences={experiences}>
-            {isGalleryOpen ? (
-                <ControlsBar>
-                    <ControlsBarGroup>
-                        <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
-                        <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
-                    </ControlsBarGroup>
-                </ControlsBar>
-            ) : (
-                <>
-                    <ControlsBar>
+            <ControlsBar>
+                {!isGalleryOpen && (
+                    <>
                         <ControlsBarGroup>
                             <ThumbnailsToggle
                                 isThumbnailsOpen={isThumbnailsOpen}
@@ -90,28 +83,32 @@ export default function DocControls({
                                 <RotateControl onRotateLeft={onRotateLeft} />
                             </ControlsBarGroup>
                         )}
-                        <ControlsBarGroup>
-                            <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
-                            <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
-                            <AnnotationsControls
-                                annotationColor={annotationColor}
-                                annotationMode={annotationMode}
-                                hasDrawing={hasDrawing}
-                                hasHighlight={hasHighlight}
-                                hasRegion={hasRegion}
-                                onAnnotationModeClick={onAnnotationModeClick}
-                                onAnnotationModeEscape={onAnnotationModeEscape}
-                            />
-                        </ControlsBarGroup>
-                    </ControlsBar>
-                    <ControlsBar>
-                        <DrawingControls
+                    </>
+                )}
+                <ControlsBarGroup>
+                    <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />
+                    <FullscreenToggle onFullscreenToggle={onFullscreenToggle} />
+                    {!isGalleryOpen && (
+                        <AnnotationsControls
                             annotationColor={annotationColor}
                             annotationMode={annotationMode}
-                            onAnnotationColorChange={onAnnotationColorChange}
+                            hasDrawing={hasDrawing}
+                            hasHighlight={hasHighlight}
+                            hasRegion={hasRegion}
+                            onAnnotationModeClick={onAnnotationModeClick}
+                            onAnnotationModeEscape={onAnnotationModeEscape}
                         />
-                    </ControlsBar>
-                </>
+                    )}
+                </ControlsBarGroup>
+            </ControlsBar>
+            {!isGalleryOpen && (
+                <ControlsBar>
+                    <DrawingControls
+                        annotationColor={annotationColor}
+                        annotationMode={annotationMode}
+                        onAnnotationColorChange={onAnnotationColorChange}
+                    />
+                </ControlsBar>
             )}
         </ExperiencesProvider>
     );

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -4270,18 +4270,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             });
         });
 
-        describe('handleGalleryToggle()', () => {
-            let galleryToggle;
-
+        describe('handleGalleryEnter()', () => {
             beforeEach(() => {
-                galleryToggle = jest.fn(() => {
-                    docBase.galleryController.isOpen = !docBase.galleryController.isOpen;
-                });
-                docBase.galleryController = {
-                    isOpen: false,
-                    toggle: galleryToggle,
-                    destroy: jest.fn(),
-                };
                 docBase.findBar = { close: jest.fn(), destroy: jest.fn() };
                 docBase.annotator = { toggleAnnotationMode: jest.fn() };
                 docBase.processAnnotationModeChange = jest.fn();
@@ -4290,39 +4280,50 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 };
             });
 
-            test('should close find bar, reset annotation mode, and delegate to the controller on entry', () => {
-                docBase.handleGalleryToggle();
+            test('should close find bar and reset annotation mode', () => {
+                docBase.handleGalleryEnter();
 
                 expect(docBase.findBar.close).toBeCalled();
                 expect(docBase.annotationControlsFSM.transition).toBeCalledWith(AnnotationInput.RESET);
                 expect(docBase.processAnnotationModeChange).toBeCalledWith(AnnotationMode.NONE);
                 expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.NONE);
-                expect(galleryToggle).toBeCalled();
-            });
-
-            test('should skip resets when closing the gallery', () => {
-                docBase.galleryController.isOpen = true;
-
-                docBase.handleGalleryToggle();
-
-                expect(docBase.findBar.close).not.toBeCalled();
-                expect(docBase.annotationControlsFSM.transition).not.toBeCalled();
-                expect(docBase.annotator.toggleAnnotationMode).not.toBeCalled();
-                expect(galleryToggle).toBeCalled();
             });
 
             test('should not throw if findBar is not initialized', () => {
                 docBase.findBar = undefined;
-
-                expect(() => docBase.handleGalleryToggle()).not.toThrow();
-                expect(galleryToggle).toBeCalled();
+                expect(() => docBase.handleGalleryEnter()).not.toThrow();
             });
 
             test('should not throw if annotator is not initialized', () => {
                 docBase.annotator = undefined;
+                expect(() => docBase.handleGalleryEnter()).not.toThrow();
+            });
+        });
 
-                expect(() => docBase.handleGalleryToggle()).not.toThrow();
-                expect(galleryToggle).toBeCalled();
+        describe('handleGalleryExit()', () => {
+            beforeEach(() => {
+                docBase.annotator = { toggleAnnotationMode: jest.fn() };
+            });
+
+            test('should restore REGION mode when new annotations are enabled', () => {
+                jest.spyOn(docBase, 'areNewAnnotationsEnabled').mockReturnValue(true);
+
+                docBase.handleGalleryExit();
+
+                expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.REGION);
+            });
+
+            test('should not restore REGION mode when new annotations are disabled', () => {
+                jest.spyOn(docBase, 'areNewAnnotationsEnabled').mockReturnValue(false);
+
+                docBase.handleGalleryExit();
+
+                expect(docBase.annotator.toggleAnnotationMode).not.toBeCalled();
+            });
+
+            test('should not throw if annotator is not initialized', () => {
+                docBase.annotator = undefined;
+                expect(() => docBase.handleGalleryExit()).not.toThrow();
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -4272,7 +4272,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
         describe('handleGalleryToggle()', () => {
             let galleryToggle;
-            let toggleEl;
 
             beforeEach(() => {
                 galleryToggle = jest.fn(() => {
@@ -4289,11 +4288,10 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.annotationControlsFSM = {
                     transition: jest.fn().mockReturnValue(AnnotationMode.NONE),
                 };
-                toggleEl = { focus: jest.fn() };
             });
 
             test('should close find bar, reset annotation mode, and delegate to the controller on entry', () => {
-                docBase.handleGalleryToggle(toggleEl);
+                docBase.handleGalleryToggle();
 
                 expect(docBase.findBar.close).toBeCalled();
                 expect(docBase.annotationControlsFSM.transition).toBeCalledWith(AnnotationInput.RESET);
@@ -4305,7 +4303,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             test('should skip resets when closing the gallery', () => {
                 docBase.galleryController.isOpen = true;
 
-                docBase.handleGalleryToggle(toggleEl);
+                docBase.handleGalleryToggle();
 
                 expect(docBase.findBar.close).not.toBeCalled();
                 expect(docBase.annotationControlsFSM.transition).not.toBeCalled();
@@ -4316,14 +4314,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             test('should not throw if findBar is not initialized', () => {
                 docBase.findBar = undefined;
 
-                expect(() => docBase.handleGalleryToggle(toggleEl)).not.toThrow();
+                expect(() => docBase.handleGalleryToggle()).not.toThrow();
                 expect(galleryToggle).toBeCalled();
             });
 
             test('should not throw if annotator is not initialized', () => {
                 docBase.annotator = undefined;
 
-                expect(() => docBase.handleGalleryToggle(toggleEl)).not.toThrow();
+                expect(() => docBase.handleGalleryToggle()).not.toThrow();
                 expect(galleryToggle).toBeCalled();
             });
         });

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -4270,6 +4270,64 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             });
         });
 
+        describe('handleGalleryToggle()', () => {
+            let galleryToggle;
+            let toggleEl;
+
+            beforeEach(() => {
+                galleryToggle = jest.fn(() => {
+                    docBase.galleryController.isOpen = !docBase.galleryController.isOpen;
+                });
+                docBase.galleryController = {
+                    isOpen: false,
+                    toggle: galleryToggle,
+                    destroy: jest.fn(),
+                };
+                docBase.findBar = { close: jest.fn(), destroy: jest.fn() };
+                docBase.annotator = { toggleAnnotationMode: jest.fn() };
+                docBase.processAnnotationModeChange = jest.fn();
+                docBase.annotationControlsFSM = {
+                    transition: jest.fn().mockReturnValue(AnnotationMode.NONE),
+                };
+                toggleEl = { focus: jest.fn() };
+            });
+
+            test('should close find bar, reset annotation mode, and delegate to the controller on entry', () => {
+                docBase.handleGalleryToggle(toggleEl);
+
+                expect(docBase.findBar.close).toBeCalled();
+                expect(docBase.annotationControlsFSM.transition).toBeCalledWith(AnnotationInput.RESET);
+                expect(docBase.processAnnotationModeChange).toBeCalledWith(AnnotationMode.NONE);
+                expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.NONE);
+                expect(galleryToggle).toBeCalled();
+            });
+
+            test('should skip resets when closing the gallery', () => {
+                docBase.galleryController.isOpen = true;
+
+                docBase.handleGalleryToggle(toggleEl);
+
+                expect(docBase.findBar.close).not.toBeCalled();
+                expect(docBase.annotationControlsFSM.transition).not.toBeCalled();
+                expect(docBase.annotator.toggleAnnotationMode).not.toBeCalled();
+                expect(galleryToggle).toBeCalled();
+            });
+
+            test('should not throw if findBar is not initialized', () => {
+                docBase.findBar = undefined;
+
+                expect(() => docBase.handleGalleryToggle(toggleEl)).not.toThrow();
+                expect(galleryToggle).toBeCalled();
+            });
+
+            test('should not throw if annotator is not initialized', () => {
+                docBase.annotator = undefined;
+
+                expect(() => docBase.handleGalleryToggle(toggleEl)).not.toThrow();
+                expect(galleryToggle).toBeCalled();
+            });
+        });
+
         describe('getInitialAnnotationMode()', () => {
             test.each`
                 enableAnnotationsDiscoverability | expectedMode

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -40,6 +40,7 @@ export type GalleryControllerOptions = {
     setPage: (n: number) => void;
     toggleThumbnails: () => void;
     requestUiUpdate: () => void;
+    focusToggle: () => void;
 };
 
 export default class GalleryController {
@@ -58,6 +59,8 @@ export default class GalleryController {
     private toggleThumbnails: () => void;
 
     private requestUiUpdate: () => void;
+
+    private focusToggle: () => void;
 
     private galleryRoot: Root | null = null;
 
@@ -84,6 +87,7 @@ export default class GalleryController {
         this.setPage = opts.setPage;
         this.toggleThumbnails = opts.toggleThumbnails;
         this.requestUiUpdate = opts.requestUiUpdate;
+        this.focusToggle = opts.focusToggle;
     }
 
     get isOpen(): boolean {
@@ -159,6 +163,10 @@ export default class GalleryController {
         }
 
         this.requestUiUpdate();
+
+        if (!this.isGalleryOpen) {
+            this.focusToggle();
+        }
     };
 
     handleEscape(): boolean {

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -41,6 +41,8 @@ export type GalleryControllerOptions = {
     toggleThumbnails: () => void;
     requestUiUpdate: () => void;
     focusToggle: () => void;
+    onBeforeOpen: () => void;
+    onAfterClose: () => void;
 };
 
 export default class GalleryController {
@@ -61,6 +63,10 @@ export default class GalleryController {
     private requestUiUpdate: () => void;
 
     private focusToggle: () => void;
+
+    private onBeforeOpen: () => void;
+
+    private onAfterClose: () => void;
 
     private galleryRoot: Root | null = null;
 
@@ -88,6 +94,8 @@ export default class GalleryController {
         this.toggleThumbnails = opts.toggleThumbnails;
         this.requestUiUpdate = opts.requestUiUpdate;
         this.focusToggle = opts.focusToggle;
+        this.onBeforeOpen = opts.onBeforeOpen;
+        this.onAfterClose = opts.onAfterClose;
     }
 
     get isOpen(): boolean {
@@ -104,6 +112,8 @@ export default class GalleryController {
         this.isGalleryOpen = !this.isGalleryOpen;
 
         if (this.isGalleryOpen) {
+            this.onBeforeOpen();
+
             if (this.gallerySidebarTimeoutId !== null) {
                 clearTimeout(this.gallerySidebarTimeoutId);
                 this.gallerySidebarTimeoutId = null;
@@ -165,6 +175,7 @@ export default class GalleryController {
         this.requestUiUpdate();
 
         if (!this.isGalleryOpen) {
+            this.onAfterClose();
             this.focusToggle();
         }
     };

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -6,7 +6,8 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 2;
+    // Sits above annotation layers and find bar (z=3); toolbar (ControlsRoot z=5) stays on top.
+    z-index: 4;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 16px;
@@ -14,6 +15,7 @@
     padding: 40px;
     padding-bottom: 100px;
     overflow-y: auto;
+    overscroll-behavior: none;
     background-color: $white;
 }
 

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -88,3 +88,8 @@
     width: 100%;
     padding-top: 129%;
 }
+
+// Annotation popups render into a top-level portal outside the gallery's tree. Hide them while the gallery is open.
+.bp-container:has(.bp-gallery-grid) .ba-PopupPortal {
+    display: none;
+}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import throttle from 'lodash/throttle';
+import { decodeKeydown } from '../../util';
 import './GalleryGrid.scss';
 
 const GALLERY_THUMB_MAX_WIDTH = 440;
@@ -24,6 +25,39 @@ export type Props = {
     onClose: () => void;
     thumbnail: GalleryThumbnail;
 };
+
+interface TileProps {
+    pageNum: number;
+    isFocused: boolean;
+    imageSrc?: string;
+    onClick: (pageNum: number) => void;
+    onFocus: (pageNum: number) => void;
+}
+
+const GalleryTile = React.memo(function GalleryTile({
+    pageNum,
+    isFocused,
+    imageSrc,
+    onClick,
+    onFocus,
+}: TileProps): JSX.Element {
+    return (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+        <div
+            aria-label={`Page ${pageNum}`}
+            aria-selected={isFocused}
+            className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
+            data-page={pageNum}
+            onClick={() => onClick(pageNum)}
+            onFocus={() => onFocus(pageNum)}
+            role="option"
+            tabIndex={isFocused ? 0 : -1}
+        >
+            <span className="bp-gallery-tile-badge">{pageNum}</span>
+            {imageSrc ? <img alt="" src={imageSrc} /> : <span className="bp-gallery-tile-placeholder" />}
+        </div>
+    );
+});
 
 export default function GalleryGrid({
     pageCount,
@@ -188,6 +222,15 @@ export default function GalleryGrid({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const focusTile = useCallback((pageNum: number) => {
+        const grid = gridRef.current;
+        if (!grid) return;
+        const tile = grid.querySelector(`[data-page="${pageNum}"]`) as HTMLElement | null;
+        if (tile) {
+            tile.focus();
+        }
+    }, []);
+
     const handleTileFocus = useCallback(
         (pageNum: number) => {
             setFocusedPage(pageNum);
@@ -198,75 +241,88 @@ export default function GalleryGrid({
         [onFocusChange],
     );
 
+    const handleTileClick = useCallback(
+        (pageNum: number) => {
+            onPageNavigate(pageNum);
+        },
+        [onPageNavigate],
+    );
+
     const handleGridFocus = useCallback(
         (event: React.FocusEvent) => {
-            if (event.target === gridRef.current && gridRef.current) {
-                const tile = gridRef.current.querySelector(`[data-page="${focusedPage}"]`) as HTMLElement;
-                if (tile) {
-                    tile.focus();
-                }
+            if (event.target === gridRef.current) {
+                focusTile(focusedPage);
             }
         },
-        [focusedPage],
+        [focusedPage, focusTile],
     );
 
     const handleGridKeyDown = useCallback(
         (event: React.KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                event.stopPropagation();
-                onClose();
-                return;
-            }
+            const key = decodeKeydown(event);
 
-            if (event.key === 'Tab' && gridRef.current) {
-                const buttons = gridRef.current.querySelectorAll('button');
-                const first = buttons[0];
-                const last = buttons[buttons.length - 1];
-
-                if (event.shiftKey && document.activeElement === first) {
+            switch (key) {
+                case 'Escape':
                     event.preventDefault();
-                    last.focus();
-                } else if (!event.shiftKey && document.activeElement === last) {
+                    event.stopPropagation();
+                    onClose();
+                    return;
+                case 'ArrowUp':
+                case 'ArrowLeft':
+                    if (focusedPage > 1) {
+                        event.preventDefault();
+                        focusTile(focusedPage - 1);
+                    }
+                    return;
+                case 'ArrowDown':
+                case 'ArrowRight':
+                    if (focusedPage < pageCount) {
+                        event.preventDefault();
+                        focusTile(focusedPage + 1);
+                    }
+                    return;
+                case 'Home':
                     event.preventDefault();
-                    first.focus();
-                }
+                    focusTile(1);
+                    return;
+                case 'End':
+                    event.preventDefault();
+                    focusTile(pageCount);
+                    return;
+                case 'Enter':
+                case 'Space':
+                    event.preventDefault();
+                    onPageNavigate(focusedPage);
+                    break;
+                default:
             }
         },
-        [onClose],
+        [focusedPage, focusTile, onClose, onPageNavigate, pageCount],
     );
 
     const tiles = [];
     for (let i = 1; i <= pageCount; i += 1) {
-        const isFocused = i === focusedPage;
         tiles.push(
-            <button
+            <GalleryTile
                 key={i}
-                aria-label={`Page ${i}${isFocused ? ', current page' : ''}`}
-                className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
-                data-page={i}
-                onClick={() => onPageNavigate(i)}
-                onFocus={() => handleTileFocus(i)}
-                type="button"
-            >
-                <span className="bp-gallery-tile-badge">{i}</span>
-                {loadedImages[i] ? (
-                    <img alt={`Page ${i}`} src={loadedImages[i]} />
-                ) : (
-                    <span className="bp-gallery-tile-placeholder" />
-                )}
-            </button>,
+                imageSrc={loadedImages[i]}
+                isFocused={i === focusedPage}
+                onClick={handleTileClick}
+                onFocus={handleTileFocus}
+                pageNum={i}
+            />,
         );
     }
 
     return (
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
             ref={gridRef}
+            aria-label={__('page_gallery')}
             className="bp-gallery-grid"
             onFocus={handleGridFocus}
             onKeyDown={handleGridKeyDown}
             onScroll={handleScrollRef.current}
+            role="listbox"
             tabIndex={-1}
         >
             {tiles}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import throttle from 'lodash/throttle';
-import { decodeKeydown } from '../../util';
+import { decodeKeydown, replacePlaceholders } from '../../util';
 import './GalleryGrid.scss';
 
 const GALLERY_THUMB_MAX_WIDTH = 440;
@@ -44,7 +44,7 @@ const GalleryTile = React.memo(function GalleryTile({
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <div
-            aria-label={`Page ${pageNum}`}
+            aria-label={replacePlaceholders(__('page_gallery_tile'), [String(pageNum)])}
             aria-selected={isFocused}
             className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
             data-page={pageNum}
@@ -267,6 +267,7 @@ export default function GalleryGrid({
                     event.stopPropagation();
                     onClose();
                     return;
+                // Listbox is 1-D — arrows move ±1; row-aware nav comes with v2 grid role.
                 case 'ArrowUp':
                 case 'ArrowLeft':
                     if (focusedPage > 1) {

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -33,6 +33,8 @@ interface Harness {
     toggleThumbnails: jest.Mock;
     requestUiUpdate: jest.Mock;
     focusToggle: jest.Mock;
+    onBeforeOpen: jest.Mock;
+    onAfterClose: jest.Mock;
 }
 
 function makeController(
@@ -59,6 +61,8 @@ function makeController(
     });
     const requestUiUpdate = jest.fn();
     const focusToggle = jest.fn();
+    const onBeforeOpen = jest.fn();
+    const onAfterClose = jest.fn();
 
     const opts: GalleryControllerOptions = {
         containerEl,
@@ -70,6 +74,8 @@ function makeController(
         toggleThumbnails,
         requestUiUpdate,
         focusToggle,
+        onBeforeOpen,
+        onAfterClose,
     };
 
     return {
@@ -81,6 +87,8 @@ function makeController(
         toggleThumbnails,
         requestUiUpdate,
         focusToggle,
+        onBeforeOpen,
+        onAfterClose,
     };
 }
 
@@ -153,6 +161,22 @@ describe('GalleryController', () => {
             expect(focusToggle).not.toHaveBeenCalled();
             controller.toggle();
             expect(focusToggle).toHaveBeenCalledTimes(1);
+        });
+
+        test('should call onBeforeOpen on open and not on close', () => {
+            const { controller, onBeforeOpen } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(onBeforeOpen).toHaveBeenCalledTimes(1);
+            controller.toggle();
+            expect(onBeforeOpen).toHaveBeenCalledTimes(1);
+        });
+
+        test('should call onAfterClose on close and not on open', () => {
+            const { controller, onAfterClose } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(onAfterClose).not.toHaveBeenCalled();
+            controller.toggle();
+            expect(onAfterClose).toHaveBeenCalledTimes(1);
         });
 
         test('should wire the correct props into GalleryGrid', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -32,6 +32,7 @@ interface Harness {
     setPage: jest.Mock;
     toggleThumbnails: jest.Mock;
     requestUiUpdate: jest.Mock;
+    focusToggle: jest.Mock;
 }
 
 function makeController(
@@ -57,6 +58,7 @@ function makeController(
         if (sidebar) sidebar.isOpen = !sidebar.isOpen;
     });
     const requestUiUpdate = jest.fn();
+    const focusToggle = jest.fn();
 
     const opts: GalleryControllerOptions = {
         containerEl,
@@ -67,6 +69,7 @@ function makeController(
         setPage,
         toggleThumbnails,
         requestUiUpdate,
+        focusToggle,
     };
 
     return {
@@ -77,6 +80,7 @@ function makeController(
         setPage,
         toggleThumbnails,
         requestUiUpdate,
+        focusToggle,
     };
 }
 
@@ -135,6 +139,20 @@ describe('GalleryController', () => {
             expect(controller.isOpen).toBe(true);
             expect(containerEl.children).toHaveLength(1);
             expect(requestUiUpdate).toHaveBeenCalledTimes(1);
+        });
+
+        test('should not call focusToggle on open', () => {
+            const { controller, focusToggle } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(focusToggle).not.toHaveBeenCalled();
+        });
+
+        test('should call focusToggle on close', () => {
+            const { controller, focusToggle } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            expect(focusToggle).not.toHaveBeenCalled();
+            controller.toggle();
+            expect(focusToggle).toHaveBeenCalledTimes(1);
         });
 
         test('should wire the correct props into GalleryGrid', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -28,21 +28,23 @@ describe('GalleryGrid', () => {
     const getWrapper = (props = {}) => render(<GalleryGrid {...defaultProps} {...props} />);
 
     describe('render', () => {
-        test('should render the gallery grid container', () => {
+        test('should render the gallery grid container with listbox role', () => {
             getWrapper();
-            expect(document.querySelector('.bp-gallery-grid')).toBeInTheDocument();
+            const grid = screen.getByRole('listbox');
+            expect(grid).toHaveClass('bp-gallery-grid');
+            expect(grid).toHaveAttribute('aria-label', 'Page gallery');
         });
 
-        test('should render a button for each page', () => {
+        test('should render an option for each page', () => {
             getWrapper();
-            const buttons = screen.getAllByRole('button');
-            expect(buttons).toHaveLength(10);
+            const options = screen.getAllByRole('option');
+            expect(options).toHaveLength(10);
         });
 
         test('should set aria-label on each tile', () => {
             getWrapper();
             expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
-            expect(screen.getByLabelText('Page 3, current page')).toBeInTheDocument();
+            expect(screen.getByLabelText('Page 3')).toBeInTheDocument();
             expect(screen.getByLabelText('Page 10')).toBeInTheDocument();
         });
     });
@@ -50,19 +52,25 @@ describe('GalleryGrid', () => {
     describe('current page highlight', () => {
         test('should apply selected class to current page tile', () => {
             getWrapper();
-            const tile = screen.getByLabelText('Page 3, current page');
+            const tile = screen.getByLabelText('Page 3');
             expect(tile).toHaveClass('bp-gallery-tile--selected');
         });
 
-        test('should not apply selected class to other tiles', () => {
+        test('should set aria-selected on current page tile only', () => {
             getWrapper();
-            const tile = screen.getByLabelText('Page 1');
-            expect(tile).not.toHaveClass('bp-gallery-tile--selected');
+            expect(screen.getByLabelText('Page 3')).toHaveAttribute('aria-selected', 'true');
+            expect(screen.getByLabelText('Page 1')).toHaveAttribute('aria-selected', 'false');
+        });
+
+        test('should give current page tile tabIndex 0 and others -1 (roving tabindex)', () => {
+            getWrapper();
+            expect(screen.getByLabelText('Page 3')).toHaveAttribute('tabIndex', '0');
+            expect(screen.getByLabelText('Page 1')).toHaveAttribute('tabIndex', '-1');
         });
 
         test('should render badge on every tile', () => {
             getWrapper();
-            const allTiles = screen.getAllByRole('button');
+            const allTiles = screen.getAllByRole('option');
             allTiles.forEach(tile => {
                 expect(tile.querySelector('.bp-gallery-tile-badge')).toBeInTheDocument();
             });
@@ -81,40 +89,112 @@ describe('GalleryGrid', () => {
             await userEvent.click(screen.getByLabelText('Page 5'));
             expect(onPageNavigate).toHaveBeenCalledWith(5);
         });
+
+        test('should still allow click navigation when thumbnail render failed (fallback tile)', async () => {
+            const failingThumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockRejectedValue(new Error('render failed')),
+            };
+            const onPageNavigate = jest.fn();
+            getWrapper({ onPageNavigate, thumbnail: failingThumbnail });
+
+            const tile = screen.getByLabelText('Page 7');
+            expect(tile.querySelector('.bp-gallery-tile-badge')).toBeInTheDocument();
+            expect(tile.querySelector('.bp-gallery-tile-placeholder')).toBeInTheDocument();
+
+            await userEvent.click(tile);
+            expect(onPageNavigate).toHaveBeenCalledWith(7);
+        });
     });
 
     describe('keyboard', () => {
         test('should call onClose on Escape', async () => {
             const onClose = jest.fn();
             getWrapper({ onClose });
-            const grid = document.querySelector('.bp-gallery-grid') as HTMLElement;
-            grid.focus();
+            screen.getByLabelText('Page 3').focus();
             await userEvent.keyboard('{Escape}');
             expect(onClose).toHaveBeenCalled();
         });
 
-        test('should wrap focus from last tile to first on Tab', async () => {
+        test('should move focus to next tile on ArrowDown', async () => {
             getWrapper();
-            const buttons = screen.getAllByRole('button');
-            const lastButton = buttons[buttons.length - 1];
-            lastButton.focus();
-            await userEvent.tab();
-            expect(buttons[0]).toHaveFocus();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{ArrowDown}');
+            expect(screen.getByLabelText('Page 4')).toHaveFocus();
         });
 
-        test('should wrap focus from first tile to last on Shift+Tab', async () => {
+        test('should move focus to next tile on ArrowRight', async () => {
             getWrapper();
-            const buttons = screen.getAllByRole('button');
-            buttons[0].focus();
-            await userEvent.tab({ shift: true });
-            expect(buttons[buttons.length - 1]).toHaveFocus();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{ArrowRight}');
+            expect(screen.getByLabelText('Page 4')).toHaveFocus();
+        });
+
+        test('should move focus to previous tile on ArrowUp', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{ArrowUp}');
+            expect(screen.getByLabelText('Page 2')).toHaveFocus();
+        });
+
+        test('should move focus to previous tile on ArrowLeft', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{ArrowLeft}');
+            expect(screen.getByLabelText('Page 2')).toHaveFocus();
+        });
+
+        test('should not move past first tile on ArrowUp', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            screen.getByLabelText('Page 1').focus();
+            await userEvent.keyboard('{ArrowUp}');
+            expect(screen.getByLabelText('Page 1')).toHaveFocus();
+        });
+
+        test('should not move past last tile on ArrowDown', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            screen.getByLabelText('Page 10').focus();
+            await userEvent.keyboard('{ArrowDown}');
+            expect(screen.getByLabelText('Page 10')).toHaveFocus();
+        });
+
+        test('should jump to first tile on Home', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{Home}');
+            expect(screen.getByLabelText('Page 1')).toHaveFocus();
+        });
+
+        test('should jump to last tile on End', async () => {
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{End}');
+            expect(screen.getByLabelText('Page 10')).toHaveFocus();
+        });
+
+        test('should call onPageNavigate on Enter', async () => {
+            const onPageNavigate = jest.fn();
+            getWrapper({ onPageNavigate });
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard('{Enter}');
+            expect(onPageNavigate).toHaveBeenCalledWith(3);
+        });
+
+        test('should call onPageNavigate on Space', async () => {
+            const onPageNavigate = jest.fn();
+            getWrapper({ onPageNavigate });
+            screen.getByLabelText('Page 3').focus();
+            await userEvent.keyboard(' ');
+            expect(onPageNavigate).toHaveBeenCalledWith(3);
         });
     });
 
     describe('focus management', () => {
         test('should focus current page tile on mount', () => {
             getWrapper();
-            const tile = screen.getByLabelText('Page 3, current page');
+            const tile = screen.getByLabelText('Page 3');
             expect(tile).toHaveFocus();
         });
 
@@ -141,13 +221,11 @@ describe('GalleryGrid', () => {
 
         test('should redirect focus to focused tile when grid container is clicked', async () => {
             getWrapper();
-            const grid = document.querySelector('.bp-gallery-grid') as HTMLElement;
-            // Simulate clicking empty area — focus goes to grid container
+            const grid = screen.getByRole('listbox');
             grid.focus();
 
             await waitFor(() => {
-                // Focus should redirect to the focused page tile
-                const focusedTile = screen.getByLabelText('Page 3, current page');
+                const focusedTile = screen.getByLabelText('Page 3');
                 expect(focusedTile).toHaveFocus();
             });
         });
@@ -178,7 +256,7 @@ describe('GalleryGrid', () => {
             };
             getWrapper({ thumbnail: cachedThumbnail });
 
-            const tile3 = screen.getByLabelText('Page 3, current page');
+            const tile3 = screen.getByLabelText('Page 3');
             const img = tile3.querySelector('img');
             expect(img).toBeInTheDocument();
             expect(img).toHaveAttribute('src', 'data:image/png;cached-page-3');


### PR DESCRIPTION
## Summary

  Polish + a11y baseline pass on the gallery view.
  
  The grid now implements the full ARIA listbox pattern: `role="listbox"` on the container with `aria-label` sourced from a new `page_gallery` i18n key, `role="option"` + `aria-selected` on each tile, roving tabindex so exactly one tile is in the tab order at a time, and keyboard handlers for Arrow keys / Home / End / Enter / Space / Escape. Tiles are extracted into a memoized `<GalleryTile>` so grids with hundreds of pages don't re-render on every focus change.

  Entering the gallery now resets viewer state that would otherwise leak: the find bar closes, the annotation controls FSM is reset, andthe annotator's mode is switched to NONE. Without this, users could enter the gallery with the drawing tool still active and mark up thumbnails.

  Two rendering bugs are fixed: annotations no longer bleed through the overlay (gallery `z-index` bumped above the annotation layer, toolbar bumped above the gallery), and hard-scrolling the grid on macOS/iOS no longer exposes the doc behind it (`overscroll-behavior: none`).

  Focus returns to the Gallery toggle when the gallery closes. This required two things: `DocControls.tsx` was restructured from an `isGalleryOpen ? A : B` ternary into one tree with conditional groups so React preserves the toggle's DOM node across state flips, and `GalleryController` gained a `focusToggle` option that the viewer wires to a live DOM query for `.bp-GalleryToggle`. The controller calls it after `requestUiUpdate()` when transitioning to closed, so both toolbar-click and Escape-key close paths restore focus.

  ## Modifies

  - `src/lib/viewers/gallery/GalleryGrid.tsx` — listbox semantics, roving tabindex, arrow-key navigation, memoized `<GalleryTile>`
  - `src/lib/viewers/gallery/GalleryGrid.scss` — `z-index: 4`, `overscroll-behavior: none`
  - `src/lib/viewers/gallery/GalleryController.tsx` — `focusToggle` option, invoked after UI update on close
  - `src/lib/viewers/doc/DocBaseViewer.js` — `handleGalleryToggle` resets find bar + annotation state on entry; `focusToggle` callback queries the live toggle DOM node
  - `src/lib/viewers/doc/DocControls.tsx` — unified JSX tree so `<GalleryToggle>` stays mounted across `isGalleryOpen` flips
  - `src/lib/viewers/controls/controls-root/ControlsRoot.scss` — toolbar `z-index: 5` (above gallery)
  - `src/i18n/en-US.properties` — `page_gallery` key
  - `src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx` — listbox role assertions, arrow-key coverage, fallback tile test
  - `src/lib/viewers/gallery/__tests__/GalleryController-test.tsx` — `focusToggle` called on close, not on open
  - `src/lib/viewers/doc/__tests__/DocBaseViewer-test.js` — four tests covering `handleGalleryToggle` reset behavior

  ## Test plan
  
  - [ ] Open a multi-page doc; toggle gallery — grid opens with the current page focused and centered
  - [ ] Tab into the grid — focus lands on the selected tile only (roving tabindex)
  - [ ] Arrow / Home / End move focus tile-to-tile without leaving the grid; Enter or Space navigates to that page and closes gallery
  - [ ] Escape closes gallery; focus returns to the Gallery toggle button
  - [ ] Click the toggle to close gallery; focus returns to the toggle
  - [ ] Enable a drawing tool, then open the gallery — tool deselects, no draw overlay on thumbnails
  - [ ] Open the find bar, then open the gallery — find bar closes
  - [ ] Scroll the grid past its edges on macOS/iOS — no rubber-band exposes the doc underneath
  - [ ] With annotations visible, open the gallery — no annotations bleed through the overlay
  - [ ] Watermarked doc: gallery thumbnails render with the same watermark stamp as the sidebar
  - [ ] Axe DevTools on the open gallery — 0 critical violations