### PR TITLE
fix(metrics): attribute preview apdex client_name to the host

### DIFF
--- a/src/lib/Logger.js
+++ b/src/lib/Logger.js
@@ -9,16 +9,17 @@ class Logger {
      *
      * @param {string} locale - Locale
      * @param {Object} browser - Browser information
+     * @param {string} [clientName] - Host-supplied client name; overrides the package default so metrics attribute to the host
      * @return {Logger} Logger instance
      */
-    constructor(locale, browser) {
+    constructor(locale, browser, clientName) {
         this.start = Date.now();
         this.log = {
             locale,
             event: 'preview',
             browser,
             client: {
-                name: CLIENT_NAME,
+                name: clientName || CLIENT_NAME,
                 version: CLIENT_VERSION,
             },
             converted: true,

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -836,7 +836,7 @@ class Preview extends EventEmitter {
         this.open = true;
 
         // Init performance logging
-        this.logger = new Logger(this.location.locale, this.browserInfo);
+        this.logger = new Logger(this.location.locale, this.browserInfo, this.options.clientName);
         this.loadMetricsEmitted = false;
 
         // Clear any existing retry timeouts

--- a/src/lib/__tests__/Logger-test.js
+++ b/src/lib/__tests__/Logger-test.js
@@ -35,6 +35,21 @@ describe('lib/Logger', () => {
         expect(log.client.version).toBe(__VERSION__);
     });
 
+    test('should use the host-supplied client name when provided', () => {
+        logger = new Logger('FOO', {}, 'preview-client');
+        const log = logger.done();
+
+        expect(log.client.name).toBe('preview-client');
+        expect(log.client.version).toBe(__VERSION__);
+    });
+
+    test('should fall back to the package name when client name is empty', () => {
+        logger = new Logger('FOO', {}, '');
+        const log = logger.done();
+
+        expect(log.client.name).toBe(__NAME__);
+    });
+
     test('should set and get correctly', () => {
         dateNowStub.mockReturnValue(0);
         logger.setCached();


### PR DESCRIPTION
## Problem

The `preview`/`preview_log` load event reads `client_name` from the Logger's `client.name`, which was hardcoded to the package name (`box-content-preview`) for **every** host. Because both host integrations (EndUserApp and the federated preview-client) reported the same value, the Preview Performance dashboard's apdex metrics (`storm_preview_apdex_points`, `storm_preview_count`, `storm_preview_apdex_points_by_country`) could not be filtered by client — selecting a specific client blanked the panels.

## Change

Pass the host-supplied `options.clientName` into the `Logger` constructor and prefer it over the package-name default. This mirrors what `emitLogEvent` already does for the `preview_log` metric family (`client_name: this.options.clientName`), so the two logging paths now attribute the client consistently. Falls back to the package name when no `clientName` is supplied, so existing consumers are unaffected.

## Testing

- Added `Logger` unit tests: host-supplied name is used when provided; falls back to the package name when empty.
- `yarn jest src/lib/__tests__/Logger-test.js` — all pass.
- Lint clean on `Logger.js` / `Preview.js`.