### PR TITLE
fix(annotations): default fallback annotator to threaded modernized UI

### DIFF
--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -1079,7 +1079,11 @@ class BaseViewer extends EventEmitter {
             return;
         }
 
-        const boxAnnotations = this.options.boxAnnotations || new global.BoxAnnotations(viewerOptions);
+        const boxAnnotations =
+            this.options.boxAnnotations ||
+            new global.BoxAnnotations(viewerOptions, {
+                features: { isThreadedAnnotation: true, modernization: true },
+            });
         this.annotatorConf = boxAnnotations.determineAnnotator(this.options, this.viewerConfig);
 
         if (!this.annotatorConf) {

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -1279,6 +1279,21 @@ describe('lib/viewers/BaseViewer', () => {
             expect(base.options.boxAnnotations.determineAnnotator).toBeCalled();
         });
 
+        test('should default the fallback BoxAnnotations to the threaded, modernized UI', () => {
+            const constructorSpy = jest.fn(function BoxAnnotations() {
+                this.determineAnnotator = jest.fn(() => conf);
+                this.getAnnotationsOptions = jest.fn(() => annotationsOptions);
+            });
+            window.BoxAnnotations = constructorSpy;
+            jest.spyOn(base, 'areAnnotationsEnabled').mockReturnValue(true);
+
+            base.createAnnotator();
+
+            expect(constructorSpy).toBeCalledWith(expect.any(Object), {
+                features: { isThreadedAnnotation: true, modernization: true },
+            });
+        });
+
         test('should call createAnnotatorOptions with locale, language, and messages from options', () => {
             const createOptionsArg = {
                 ...annotationsOptions,


### PR DESCRIPTION
## Problem
When a host does not pass a `boxAnnotations` instance into Preview options, `BaseViewer.createAnnotator()` builds its own via:

```js
const boxAnnotations = this.options.boxAnnotations || new global.BoxAnnotations(viewerOptions);
```

This fallback passes only `viewerOptions` (the first constructor arg) and no `features` (the second arg). Every feature then resolves through `getProp(features, name, false)` → `false`, so `isThreadedAnnotation` is `false` and the annotator renders the **legacy `PopupReply`** instead of the GA'd threaded `PopupV2`.

This surfaces during a race where a host constructs its annotator instance asynchronously (e.g. inside `requestIdleCallback`) but Preview loads before the instance is ready — Preview receives `boxAnnotations: undefined`, hits this fallback, and shows the legacy popup even though the global `BoxAnnotations` bundle supports the threaded UI.

## Fix
Default the fallback annotator's features to the two GA'd flags:

```js
const boxAnnotations =
    this.options.boxAnnotations ||
    new global.BoxAnnotations(viewerOptions, {
        features: { isThreadedAnnotation: true, modernization: true },
    });
```

- `isThreadedAnnotation` and `modernization` are GA and set unconditionally by hosts, so a shared default of `true` is always correct.
- Flag-gated features (`drawing`, `discoverability`) are intentionally **left off** in the fallback — force-enabling them for all consumers would be a behavior change. A host that wants them passes its own instance (the normal path, which this fallback yields to).

## Test
Added a `createAnnotator()` test asserting the fallback constructor is called with `{ features: { isThreadedAnnotation: true, modernization: true } }`. All 11 `createAnnotator` tests pass; lint clean.
