### PR TITLE
refactor(video-player-v2): gate time view dropdown behind split

### DIFF
--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import formatTimecode from '../../media/formatTimecode';
-import { DEFAULT_FPS } from '../../media/videoFps';
+import { formatTime } from './DurationLabels';
 import './FilmstripV2.scss';
 
 const FILMSTRIP_FRAMES_PER_ROW = 100;
@@ -22,7 +22,7 @@ export type Props = {
 
 export default function FilmstripV2({
     aspectRatio = 0,
-    fps = DEFAULT_FPS,
+    fps,
     imageUrl = '',
     interval = 1,
     isShown,
@@ -84,7 +84,7 @@ export default function FilmstripV2({
                 )}
             </div>
             <div className="bp-FilmstripV2-time" data-testid="bp-FilmstripV2-time">
-                {formatTimecode(time, fps)}
+                {fps ? formatTimecode(time, fps) : formatTime(time)}
             </div>
         </div>
     );

--- a/src/lib/viewers/controls/media/TimestampControl.scss
+++ b/src/lib/viewers/controls/media/TimestampControl.scss
@@ -6,14 +6,11 @@
     align-items: center;
 }
 
-.bp-TimestampControl-button {
-    @include bp-Control--fade;
-    @include bp-Control--outline;
-
+.bp-TimestampControl-button,
+.bp-TimestampControl-static {
     display: flex;
     gap: 4px;
     align-items: center;
-    margin: 0;
     padding: 6px 12px;
     color: $white;
     font-weight: normal;
@@ -22,11 +19,18 @@
     line-height: 20px;
     letter-spacing: .3px;
     white-space: nowrap;
+    user-select: none;
+}
+
+.bp-TimestampControl-button {
+    @include bp-Control--fade;
+    @include bp-Control--outline;
+
+    margin: 0;
     background: transparent;
     border: 0;
     border-radius: $bp-controls-button-radius;
     cursor: pointer;
-    user-select: none;
 
     &:focus:not(:disabled),
     &.bp-is-open {

--- a/src/lib/viewers/controls/media/TimestampControl.tsx
+++ b/src/lib/viewers/controls/media/TimestampControl.tsx
@@ -20,6 +20,7 @@ export type Props = {
     currentTime?: number;
     durationTime?: number;
     fps?: number;
+    canChangeTimeFormat?: boolean;
     isNarrowWidth?: boolean;
     mediaEl?: HTMLVideoElement | null;
 };
@@ -46,6 +47,7 @@ export default function TimestampControl({
     currentTime = 0,
     durationTime = 0,
     fps = DEFAULT_FPS,
+    canChangeTimeFormat = false,
     isNarrowWidth = false,
     mediaEl,
 }: Props): JSX.Element {
@@ -137,6 +139,22 @@ export default function TimestampControl({
         event.stopPropagation();
         handleSelect(selectedFormat);
     };
+
+    if (!canChangeTimeFormat) {
+        return (
+            <div className="bp-TimestampControl" data-testid="bp-TimestampControl">
+                <span className="bp-TimestampControl-static" data-testid="bp-TimestampControl-static">
+                    <span className="bp-TimestampControl-current">{formatTime(currentTime)}</span>
+                    {!isNarrowWidth && (
+                        <>
+                            <span className="bp-TimestampControl-separator">/</span>
+                            <span className="bp-TimestampControl-duration">{formatTime(durationTime)}</span>
+                        </>
+                    )}
+                </span>
+            </div>
+        );
+    }
 
     return (
         <div ref={containerElRef} className="bp-TimestampControl" data-testid="bp-TimestampControl">

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -55,17 +55,23 @@ describe('FilmstripV2', () => {
         });
     });
 
-    describe('timecode', () => {
-        test('should display formatted time', () => {
+    describe('time display', () => {
+        test('should display standard time when fps is not provided', () => {
             render(<FilmstripV2 time={65} />);
             const timeEl = screen.getByTestId('bp-FilmstripV2-time');
             expect(timeEl).toHaveTextContent('1:05');
         });
 
-        test('should display 0:00 for time 0', () => {
+        test('should display 0:00 for time 0 when fps is not provided', () => {
             render(<FilmstripV2 time={0} />);
             const timeEl = screen.getByTestId('bp-FilmstripV2-time');
             expect(timeEl).toHaveTextContent('0:00');
+        });
+
+        test('should display timecode when fps is provided', () => {
+            render(<FilmstripV2 fps={30} time={61.5} />);
+            const timeEl = screen.getByTestId('bp-FilmstripV2-time');
+            expect(timeEl).toHaveTextContent('00:01:01:15');
         });
     });
 

--- a/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
@@ -20,7 +20,16 @@ describe('TimestampControl', () => {
     });
 
     const getWrapper = (props = {}) =>
-        render(<TimestampControl currentTime={65} durationTime={120} fps={24} mediaEl={videoEl} {...props} />);
+        render(
+            <TimestampControl
+                canChangeTimeFormat
+                currentTime={65}
+                durationTime={120}
+                fps={24}
+                mediaEl={videoEl}
+                {...props}
+            />,
+        );
 
     const getButton = () => screen.getByTestId('bp-TimestampControl-button');
 
@@ -40,6 +49,23 @@ describe('TimestampControl', () => {
         test('should not render the flyout by default', () => {
             getWrapper();
             expect(screen.queryByTestId('bp-TimestampControl-flyout')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('when canChangeTimeFormat is false', () => {
+        test('should render static standard time without a dropdown', () => {
+            render(<TimestampControl currentTime={65} durationTime={120} fps={24} mediaEl={videoEl} />);
+
+            expect(screen.getByTestId('bp-TimestampControl-static')).toBeInTheDocument();
+            expect(screen.getByTestId('bp-TimestampControl-static')).toHaveTextContent('1:05/2:00');
+            expect(screen.queryByTestId('bp-TimestampControl-button')).not.toBeInTheDocument();
+        });
+
+        test('should render only current time when isNarrowWidth is true', () => {
+            render(<TimestampControl currentTime={65} durationTime={120} fps={24} isNarrowWidth mediaEl={videoEl} />);
+
+            expect(screen.getByTestId('bp-TimestampControl-static')).toHaveTextContent('1:05');
+            expect(screen.getByTestId('bp-TimestampControl-static')).not.toHaveTextContent('/');
         });
     });
 

--- a/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/TimestampControl-test.tsx
@@ -54,7 +54,7 @@ describe('TimestampControl', () => {
 
     describe('when canChangeTimeFormat is false', () => {
         test('should render static standard time without a dropdown', () => {
-            render(<TimestampControl currentTime={65} durationTime={120} fps={24} mediaEl={videoEl} />);
+            getWrapper({ canChangeTimeFormat: false });
 
             expect(screen.getByTestId('bp-TimestampControl-static')).toBeInTheDocument();
             expect(screen.getByTestId('bp-TimestampControl-static')).toHaveTextContent('1:05/2:00');
@@ -62,7 +62,7 @@ describe('TimestampControl', () => {
         });
 
         test('should render only current time when isNarrowWidth is true', () => {
-            render(<TimestampControl currentTime={65} durationTime={120} fps={24} isNarrowWidth mediaEl={videoEl} />);
+            getWrapper({ canChangeTimeFormat: false, isNarrowWidth: true });
 
             expect(screen.getByTestId('bp-TimestampControl-static')).toHaveTextContent('1:05');
             expect(screen.getByTestId('bp-TimestampControl-static')).not.toHaveTextContent('/');

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -1214,16 +1214,11 @@ class DashViewer extends VideoBaseViewer {
 
     /**
      * Returns the FPS to use for frame-based UI (timecode/frame formats, scrubber step).
-     * V2 player always has an FPS (manifest value or 24fps fallback); the V1 player
-     * only exposes it when frame stepping is enabled and the manifest provides it.
+     * Only exposes FPS when frame stepping is enabled and the manifest provides it.
      *
      * @return {number|undefined} Frames per second
      */
     getFps() {
-        if (this.isVideoPlayerV2) {
-            return getVideoFps(this.player);
-        }
-
         return this.featureEnabled('frameStep.enabled') && isFpsAvailable(this.player)
             ? getVideoFps(this.player)
             : undefined;
@@ -1280,6 +1275,7 @@ class DashViewer extends VideoBaseViewer {
             audioTracks: this.audioTracks,
             autoplay: this.isAutoplayEnabled(),
             bufferedRange: this.mediaEl.buffered,
+            canChangeTimeFormat: this.featureEnabled('frameStep.enabled'),
             currentTime: this.mediaEl.currentTime,
             durationTime: this.mediaEl.duration,
             experiences: this.experiences,

--- a/src/lib/viewers/media/VideoControlsV2.tsx
+++ b/src/lib/viewers/media/VideoControlsV2.tsx
@@ -26,6 +26,7 @@ export type Props = DurationLabelsProps &
     TimeControlsProps &
     VolumeControlsProps & {
         fps?: number;
+        canChangeTimeFormat?: boolean;
         annotationColor?: string;
         annotationMode?: AnnotationMode;
         experiences?: Experiences;
@@ -57,6 +58,7 @@ export default function VideoControlsV2({
     filmstripInterval,
     filmstripUrl,
     fps,
+    canChangeTimeFormat,
     guide,
     hasDrawing,
     hasRegion,
@@ -152,6 +154,7 @@ export default function VideoControlsV2({
                             </>
                         )}
                         <TimestampControl
+                            canChangeTimeFormat={canChangeTimeFormat}
                             currentTime={currentTime}
                             durationTime={durationTime}
                             fps={fps}

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -1884,27 +1884,7 @@ describe('lib/viewers/media/DashViewer', () => {
     });
 
     describe('getFps()', () => {
-        test('should return manifest fps when videoPlayerV2 is enabled', () => {
-            dash.player = {
-                getVariantTracks: () => [{ frameRate: 30, active: true }],
-                destroy: jest.fn(),
-            };
-            dash.isVideoPlayerV2 = true;
-
-            expect(dash.getFps()).toBe(30);
-        });
-
-        test('should return 24fps fallback when videoPlayerV2 is enabled but manifest fps is unavailable', () => {
-            dash.player = {
-                getVariantTracks: () => [{ active: true }],
-                destroy: jest.fn(),
-            };
-            dash.isVideoPlayerV2 = true;
-
-            expect(dash.getFps()).toBe(24);
-        });
-
-        test('should return manifest fps when only frameStep is enabled and fps is available', () => {
+        test('should return manifest fps when frameStep is enabled and fps is available', () => {
             dash.player = {
                 getVariantTracks: () => [{ frameRate: 30, active: true }],
                 destroy: jest.fn(),
@@ -1914,7 +1894,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(dash.getFps()).toBe(30);
         });
 
-        test('should return undefined when only frameStep is enabled and fps is unavailable', () => {
+        test('should return undefined when frameStep is enabled but fps is unavailable', () => {
             dash.player = {
                 getVariantTracks: () => [{ active: true }],
                 destroy: jest.fn(),
@@ -1924,7 +1904,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(dash.getFps()).toBeUndefined();
         });
 
-        test('should return undefined when neither feature is enabled', () => {
+        test('should return undefined when frameStep is not enabled', () => {
             dash.player = {
                 getVariantTracks: () => [{ frameRate: 30, active: true }],
                 destroy: jest.fn(),

--- a/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/VideoControlsV2-test.tsx
@@ -84,14 +84,29 @@ describe('VideoControlsV2', () => {
     });
 
     describe('timestamp', () => {
-        test('should show current / total time when not narrow', () => {
+        test('should show static standard time when canChangeTimeFormat is false', () => {
             render(<VideoControlsV2 {...defaultProps} currentTime={65} durationTime={120} />);
+            const timestamp = screen.getByTestId('bp-TimestampControl-static');
+            expect(timestamp).toHaveTextContent('1:05/2:00');
+            expect(screen.queryByTestId('bp-TimestampControl-button')).not.toBeInTheDocument();
+        });
+
+        test('should show current / total time when not narrow', () => {
+            render(<VideoControlsV2 {...defaultProps} canChangeTimeFormat currentTime={65} durationTime={120} />);
             const timestamp = screen.getByTestId('bp-TimestampControl-button');
             expect(timestamp).toHaveTextContent('1:05/2:00');
         });
 
         test('should show only current time when narrow', () => {
-            render(<VideoControlsV2 {...defaultProps} currentTime={65} durationTime={120} isNarrowVideo />);
+            render(
+                <VideoControlsV2
+                    {...defaultProps}
+                    canChangeTimeFormat
+                    currentTime={65}
+                    durationTime={120}
+                    isNarrowVideo
+                />,
+            );
             const timestamp = screen.getByTestId('bp-TimestampControl-button');
             expect(timestamp).toHaveTextContent('1:05');
             expect(timestamp).not.toHaveTextContent('/');
@@ -99,7 +114,7 @@ describe('VideoControlsV2', () => {
 
         test('should open the time format dropdown when timestamp is clicked', async () => {
             const user = userEvent.setup();
-            render(<VideoControlsV2 {...defaultProps} currentTime={65} durationTime={120} />);
+            render(<VideoControlsV2 {...defaultProps} canChangeTimeFormat currentTime={65} durationTime={120} />);
 
             await user.click(screen.getByTestId('bp-TimestampControl-button'));
             expect(screen.getByTestId('bp-TimestampControl-flyout')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Repurposes the `frameStep.enabled` feature flag to gate all frame-based UI features in the v2 video player (time format dropdown, frame-level scrubber stepping, time display in filmstrip thumbnail)
- Unifies `DashViewer.getFps()` logic so both v1 and v2 players require `frameStep.enabled` to expose FPS — previously v2 always returned FPS unconditionally

## Behavior matrix

### V2 video player

  | Feature | `frameStep.enabled` OFF | `frameStep.enabled` ON |
  |---------|------------------------|------------------------|
  | Timestamp display | Static standard time (e.g. `1:05 / 2:00`), no dropdown | Dropdown with standard time, timecode, and frame number options |
  | Arrow key behavior (when scrubber focused) | 5 second jumps | Frame-level stepping (1/fps) |
  | Arrow key behavior (general) | 5 second jumps | 5 second jumps |
  | `,` / `.` shortcuts | No-op | Steps one frame back/forward |
  | Filmstrip thumbnail | Standard time (e.g. `1:05`) | Timecode (e.g. `00:01:05:12`) |

  ### V1 video player (unchanged)

  | Feature | `frameStep.enabled` OFF | `frameStep.enabled` ON |
  |---------|------------------------|------------------------|
  | Timestamp display | Standard time | Timecode (always — no dropdown) |
  | Arrow key behavior (when scrubber focused) | 5 second jumps | Frame-level stepping (1/fps) |
  | Arrow key behavior (general) | 5 second jumps | 5 second jumps |
  | `,` / `.` shortcuts | No-op | Steps one frame back/forward |
  | Filmstrip thumbnail| N/A (v1 filmstrip doesn't use fps, it always shows standard time) | N/A |

## Test plan
  - [ ] Verify v2 player with `frameStep.enabled: false`: timestamp shows static standard time, no chevron/dropdown, arrow keys on scrubber jump 5s, filmstrip tooltip shows standard time
  - [ ] Verify v2 player with `frameStep.enabled: true`: timestamp shows dropdown with 3 format options, arrow keys on scrubber step by frame, `,`/`.` step one frame, filmstrip tooltip shows timecode
  - [ ] Verify v1 player with `frameStep.enabled: false`: duration labels show standard time, arrow keys jump 5s
  - [ ] Verify v1 player with `frameStep.enabled: true`: duration labels show timecode, arrow keys step by frame, `,`/`.` step one frame
  - [ ] Verify buffered range gradient renders correctly on the v2 scrubber bar
