### PR TITLE
fix(doc): restore pdf.js endOfContent selection affordances (PREVIEW-1222)

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -336,6 +336,14 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
             user-select: text;
         }
 
+        // The rule above outranks pdf.js's `.textLayer .endOfContent { user-select: none; }`
+        // (endOfContent is the layer's only remaining div child since text items became
+        // spans in pdf.js 2.14). It must stay non-selectable: the browser skipping over
+        // it is what snaps an in-progress selection to line boundaries.
+        > .endOfContent {
+            user-select: none;
+        }
+
         .highlight {
             display: inline-block;
             background-color: fade-out($pdfjs-highlight, .8);
@@ -424,6 +432,21 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
             pointer-events: none;
 
             span {
+                pointer-events: auto;
+            }
+
+            // pdf.js appends an .endOfContent div to the text layer and, while the
+            // primary button is down, expands it behind the text spans and moves it
+            // next to the selection focus on every selectionchange. The browser's
+            // native selection uses it as the hit target for pointer positions that
+            // are not directly over text, which is what makes dragging past a line
+            // end select to the end of the line and lets a selection shrink when
+            // dragging back up. It is a div, not a span, so the rules above leave it
+            // with inherited pointer-events: none, disabling that mechanism and
+            // causing mid-word cutoffs and erratic jumps when the drag leaves the
+            // text. While inactive it has zero height, so restoring pointer events
+            // does not affect clicks or region creation on blank areas.
+            .endOfContent {
                 pointer-events: auto;
             }
         }


### PR DESCRIPTION
## Summary

Fixes erratic highlight-annotation drag selection (PREVIEW-1222):

- Dragging past a line end, into a margin, or between paragraphs froze the in-progress selection mid-word instead of snapping to the line boundary.
- Dragging down and then back up (shrinking the selection) grew the highlight and then stopped tracking, instead of shrinking it.

| Symptom 1: selection cut mid-word | Symptom 2: shrink-drag over-highlights |
|---|---|
| Drag past end of line → selection freezes at last glyph touched | Drag down, move back up → selection grows, then sticks |

## Root cause

pdf.js appends a `div.endOfContent` to every text layer. While the primary mouse button is down it expands the div behind the text spans and moves it beside the selection focus on each `selectionchange`. Because the div is hit-testable but `user-select: none`, the browser's native selection uses it as the drag target for pointer positions that aren't directly over text — that's the standard "select to end of line" affordance, and it's also what lets a selection shrink on the way back up.

Two rules in `_docBase.scss` defeat that mechanism:

1. **Discoverability mode makes the div unhittable.** `.bp-annotations-discoverable .textLayer { pointer-events: none }` only re-enables `span`s. `endOfContent` is a `div`, so mid-drag the selection can only update when the pointer is exactly on a glyph span.
2. **A legacy rule makes the barrier selectable.** `.textLayer > div { user-select: text }` dates from when pdf.js rendered text items as divs (pre-2.14). Today its only match is `endOfContent`, and it outranks pdf.js's own `.endOfContent { user-select: none }` — so the selection can land inside an empty element that pdf.js is actively re-inserting next to the focus, producing the erratic grow-then-stick behavior.

## Fix

- Re-enable `pointer-events` on `.endOfContent` within discoverability mode.
- Re-assert `user-select: none` on `.textLayer > .endOfContent` over the legacy `> div` rule.

While inactive the div has zero height (`inset: 100% 0 0`), so blank-area clicks and region-annotation drags are unaffected.

## Testing

- `yarn lint:css` passes on the changed file.
- Manual verification on a devpod (drag highlight past line ends / margins, and down-then-up shrink drags) still pending — draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)