### PR TITLE
fix(doc): correct text layer offset when using npm pdfjs

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -324,7 +324,7 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
         }
     }
 
-    .textLayer {
+    .pdfViewer .page .textLayer {
         top: $pdfjs-page-padding;
         bottom: auto;
         z-index: 1;


### PR DESCRIPTION
## Summary
- Fixes text annotation highlight layer being offset from actual text when the `useNpmPdfjs` feature flag is enabled
- Increases CSS selector specificity for `.textLayer` positioning to `.pdfViewer .page .textLayer` so it reliably overrides the dynamically-loaded `pdfjs-dist/web/pdf_viewer.css`
  
## Problem
When `useNpmPdfjs` is on, the npm CSS is loaded dynamically at runtime via `import('pdfjs-dist/web/pdf_viewer.css')` and scoped by PostCSS to `.bp-doc .textLayer { inset: 0 }`. Because our SCSS override compiled to the same specificity (`.bp-doc .textLayer { top: 15px }`), the npm CSS won by load order, causing the text layer to sit at `top: 0` instead of being offset by the 15px page padding. 
   
## Fix
Changed the selector from `.textLayer` to `.pdfViewer .page .textLayer`, increasing specificity from `0,2,0` to `0,4,0`. This ensures our positioning override wins regardless of CSS load order. The selector still matches the same elements since `.textLayer` is always a child of `.pdfViewer .page` in the pdf.js DOM.

## Screenshots 

BEFORE (with npm for pdf.js flag on)

<img width="440" height="231" alt="chrome-capture-2026-07-10 (1)" src="https://github.com/user-attachments/assets/1ad0e2b1-02e7-432c-b14b-abdaa83bf656" />

AFTER (same behavior when npm for pdf.js flag on/off)
  
<img width="426" height="229" alt="chrome-capture-2026-07-10" src="https://github.com/user-attachments/assets/0c46c4e7-8a28-4fd1-807e-e287a3cf752a" />

  ## Test plan
  - [ ] Open a PDF with the `useNpmPdfjs` flag enabled
  - [ ] Highlight text to create an annotation — verify the highlight overlay aligns with the actual text
  - [ ] Verify the same behavior with the flag disabled (no regression)
  - [ ] Check that pinch-to-zoom still hides the text layer correctly