### PR TITLE
fix(gallery): gallery row spacing, scrollbar fixes, and loading updates

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -941,8 +941,10 @@ class DocBaseViewer extends BaseViewer {
             }
 
             // Swallow page-nav keys so they can't flip the doc page underneath the gallery
-            // or trigger the host's collection navigation.
+            // or trigger the host's collection navigation. Arrows pressed outside the grid
+            // are redirected into it so the first press navigates the tiles.
             if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(key)) {
+                this.galleryController.handleArrowKey(key, event && event.target);
                 return true;
             }
         }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -944,7 +944,7 @@ class DocBaseViewer extends BaseViewer {
             // or trigger the host's collection navigation. Arrows pressed outside the grid
             // are redirected into it so the first press navigates the tiles.
             if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(key)) {
-                this.galleryController.handleArrowKey(key, event && event.target);
+                this.galleryController.handleArrowKey(key);
                 return true;
             }
         }
@@ -1780,12 +1780,9 @@ class DocBaseViewer extends BaseViewer {
             this.annotator.toggleAnnotationMode(AnnotationMode.REGION);
         }
 
-        // Restore focus to the toggle, mirroring BaseViewer.handleFullscreenEnter — the browser
-        // otherwise drops focus to the body on exit, and keyboard input (e.g. gallery arrow
-        // keys) no longer reaches the viewer.
-        if (this.fullscreenToggleEl && this.fullscreenToggleEl.focus) {
-            this.fullscreenToggleEl.focus();
-        }
+        // Restore focus to the toggle, the browser otherwise drops focus to the body on exit,
+        // and keyboard input (e.g. gallery arrow keys) no longer reach the viewer
+        this.fullscreenToggleEl?.focus?.();
     }
 
     /**

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1779,6 +1779,13 @@ class DocBaseViewer extends BaseViewer {
         if (this.annotator && this.areNewAnnotationsEnabled() && this.options.enableAnnotationsDiscoverability) {
             this.annotator.toggleAnnotationMode(AnnotationMode.REGION);
         }
+
+        // Restore focus to the toggle, mirroring BaseViewer.handleFullscreenEnter — the browser
+        // otherwise drops focus to the body on exit, and keyboard input (e.g. gallery arrow
+        // keys) no longer reaches the viewer.
+        if (this.fullscreenToggleEl && this.fullscreenToggleEl.focus) {
+            this.fullscreenToggleEl.focus();
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1686,12 +1686,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
                     'should swallow %s without paging',
                     key => {
-                        const target = document.createElement('button');
-                        const consumed = docBase.onKeydown(key, { defaultPrevented: false, target });
+                        const consumed = docBase.onKeydown(key, { defaultPrevented: false });
 
                         expect(stubs.previousPage).not.toBeCalled();
                         expect(stubs.nextPage).not.toBeCalled();
-                        expect(docBase.galleryController.handleArrowKey).toBeCalledWith(key, target);
+                        expect(docBase.galleryController.handleArrowKey).toBeCalledWith(key);
                         expect(consumed).toBe(true);
                     },
                 );

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1670,6 +1670,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 beforeEach(() => {
                     docBase.galleryController = {
                         isOpen: true,
+                        handleArrowKey: jest.fn(),
                         handleEscape: jest.fn().mockReturnValue(true),
                         destroy: jest.fn(),
                     };
@@ -1685,10 +1686,12 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
                     'should swallow %s without paging',
                     key => {
-                        const consumed = docBase.onKeydown(key, { defaultPrevented: false });
+                        const target = document.createElement('button');
+                        const consumed = docBase.onKeydown(key, { defaultPrevented: false, target });
 
                         expect(stubs.previousPage).not.toBeCalled();
                         expect(stubs.nextPage).not.toBeCalled();
+                        expect(docBase.galleryController.handleArrowKey).toBeCalledWith(key, target);
                         expect(consumed).toBe(true);
                     },
                 );

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -4471,6 +4471,27 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             });
         });
 
+        describe('handleFullscreenExit()', () => {
+            beforeEach(() => {
+                docBase.pdfViewer = { currentScaleValue: 'page-fit' };
+                jest.spyOn(docBase, 'resize').mockImplementation();
+            });
+
+            test('should restore focus to the fullscreen toggle, mirroring fullscreen enter', () => {
+                docBase.fullscreenToggleEl = { focus: jest.fn() };
+
+                docBase.handleFullscreenExit();
+
+                expect(docBase.fullscreenToggleEl.focus).toBeCalled();
+            });
+
+            test('should not throw when no fullscreen toggle element is set', () => {
+                docBase.fullscreenToggleEl = null;
+
+                expect(() => docBase.handleFullscreenExit()).not.toThrow();
+            });
+        });
+
         describe('getInitialAnnotationMode()', () => {
             test.each`
                 enableAnnotationsDiscoverability | expectedMode

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -229,6 +229,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
         test('should defer to the gallery key policy instead of paging or zooming while the gallery is open', () => {
             doc.galleryController = {
                 isOpen: true,
+                handleArrowKey: jest.fn(),
                 handleEscape: jest.fn(),
                 destroy: jest.fn(),
             };

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -205,6 +205,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
         test('should defer arrows to the gallery key policy instead of paging while the gallery is open', () => {
             presentation.galleryController = {
                 isOpen: true,
+                handleArrowKey: jest.fn(),
                 handleEscape: jest.fn(),
                 destroy: jest.fn(),
             };

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -195,14 +195,14 @@ export default class GalleryController {
     /**
      * Redirects an arrow key pressed outside the grid (e.g. focus parked on a toggle after
      * toggling fullscreen) back into it: refocuses the selected tile and replays the key so
-     * the first press navigates, like the thumbnail sidebar. The contains() check makes the
-     * replayed event (which lands inside the grid) a no-op, preventing re-entry.
+     * the first press navigates, like the thumbnail sidebar. Keys pressed inside the grid
+     * never arrive here — GalleryGrid stops propagation on every arrow it handles.
      */
