### PR TITLE
feat(npm): accept location and pdfjs workerSrc options for npm consumers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     extends: [eslintrc],
     globals: {
         __: false,
+        __BCP_NPM_BUILD__: false,
         __I18N__: false,
         __NAME__: false,
         __VERSION__: false,

--- a/build/lib-types/index.d.ts
+++ b/build/lib-types/index.d.ts
@@ -43,8 +43,10 @@ export interface PreviewOptions {
     fixDependencies?: boolean;
     header?: 'light' | 'dark' | 'none';
     headerElement?: HTMLElement;
+    location?: { staticBaseURI?: string; version?: string; locale?: string };
     logoUrl?: string;
     pauseRequireJS?: boolean;
+    pdfjs?: { workerSrc?: string };
     previewWMPref?: string;
     requestInterceptor?: (config: unknown) => unknown;
     responseInterceptor?: (response: unknown) => unknown;

--- a/build/verifyLibBundle.js
+++ b/build/verifyLibBundle.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+// Guards against webpack emitting its chunk-loading runtime into the lib bundle.
+// The runtime contains a literal `import("./" + chunkId)` expression, which downstream
+// webpack builds re-parse as a context module over dist/lib/ and choke on .bin / .d.ts
+// files. output.chunkLoading: false and optimization.splitChunks: false in
+// webpack.config.lib.js prevent it; this check keeps that from silently regressing.
+const bundlePath = path.resolve(__dirname, '../dist/lib/index.js');
+
+if (!fs.existsSync(bundlePath)) {
+    console.error(`verifyLibBundle: ${bundlePath} not found. Run yarn build:lib:js first.`);
+    process.exit(1);
+}
+
+const bundle = fs.readFileSync(bundlePath, 'utf8');
+const chunkLoadingPattern = /import\(\s*["']\.\/["']\s*\+/;
+const match = bundle.match(chunkLoadingPattern);
+
+if (match) {
+    const line = bundle.slice(0, match.index).split('\n').length;
+    console.error(
+        `verifyLibBundle: dist/lib/index.js contains a chunk-loading expression at line ${line}: ${match[0]}`,
+    );
+    console.error(
+        'The lib bundle must be self-contained. Check chunkLoading/splitChunks in build/webpack.config.lib.js.',
+    );
+    process.exit(1);
+}
+
+console.log('verifyLibBundle: OK, no chunk-loading runtime in dist/lib/index.js');

--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -54,6 +54,7 @@ module.exports = language => {
         plugins: [
             new BannerPlugin(license),
             new DefinePlugin({
+                __BCP_NPM_BUILD__: JSON.stringify(false),
                 __LANGUAGE__: JSON.stringify(language),
                 __NAME__: JSON.stringify(pkg.name),
                 __VERSION__: JSON.stringify(pkg.version),

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -49,7 +49,13 @@ module.exports = {
         filename: '[name].js',
         library: { type: 'module' },
         module: true,
-        environment: { module: true, dynamicImport: true },
+        // chunkLoading: false stops webpack from emitting `import("./" + chunkId)`, which
+        // downstream webpack builds re-parse as a context module over dist/lib/ and choke
+        // on .bin / .d.ts files. publicPath: 'auto' lets new URL(..., import.meta.url)
+        // resolve relative to the chunk's runtime location.
+        environment: { module: true, dynamicImport: false },
+        chunkLoading: false,
+        publicPath: 'auto',
         clean: true,
     },
     experiments: {
@@ -107,6 +113,9 @@ module.exports = {
     },
     optimization: {
         minimize: false,
+        // Inline dynamic imports into the single bundle so no chunk-loading runtime is needed.
+        splitChunks: false,
+        runtimeChunk: false,
     },
     ignoreWarnings: [
         // pdfjs-dist contains an internal dynamic require that webpack flags as a critical
@@ -116,6 +125,7 @@ module.exports = {
     plugins: [
         new BannerPlugin(license),
         new DefinePlugin({
+            __BCP_NPM_BUILD__: JSON.stringify(true),
             __LANGUAGE__: JSON.stringify(language),
             __NAME__: JSON.stringify(pkg.name),
             __VERSION__: JSON.stringify(pkg.version),

--- a/package.json
+++ b/package.json
@@ -19,13 +19,8 @@
         "./styles.css": "./dist/lib/index.css",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },
@@ -145,7 +140,8 @@
         "build:ci": "yarn setup && yarn webpack --progress --config build/webpack.config.js",
         "build:dev": "BABEL_ENV=dev NODE_ENV=dev yarn webpack --progress --config build/webpack.config.js",
         "build:i18n": "mojito-rb-gen -s src/i18n -o src/i18n/json -b en-US.properties",
-        "build:lib": "yarn build:i18n && yarn build:lib:js && yarn build:lib:types",
+        "build:lib": "yarn build:i18n && yarn build:lib:js && yarn build:lib:verify && yarn build:lib:types",
+        "build:lib:verify": "node build/verifyLibBundle.js",
         "build:lib:js": "BABEL_ENV=production NODE_ENV=production yarn webpack --config build/webpack.config.lib.js",
         "build:lib:types": "cp build/lib-types/index.d.ts dist/lib/index.d.ts",
         "build:prod": "BABEL_ENV=production NODE_ENV=production node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --progress --config build/webpack.config.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,3 @@
-// Re-export the legacy Preview class as the default export of the npm package.
-// Consumers can `import Preview from 'box-content-preview'` to use the imperative API.
-import LegacyPreview from './lib/Preview';
-
-// npm consumers always use the bundled pdfjs-dist (PREVIEW-111) — there's no CDN serving
-// the vendored pdf.min.mjs at runtime. Inject useNpmPdfjs=true into options.features
-// before delegating to the underlying show().
-class Preview extends LegacyPreview {
-    show(fileIdOrFile: string | object, token: unknown, options: { features?: Record<string, unknown> } = {}): void {
-        const features = { useNpmPdfjs: true, ...(options.features ?? {}) };
-        // @ts-expect-error — LegacyPreview is a JS class without a typed signature.
-        return super.show(fileIdOrFile, token, { ...options, features });
-    }
-}
-
-export default Preview;
-export { Preview };
+// useNpmPdfjs is auto-injected by Preview.show() under __BCP_NPM_BUILD__.
+// Keep this file a pure re-export to avoid a webpack TDZ trap on the harmony bindings.
+export { default, default as Preview } from './lib/Preview';

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -89,7 +89,14 @@ const SUPPORT_URL = 'https://support.box.com';
 // preview.js is loaded from by the browser. This needs to be done statically
 // outside the class so that location is found while this script is executing
 // and not when preview is instantiated, which is too late.
-const PREVIEW_LOCATION = findScriptLocation(PREVIEW_SCRIPT_NAME, document.currentScript);
+// findScriptLocation throws when there is no preview.js <script> tag in the DOM;
+// npm consumers have no such tag and populate this via Preview.show({ location }).
+let PREVIEW_LOCATION;
+try {
+    PREVIEW_LOCATION = findScriptLocation(PREVIEW_SCRIPT_NAME, document.currentScript);
+} catch (e) {
+    PREVIEW_LOCATION = {};
+}
 
 class Preview extends EventEmitter {
     /** @property {Api} - Previews Api instance used for XHR calls  */
@@ -239,7 +246,12 @@ class Preview extends EventEmitter {
         // Token can also be null or undefined for offline use case.
         // But it cannot be a random object.
         if (token === null || typeof token !== 'object') {
-            this.previewOptions = { ...options, token };
+            // npm consumers have no CDN-served pdfjs at runtime; force the bundled npm pdfjs path.
+            const finalOptions =
+                typeof __BCP_NPM_BUILD__ !== 'undefined' && __BCP_NPM_BUILD__
+                    ? { ...options, features: { useNpmPdfjs: true, ...(options.features || {}) } }
+                    : options;
+            this.previewOptions = { ...finalOptions, token };
         } else {
             throw new Error('Bad access token!');
         }
@@ -1142,6 +1154,14 @@ class Preview extends EventEmitter {
         // This makes features available everywhere that features is passed in, which includes
         // all of the viewers for different files
         this.options.features = options.features || {};
+
+        // npm consumers supply staticBaseURI / version / locale here since there is no
+        // preview.js <script> tag for findScriptLocation to read.
+        if (options.location) {
+            this.location = { ...this.location, ...options.location };
+        }
+
+        this.options.pdfjs = options.pdfjs || {};
 
         // Disable or enable viewers based on viewer options
         Object.keys(this.options.viewers).forEach(viewerName => {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1705,6 +1705,39 @@ describe('lib/Preview', () => {
                 'Bad annotatorToken!',
             );
         });
+
+        test('should merge options.location into this.location', () => {
+            preview.location = { baseURI: 'preserved/' };
+            preview.parseOptions({
+                ...preview.previewOptions,
+                location: { staticBaseURI: 'static/', locale: 'en-US', version: '1.2.3' },
+            });
+            expect(preview.location).toEqual({
+                baseURI: 'preserved/',
+                staticBaseURI: 'static/',
+                locale: 'en-US',
+                version: '1.2.3',
+            });
+        });
+
+        test('should leave this.location unchanged when options.location is omitted', () => {
+            preview.location = { baseURI: 'preserved/' };
+            preview.parseOptions(preview.previewOptions);
+            expect(preview.location).toEqual({ baseURI: 'preserved/' });
+        });
+
+        test('should stash options.pdfjs on this.options.pdfjs', () => {
+            preview.parseOptions({
+                ...preview.previewOptions,
+                pdfjs: { workerSrc: 'https://cdn.example/pdf.worker.mjs' },
+            });
+            expect(preview.options.pdfjs).toEqual({ workerSrc: 'https://cdn.example/pdf.worker.mjs' });
+        });
+
+        test('should default this.options.pdfjs to an empty object when omitted', () => {
+            preview.parseOptions(preview.previewOptions);
+            expect(preview.options.pdfjs).toEqual({});
+        });
     });
 
     describe('createViewerOptions()', () => {

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1275,9 +1275,12 @@ class DocBaseViewer extends BaseViewer {
      */
     setupPdfjs() {
         if (this.featureEnabled('useNpmPdfjs')) {
+            // npm consumers supply the worker URL via show({ pdfjs: { workerSrc } }) because their
+            // bundler emits the worker as an asset (e.g. webpack `?url`). CDN builds derive it from
+            // import.meta.url, which resolves against this bundle's own emitted assets.
+            const consumerWorkerSrc = this.options.pdfjs && this.options.pdfjs.workerSrc;
             // eslint-disable-next-line global-require
-            const getPdfjsWorkerSrc = require('./pdfjsNpmWorker').default;
-            this.pdfjsLib.GlobalWorkerOptions.workerSrc = getPdfjsWorkerSrc();
+            this.pdfjsLib.GlobalWorkerOptions.workerSrc = consumerWorkerSrc || require('./pdfjsNpmWorker').default();
             return;
         }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2445,14 +2445,25 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.pdfjsLib.GlobalWorkerOptions.workerSrc).toBe('asset');
             });
 
-            test('should set workerSrc from npm worker module when useNpmPdfjs flag is on', () => {
-                jest.doMock('../pdfjsNpmWorker', () => ({ default: () => 'npm-worker-src' }));
+            test('should set workerSrc from consumer-supplied options.pdfjs.workerSrc when useNpmPdfjs flag is on', () => {
                 docBase.pdfjsLib = { GlobalWorkerOptions: {} };
+                docBase.options = { pdfjs: { workerSrc: 'consumer-worker-src' } };
                 jest.spyOn(docBase, 'featureEnabled').mockImplementation(flag => flag === 'useNpmPdfjs');
 
                 docBase.setupPdfjs();
 
-                expect(docBase.pdfjsLib.GlobalWorkerOptions.workerSrc).toBe('npm-worker-src');
+                expect(docBase.pdfjsLib.GlobalWorkerOptions.workerSrc).toBe('consumer-worker-src');
+            });
+
+            test('should fall back to the derived npm worker url when useNpmPdfjs flag is on but consumer omits workerSrc', () => {
+                jest.doMock('../pdfjsNpmWorker', () => ({ default: () => 'derived-worker-src' }));
+                docBase.pdfjsLib = { GlobalWorkerOptions: {} };
+                docBase.options = { pdfjs: {} };
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(flag => flag === 'useNpmPdfjs');
+
+                docBase.setupPdfjs();
+
+                expect(docBase.pdfjsLib.GlobalWorkerOptions.workerSrc).toBe('derived-worker-src');
                 jest.dontMock('../pdfjsNpmWorker');
             });
         });


### PR DESCRIPTION
## Summary

Consumers importing `box-content-preview` from npm have no `<script src=preview.js>` tag, so the values Preview normally derives from it (asset location) and the pdfjs worker URL (previously derived via `import.meta.url`, which does not survive consumer bundlers) need to be supplied explicitly. This PR adds that contract to `Preview.show()` and hardens the npm bundle.

## Changes

### Runtime options for npm consumers

- `Preview.show()` accepts `location: { staticBaseURI, version, locale }`, merged into `this.location`. Replaces script-tag derivation on the npm path.
- `Preview.show()` accepts `pdfjs: { workerSrc }`. `setupPdfjs()` prefers the consumer-supplied URL and falls back to the existing `import.meta.url` derivation, so current `useNpmPdfjs` behavior on script-tag builds is unchanged.
- `findScriptLocation` no longer throws at module load when no `preview.js` script tag exists; it falls back to an empty location that consumers populate via the new option.

### npm build behavior

- New build-time `__BCP_NPM_BUILD__` define: `false` in the standard build, `true` in the lib build. On the npm artifact, `show()` auto-injects `features.useNpmPdfjs` since there is no CDN-served pdfjs at runtime.
- `src/index.ts` is now a pure re-export. The previous wrapper class declared in the module body created live-binding exports that threw `Cannot access before initialization` when consumers read them before module evaluation completed.

### Lib bundle hardening

- The lib build no longer emits chunk-loading runtime (`chunkLoading: false`, `splitChunks`/`runtimeChunk: false`, `publicPath: 'auto'`). The runtime contains a literal `import("./" + chunkId)` that downstream webpack builds re-parse as a context module over `dist/lib/` and fail on `.bin`/`.d.ts` files.
- New `build/verifyLibBundle.js` guards against that regressing; it runs as part of `build:lib`.
- Type definitions for the new options in `dist/lib/index.d.ts`.

## Consumer usage

```js
import Preview from 'box-content-preview';
import 'box-content-preview/styles.css';
import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';

const preview = new Preview();
preview.show(fileId, token, {
    container: '.preview-container',
    location: { locale: 'en-US', staticBaseURI: 'https://cdn.example.com/box-assets/', version: '3.60.0' },
    pdfjs: { workerSrc: pdfjsWorkerUrl },
});
```

The `pdfjs-dist` version installed by the consumer must match the version pinned by this package (currently 4.3.136). Third-party viewer assets (Shaka, highlight.js, three.js) are not bundled and must be reachable at `staticBaseURI/third-party/...`.

## Testing

- Unit tests for `parseOptions` (`location` merge, `pdfjs` stash, omitted-option defaults) and `setupPdfjs` (consumer URL wins, derivation fallback when omitted).
- Full suite: 170 suites / 4082 tests pass; lint and tsc clean; both build targets compile.
- Validated end to end in a consumer app loading this package from npm through module federation: PDF renders with the worker served from the consumer bundle, video loads Shaka from `staticBaseURI`, and flag-off behavior via the script tag is unchanged.
- `verifyLibBundle.js` verified in both directions (passes on the real bundle, fails on an injected chunk-loading expression).
