### PR TITLE
fix(npm): add default export condition for CJS resolvers

### DIFF
--- a/build/verifyLibBundle.js
+++ b/build/verifyLibBundle.js
@@ -29,4 +29,19 @@ if (match) {
     process.exit(1);
 }
 
-console.log('verifyLibBundle: OK, no chunk-loading runtime in dist/lib/index.js');
+// Resolves the package by its own name (Node self-reference goes through the exports
+// map exactly like a consumer would). A CJS context matches the "default" condition;
+// without it, jest, Vitest in CJS mode, and require.resolve all fail with
+// "Cannot find module 'box-content-preview'".
+try {
+    require.resolve('box-content-preview');
+} catch (error) {
+    console.error('verifyLibBundle: require.resolve("box-content-preview") failed from a CJS context.');
+    console.error(
+        'The exports map needs a "default" condition so CJS resolvers (jest, require.resolve) can resolve the package.',
+    );
+    console.error(error.message);
+    process.exit(1);
+}
+
+console.log('verifyLibBundle: OK, no chunk-loading runtime in dist/lib/index.js and CJS resolution works');

--- a/package.json
+++ b/package.json
@@ -14,18 +14,14 @@
     "exports": {
         ".": {
             "types": "./dist/lib/index.d.ts",
-            "import": "./dist/lib/index.js"
+            "import": "./dist/lib/index.js",
+            "default": "./dist/lib/index.js"
         },
         "./styles.css": "./dist/lib/index.css",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
## Problem

The npm package's exports map for the main entry declares only `types` and `import` conditions. With no fallback condition, any CommonJS-context resolver fails with `Cannot find module 'box-content-preview'`. This breaks jest in consumer repos even when tests only need `jest.mock('box-content-preview', factory)` - the factory replaces the module, but jest must resolve the specifier first. Consumers currently work around it with `jest.mock(..., { virtual: true })`. The same gap affects Vitest in CJS mode and `require.resolve` generally.

The `./styles.css` subpath is a bare string (an unconditional fallback) and resolves fine everywhere; only the main entry's conditional object is affected.

## Change

Add a `default` condition after `import`:

```json
".": {
    "types": "./dist/lib/index.d.ts",
    "import": "./dist/lib/index.js",
    "default": "./dist/lib/index.js"
}
```

- Conditions match in object order, so `import` still wins in every context where it matched before. Zero behavior change for webpack/rspack/Vite/Node-ESM consumers.
- `default` makes no module-format promise (unlike `require`, which would imply a CJS-parseable file). A CJS consumer that resolves and then actually executes the ESM file gets a clear syntax error, which is honest for an ESM-only package. Tooling that only needs resolution (jest with mock factories, `require.resolve`, TS node resolution) starts working.
- The Node.js docs on conditional exports recommend every condition object end with a `default` fallback. This is the shape ESM-only packages conventionally ship.

Also extends `build/verifyLibBundle.js` (runs during `build:lib`) to assert `require.resolve('box-content-preview')` succeeds from a CJS context via Node package self-reference, so the fallback cannot silently regress in future exports-map edits.

The `files`/`sideEffects` array reformatting is the repo's own prettier config; the multi-line form on master fails `prettier --check` and the pre-commit hook rewrites it on any commit touching package.json.

## Testing

- Patched the installed box-content-preview@3.62.0 in box-ui-elements' node_modules with exactly this change, removed all `{ virtual: true }` flags from the ContentPreview jest mocks, and ran the suite: 158/158 passed.
- `yarn build:lib` passes end to end including the new guard.
- Negative-tested the guard: with the `default` condition removed, it fails the build with exit 1 and a pointed error message.