-    handleArrowKey(key: string, target: EventTarget | null): void {
+    handleArrowKey(key: string): void {
         if (!this.isGalleryOpen || !key.startsWith('Arrow')) return;
 
         const grid = this.galleryEl;
-        if (!grid || grid.contains(target as Node)) return;
+        if (!grid) return;
 
         const tile = grid.querySelector<HTMLElement>('[role="option"][tabindex="0"]');
         if (tile) {

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -189,6 +189,25 @@ export default class GalleryController {
         return true;
     }
 
+    /**
+     * Redirects an arrow key pressed outside the grid (e.g. focus parked on a toggle after
+     * toggling fullscreen) back into it: refocuses the selected tile and replays the key so
+     * the first press navigates, like the thumbnail sidebar. The contains() check makes the
+     * replayed event (which lands inside the grid) a no-op, preventing re-entry.
+     */
+    handleArrowKey(key: string, target: EventTarget | null): void {
+        if (!this.isGalleryOpen || !key.startsWith('Arrow')) return;
+
+        const grid = this.galleryEl;
+        if (!grid || grid.contains(target as Node)) return;
+
+        const tile = grid.querySelector<HTMLElement>('[role="option"][tabindex="0"]');
+        if (tile) {
+            tile.focus();
+            tile.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+        }
+    }
+
     handleRotate(): void {
         if (this.galleryThumbnail) {
             this.galleryThumbnail.destroy();

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -20,6 +20,9 @@ const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // ms
 interface PdfViewerLike {
     currentPageNumber: number;
     pagesCount: number;
+    // PDF.js PDFViewer API. pdfPage is only set once the page's metadata has been fetched;
+    // before that, viewport holds the first page's default dimensions.
+    getPageView?: (index: number) => { pdfPage?: unknown; viewport?: { width: number; height: number } } | undefined;
 }
 
 interface ThumbnailsSidebarLike {
@@ -267,6 +270,20 @@ export default class GalleryController {
         this.galleryFocusedPage = pageNum;
     };
 
+    // Per-page width:height ratio from PDF.js page metadata; null until the page's metadata
+    // is fetched (see PdfViewerLike.getPageView), which matters for mixed-size docs.
+    private getPageRatio = (pageNum: number): number | null => {
+        const pdfViewer = this.getPdfViewer();
+        const pageView = pdfViewer.getPageView && pdfViewer.getPageView(pageNum - 1);
+
+        if (!pageView || !pageView.pdfPage || !pageView.viewport) {
+            return null;
+        }
+
+        const { width, height } = pageView.viewport;
+        return width > 0 && height > 0 ? width / height : null;
+    };
+
     private mountGrid(): void {
         if (this.galleryRoot) {
             return;
@@ -290,6 +307,7 @@ export default class GalleryController {
         this.galleryRoot.render(
             <GalleryGrid
                 currentPage={pdfViewer.currentPageNumber}
+                getPageRatio={this.getPageRatio}
                 onClose={this.toggle}
                 onFocusChange={this.handleFocusChange}
                 onPageNavigate={this.handleGalleryNavigate}

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -9,6 +9,7 @@
     // Sits above annotation layers and find bar (z=3); toolbar (ControlsRoot z=5) stays on top.
     z-index: 4;
     display: grid;
+    grid-auto-rows: min-content;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 16px;
     align-items: start;

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -4,7 +4,6 @@ import { decodeKeydown, replacePlaceholders } from '../../util';
 import './GalleryGrid.scss';
 
 const GALLERY_THUMB_MAX_WIDTH = 440;
-const INITIAL_LOAD_BUFFER = 40;
 const CONCURRENT_LOADS = 4;
 const SCROLL_THROTTLE_MS = 200;
 
@@ -15,11 +14,15 @@ export interface GalleryThumbnail {
         itemIndex: number,
         options: { createImgTag: boolean; thumbMaxWidth: number },
     ) => Promise<HTMLImageElement | null>;
+    /** First-page width:height ratio, populated by init(). Used to size placeholders to the real page shape. */
+    pageRatio?: number;
 }
 
 export type Props = {
     pageCount: number;
     currentPage: number;
+    /** Per-page width:height ratio (null while unknown). Falls back to the first-page ratio. */
+    getPageRatio?: (pageNum: number) => number | null;
     onFocusChange?: (pageNum: number) => void;
     onPageNavigate: (n: number) => void;
     onClose: () => void;
@@ -32,6 +35,7 @@ interface TileProps {
     imageSrc?: string;
     onClick: (pageNum: number) => void;
     onFocus: (pageNum: number) => void;
+    pageRatio?: number | null;
 }
 
 const GalleryTile = React.memo(function GalleryTile({
@@ -40,7 +44,11 @@ const GalleryTile = React.memo(function GalleryTile({
     imageSrc,
     onClick,
     onFocus,
+    pageRatio,
 }: TileProps): JSX.Element {
+    // Match the placeholder to the real page shape so tiles don't resize (reflow/jitter) as images arrive
+    const placeholderStyle = pageRatio ? { paddingTop: `${100 / pageRatio}%` } : undefined;
+
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <div
@@ -54,7 +62,11 @@ const GalleryTile = React.memo(function GalleryTile({
             tabIndex={isFocused ? 0 : -1}
         >
             <span className="bp-gallery-tile-badge">{pageNum}</span>
-            {imageSrc ? <img alt="" src={imageSrc} /> : <span className="bp-gallery-tile-placeholder" />}
+            {imageSrc ? (
+                <img alt="" src={imageSrc} />
+            ) : (
+                <span className="bp-gallery-tile-placeholder" style={placeholderStyle} />
+            )}
         </div>
     );
 });
@@ -62,6 +74,7 @@ const GalleryTile = React.memo(function GalleryTile({
 export default function GalleryGrid({
     pageCount,
     currentPage,
+    getPageRatio,
     onClose,
     onFocusChange,
     onPageNavigate,
@@ -69,14 +82,50 @@ export default function GalleryGrid({
 }: Props): JSX.Element {
     const [loadedImages, setLoadedImages] = useState<Record<number, string>>({});
     const [focusedPage, setFocusedPage] = useState(currentPage);
+    const [pageRatio, setPageRatio] = useState<number | null>(null);
     // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
     const anchorPageRef = useRef(currentPage);
     const gridRef = useRef<HTMLDivElement>(null);
     const queueRef = useRef<number[]>([]);
     const isProcessingRef = useRef(false);
     const isMountedRef = useRef(true);
-    const initialLoadDoneRef = useRef(false);
-    const initialLoadCountRef = useRef(0);
+    const inFlightRef = useRef<Set<number>>(new Set());
+
+    const byDistanceFromAnchor = (a: number, b: number): number =>
+        Math.abs(a - anchorPageRef.current) - Math.abs(b - anchorPageRef.current);
+
+    // Unloaded tiles within viewport + buffer, on-screen tiles first so the user never
+    // watches a visible hole while off-screen pages load. Pages already being rendered
+    // (in flight) are excluded so re-derives can't waste loader slots on them.
+    function getUnloadedNearViewport(): number[] {
+        const grid = gridRef.current;
+        if (!grid) return [];
+
+        const { scrollTop, clientHeight } = grid;
+        const bufferZone = clientHeight * 3;
+        const viewportBottom = scrollTop + clientHeight;
+
+        const visibleUnloaded: number[] = [];
+        const bufferedUnloaded: number[] = [];
+        const tiles = grid.querySelectorAll('[data-page]');
+
+        tiles.forEach(tile => {
+            const el = tile as HTMLElement;
+            if (!el.dataset.page) return;
+            const pageNum = parseInt(el.dataset.page, 10);
+            if (inFlightRef.current.has(pageNum) || el.querySelector('img')) return;
+            const tileTop = el.offsetTop;
+            const tileBottom = tileTop + el.offsetHeight;
+
+            if (tileBottom > scrollTop && tileTop < viewportBottom) {
+                visibleUnloaded.push(pageNum);
+            } else if (tileBottom > scrollTop - bufferZone && tileTop < viewportBottom + bufferZone) {
+                bufferedUnloaded.push(pageNum);
+            }
+        });
+
+        return [...visibleUnloaded.sort(byDistanceFromAnchor), ...bufferedUnloaded.sort(byDistanceFromAnchor)];
+    }
 
     function processQueue() {
         if (!isMountedRef.current || !thumbnail || queueRef.current.length === 0) {
@@ -84,9 +133,8 @@ export default function GalleryGrid({
             return;
         }
 
-        const batchSize = initialLoadDoneRef.current ? CONCURRENT_LOADS : 1;
-        const batch = queueRef.current.slice(0, batchSize);
-        queueRef.current = queueRef.current.slice(batchSize);
+        const batch = queueRef.current.slice(0, CONCURRENT_LOADS);
+        queueRef.current = queueRef.current.slice(CONCURRENT_LOADS);
 
         requestAnimationFrame(() => {
             if (!isMountedRef.current || !thumbnail) {
@@ -105,27 +153,31 @@ export default function GalleryGrid({
                     return;
                 }
 
-                if (!initialLoadDoneRef.current) {
-                    initialLoadCountRef.current += batch.length;
-                    if (initialLoadCountRef.current >= INITIAL_LOAD_BUFFER) {
-                        initialLoadDoneRef.current = true;
-                        isProcessingRef.current = false;
-                        return;
-                    }
+                // Keep only what the viewport + buffer still needs, then go idle. This prune is
+                // what makes loading lazy (the mount queue starts as the whole document); the
+                // scroll/resize handlers re-derive what to load on demand after that.
+                const remaining = new Set(queueRef.current);
+                queueRef.current = getUnloadedNearViewport().filter(p => remaining.has(p));
+                if (queueRef.current.length === 0) {
+                    isProcessingRef.current = false;
+                    return;
                 }
                 processQueue();
             };
 
             batch.forEach(pageNum => {
+                inFlightRef.current.add(pageNum);
                 thumbnail
                     .createThumbnailImage(pageNum - 1, { createImgTag: true, thumbMaxWidth: GALLERY_THUMB_MAX_WIDTH })
                     .then((imageEl: HTMLImageElement | null) => {
+                        inFlightRef.current.delete(pageNum);
                         if (isMountedRef.current && imageEl && imageEl.src) {
                             setLoadedImages(prev => ({ ...prev, [pageNum]: imageEl.src }));
                         }
                         onComplete();
                     })
                     .catch(() => {
+                        inFlightRef.current.delete(pageNum);
                         onComplete();
                     });
             });
@@ -139,40 +191,13 @@ export default function GalleryGrid({
         }
     }
 
-    function getUnloadedNearViewport(): number[] {
-        const grid = gridRef.current;
-        if (!grid) return [];
-
-        const { scrollTop, clientHeight } = grid;
-        const bufferZone = clientHeight * 3;
-        const viewportTop = scrollTop - bufferZone;
-        const viewportBottom = scrollTop + clientHeight + bufferZone;
-
-        const nearbyUnloaded: number[] = [];
-        const tiles = grid.querySelectorAll('[data-page]');
-
-        tiles.forEach(tile => {
-            const el = tile as HTMLElement;
-            if (!el.dataset.page) return;
-            const pageNum = parseInt(el.dataset.page, 10);
-            const tileTop = el.offsetTop;
-            const tileBottom = tileTop + el.offsetHeight;
-
-            if (tileBottom > viewportTop && tileTop < viewportBottom && !el.querySelector('img')) {
-                nearbyUnloaded.push(pageNum);
-            }
-        });
-
-        return nearbyUnloaded;
-    }
-
     const handleScrollRef = useRef(
         throttle(() => {
             const nearbyUnloaded = getUnloadedNearViewport();
             if (nearbyUnloaded.length > 0) {
-                const currentQueue = queueRef.current;
-                const toAdd = nearbyUnloaded.filter(p => !currentQueue.includes(p));
-                queueRef.current = [...toAdd, ...currentQueue];
+                const currentQueue = new Set(queueRef.current);
+                const toAdd = nearbyUnloaded.filter(p => !currentQueue.has(p));
+                queueRef.current = [...toAdd, ...queueRef.current];
                 startProcessing();
             }
         }, SCROLL_THROTTLE_MS),
@@ -214,7 +239,6 @@ export default function GalleryGrid({
             const cached = thumbnail.getImageFromCache(i - 1);
             if (cached && cached.image && cached.image.src) {
                 initialImages[i] = cached.image.src;
-                initialLoadCountRef.current += 1;
             } else {
                 uncachedPages.push(i);
             }
@@ -229,8 +253,12 @@ export default function GalleryGrid({
 
         thumbnail.init().then(() => {
             if (!isMountedRef.current) return;
-            isProcessingRef.current = true;
-            processQueue();
+            if (typeof thumbnail.pageRatio === 'number' && thumbnail.pageRatio > 0) {
+                setPageRatio(thumbnail.pageRatio);
+            }
+            // Guarded start: the mount scrollIntoView can fire the scroll handler first, and a
+            // second unguarded pump would double the concurrent thumbnail renders.
+            startProcessing();
         });
 
         return () => {
@@ -258,6 +286,9 @@ export default function GalleryGrid({
             if (tile) {
                 tile.scrollIntoView({ block: 'start' });
             }
+            // A larger viewport (fullscreen enter, window resize) can reveal unloaded tiles
+            // without any scroll event, so run the same catch-up the scroll handler does.
+            handleScrollRef.current();
         });
         observer.observe(grid);
 
@@ -358,6 +389,7 @@ export default function GalleryGrid({
                 onClick={handleTileClick}
                 onFocus={handleTileFocus}
                 pageNum={i}
+                pageRatio={(getPageRatio && getPageRatio(i)) || pageRatio}
             />,
         );
     }

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -69,6 +69,8 @@ export default function GalleryGrid({
 }: Props): JSX.Element {
     const [loadedImages, setLoadedImages] = useState<Record<number, string>>({});
     const [focusedPage, setFocusedPage] = useState(currentPage);
+    // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
+    const anchorPageRef = useRef(currentPage);
     const gridRef = useRef<HTMLDivElement>(null);
     const queueRef = useRef<number[]>([]);
     const isProcessingRef = useRef(false);
@@ -176,6 +178,24 @@ export default function GalleryGrid({
         }, SCROLL_THROTTLE_MS),
     );
 
+    // Unthrottled so the anchor is accurate the instant a reflow (e.g. fullscreen) happens.
+    const handleScroll = useCallback(() => {
+        const grid = gridRef.current;
+        if (grid) {
+            const tiles = grid.querySelectorAll<HTMLElement>('[data-page]');
+            for (let i = 0; i < tiles.length; i += 1) {
+                if (tiles[i].offsetTop + tiles[i].offsetHeight > grid.scrollTop) {
+                    const { page } = tiles[i].dataset;
+                    if (page) {
+                        anchorPageRef.current = parseInt(page, 10);
+                    }
+                    break;
+                }
+            }
+        }
+        handleScrollRef.current();
+    }, []);
+
     useEffect(() => {
         const throttledScroll = handleScrollRef.current;
 
@@ -220,6 +240,28 @@ export default function GalleryGrid({
             throttledScroll.cancel();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Keep the viewed area in place when the grid reflows (fullscreen enter/exit, window resize):
+    // the scroll offset is preserved while tile positions shift, drifting the view otherwise.
+    useEffect(() => {
+        const grid = gridRef.current;
+        if (!grid) return undefined;
+
+        let isFirstObservation = true;
+        const observer = new ResizeObserver(() => {
+            if (isFirstObservation) {
+                isFirstObservation = false; // ResizeObserver always fires once on observe()
+                return;
+            }
+            const tile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
+            if (tile) {
+                tile.scrollIntoView({ block: 'start' });
+            }
+        });
+        observer.observe(grid);
+
+        return () => observer.disconnect();
     }, []);
 
     const focusTile = useCallback((pageNum: number) => {
@@ -327,7 +369,7 @@ export default function GalleryGrid({
             className="bp-gallery-grid"
             onFocus={handleGridFocus}
             onKeyDown={handleGridKeyDown}
-            onScroll={handleScrollRef.current}
+            onScroll={handleScroll}
             role="listbox"
             tabIndex={-1}
         >

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -344,6 +344,75 @@ describe('GalleryController', () => {
         });
     });
 
+    describe('handleArrowKey', () => {
+        // Adds the selected tile to the gallery root (mounted before .bp-ControlsRoot; with no
+        // controls seeded it lands as containerEl's last child).
+        function seedSelectedTile(containerEl: HTMLElement): HTMLElement {
+            const galleryEl = containerEl.lastElementChild as HTMLElement;
+            const tile = document.createElement('div');
+            tile.setAttribute('role', 'option');
+            tile.setAttribute('tabindex', '0');
+            galleryEl.appendChild(tile);
+            return tile;
+        }
+
+        function seedToggle(containerEl: HTMLElement): HTMLElement {
+            const toggle = document.createElement('button');
+            toggle.className = 'bp-GalleryToggle';
+            containerEl.appendChild(toggle);
+            return toggle;
+        }
+
+        test('should refocus the selected tile and replay the arrow into the grid when target is outside it', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = seedToggle(containerEl);
+            controller.toggle();
+            const tile = seedSelectedTile(containerEl);
+            const tileKeydown = jest.fn();
+            tile.addEventListener('keydown', tileKeydown);
+
+            controller.handleArrowKey('ArrowDown', toggle);
+
+            expect(document.activeElement).toBe(tile);
+            expect(tileKeydown).toHaveBeenCalledTimes(1);
+            expect(tileKeydown.mock.calls[0][0].key).toBe('ArrowDown');
+        });
+
+        test('should not redirect focus for non-arrow keys', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = seedToggle(containerEl);
+            controller.toggle();
+            seedSelectedTile(containerEl);
+
+            toggle.focus();
+            controller.handleArrowKey('[', toggle);
+
+            expect(document.activeElement).toBe(toggle);
+        });
+
+        test('should not redirect when the target is already inside the grid (no re-entry)', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            const tile = seedSelectedTile(containerEl);
+            const tileKeydown = jest.fn();
+            tile.addEventListener('keydown', tileKeydown);
+
+            controller.handleArrowKey('ArrowDown', tile);
+
+            expect(tileKeydown).not.toHaveBeenCalled();
+        });
+
+        test('should be a no-op when the gallery is closed', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = seedToggle(containerEl);
+
+            toggle.focus();
+            controller.handleArrowKey('ArrowDown', toggle);
+
+            expect(document.activeElement).toBe(toggle);
+        });
+    });
+
     describe('handleRotate', () => {
         test('should be a no-op when gallery has never been opened', () => {
             const { controller } = makeController();

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -401,7 +401,7 @@ describe('GalleryController', () => {
             return toggle;
         }
 
-        test('should refocus the selected tile and replay the arrow into the grid when target is outside it', () => {
+        test('should refocus the selected tile and replay the arrow into the grid', () => {
             const { controller, containerEl } = makeController({ sidebarOpen: false });
             const toggle = seedToggle(containerEl);
             controller.toggle();
@@ -409,7 +409,8 @@ describe('GalleryController', () => {
             const tileKeydown = jest.fn();
             tile.addEventListener('keydown', tileKeydown);
 
-            controller.handleArrowKey('ArrowDown', toggle);
+            toggle.focus();
+            controller.handleArrowKey('ArrowDown');
 
             expect(document.activeElement).toBe(tile);
             expect(tileKeydown).toHaveBeenCalledTimes(1);
@@ -423,21 +424,9 @@ describe('GalleryController', () => {
             seedSelectedTile(containerEl);
 
             toggle.focus();
-            controller.handleArrowKey('[', toggle);
+            controller.handleArrowKey('[');
 
             expect(document.activeElement).toBe(toggle);
-        });
-
-        test('should not redirect when the target is already inside the grid (no re-entry)', () => {
-            const { controller, containerEl } = makeController({ sidebarOpen: false });
-            controller.toggle();
-            const tile = seedSelectedTile(containerEl);
-            const tileKeydown = jest.fn();
-            tile.addEventListener('keydown', tileKeydown);
-
-            controller.handleArrowKey('ArrowDown', tile);
-
-            expect(tileKeydown).not.toHaveBeenCalled();
         });
 
         test('should be a no-op when the gallery is closed', () => {
@@ -445,7 +434,7 @@ describe('GalleryController', () => {
             const toggle = seedToggle(containerEl);
 
             toggle.focus();
-            controller.handleArrowKey('ArrowDown', toggle);
+            controller.handleArrowKey('ArrowDown');
 
             expect(document.activeElement).toBe(toggle);
         });

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -272,6 +272,44 @@ describe('GalleryController', () => {
             expect(grid.props.onClose).toBe(controller.toggle);
             expect(typeof grid.props.onPageNavigate).toBe('function');
             expect(typeof grid.props.onFocusChange).toBe('function');
+            expect(typeof grid.props.getPageRatio).toBe('function');
+        });
+
+        describe('getPageRatio prop', () => {
+            function getGridGetPageRatio(controller: GalleryController): (pageNum: number) => number | null {
+                controller.toggle();
+                return mockLastRoot.render.mock.calls[0][0].props.getPageRatio;
+            }
+
+            test('should return the page ratio from fetched PDF.js page metadata', () => {
+                const { controller, pdfViewer } = makeController({ sidebarOpen: false });
+                (pdfViewer as { getPageView?: unknown }).getPageView = (index: number) =>
+                    index === 1 ? { pdfPage: {}, viewport: { width: 1600, height: 900 } } : undefined;
+
+                const getPageRatio = getGridGetPageRatio(controller);
+
+                expect(getPageRatio(2)).toBeCloseTo(16 / 9);
+            });
+
+            test('should return null while the page metadata has not been fetched', () => {
+                const { controller, pdfViewer } = makeController({ sidebarOpen: false });
+                // pdfPage missing: the view still carries the first page's default viewport
+                (pdfViewer as { getPageView?: unknown }).getPageView = () => ({
+                    viewport: { width: 800, height: 600 },
+                });
+
+                const getPageRatio = getGridGetPageRatio(controller);
+
+                expect(getPageRatio(2)).toBeNull();
+            });
+
+            test('should return null when the viewer does not expose getPageView', () => {
+                const { controller } = makeController({ sidebarOpen: false });
+
+                const getPageRatio = getGridGetPageRatio(controller);
+
+                expect(getPageRatio(1)).toBeNull();
+            });
         });
 
         test('should close sidebar first and defer grid mount by half the transition time when sidebar is open', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GalleryGrid from '../GalleryGrid';
 
@@ -156,16 +156,16 @@ describe('GalleryGrid', () => {
 
         test('should not move past first tile on ArrowUp', async () => {
             getWrapper();
-            screen.getByLabelText('Page 3').focus();
-            screen.getByLabelText('Page 1').focus();
+            act(() => screen.getByLabelText('Page 3').focus());
+            act(() => screen.getByLabelText('Page 1').focus());
             await userEvent.keyboard('{ArrowUp}');
             expect(screen.getByLabelText('Page 1')).toHaveFocus();
         });
 
         test('should not move past last tile on ArrowDown', async () => {
             getWrapper();
-            screen.getByLabelText('Page 3').focus();
-            screen.getByLabelText('Page 10').focus();
+            act(() => screen.getByLabelText('Page 3').focus());
+            act(() => screen.getByLabelText('Page 10').focus());
             await userEvent.keyboard('{ArrowDown}');
             expect(screen.getByLabelText('Page 10')).toHaveFocus();
         });
@@ -233,7 +233,7 @@ describe('GalleryGrid', () => {
         test('should move selected class when tile receives focus', async () => {
             getWrapper();
             const tile5 = screen.getByLabelText('Page 5');
-            tile5.focus();
+            act(() => tile5.focus());
 
             await waitFor(() => {
                 expect(tile5).toHaveClass('bp-gallery-tile--selected');
@@ -247,7 +247,7 @@ describe('GalleryGrid', () => {
             const onFocusChange = jest.fn();
             getWrapper({ onFocusChange });
             const tile5 = screen.getByLabelText('Page 5');
-            tile5.focus();
+            act(() => tile5.focus());
             expect(onFocusChange).toHaveBeenCalledWith(5);
         });
 
@@ -274,10 +274,10 @@ describe('GalleryGrid', () => {
                 tile.scrollIntoView = tile === screen.getByLabelText('Page 3') ? tile3Spy : otherTilesSpy;
             });
 
-            resizeCallback(); // initial fire on observe() is skipped
+            act(() => resizeCallback()); // initial fire on observe() is skipped
             expect(tile3Spy).not.toHaveBeenCalled();
 
-            resizeCallback();
+            act(() => resizeCallback());
             expect(tile3Spy).toHaveBeenCalledWith({ block: 'start' });
             expect(otherTilesSpy).not.toHaveBeenCalled();
         });
@@ -302,8 +302,8 @@ describe('GalleryGrid', () => {
                 tile.scrollIntoView = tile === screen.getByLabelText('Page 7') ? tile7Spy : otherTilesSpy;
             });
 
-            resizeCallback(); // skipped initial fire
-            resizeCallback();
+            act(() => resizeCallback()); // skipped initial fire
+            act(() => resizeCallback());
 
             expect(tile7Spy).toHaveBeenCalledWith({ block: 'start' });
             expect(otherTilesSpy).not.toHaveBeenCalled();
@@ -313,6 +313,137 @@ describe('GalleryGrid', () => {
             const { unmount } = getWrapper();
             unmount();
             expect(disconnectMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('viewport-aware loading', () => {
+        // Lay the grid out as a single column of 100px-tall tiles so getUnloadedNearViewport
+        // has real geometry to work with (jsdom defaults all dimensions to 0).
+        const layoutGrid = (clientHeight: number) => {
+            const grid = screen.getByRole('listbox');
+            Object.defineProperty(grid, 'clientHeight', { configurable: true, value: clientHeight });
+            screen.getAllByRole('option').forEach((tile, index) => {
+                Object.defineProperty(tile, 'offsetTop', { configurable: true, value: index * 100 });
+                Object.defineProperty(tile, 'offsetHeight', { configurable: true, value: 100 });
+            });
+        };
+
+        let rafSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            // Run the queue pump synchronously so 40+ load cycles don't need real frames
+            rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+                cb(0);
+                return 0;
+            });
+        });
+
+        afterEach(() => {
+            rafSpy.mockRestore();
+        });
+
+        test('should load exactly the viewport + buffer, then go idle', async () => {
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue({ src: 'data:image/png;test' }),
+            };
+            getWrapper({ pageCount: 50, currentPage: 1, thumbnail });
+            // clientHeight 1200 → 3x buffer 3600 → tiles above 4800px (pages 1-48) are near the viewport
+            layoutGrid(1200);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Page 48').querySelector('img')).toBeInTheDocument();
+            });
+            // Pages beyond the viewport + buffer stay lazy
+            expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(48);
+            expect(screen.getByLabelText('Page 49').querySelector('img')).not.toBeInTheDocument();
+        });
+
+        test('should load radiating outward from the viewed area', async () => {
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue({ src: 'data:image/png;test' }),
+            };
+            getWrapper({ pageCount: 50, currentPage: 25, thumbnail });
+            // Large viewport: every tile falls within viewport + buffer, so all 50 load
+            layoutGrid(5000);
+
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(50);
+            });
+
+            // Distance-sorted from the anchor (page 25) throughout, never DOM order
+            const pages = thumbnail.createThumbnailImage.mock.calls.map(([index]) => index + 1);
+            const distances = pages.map(p => Math.abs(p - 25));
+            expect(distances).toEqual([...distances].sort((a, b) => a - b));
+        });
+
+        test('should load visible tiles before buffered off-screen tiles when scrolling into an unloaded area', async () => {
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue({ src: 'data:image/png;test' }),
+            };
+            getWrapper({ pageCount: 60, currentPage: 1, thumbnail });
+            // Single column, 100px tiles, 300px viewport: initial load covers pages 1-12
+            layoutGrid(300);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Page 12').querySelector('img')).toBeInTheDocument();
+            });
+            thumbnail.createThumbnailImage.mockClear();
+
+            // Jump deep into unloaded territory: pages 51-53 visible, 42-50/54-60 in the buffer
+            const grid = screen.getByRole('listbox');
+            Object.defineProperty(grid, 'scrollTop', { configurable: true, value: 5000 });
+            fireEvent.scroll(grid);
+
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage.mock.calls.length).toBeGreaterThanOrEqual(3);
+            });
+            const firstPages = thumbnail.createThumbnailImage.mock.calls.slice(0, 3).map(([index]) => index + 1);
+            expect(firstPages).toEqual([51, 52, 53]);
+        });
+
+        test('should go idle after the first batch when the grid has no measurable geometry', async () => {
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue({ src: 'data:image/png;test' }),
+            };
+            // No layout: every tile reports zero geometry, so nothing registers as near the
+            // viewport and the pump parks after its first batch (scroll/resize revive it)
+            getWrapper({ pageCount: 50, currentPage: 1, thumbnail });
+
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(4);
+            });
+            // Give the pump a chance to (incorrectly) continue before asserting it went idle
+            await new Promise(resolve => {
+                setTimeout(resolve, 50);
+            });
+            expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(4);
+        });
+
+        test('should load newly revealed tiles on resize without a scroll event', async () => {
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue(null),
+            };
+            getWrapper({ pageCount: 10, currentPage: 1, thumbnail });
+
+            // No geometry yet, so only the first batch runs (and resolves no images)
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(4);
+            });
+            thumbnail.createThumbnailImage.mockClear();
+
+            // Simulate a resize (e.g. fullscreen enter) revealing the tiles
+            layoutGrid(500);
+            act(() => resizeCallback()); // initial fire on observe() is skipped
+            act(() => resizeCallback());
+
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(10);
+            });
         });
     });
 
@@ -352,6 +483,51 @@ describe('GalleryGrid', () => {
             const tile1 = screen.getByLabelText('Page 1');
             expect(tile1.querySelector('.bp-gallery-tile-placeholder')).toBeInTheDocument();
             expect(tile1.querySelector('img')).not.toBeInTheDocument();
+        });
+
+        test('should size placeholders from the page ratio once init resolves', async () => {
+            // 16:9 landscape page: ratio 16/9 -> padding-top 56.25%
+            const thumbnail = { ...mockThumbnail, pageRatio: 16 / 9 };
+            getWrapper({ thumbnail });
+
+            await waitFor(() => {
+                const placeholder = screen
+                    .getByLabelText('Page 1')
+                    .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+                expect(placeholder.style.paddingTop).toBe('56.25%');
+            });
+        });
+
+        test('should size each placeholder from its own page ratio when getPageRatio provides one', async () => {
+            // First page portrait (3:4), page 2 landscape (16:9); pages beyond have no
+            // metadata yet and fall back to the first-page ratio.
+            const thumbnail = { ...mockThumbnail, pageRatio: 3 / 4 };
+            const getPageRatio = (pageNum: number): number | null => (pageNum === 2 ? 16 / 9 : null);
+            getWrapper({ thumbnail, getPageRatio });
+
+            await waitFor(() => {
+                const landscape = screen
+                    .getByLabelText('Page 2')
+                    .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+                expect(landscape.style.paddingTop).toBe('56.25%');
+            });
+
+            const fallback = screen
+                .getByLabelText('Page 5')
+                .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+            expect(parseFloat(fallback.style.paddingTop)).toBeCloseTo(133.333);
+        });
+
+        test('should leave placeholder sizing to the stylesheet when no page ratio is available', async () => {
+            getWrapper(); // mockThumbnail has no pageRatio
+            await waitFor(() => {
+                expect(mockThumbnail.init).toHaveBeenCalled();
+            });
+
+            const placeholder = screen
+                .getByLabelText('Page 1')
+                .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+            expect(placeholder.style.paddingTop).toBe('');
         });
     });
 });

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GalleryGrid from '../GalleryGrid';
+
+const observeMock = jest.fn();
+const disconnectMock = jest.fn();
+let resizeCallback: () => void;
+((global as unknown) as { ResizeObserver: jest.Mock }).ResizeObserver = jest
+    .fn()
+    .mockImplementation((callback: () => void) => {
+        resizeCallback = callback;
+        return { observe: observeMock, disconnect: disconnectMock };
+    });
 
 describe('GalleryGrid', () => {
     const mockThumbnail = {
@@ -250,6 +260,59 @@ describe('GalleryGrid', () => {
                 const focusedTile = screen.getByLabelText('Page 3');
                 expect(focusedTile).toHaveFocus();
             });
+        });
+    });
+
+    describe('resize handling', () => {
+        test('should restore the current page tile to the top when the grid resizes before any scroll', () => {
+            getWrapper();
+            expect(observeMock).toHaveBeenCalled();
+
+            const otherTilesSpy = jest.fn();
+            const tile3Spy = jest.fn();
+            screen.getAllByRole('option').forEach(tile => {
+                tile.scrollIntoView = tile === screen.getByLabelText('Page 3') ? tile3Spy : otherTilesSpy;
+            });
+
+            resizeCallback(); // initial fire on observe() is skipped
+            expect(tile3Spy).not.toHaveBeenCalled();
+
+            resizeCallback();
+            expect(tile3Spy).toHaveBeenCalledWith({ block: 'start' });
+            expect(otherTilesSpy).not.toHaveBeenCalled();
+        });
+
+        test('should anchor to the topmost visible tile after a scroll so resize restores the viewed area', () => {
+            getWrapper();
+            const grid = screen.getByRole('listbox');
+            const tiles = screen.getAllByRole('option');
+
+            // Simulate a layout where each tile is 100px tall and the grid is scrolled to 620px,
+            // making page 7 (offsetTop 600–700) the topmost visible tile.
+            tiles.forEach((tile, index) => {
+                Object.defineProperty(tile, 'offsetTop', { configurable: true, value: index * 100 });
+                Object.defineProperty(tile, 'offsetHeight', { configurable: true, value: 100 });
+            });
+            Object.defineProperty(grid, 'scrollTop', { configurable: true, value: 620 });
+            fireEvent.scroll(grid);
+
+            const otherTilesSpy = jest.fn();
+            const tile7Spy = jest.fn();
+            tiles.forEach(tile => {
+                tile.scrollIntoView = tile === screen.getByLabelText('Page 7') ? tile7Spy : otherTilesSpy;
+            });
+
+            resizeCallback(); // skipped initial fire
+            resizeCallback();
+
+            expect(tile7Spy).toHaveBeenCalledWith({ block: 'start' });
+            expect(otherTilesSpy).not.toHaveBeenCalled();
+        });
+
+        test('should disconnect the observer on unmount', () => {
+            const { unmount } = getWrapper();
+            unmount();
+            expect(disconnectMock).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Fix gallery view's grid layout, reflow, and loading behavior: tiles keep their shape and position while thumbnails load, visible tiles always load first, and keyboard navigation works when focus is parked on a toolbar toggle or after exiting fullscreen.
## What changed
**Layout & reflow (`fix(gallery): fix reflow gaps & nav`)**
- Size grid rows with `grid-auto-rows: min-content` so landscape thumbnails no longer leave large vertical gaps between rows.
- Size tile placeholders from real PDF page dimensions — per page via PDF.js page metadata (`getPageView`), falling back to the first-page ratio from `Thumbnail.init()` — so tiles are born at their final shape and the grid no longer shifts or creeps the scrollbar as images arrive (~500px of `scrollHeight` drift per load reduced to single-digit px).
- Preserve the viewed area when the grid reflows: an unthrottled scroll handler tracks the topmost visible tile as an anchor, and a `ResizeObserver` scrolls that tile back to the top after fullscreen enter/exit or window resize (previously the raw scroll offset was kept while tile positions shifted, drifting the view).
**Keyboard navigation**
- Redirect arrow keys pressed outside the grid back into it: `GalleryController.handleArrowKey()` refocuses the selected tile and replays the key so the first press navigates (like the thumbnails sidebar), called from `DocBaseViewer`'s gallery key policy (#1700) where those keys were already being swallowed. A `contains()` check ignores the replayed event to prevent re-entry, and brackets (`[` `]`) stay swallowed without redirecting.
- Restore focus to the fullscreen toggle on fullscreen exit (`DocBaseViewer.handleFullscreenExit`, mirroring what enter has always done) — the browser otherwise drops focus to the page body, leaving arrow keys dead until the user clicks back into the preview. Doc-family viewers only.
**Viewport-driven lazy loading**
- Replace the fixed 40-tile initial load with a viewport-driven queue: after every 4-concurrent batch, the queue is re-derived from actual grid geometry (unloaded tiles in the viewport first, then a 3-screen buffer, both radiating outward from the viewed area) and the loader idles once that set is empty. Fixes screens that were left partially gray (large monitors + landscape tiles exceeded the old fixed budget) and the slow serial fill around the entry point.
- Scroll and resize catch-ups run through the same path, so entry fill, scroll catch-up, and fullscreen reveal all load at the same rate with visible tiles always winning over off-screen prefetch. Pages already being rendered are tracked in-flight and never re-queued.
- Loading is strictly lazy now: only viewport ± buffer ever loads per trigger (previously the first scroll kicked off background-loading the entire document).
## Test plan
- [ ] Grid shows consistent 16px gaps between rows for landscape/mixed-orientation documents
- [ ] Placeholders match page shape immediately; no tile resizing or scrollbar creep while thumbnails load (mixed-size docs included)
- [ ] Open gallery anywhere in a long document — the visible screen fills first, radiating outward, then loading stops
- [ ] Fling-scroll into an unloaded area — visible tiles fill before off-screen ones
- [ ] Scroll deep into a long document, enter/exit fullscreen — the same tiles remain in view and newly revealed tiles load without scrolling
- [ ] Resize the window while scrolled — the viewed area is preserved
- [ ] With focus on the Gallery or Fullscreen toggle, the first arrow press moves tile selection; subsequent presses keep navigating
- [ ] Click the fullscreen toggle to exit fullscreen — arrow keys navigate tiles immediately, no click needed
- [ ] `[` and `]` still do nothing with the gallery open
- [ ] Keyboard behavior from #1700 is unchanged (Escape, Tab flow, no page flips underneath)