### PR TITLE
fix(gallery): trap keys while open

### DIFF
--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -8,8 +8,9 @@ const FOCUSABLE_ELEMENT_SELECTORS = [
     'input[type="radio"]',
     'input[type="checkbox"]',
     'select',
+    '[role="option"][tabindex="0"]',
 ];
-const EXCLUDED_SELECTOR_ATTRIBUTES = ['disabled', 'tabindex="-1"', 'aria-disabled="true"'];
+const EXCLUDED_SELECTOR_ATTRIBUTES = ['disabled', 'tabindex="-1"', 'aria-disabled="true"', 'aria-hidden="true"'];
 const FOCUSABLE_ELEMENTS_SELECTOR = FOCUSABLE_ELEMENT_SELECTORS.map(element => {
     let selector = element;
     EXCLUDED_SELECTOR_ATTRIBUTES.forEach(attribute => {
@@ -75,8 +76,11 @@ class FocusTrap {
     getFocusableElements = (): Array<HTMLElement> => {
         // Look for focusable elements
         const foundElements = this.element.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENTS_SELECTOR);
-        // Filter out the buttons that are invisible (in case display: 'none' is used for hidden buttons)
-        return Array.from(foundElements).filter(el => (isButton(el) && isVisible(el)) || !isButton(el));
+        // Filter out elements in inert subtrees (e.g. the doc while the gallery is open) and
+        // buttons that are invisible (in case display: 'none' is used for hidden buttons)
+        return Array.from(foundElements).filter(
+            el => !el.closest('[inert]') && ((isButton(el) && isVisible(el)) || !isButton(el)),
+        );
     };
 
     handleTrapKeydown = (event: KeyboardEvent): void => {

--- a/src/lib/__tests__/FocusTrap-test.ts
+++ b/src/lib/__tests__/FocusTrap-test.ts
@@ -180,4 +180,37 @@ describe('lib/FocusTrap', () => {
             },
         );
     });
+
+    describe('getFocusableElements()', () => {
+        test('should include explicitly tabbable elements but not the trap anchors', () => {
+            const container = getContainerElement();
+            const tile = document.createElement('div');
+            tile.setAttribute('role', 'option');
+            tile.setAttribute('tabindex', '0');
+            container.appendChild(tile);
+
+            const focusTrap = getFocusTrap();
+            focusTrap.enable();
+
+            const focusable = focusTrap.getFocusableElements();
+            expect(focusable).toContain(tile);
+            expect(focusable.some(el => el.tagName.toLowerCase() === 'i')).toBe(false);
+        });
+
+        test('should exclude elements inside an inert subtree', () => {
+            const container = getContainerElement();
+            const inertWrapper = document.createElement('div');
+            inertWrapper.setAttribute('inert', '');
+            const hiddenTabbable = document.createElement('div');
+            hiddenTabbable.setAttribute('role', 'option');
+            hiddenTabbable.setAttribute('tabindex', '0');
+            inertWrapper.appendChild(hiddenTabbable);
+            container.appendChild(inertWrapper);
+
+            const focusTrap = getFocusTrap();
+            focusTrap.enable();
+
+            expect(focusTrap.getFocusableElements()).not.toContain(hiddenTabbable);
+        });
+    });
 });

--- a/src/lib/_navigation.scss
+++ b/src/lib/_navigation.scss
@@ -1,6 +1,7 @@
 $navigationBtnWidth: 50px;
 
-.bp-is-fullscreen .bp-navigate {
+.bp-is-fullscreen .bp-navigate,
+.bp-is-gallery-open .bp-navigate {
     display: none;
 }
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -3,6 +3,8 @@ export const VIEWER_EVENT = {
     default: 'viewerevent', // The default viewer event.
     download: 'download', // Begin downloading the file.
     error: 'error', // When an error occurs.
+    galleryClose: 'galleryClose', // When gallery view closes
+    galleryOpen: 'galleryOpen', // When gallery view opens
     load: 'load', // Preview is finished loading.
     mediaEndAutoplay: 'mediaendautoplay', // Media playback has completed, with autoplay enabled.
     metric: 'viewermetric', // A viewer metric.

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -930,6 +930,23 @@ class DocBaseViewer extends BaseViewer {
      * @return {boolean} consumed or not
      */
     onKeydown(key, event) {
+        if (this.galleryController && this.galleryController.isOpen) {
+            if (event && event.defaultPrevented) {
+                return false;
+            }
+
+            if (key === 'Escape') {
+                this.galleryController.handleEscape();
+                return true;
+            }
+
+            // Swallow page-nav keys so they can't flip the doc page underneath the gallery
+            // or trigger the host's collection navigation.
+            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(key)) {
+                return true;
+            }
+        }
+
         switch (key) {
             case 'ArrowLeft':
                 this.previousPage();
@@ -1739,10 +1756,6 @@ class DocBaseViewer extends BaseViewer {
     handleDocElKeydown(event) {
         const key = decodeKeydown(event);
 
-        if (key === 'Escape' && this.galleryController.handleEscape()) {
-            return;
-        }
-
         if (event.altKey && key.includes('Arrow')) {
             event.stopPropagation(); // Prevent collection/page navigation for caret navigation users
         }
@@ -2009,6 +2022,7 @@ class DocBaseViewer extends BaseViewer {
      * Called before the gallery opens. Closes the find bar and resets annotation mode.
      *
      * @protected
+     * @emits galleryOpen
      * @return {void}
      */
     handleGalleryEnter() {
@@ -2019,18 +2033,32 @@ class DocBaseViewer extends BaseViewer {
         if (this.annotator) {
             this.annotator.toggleAnnotationMode(AnnotationMode.NONE);
         }
+        this.emit(VIEWER_EVENT.galleryOpen);
     }
 
     /**
      * Called after the gallery closes. Restores REGION mode so the region-comment cursor is active.
      *
      * @protected
+     * @emits galleryClose
      * @return {void}
      */
     handleGalleryExit() {
         if (this.annotator && this.areNewAnnotationsEnabled()) {
             this.annotator.toggleAnnotationMode(AnnotationMode.REGION);
         }
+        this.emit(VIEWER_EVENT.galleryClose);
+    }
+
+    /**
+     * Closes the gallery view if it is open. Exposed for host applications (e.g. the
+     * preview header's Escape hotkey) that see keys the viewer's own handlers cannot.
+     *
+     * @public
+     * @return {boolean} Whether the gallery was open and has been closed
+     */
+    closeGallery() {
+        return this.galleryController ? this.galleryController.handleEscape() : false;
     }
 
     /**

--- a/src/lib/viewers/doc/DocumentViewer.js
+++ b/src/lib/viewers/doc/DocumentViewer.js
@@ -81,6 +81,10 @@ class DocumentViewer extends DocBaseViewer {
      * @return {boolean} Consumed or not
      */
     onKeydown(key, event) {
+        if (this.galleryController && this.galleryController.isOpen) {
+            return super.onKeydown(key, event);
+        }
+
         if (key === 'Shift++') {
             this.zoomIn();
             return true;

--- a/src/lib/viewers/doc/PresentationViewer.js
+++ b/src/lib/viewers/doc/PresentationViewer.js
@@ -112,6 +112,10 @@ class PresentationViewer extends DocBaseViewer {
      * @return {boolean} Consumed or not
      */
     onKeydown(key, event) {
+        if (this.galleryController && this.galleryController.isOpen) {
+            return super.onKeydown(key, event);
+        }
+
         if (key === 'ArrowUp') {
             this.previousPage();
             return true;

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1665,6 +1665,48 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.nextPage).not.toBeCalled();
                 expect(arrowLeft).toBe(false);
             });
+
+            describe('while the gallery is open', () => {
+                beforeEach(() => {
+                    docBase.galleryController = {
+                        isOpen: true,
+                        handleEscape: jest.fn().mockReturnValue(true),
+                        destroy: jest.fn(),
+                    };
+                });
+
+                test('should close the gallery and consume Escape', () => {
+                    const consumed = docBase.onKeydown('Escape', { defaultPrevented: false });
+
+                    expect(docBase.galleryController.handleEscape).toBeCalledTimes(1);
+                    expect(consumed).toBe(true);
+                });
+
+                test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
+                    'should swallow %s without paging',
+                    key => {
+                        const consumed = docBase.onKeydown(key, { defaultPrevented: false });
+
+                        expect(stubs.previousPage).not.toBeCalled();
+                        expect(stubs.nextPage).not.toBeCalled();
+                        expect(consumed).toBe(true);
+                    },
+                );
+
+                test('should not act on Escape already handled by a descendant (defaultPrevented)', () => {
+                    const consumed = docBase.onKeydown('Escape', { defaultPrevented: true });
+
+                    expect(docBase.galleryController.handleEscape).not.toBeCalled();
+                    expect(consumed).toBe(false);
+                });
+
+                test('should not consume unrelated keys', () => {
+                    const consumed = docBase.onKeydown('Enter', { defaultPrevented: false });
+
+                    expect(docBase.galleryController.handleEscape).not.toBeCalled();
+                    expect(consumed).toBe(false);
+                });
+            });
         });
 
         describe('initViewer()', () => {
@@ -4300,6 +4342,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.NONE);
             });
 
+            test('should emit galleryOpen', () => {
+                const emitSpy = jest.spyOn(docBase, 'emit');
+
+                docBase.handleGalleryEnter();
+
+                expect(emitSpy).toBeCalledWith(VIEWER_EVENT.galleryOpen);
+            });
+
             test('should not throw if findBar is not initialized', () => {
                 docBase.findBar = undefined;
                 expect(() => docBase.handleGalleryEnter()).not.toThrow();
@@ -4332,9 +4382,30 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.annotator.toggleAnnotationMode).not.toBeCalled();
             });
 
+            test('should emit galleryClose', () => {
+                jest.spyOn(docBase, 'areNewAnnotationsEnabled').mockReturnValue(false);
+                const emitSpy = jest.spyOn(docBase, 'emit');
+
+                docBase.handleGalleryExit();
+
+                expect(emitSpy).toBeCalledWith(VIEWER_EVENT.galleryClose);
+            });
+
             test('should not throw if annotator is not initialized', () => {
                 docBase.annotator = undefined;
                 expect(() => docBase.handleGalleryExit()).not.toThrow();
+            });
+        });
+
+        describe('closeGallery()', () => {
+            test('should delegate to galleryController.handleEscape and return its result', () => {
+                docBase.galleryController = {
+                    handleEscape: jest.fn().mockReturnValue(true),
+                    destroy: jest.fn(),
+                };
+
+                expect(docBase.closeGallery()).toBe(true);
+                expect(docBase.galleryController.handleEscape).toBeCalledTimes(1);
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -225,6 +225,22 @@ describe('lib/viewers/doc/DocumentViewer', () => {
 
             expect(docbaseStub).toBeCalledTimes(2);
         });
+
+        test('should defer to the gallery key policy instead of paging or zooming while the gallery is open', () => {
+            doc.galleryController = {
+                isOpen: true,
+                handleEscape: jest.fn(),
+                destroy: jest.fn(),
+            };
+
+            const arrowResult = doc.onKeydown('ArrowUp', { defaultPrevented: false });
+            expect(stubs.previousPage).not.toBeCalled();
+            expect(arrowResult).toBe(true);
+
+            const zoomResult = doc.onKeydown('Shift++', { defaultPrevented: false });
+            expect(stubs.zoomIn).not.toBeCalled();
+            expect(zoomResult).toBe(false);
+        });
     });
 
     describe('handleFirstRender()', () => {

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -201,6 +201,19 @@ describe('lib/viewers/doc/PresentationViewer', () => {
 
             expect(result2).toBe(false);
         });
+
+        test('should defer arrows to the gallery key policy instead of paging while the gallery is open', () => {
+            presentation.galleryController = {
+                isOpen: true,
+                handleEscape: jest.fn(),
+                destroy: jest.fn(),
+            };
+
+            const result = presentation.onKeydown('ArrowUp', { defaultPrevented: false });
+
+            expect(stubs.previousPage).not.toBeCalled();
+            expect(result).toBe(true);
+        });
     });
 
     describe('checkOverflow()', () => {

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -232,47 +232,12 @@ export default class GalleryController {
     private applyGalleryOpenState(): void {
         this.containerEl.classList.add('bp-is-gallery-open');
         this.containerEl.querySelector('.bp-doc')?.setAttribute('inert', '');
-        this.containerEl.addEventListener('keydown', this.handleContainerKeyDown);
     }
 
     private clearGalleryOpenState(): void {
         this.containerEl.classList.remove('bp-is-gallery-open');
         this.containerEl.querySelector('.bp-doc')?.removeAttribute('inert');
-        this.containerEl.removeEventListener('keydown', this.handleContainerKeyDown);
     }
-
-    // Keeps gallery keystrokes contained: Tab cycles tile/toggle/fullscreen; Escape closes the gallery.
-    private handleContainerKeyDown = (event: KeyboardEvent): void => {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            event.stopPropagation();
-            this.toggle();
-            return;
-        }
-        // Page-nav keys that bubble here originate outside the grid (the grid consumes its
-        // own with stopPropagation). Swallow them so they can't flip the doc page underneath
-        // the gallery (ArrowLeft/Right, [, ]) or escape to the host page (ArrowUp/Down).
-        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(event.key)) {
-            event.preventDefault();
-            event.stopPropagation();
-            return;
-        }
-        if (event.key !== 'Tab') return;
-        const tile = this.galleryEl?.querySelector<HTMLElement>('[role="option"][tabindex="0"]') ?? null;
-        const toggle = this.containerEl.querySelector<HTMLElement>('.bp-GalleryToggle');
-        const fullscreen = this.containerEl.querySelector<HTMLElement>('.bp-FullscreenToggle');
-        const cycle: HTMLElement[] = [tile, toggle, fullscreen].filter((el): el is HTMLElement => el !== null);
-        if (cycle.length === 0) return;
-
-        const currentIndex = cycle.indexOf(document.activeElement as HTMLElement);
-        if (currentIndex === -1) return;
-
-        event.preventDefault();
-        event.stopPropagation();
-        const step = event.shiftKey ? -1 : 1;
-        const nextIndex = (currentIndex + step + cycle.length) % cycle.length;
-        cycle[nextIndex].focus();
-    };
 
     private handleGalleryNavigate = (pageNum: number): void => {
         this.galleryFocusedPage = pageNum;
@@ -300,7 +265,7 @@ export default class GalleryController {
 
         const thumbnail = this.galleryThumbnail;
         this.galleryEl = document.createElement('div');
-        this.containerEl.appendChild(this.galleryEl);
+        this.containerEl.insertBefore(this.galleryEl, this.containerEl.querySelector('.bp-ControlsRoot'));
         this.galleryRoot = createRoot(this.galleryEl);
         this.galleryFocusedPage = pdfViewer.currentPageNumber;
         this.galleryRoot.render(

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -113,6 +113,7 @@ export default class GalleryController {
 
         if (this.isGalleryOpen) {
             this.onBeforeOpen();
+            this.applyGalleryOpenState();
 
             if (this.gallerySidebarTimeoutId !== null) {
                 clearTimeout(this.gallerySidebarTimeoutId);
@@ -147,6 +148,8 @@ export default class GalleryController {
                 this.galleryRoot.unmount();
                 this.galleryRoot = null;
             }
+
+            this.clearGalleryOpenState();
 
             if (this.galleryEl) {
                 this.galleryEl.remove();
@@ -203,6 +206,8 @@ export default class GalleryController {
             this.gallerySidebarTimeoutId = null;
         }
 
+        this.clearGalleryOpenState();
+
         if (this.galleryRoot) {
             this.galleryRoot.unmount();
             this.galleryRoot = null;
@@ -223,6 +228,51 @@ export default class GalleryController {
         this.sidebarWasOpen = false;
         this.galleryFocusedPage = null;
     }
+
+    private applyGalleryOpenState(): void {
+        this.containerEl.classList.add('bp-is-gallery-open');
+        this.containerEl.querySelector('.bp-doc')?.setAttribute('inert', '');
+        this.containerEl.addEventListener('keydown', this.handleContainerKeyDown);
+    }
+
+    private clearGalleryOpenState(): void {
+        this.containerEl.classList.remove('bp-is-gallery-open');
+        this.containerEl.querySelector('.bp-doc')?.removeAttribute('inert');
+        this.containerEl.removeEventListener('keydown', this.handleContainerKeyDown);
+    }
+
+    // Keeps gallery keystrokes contained: Tab cycles tile/toggle/fullscreen; Escape closes the gallery.
+    private handleContainerKeyDown = (event: KeyboardEvent): void => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.toggle();
+            return;
+        }
+        // Page-nav keys that bubble here originate outside the grid (the grid consumes its
+        // own with stopPropagation). Swallow them so they can't flip the doc page underneath
+        // the gallery (ArrowLeft/Right, [, ]) or escape to the host page (ArrowUp/Down).
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(event.key)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+        if (event.key !== 'Tab') return;
+        const tile = this.galleryEl?.querySelector<HTMLElement>('[role="option"][tabindex="0"]') ?? null;
+        const toggle = this.containerEl.querySelector<HTMLElement>('.bp-GalleryToggle');
+        const fullscreen = this.containerEl.querySelector<HTMLElement>('.bp-FullscreenToggle');
+        const cycle: HTMLElement[] = [tile, toggle, fullscreen].filter((el): el is HTMLElement => el !== null);
+        if (cycle.length === 0) return;
+
+        const currentIndex = cycle.indexOf(document.activeElement as HTMLElement);
+        if (currentIndex === -1) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        const step = event.shiftKey ? -1 : 1;
+        const nextIndex = (currentIndex + step + cycle.length) % cycle.length;
+        cycle[nextIndex].focus();
+    };
 
     private handleGalleryNavigate = (pageNum: number): void => {
         this.galleryFocusedPage = pageNum;

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -94,6 +94,13 @@
     display: none;
 }
 
+// Hide prev/next-file arrows while the gallery is open. They would otherwise stay in the tab order
+// underneath the grid.
+.bcpr-container:has(.bp-is-gallery-open) .bcpr-navigate-left,
+.bcpr-container:has(.bp-is-gallery-open) .bcpr-navigate-right {
+    display: none;
+}
+
 // Stop the underlying doc from scrolling when arrow keys are pressed and focus isn't on a tile.
 // `.bp` prefix bumps specificity above Document.scss `.bp .bp-doc.bp-doc-document { overflow-y: scroll }`.
 .bp .bp-is-gallery-open .bp-doc.bp-doc-document,

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -93,3 +93,11 @@
 .bp-container:has(.bp-gallery-grid) .ba-PopupPortal {
     display: none;
 }
+
+// Stop the underlying doc from scrolling when arrow keys are pressed and focus isn't on a tile.
+// `.bp` prefix bumps specificity above Document.scss `.bp .bp-doc.bp-doc-document { overflow-y: scroll }`.
+.bp .bp-is-gallery-open .bp-doc.bp-doc-document,
+.bp .bp-is-gallery-open .bp-doc.bp-is-scrollable {
+    overflow-x: hidden;
+    overflow-y: hidden;
+}

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -234,164 +234,30 @@ describe('GalleryController', () => {
             });
         });
 
-        describe('tab cycle', () => {
-            function seedToolbarAndTile(containerEl: HTMLElement) {
-                const toggle = document.createElement('button');
-                toggle.className = 'bp-GalleryToggle';
-                const fullscreen = document.createElement('button');
-                fullscreen.className = 'bp-FullscreenToggle';
-                containerEl.appendChild(toggle);
-                containerEl.appendChild(fullscreen);
-                return { toggle, fullscreen };
-            }
+        // Tab is intentionally not trapped: with .bp-doc inert, natural tab order flows from
+        // the gallery controls out to the host's sidebar/header. Verify keys pressed inside
+        // the container bubble freely so DocBaseViewer.onKeydown (via the host) can own the
+        // gallery-wide Escape/arrow policy.
+        test('should not intercept keydown events on containerEl while the gallery is open', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = document.createElement('button');
+            toggle.className = 'bp-GalleryToggle';
+            containerEl.appendChild(toggle);
+            controller.toggle();
 
-            // Must be called AFTER controller.toggle(): the controller appends the gallery
-            // root element (galleryEl) to containerEl as its last child during mount.
-            function seedTile(containerEl: HTMLElement): HTMLElement {
-                const galleryEl = containerEl.lastElementChild as HTMLElement;
-                const tile = document.createElement('div');
-                tile.setAttribute('role', 'option');
-                tile.setAttribute('tabindex', '0');
-                galleryEl.appendChild(tile);
-                return tile;
-            }
-
-            function makeTabEvent(shiftKey = false): KeyboardEvent {
-                return new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true, cancelable: true });
-            }
-
-            test('should Tab forward from Gallery toggle to Fullscreen toggle', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { toggle, fullscreen } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-
-                toggle.focus();
-                containerEl.dispatchEvent(makeTabEvent(false));
-
-                expect(document.activeElement).toBe(fullscreen);
-            });
-
-            test('should Shift+Tab backward from Fullscreen toggle to Gallery toggle', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { toggle, fullscreen } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-
-                fullscreen.focus();
-                containerEl.dispatchEvent(makeTabEvent(true));
-
-                expect(document.activeElement).toBe(toggle);
-            });
-
-            test('should ignore keys other than Tab and Escape', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { toggle } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-
-                toggle.focus();
-                containerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-
-                expect(document.activeElement).toBe(toggle);
-            });
-
-            test('should close the gallery when Escape is pressed on containerEl', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                seedToolbarAndTile(containerEl);
-                controller.toggle();
-                expect(controller.isOpen).toBe(true);
-
-                containerEl.dispatchEvent(
-                    new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
-                );
-
-                expect(controller.isOpen).toBe(false);
-            });
-
-            test('should Tab forward from the tile to the Gallery toggle', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { toggle } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-                const tile = seedTile(containerEl);
-
-                tile.focus();
-                containerEl.dispatchEvent(makeTabEvent(false));
-
-                expect(document.activeElement).toBe(toggle);
-            });
-
-            test('should Shift+Tab backward from the tile to the Fullscreen toggle (wraparound)', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { fullscreen } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-                const tile = seedTile(containerEl);
-
-                tile.focus();
-                containerEl.dispatchEvent(makeTabEvent(true));
-
-                expect(document.activeElement).toBe(fullscreen);
-            });
-
-            test('should Tab forward from the Fullscreen toggle to the tile (wraparound)', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const { fullscreen } = seedToolbarAndTile(containerEl);
-                controller.toggle();
-                const tile = seedTile(containerEl);
-
-                fullscreen.focus();
-                containerEl.dispatchEvent(makeTabEvent(false));
-
-                expect(document.activeElement).toBe(tile);
-            });
-        });
-
-        describe('nav key containment', () => {
-            function seedToggle(containerEl: HTMLElement): HTMLElement {
-                const toggle = document.createElement('button');
-                toggle.className = 'bp-GalleryToggle';
-                containerEl.appendChild(toggle);
-                return toggle;
-            }
-
-            test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
-                'should swallow %s pressed outside the grid while gallery is open',
-                key => {
-                    const { controller, containerEl } = makeController({ sidebarOpen: false });
-                    const toggle = seedToggle(containerEl);
-                    controller.toggle();
-
-                    const documentSpy = jest.fn();
-                    document.addEventListener('keydown', documentSpy);
-                    try {
-                        toggle.focus();
-                        const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
-                        toggle.dispatchEvent(event);
-
-                        expect(event.defaultPrevented).toBe(true);
-                        expect(documentSpy).not.toHaveBeenCalled();
-                    } finally {
-                        document.removeEventListener('keydown', documentSpy);
-                    }
-                },
-            );
-
-            test('should let arrow keys propagate again after the gallery closes', () => {
-                const { controller, containerEl } = makeController({ sidebarOpen: false });
-                const toggle = seedToggle(containerEl);
-                controller.toggle();
-                controller.toggle();
-
-                const documentSpy = jest.fn();
-                document.addEventListener('keydown', documentSpy);
-                try {
-                    toggle.focus();
-                    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+            const documentSpy = jest.fn();
+            document.addEventListener('keydown', documentSpy);
+            try {
+                ['Tab', 'Escape', 'ArrowDown', '['].forEach(key => {
+                    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
                     toggle.dispatchEvent(event);
-
                     expect(event.defaultPrevented).toBe(false);
-                    expect(documentSpy).toHaveBeenCalledTimes(1);
-                } finally {
-                    document.removeEventListener('keydown', documentSpy);
-                }
-            });
+                });
+                expect(documentSpy).toHaveBeenCalledTimes(4);
+                expect(controller.isOpen).toBe(true);
+            } finally {
+                document.removeEventListener('keydown', documentSpy);
+            }
         });
 
         test('should wire the correct props into GalleryGrid', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -179,6 +179,221 @@ describe('GalleryController', () => {
             expect(onAfterClose).toHaveBeenCalledTimes(1);
         });
 
+        describe('gallery open state', () => {
+            function seedDoc(containerEl: HTMLElement) {
+                const doc = document.createElement('div');
+                doc.className = 'bp-doc';
+                containerEl.appendChild(doc);
+                return doc;
+            }
+
+            test('should add the container class and mark bp-doc inert on open', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const doc = seedDoc(containerEl);
+
+                controller.toggle();
+
+                expect(containerEl.classList.contains('bp-is-gallery-open')).toBe(true);
+                expect(doc.hasAttribute('inert')).toBe(true);
+            });
+
+            test('should clear the container class and bp-doc inert on close', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const doc = seedDoc(containerEl);
+
+                controller.toggle();
+                controller.toggle();
+
+                expect(containerEl.classList.contains('bp-is-gallery-open')).toBe(false);
+                expect(doc.hasAttribute('inert')).toBe(false);
+            });
+
+            test('should clear the container class and bp-doc inert on destroy while gallery is open', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const doc = seedDoc(containerEl);
+
+                controller.toggle();
+                expect(containerEl.classList.contains('bp-is-gallery-open')).toBe(true);
+                expect(doc.hasAttribute('inert')).toBe(true);
+
+                controller.destroy();
+                expect(containerEl.classList.contains('bp-is-gallery-open')).toBe(false);
+                expect(doc.hasAttribute('inert')).toBe(false);
+            });
+
+            test('should apply the open state immediately even when grid mount is deferred behind the sidebar', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: true });
+                const doc = seedDoc(containerEl);
+
+                controller.toggle();
+
+                // Grid mount is deferred (only the seeded .bp-doc is present), but the open state applies right away
+                expect(containerEl.children).toHaveLength(1);
+                expect(containerEl.classList.contains('bp-is-gallery-open')).toBe(true);
+                expect(doc.hasAttribute('inert')).toBe(true);
+            });
+        });
+
+        describe('tab cycle', () => {
+            function seedToolbarAndTile(containerEl: HTMLElement) {
+                const toggle = document.createElement('button');
+                toggle.className = 'bp-GalleryToggle';
+                const fullscreen = document.createElement('button');
+                fullscreen.className = 'bp-FullscreenToggle';
+                containerEl.appendChild(toggle);
+                containerEl.appendChild(fullscreen);
+                return { toggle, fullscreen };
+            }
+
+            // Must be called AFTER controller.toggle(): the controller appends the gallery
+            // root element (galleryEl) to containerEl as its last child during mount.
+            function seedTile(containerEl: HTMLElement): HTMLElement {
+                const galleryEl = containerEl.lastElementChild as HTMLElement;
+                const tile = document.createElement('div');
+                tile.setAttribute('role', 'option');
+                tile.setAttribute('tabindex', '0');
+                galleryEl.appendChild(tile);
+                return tile;
+            }
+
+            function makeTabEvent(shiftKey = false): KeyboardEvent {
+                return new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true, cancelable: true });
+            }
+
+            test('should Tab forward from Gallery toggle to Fullscreen toggle', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { toggle, fullscreen } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+
+                toggle.focus();
+                containerEl.dispatchEvent(makeTabEvent(false));
+
+                expect(document.activeElement).toBe(fullscreen);
+            });
+
+            test('should Shift+Tab backward from Fullscreen toggle to Gallery toggle', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { toggle, fullscreen } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+
+                fullscreen.focus();
+                containerEl.dispatchEvent(makeTabEvent(true));
+
+                expect(document.activeElement).toBe(toggle);
+            });
+
+            test('should ignore keys other than Tab and Escape', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { toggle } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+
+                toggle.focus();
+                containerEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+                expect(document.activeElement).toBe(toggle);
+            });
+
+            test('should close the gallery when Escape is pressed on containerEl', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                seedToolbarAndTile(containerEl);
+                controller.toggle();
+                expect(controller.isOpen).toBe(true);
+
+                containerEl.dispatchEvent(
+                    new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+                );
+
+                expect(controller.isOpen).toBe(false);
+            });
+
+            test('should Tab forward from the tile to the Gallery toggle', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { toggle } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+                const tile = seedTile(containerEl);
+
+                tile.focus();
+                containerEl.dispatchEvent(makeTabEvent(false));
+
+                expect(document.activeElement).toBe(toggle);
+            });
+
+            test('should Shift+Tab backward from the tile to the Fullscreen toggle (wraparound)', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { fullscreen } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+                const tile = seedTile(containerEl);
+
+                tile.focus();
+                containerEl.dispatchEvent(makeTabEvent(true));
+
+                expect(document.activeElement).toBe(fullscreen);
+            });
+
+            test('should Tab forward from the Fullscreen toggle to the tile (wraparound)', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const { fullscreen } = seedToolbarAndTile(containerEl);
+                controller.toggle();
+                const tile = seedTile(containerEl);
+
+                fullscreen.focus();
+                containerEl.dispatchEvent(makeTabEvent(false));
+
+                expect(document.activeElement).toBe(tile);
+            });
+        });
+
+        describe('nav key containment', () => {
+            function seedToggle(containerEl: HTMLElement): HTMLElement {
+                const toggle = document.createElement('button');
+                toggle.className = 'bp-GalleryToggle';
+                containerEl.appendChild(toggle);
+                return toggle;
+            }
+
+            test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
+                'should swallow %s pressed outside the grid while gallery is open',
+                key => {
+                    const { controller, containerEl } = makeController({ sidebarOpen: false });
+                    const toggle = seedToggle(containerEl);
+                    controller.toggle();
+
+                    const documentSpy = jest.fn();
+                    document.addEventListener('keydown', documentSpy);
+                    try {
+                        toggle.focus();
+                        const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+                        toggle.dispatchEvent(event);
+
+                        expect(event.defaultPrevented).toBe(true);
+                        expect(documentSpy).not.toHaveBeenCalled();
+                    } finally {
+                        document.removeEventListener('keydown', documentSpy);
+                    }
+                },
+            );
+
+            test('should let arrow keys propagate again after the gallery closes', () => {
+                const { controller, containerEl } = makeController({ sidebarOpen: false });
+                const toggle = seedToggle(containerEl);
+                controller.toggle();
+                controller.toggle();
+
+                const documentSpy = jest.fn();
+                document.addEventListener('keydown', documentSpy);
+                try {
+                    toggle.focus();
+                    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+                    toggle.dispatchEvent(event);
+
+                    expect(event.defaultPrevented).toBe(false);
+                    expect(documentSpy).toHaveBeenCalledTimes(1);
+                } finally {
+                    document.removeEventListener('keydown', documentSpy);
+                }
+            });
+        });
+
         test('should wire the correct props into GalleryGrid', () => {
             const { controller } = makeController({ currentPage: 3, pageCount: 25, sidebarOpen: false });
             controller.toggle();


### PR DESCRIPTION
Contain gallery view's keyboard behavior without walling it off: keystrokes can't leak into the underlying document or the host page's file browser, but Tab now flows out of the gallery to the sidebar and header, and Escape closes only the gallery from anywhere unless an open menu consumes it first.

## What changed
- Add `bp-is-gallery-open` on the container while the gallery is open, used to hide Preview's Prev/Next File nav (`_navigation.scss`), hide box-ui-elements' file-nav arrows that sit outside `.bp` (`GalleryGrid.scss`), and lock the underlying `.bp-doc` overflow so arrow keys can't scroll the doc or flash its scrollbar.
- Mark `.bp-doc` as `inert` while open, removing PDF.js text/annotation layers from the tab order and accessibility tree. With the doc inert, natural tab order runs tile → Gallery toggle → Fullscreen toggle → sidebar → header — no custom Tab cycling needed (the grid mounts before the controls root to keep that order).
- Centralize the gallery key policy in `DocBaseViewer.onKeydown`, which hosts invoke for any keydown inside the preview root (including the sidebar): Escape closes only the gallery and is consumed before it reaches the host's window-level Escape hotkey; arrow and bracket (`[` `]`) keys are swallowed so they can't flip the doc page or trigger collection navigation. A `defaultPrevented` guard defers to menus/dropdowns that already handled the key. `DocumentViewer` and `PresentationViewer` defer their own paging/zoom shortcuts to this policy while the gallery is open.
- Emit `galleryOpen`/`galleryClose` viewer events and expose a guarded `closeGallery()` method so hosts (preview-client/EUA header, follow-up PR) can dismiss the gallery when Escape is pressed with focus in the header.
- Teach `FocusTrap` to include roving-tabindex listbox options (`[role="option"][tabindex="0"]`, i.e. gallery tiles) and skip inert subtrees, so the fullscreen tab cycle reaches the focused tile. Scoped so no other viewer's fullscreen behavior changes.
- Apply the open state in `toggle()` (not `mountGrid()`) so it also covers the deferred grid mount behind the thumbnails-sidebar transition.

## Test plan
- [ ] Tab flows tile → Gallery toggle → Fullscreen toggle → sidebar → header and wraps via the host's focus trap; Shift+Tab reverses it
- [ ] In fullscreen, Tab cycles tile → Gallery toggle → Fullscreen toggle
- [ ] Escape closes only the gallery from a tile, either toggle, or with focus/click in the sidebar — the preview stays open
- [ ] Escape inside an open menu/dropdown closes only that menu; the gallery stays open
- [ ] With the gallery open, Arrow keys and `[` `]` don't flip pages underneath, no scroll into the host file browser
- [ ] Prev/Next File nav (both `.bp-navigate-*` and the host's arrows) is not tab-reachable while open
- [ ] Underlying document does not show a scrollbar on arrow-key nav
- [ ] Behavior is correct whether the thumbnails sidebar was open or closed when the gallery was toggled
- [ ] Regular (non-gallery) fullscreen tab behavior is unchanged for all viewer types

## Out of scope
- Escape with focus in the header still closes the preview — fixed by the follow-up preview-client and EUA PRs consuming `closeGallery()`