### PR TITLE
fix(video): center buffering spinner correctly in v2 player

### DIFF
--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -100,7 +100,7 @@ class VideoBaseViewer extends MediaBaseViewer {
         this.bufferingSpinnerEl = this.mediaContainerEl.appendChild(document.createElement('div'));
         this.bufferingSpinnerEl.classList.add('bp-media-buffering-spinner');
         this.bufferingSpinnerEl.classList.add(CLASS_HIDDEN);
-        if (this.useReactControls()) {
+        if (this.useReactControls() && !this.featureEnabled('videoPlayerV2.enabled')) {
             // Shift up by half the control bar + half the spinner to visually center above the controls
             this.bufferingSpinnerEl.style.marginTop = `-${VIDEO_PLAYER_CONTROL_BAR_HEIGHT / 2 + SPINNER_HALF_SIZE}px`;
         }

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -167,6 +167,56 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 value: lowerLights,
             });
         });
+
+        test('should not shift buffering spinner when videoPlayerV2 is enabled', () => {
+            const { lowerLights } = VideoBaseViewer.prototype;
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: jest.fn(),
+            });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: jest.fn() });
+            videoBase = new VideoBaseViewer({
+                file: {
+                    id: 1,
+                },
+                container: containerEl,
+            });
+            jest.spyOn(videoBase, 'getViewerOption').mockImplementation(option => option === 'useReactControls');
+            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBase.containerEl = containerEl;
+            videoBase.setup();
+
+            expect(videoBase.bufferingSpinnerEl.style.marginTop).toBe('');
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: lowerLights,
+            });
+        });
+
+        test('should shift buffering spinner when useReactControls is true but videoPlayerV2 is disabled', () => {
+            const { lowerLights } = VideoBaseViewer.prototype;
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: jest.fn(),
+            });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: jest.fn() });
+            videoBase = new VideoBaseViewer({
+                file: {
+                    id: 1,
+                },
+                container: containerEl,
+            });
+            jest.spyOn(videoBase, 'getViewerOption').mockImplementation(option => option === 'useReactControls');
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            videoBase.containerEl = containerEl;
+            videoBase.setup();
+
+            expect(videoBase.bufferingSpinnerEl.style.marginTop).toBe('-100px');
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: lowerLights,
+            });
+        });
     });
 
     describe('destroy()', () => {


### PR DESCRIPTION
## Summary
 - Remove the -100px vertical offset on the buffering spinner when v2 controls are enabled
 - In v2, the control bar is an absolute overlay that doesn't reduce the video's visible area, so the spinner should remain at the true center of the container rather than shifting upward
- The offset is preserved for v1 React controls where the control bar takes up layout space
  
## Test plan
- [ ] Verify buffering spinner appears centered on the video in v2 player
- [ ] Verify buffering spinner still shifts upward in v1 React controls mode
- [ ] Unit tests pass (`npx jest src/lib/viewers/media/__tests__/VideoBaseViewer-test.js`)