### PR TITLE
fix(doc): disable wheel zoom handler on mobile behind query param gate

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1554,7 +1554,8 @@ class DocBaseViewer extends BaseViewer {
             this.docEl.addEventListener('touchend', this.pinchToZoomEndHandler);
         }
 
-        if (this.featureEnabled('pinchToZoom.enabled')) {
+        const disableMobileWheelZoom = new URLSearchParams(window.location.search).has('disableMobileWheelZoom');
+        if (this.featureEnabled('pinchToZoom.enabled') && !(this.isMobile && disableMobileWheelZoom)) {
             this.docEl.addEventListener('wheel', this.trackpadPinchToZoomHandler, { passive: false });
         }
     }
@@ -1576,7 +1577,8 @@ class DocBaseViewer extends BaseViewer {
                 this.docEl.removeEventListener('touchend', this.pinchToZoomEndHandler);
             }
 
-            if (this.featureEnabled('pinchToZoom.enabled')) {
+            const disableMobileWheelZoom = new URLSearchParams(window.location.search).has('disableMobileWheelZoom');
+            if (this.featureEnabled('pinchToZoom.enabled') && !(this.isMobile && disableMobileWheelZoom)) {
                 this.docEl.removeEventListener('wheel', this.trackpadPinchToZoomHandler);
             }
         }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2906,6 +2906,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         });
 
         describe('bindDOMListeners()', () => {
+            const originalLocation = window.location;
+
             beforeEach(() => {
                 stubs.addEventListener = jest.spyOn(docBase.docEl, 'addEventListener').mockImplementation();
                 stubs.addListener = jest.spyOn(fullscreen, 'addListener').mockImplementation();
@@ -2950,9 +2952,43 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.anything(),
                 );
             });
+
+            test('should not add wheel listener on mobile when disableMobileWheelZoom query param is present', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
+                docBase.isMobile = true;
+                delete window.location;
+                window.location = { search: '?disableMobileWheelZoom' };
+
+                docBase.bindDOMListeners();
+
+                expect(stubs.addEventListener).not.toBeCalledWith(
+                    'wheel',
+                    docBase.trackpadPinchToZoomHandler,
+                    expect.anything(),
+                );
+
+                window.location = originalLocation;
+            });
+
+            test('should still add wheel listener on mobile when disableMobileWheelZoom query param is absent', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
+                docBase.isMobile = true;
+                delete window.location;
+                window.location = { search: '' };
+
+                docBase.bindDOMListeners();
+
+                expect(stubs.addEventListener).toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler, {
+                    passive: false,
+                });
+
+                window.location = originalLocation;
+            });
         });
 
         describe('unbindDOMListeners()', () => {
+            const originalLocation = window.location;
+
             beforeEach(() => {
                 stubs.removeEventListener = jest.spyOn(docBase.docEl, 'removeEventListener').mockImplementation();
                 stubs.removeFullscreenListener = jest.spyOn(fullscreen, 'removeListener').mockImplementation();
@@ -2998,6 +3034,19 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.unbindDOMListeners();
 
                 expect(stubs.removeEventListener).toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler);
+            });
+
+            test('should not remove wheel listener on mobile when disableMobileWheelZoom query param is present', () => {
+                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
+                docBase.isMobile = true;
+                delete window.location;
+                window.location = { search: '?disableMobileWheelZoom' };
+
+                docBase.unbindDOMListeners();
+
+                expect(stubs.removeEventListener).not.toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler);
+
+                window.location = originalLocation;
             });
         });
 


### PR DESCRIPTION
  ## Summary
  - After enabling pinch-to-zoom features (`pinchToZoom.enabled`), mobile users (i.e. using the web app on a mobile browser, not to be confused with mobile Box app) experienced page refreshes when attempting to zoom in/out
- The wheel event handler (intended for trackpad pinch-to-zoom on desktop) may conflict with mobile browser gesture handling, causing erratic behavior and page refreshes
- Adds a `disableMobileWheelZoom` query param gate to skip registering the wheel zoom handler on mobile for testing before a full rollout (not sure how else to test this works on mobile)
    
## Test plan
- [ ] Open a document preview on mobile browser without query param — behavior unchanged
- [ ] Open a document preview on mobile browser with `?disableMobileWheelZoom` — wheel zoom handler is not registered, no page refresh on pinch
- [ ] Open a document preview on desktop — trackpad pinch-to-zoom still works regardless of query param