### PR TITLE
feat(video-player-v2): add resin tags and fix flyout z-index

### DIFF
--- a/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
@@ -20,6 +20,7 @@ export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JS
                 <button
                     key={marker.id}
                     className="bp-MarkerAvatarStack-item"
+                    data-resin-target="commentMarkerStackAvatar"
                     onClick={(e): void => {
                         e.stopPropagation();
                         onMarkerClick?.(marker);
@@ -36,6 +37,7 @@ export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JS
             {hasOverflow && (
                 <button
                     className="bp-MarkerAvatarStack-item bp-MarkerAvatarStack-overflow"
+                    data-resin-target="commentMarkerStackAvatarOverflow"
                     onClick={(e): void => {
                         e.stopPropagation();
                         onMarkerClick?.(markers[MAX_VISIBLE_AVATARS - 1]);

--- a/src/lib/viewers/controls/media/MarkerCluster.tsx
+++ b/src/lib/viewers/controls/media/MarkerCluster.tsx
@@ -21,6 +21,7 @@ export default function MarkerCluster({ cluster, onMarkerClick }: Props): JSX.El
             <button
                 aria-label={__('media_comment_marker')}
                 className="bp-MarkerCluster-tick"
+                data-resin-target="commentMarkerCluster"
                 onClick={(e): void => {
                     e.stopPropagation();
                     onMarkerClick?.(markers[0]);

--- a/src/lib/viewers/controls/media/MarkerTick.tsx
+++ b/src/lib/viewers/controls/media/MarkerTick.tsx
@@ -16,6 +16,7 @@ export default function MarkerTick({ markers, onMarkerClick, position }: Props):
         <button
             aria-label={__('media_comment_marker')}
             className={`bp-TimeControlsV2-marker${isGroup ? ' bp-TimeControlsV2-marker--group' : ''}`}
+            data-resin-target="commentMarker"
             data-testid="bp-time-controls-marker"
             onClick={(e): void => {
                 e.stopPropagation();

--- a/src/lib/viewers/controls/media/TimestampControl.tsx
+++ b/src/lib/viewers/controls/media/TimestampControl.tsx
@@ -203,6 +203,7 @@ export default function TimestampControl({
                             key={value}
                             aria-selected={format === value}
                             className="bp-TimestampControl-listitem"
+                            data-resin-target={`timeFormat-${value}`}
                             onClick={(): void => handleSelect(value)}
                             onKeyDown={createKeyDownHandler(value)}
                             role="option"

--- a/src/lib/viewers/controls/media/VideoFullscreenButton.tsx
+++ b/src/lib/viewers/controls/media/VideoFullscreenButton.tsx
@@ -51,6 +51,7 @@ export default function VideoFullscreenButton({ mediaEl, onFullscreenToggle }: P
         <button
             ref={ref}
             className="bp-VideoFullscreenButton"
+            data-resin-target="videoFullscreen"
             onClick={handleClick}
             style={position ? { top: position.top, right: position.right } : undefined}
             title={title}

--- a/src/lib/viewers/controls/media/VolumeControls.scss
+++ b/src/lib/viewers/controls/media/VolumeControls.scss
@@ -21,6 +21,10 @@
         display: block;
         overflow: visible;
     }
+
+    .bp-media--v2 & {
+        z-index: 10;
+    }
 }
 
 .bp-VolumeControls-slider {

--- a/src/lib/viewers/controls/settings/SettingsFlyout.scss
+++ b/src/lib/viewers/controls/settings/SettingsFlyout.scss
@@ -33,6 +33,7 @@
 // V2 video player flyout — restyled to match the TimestampControl flyout
 .bp-media--v2 {
     .bp-SettingsFlyout {
+        z-index: 10;
         min-width: 250px;
         color: $black;
         font-size: 16px;

--- a/src/lib/viewers/controls/settings/SettingsMenuItem.tsx
+++ b/src/lib/viewers/controls/settings/SettingsMenuItem.tsx
@@ -42,7 +42,7 @@ function SettingsMenuItem(props: Props, ref: React.Ref<Ref>): JSX.Element {
             aria-disabled={isDisabled}
             aria-haspopup="true"
             className={classNames('bp-SettingsMenuItem', className)}
-            data-resin-target="settingsMenuItem"
+            data-resin-target={`settingsMenuItem-${target}`}
             onClick={handleClick}
             onKeyDown={handleKeydown}
             role="menuitem"


### PR DESCRIPTION
## Summary
- Add data-resin-target attributes to V2 video player controls that were missing instrumentation: fullscreen button, comment marker ticks, marker clusters, marker avatar stacks (including overflow), and time format dropdown options
- Make SettingsMenuItem resin target more specific by appending the menu target name (e.g. settingsMenuItem-autoplay, settingsMenuItem-rate)
- Fix `z-index` issue where comment marker avatars appeared above the settings dropdown and volume slider flyouts by adding `z-index: 10` to both in the V2 player

## Test plan
  - [ ] Verify fullscreen button emits videoFullscreen resin event on click
  - [ ] Verify comment marker ticks emit commentMarker resin event
  - [ ] Verify clustered marker tick emits commentMarkerCluster resin event
  - [ ] Verify individual avatars in a stack emit commentMarkerStackAvatar resin event
  - [ ] Verify overflow avatar button emits commentMarkerStackAvatarOverflow resin event
  - [ ] Verify time format options emit timeFormat-standard, timeFormat-timecode, timeFormat-frames respectively
  - [ ] Verify settings menu items emit specific targets (e.g. settingsMenuItem-autoplay)
  - [ ] Verify settings dropdown renders above comment marker avatars when open
  - [ ] Verify volume slider flyout renders above comment marker avatars when open

