### PR TITLE
fix(doc): restore PDF link clicks after pdf.js 6 upgrade

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -363,6 +363,12 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 
     .annotationLayer {
+        // pdf.js 6 inserts its layers before the box-annotations layers, so the
+        // region creation overlay (pointer-events: auto) paints above the link
+        // annotations and swallows their clicks. Lift the annotation layer above
+        // the overlay but below the region/highlight targets (z-index: 3).
+        z-index: 2;
+
         h1,
         h2,
         h3,


### PR DESCRIPTION
## Problem

After the pdfjs-dist 4.3.136 → 6.0.227 upgrade (#1666), external link annotations in PDFs render but are not clickable.

## Root cause

pdf.js renders each link as an invisible `<a>` inside `section.linkAnnotation` in the `.annotationLayer`, overlaying the visible text span. All page layers are absolutely-positioned siblings with `z-index: auto`, so DOM order decides hit-testing.

pdf.js 6 inserts its layers earlier in the page render lifecycle than v4 did, which changes the sibling order:

- **v4 (working):** `canvasWrapper → ba-Layer--regionCreation → textLayer → annotationLayer` — links on top
- **v6 (broken):** `canvasWrapper → textLayer → annotationLayer → annotationEditorLayer → ba-Layer--regionCreation` — the box-annotations region-creation overlay (full-page, `pointer-events: auto`, swallows clicks via PointerCapture) lands above the links

## Fix

Give `.annotationLayer` `z-index: 2` inside `.bp-doc`: above the region-creation overlay (`auto`) and textLayer (`1`), below the box-annotations region/highlight/drawing layers (`3`) and popups (`4`). This restores the exact stacking relationships v4 had.

## Testing

Verified live against a devpod with both pdf.js versions A/B tested:

- [x] Link markup is identical in v4 and v6 — regression is purely stacking order
- [x] With fix: clicking the link opens the target URL in a new tab
- [x] Existing region/highlight/drawing annotations overlapping a link still win clicks (z-index 3 > 2), matching v4
- [x] Region-creation mode over a link behaves identically to v4
- [x] Text selection unaffected
- [x] stylelint passes; CSS-only change

**Note:** pdf.js's native `annotationEditorLayer` (rendered permanently disabled — box-annotations is used instead) now stacks below the link layer. Inert today; revisit if native pdf.js editors are ever enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)