### PR TITLE
fix(gallery): stop propagation on handled keys

### DIFF
--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -270,29 +270,34 @@ export default function GalleryGrid({
                 // Listbox is 1-D — arrows move ±1; row-aware nav comes with v2 grid role.
                 case 'ArrowUp':
                 case 'ArrowLeft':
+                    event.preventDefault();
+                    event.stopPropagation();
                     if (focusedPage > 1) {
-                        event.preventDefault();
                         focusTile(focusedPage - 1);
                     }
                     return;
                 case 'ArrowDown':
                 case 'ArrowRight':
+                    event.preventDefault();
+                    event.stopPropagation();
                     if (focusedPage < pageCount) {
-                        event.preventDefault();
                         focusTile(focusedPage + 1);
                     }
                     return;
                 case 'Home':
                     event.preventDefault();
+                    event.stopPropagation();
                     focusTile(1);
                     return;
                 case 'End':
                     event.preventDefault();
+                    event.stopPropagation();
                     focusTile(pageCount);
                     return;
                 case 'Enter':
                 case 'Space':
                     event.preventDefault();
+                    event.stopPropagation();
                     onPageNavigate(focusedPage);
                     break;
                 default:

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -189,6 +189,28 @@ describe('GalleryGrid', () => {
             await userEvent.keyboard(' ');
             expect(onPageNavigate).toHaveBeenCalledWith(3);
         });
+
+        test.each([
+            '{ArrowUp}',
+            '{ArrowDown}',
+            '{ArrowLeft}',
+            '{ArrowRight}',
+            '{Home}',
+            '{End}',
+            '{Enter}',
+            ' ',
+            '{Escape}',
+        ])('should stop propagation on %s so parent handlers do not fire', async keyString => {
+            const parentHandler = jest.fn();
+            document.addEventListener('keydown', parentHandler);
+            getWrapper();
+            screen.getByLabelText('Page 3').focus();
+
+            await userEvent.keyboard(keyString);
+
+            expect(parentHandler).not.toHaveBeenCalled();
+            document.removeEventListener('keydown', parentHandler);
+        });
     });
 
     describe('focus management', () => {


### PR DESCRIPTION
Prevents ArrowUp/ArrowDown keystrokes inside the gallery grid from bubbling to EndUserApp's HotkeyLayer, which was hijacking focus to the file browser (found during bug bash)

## Summary

  Preview lives inside EndUserApp's `HotkeyLayer`, which binds ArrowUp/Down/Home/End/Enter to file browser navigation. Without `stopPropagation`, gallery keystrokes bubbled out and hijacked focus to the surrounding UI — arrow keys jumped between files, Enter opened a different document, Escape closed the whole preview.

  Adds `event.stopPropagation()` alongside the existing `event.preventDefault()` on all handled keys in `handleGridKeyDown`, matching the pattern used by `AIQuickActionDropdown` for the same class of bug.

  ## Test plan
 
Can't really test visually because this issue doesn't happen on dev, but this is the same fix the AI team had for a very similar issue.