### PR TITLE
feat(video): add v2 controls to MP4Viewer and disable for 360 videos

### DIFF
--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -53,6 +53,11 @@ class Video360Viewer extends DashViewer {
         // Call super() to set up common layout
         super.setup();
 
+        // 360 videos do not support v2 video player yet, so remove the v2 classes
+        this.isVideoPlayerV2 = false;
+        this.wrapperEl.classList.remove('bp-media--v2');
+        this.mediaContainerEl.classList.remove('bp-media-container--v2');
+
         this.destroyed = false;
 
         // Hide video element

--- a/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
+++ b/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
@@ -62,6 +62,16 @@ describe('lib/viewers/box3d/video360/Video360Viewer', () => {
             viewer.setup();
         });
 
+        test('should disable v2 video player regardless of feature flag', () => {
+            viewer.destroy();
+            jest.spyOn(viewer, 'featureEnabled').mockImplementation(feature => feature === 'videoPlayerV2.enabled');
+            viewer.isSetup = false;
+            viewer.setup();
+            expect(viewer.isVideoPlayerV2).toBe(false);
+            expect(viewer.wrapperEl).not.toHaveClass('bp-media--v2');
+            expect(viewer.mediaContainerEl).not.toHaveClass('bp-media-container--v2');
+        });
+
         test('should create .destroyed property of false', () => {
             expect(viewer.destroyed).toBe(false);
         });

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -3,6 +3,7 @@ import { CLASS_INVISIBLE, DEFAULT_VIDEO_FPS, PRELOAD_REP_NAME } from '../../cons
 import { VIEWER_EVENT } from '../../events';
 import VideoBaseViewer from './VideoBaseViewer';
 import VideoControls from './VideoControls';
+import VideoControlsV2 from './VideoControlsV2';
 import './MP4.scss';
 
 const CSS_CLASS_MP4 = 'bp-media-mp4';
@@ -18,6 +19,8 @@ class MP4Viewer extends VideoBaseViewer {
 
         // Call super() first to set up common layout
         super.setup();
+
+        this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled');
 
         // mp4 specific class
         this.wrapperEl.classList.add(CSS_CLASS_MP4);
@@ -115,38 +118,43 @@ class MP4Viewer extends VideoBaseViewer {
             this.areNewAnnotationsEnabled() && this.hasAnnotationCreatePermission() && this.videoAnnotationsEnabled;
 
         const annotationsEnabled = !!this.annotator && this.videoAnnotationsEnabled;
-        this.controls.render(
-            <VideoControls
-                annotationColor={this.annotationModule.getColor()}
-                annotationMode={this.annotationControlsFSM.getMode()}
-                autoplay={this.isAutoplayEnabled()}
-                bufferedRange={this.mediaEl.buffered}
-                currentTime={this.mediaEl.currentTime}
-                durationTime={this.mediaEl.duration}
-                experiences={this.experiences}
-                fps={this.featureEnabled('frameStep.enabled') ? DEFAULT_VIDEO_FPS : undefined}
-                hasDrawing={canDraw}
-                hasHighlight={false}
-                hasRegion={canAnnotate}
-                isNarrowVideo={this.isNarrowVideo}
-                isPlaying={!this.mediaEl.paused}
-                mediaEl={this.mediaEl}
-                movePlayback={this.movePlayback}
-                onAnnotationColorChange={this.handleAnnotationColorChange}
-                onAnnotationModeClick={this.handleAnnotationControlsClick}
-                onAnnotationModeEscape={this.handleAnnotationControlsEscape}
-                onAutoplayChange={this.setAutoplay}
-                onFullscreenToggle={this.toggleFullscreen}
-                onMuteChange={this.toggleMute}
-                onPlayPause={this.handlePlayRequest}
-                onRateChange={this.setRate}
-                onTimeChange={this.handleTimeupdateFromMediaControls}
-                onVolumeChange={this.setVolume}
-                rate={this.getRate()}
-                videoAnnotationsEnabled={annotationsEnabled}
-                volume={this.mediaEl.volume}
-            />,
-        );
+        const sharedProps = {
+            annotationColor: this.annotationModule.getColor(),
+            annotationMode: this.annotationControlsFSM.getMode(),
+            aspectRatio: this.aspect,
+            autoplay: this.isAutoplayEnabled(),
+            bufferedRange: this.mediaEl.buffered,
+            currentTime: this.mediaEl.currentTime,
+            durationTime: this.mediaEl.duration,
+            experiences: this.experiences,
+            fps: this.featureEnabled('frameStep.enabled') ? DEFAULT_VIDEO_FPS : undefined,
+            hasDrawing: canDraw,
+            hasRegion: canAnnotate,
+            isNarrowVideo: this.isNarrowVideo,
+            isPlaying: !this.mediaEl.paused,
+            mediaEl: this.mediaEl,
+            movePlayback: this.movePlayback,
+            onAnnotationColorChange: this.handleAnnotationColorChange,
+            onAnnotationModeClick: this.handleAnnotationControlsClick,
+            onAnnotationModeEscape: this.handleAnnotationControlsEscape,
+            onAutoplayChange: this.setAutoplay,
+            onFullscreenToggle: this.toggleFullscreen,
+            onMuteChange: this.toggleMute,
+            onPlayPause: this.handlePlayRequest,
+            onRateChange: this.setRate,
+            onTimeChange: this.handleTimeupdateFromMediaControls,
+            onVolumeChange: this.setVolume,
+            rate: this.getRate(),
+            videoAnnotationsEnabled: annotationsEnabled,
+            volume: this.mediaEl.volume,
+        };
+
+        if (this.isVideoPlayerV2) {
+            this.controls.render(<VideoControlsV2 {...sharedProps} />);
+            return;
+        }
+
+        this.controls.render(<VideoControls {...sharedProps} hasHighlight={false} />);
     }
 
     calculateVideoDimensions() {

--- a/src/lib/viewers/media/__tests__/MP4Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP4Viewer-test.js
@@ -1,4 +1,6 @@
 import MP4Viewer from '../MP4Viewer';
+import VideoControls from '../VideoControls';
+import VideoControlsV2 from '../VideoControlsV2';
 import BaseViewer from '../../BaseViewer';
 import { VIEWER_EVENT } from '../../../events';
 import { PRELOAD_REP_NAME } from '../../../constants';
@@ -162,6 +164,32 @@ describe('lib/viewers/media/MP4Viewer', () => {
 
             expect(mp4.showPreload).toHaveBeenCalled();
             expect(mp4.emit).not.toHaveBeenCalledWith(VIEWER_EVENT.load);
+        });
+    });
+
+    describe('renderUI()', () => {
+        beforeEach(() => {
+            mp4.controls = { render: jest.fn() };
+            mp4.annotationModule = { getColor: jest.fn() };
+            mp4.options = { showAnnotationsDrawingCreate: false };
+            mp4.aspect = 1.78;
+            jest.spyOn(mp4, 'areNewAnnotationsEnabled').mockReturnValue(false);
+            jest.spyOn(mp4, 'hasAnnotationCreatePermission').mockReturnValue(false);
+            jest.spyOn(mp4, 'isAutoplayEnabled').mockReturnValue(false);
+            jest.spyOn(mp4, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(mp4, 'getRate').mockReturnValue(1);
+        });
+
+        test('should render VideoControlsV2 when isVideoPlayerV2 is true', () => {
+            mp4.isVideoPlayerV2 = true;
+            mp4.renderUI();
+            expect(mp4.controls.render).toHaveBeenCalledWith(expect.objectContaining({ type: VideoControlsV2 }));
+        });
+
+        test('should render VideoControls when isVideoPlayerV2 is false', () => {
+            mp4.isVideoPlayerV2 = false;
+            mp4.renderUI();
+            expect(mp4.controls.render).toHaveBeenCalledWith(expect.objectContaining({ type: VideoControls }));
         });
     });
 


### PR DESCRIPTION
## Summary
  - Add v2 video player support to MP4Viewer so it renders `VideoControlsV2` with the v2 layout when the `videoPlayerV2.enabled` feature flag is on, matching DashViewer behavior
  - Disable v2 video player mode in Video360Viewer since the Box3D canvas rendering and custom `Video360Controls` are incompatible with the v2 React controls and layout (48px padding
  breaks the full-bleed skybox canvas)
  
## Test plan
- [ ] Verify MP4Viewer renders v2 controls (scrubber, play/pause, skip, volume, fullscreen) when `videoPlayerV2.enabled` is on
- [ ] Verify MP4Viewer renders v1 controls when the flag is off
- [ ] Verify 360 videos render correctly with the old controls regardless of the v2 flag
- [ ] Verify DashViewer v2 behavior is unaffected 
- [ ] Unit tests pass: `npx jest --testPathPattern="MP4Viewer|Video360Viewer"`