### PR TITLE
fix(gallery): refine UX

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1501,7 +1501,7 @@ class DocBaseViewer extends BaseViewer {
         const canDownload = checkPermission(this.options.file, PERMISSION_DOWNLOAD);
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
         const canRotate = this.featureEnabled('rotate.enabled');
-        const canGallery = this.galleryController.canRender(this.pdfViewer.pagesCount);
+        const canGallery = !this.isMobile && this.galleryController.canRender(this.pdfViewer.pagesCount);
 
         this.controls.render(
             <DocControls

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2770,6 +2770,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
+            test.each([true, false])('should enable or disable the gallery toggle based on mobile', isMobile => {
+                docBase.isMobile = isMobile;
+                jest.spyOn(docBase.galleryController, 'canRender').mockReturnValue(true);
+                docBase.renderUI();
+
+                expect(getProps(docBase)).toMatchObject({
+                    onGalleryToggle: isMobile ? undefined : docBase.galleryController.toggle,
+                });
+            });
+
             test('should hide annotation create controls when in bounding box mode', () => {
                 docBase.currentAnnotatorViewMode = 'boundingBoxes';
                 docBase.options.showAnnotationsDrawingCreate = true;

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -27,10 +27,11 @@
     border-radius: 12px;
     box-shadow: 0 0 0 1px $off-white;
     cursor: pointer;
-    transition: box-shadow .2s ease-in-out;
+    transition: box-shadow .2s ease-in-out, transform .2s ease-in-out;
 
     &:hover {
         box-shadow: 0 0 0 3px $seventy-sixers, 0 4px 5px 0 rgba(0, 0, 0, .15);
+        transform: translateY(-1px) scale(1.02);
 
         .bp-gallery-tile-badge {
             opacity: 1;


### PR DESCRIPTION
Refine Gallery View interactions by matching the sidebar thumbnail hover effect and hiding the Gallery toggle on mobile devices.
## What changed
### Gallery tile hover
- Add the same animation used by sidebar thumbnails when you hover over them
### Mobile behavior
- Prevent the Gallery toggle from rendering on mobile devices.
- Add unit coverage for desktop and mobile visibility.
## Test plan
- [ ] Hover gallery tiles and verify they match sidebar thumbnails (thicker outline in gallery)
- [ ] Verify selected tiles retain their blue outline when hovered.
- [ ] Verify the Gallery toggle appears on desktop.
- [ ] Verify the Gallery toggle does not appear on mobile (can check with devtools, must reload page though)
- [ ] Confirm Gallery View continues to open and navigate normally on desktop.