### PR TITLE
fix(annotations): keep mode on Escape mid-creation (PREVIEW-1219)

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -64,6 +64,13 @@ export const CLASS_PREFETCHED_IMAGE = 'bp-prefetched-image';
 
 export const DISCOVERABILITY_ATTRIBUTE = 'data-resin-discoverability';
 
+// Annotation-creation popups rendered by box-annotations. While one is open, Escape
+// should cancel the in-progress annotation instead of exiting the annotation mode.
+// popupReplyV2 is the creation variant of PopupV2; popupThreadV2 (viewing an existing
+// thread) is intentionally excluded.
+export const SELECTOR_ANNOTATIONS_CREATE_POPUP =
+    '.ba-PopupDrawingToolbar, .ba-PopupV2[data-resin-component="popupReplyV2"], .ba-ReplyForm';
+
 export const SELECTOR_BOX_PREVIEW_CONTAINER = `.${CLASS_BOX_PREVIEW_CONTAINER}`;
 export const SELECTOR_BOX_PREVIEW = `.${CLASS_BOX_PREVIEW}`;
 export const SELECTOR_BOX_PREVIEW_CONTENT = `.${CLASS_BOX_PREVIEW_CONTENT}`;

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -29,6 +29,7 @@ import {
     CLASS_ANNOTATIONS_ONLY_CONTROLS,
     CLASS_BOX_PREVIEW_MOBILE,
     FILE_OPTION_START,
+    SELECTOR_ANNOTATIONS_CREATE_POPUP,
     SELECTOR_BOX_PREVIEW_BTN_ANNOTATE_DRAW,
     SELECTOR_BOX_PREVIEW_BTN_ANNOTATE_POINT,
     SELECTOR_BOX_PREVIEW_CONTENT,
@@ -1197,14 +1198,44 @@ class BaseViewer extends EventEmitter {
     }
 
     /**
+     * If an annotation-creation popup is open, cancels the in-progress annotation
+     * while keeping the current annotation mode active. Re-toggling the current mode
+     * resets box-annotations' creator state, which dismisses the popup and discards
+     * the staged annotation.
+     *
+     * @protected
+     * @return {boolean} Whether an in-progress annotation was cancelled
+     */
+    cancelStagedAnnotation() {
+        if (!this.containerEl || !this.containerEl.querySelector(SELECTOR_ANNOTATIONS_CREATE_POPUP)) {
+            return false;
+        }
+
+        const nextMode = this.annotationControlsFSM.transition(
+            AnnotationInput.CANCEL,
+            this.annotationControlsFSM.getMode(),
+        );
+        this.annotator.toggleAnnotationMode(
+            nextMode === AnnotationMode.NONE ? this.getInitialAnnotationMode() : nextMode,
+        );
+        this.processAnnotationModeChange(nextMode);
+        return true;
+    }
+
+    /**
      * Handler for annotation toolbar button reset. No-op if the viewer
-     * has been destroyed or no annotator is attached.
+     * has been destroyed or no annotator is attached. If an annotation is
+     * mid-creation, only cancels that creation and stays in the current mode.
      *
      * @private
      * @return {void}
      */
     handleAnnotationControlsEscape() {
         if (!this.canHandleAnnotationControls()) {
+            return;
+        }
+
+        if (this.cancelStagedAnnotation()) {
             return;
         }
 

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -11,6 +11,7 @@ import intl from '../../i18n';
 import PreviewError from '../../PreviewError';
 import RepStatus from '../../RepStatus';
 import Timer from '../../Timer';
+import { AnnotationInput } from '../../AnnotationControlsFSM';
 import { AnnotationMode } from '../../types';
 import { ERROR_CODE, FIRST_RENDER_METRIC, LOAD_METRIC, VIEWER_EVENT } from '../../events';
 import { EXCLUDED_EXTENSIONS } from '../../extensions';
@@ -1993,6 +1994,81 @@ describe('lib/viewers/BaseViewer', () => {
             base.handleAnnotationControlsEscape();
 
             expect(base.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.NONE);
+        });
+
+        test('should stay in the current mode and only cancel the staged annotation if a creation popup is open', () => {
+            base.annotator = {
+                emit: jest.fn(),
+                toggleAnnotationMode: jest.fn(),
+            };
+            base.annotationModule.cache = { get: jest.fn().mockReturnValue('#000') };
+            base.containerEl = document.querySelector(constants.SELECTOR_BOX_PREVIEW_CONTENT);
+            jest.spyOn(base, 'areNewAnnotationsEnabled').mockReturnValue(true);
+            base.annotationControlsFSM.transition(AnnotationInput.CLICK, AnnotationMode.DRAWING);
+
+            const popupEl = document.createElement('div');
+            popupEl.className = 'ba-PopupDrawingToolbar';
+            base.containerEl.appendChild(popupEl);
+
+            base.handleAnnotationControlsEscape();
+
+            expect(base.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.DRAWING);
+            expect(base.annotator.toggleAnnotationMode).not.toBeCalledWith(AnnotationMode.NONE);
+            expect(base.annotationControlsFSM.getMode()).toBe(AnnotationMode.DRAWING);
+        });
+    });
+
+    describe('cancelStagedAnnotation()', () => {
+        beforeEach(() => {
+            base.annotator = {
+                emit: jest.fn(),
+                toggleAnnotationMode: jest.fn(),
+            };
+            base.annotationModule.cache = { get: jest.fn().mockReturnValue('#000') };
+            base.containerEl = document.querySelector(constants.SELECTOR_BOX_PREVIEW_CONTENT);
+            jest.spyOn(base, 'areNewAnnotationsEnabled').mockReturnValue(true);
+        });
+
+        test('should return false if no creation popup is open', () => {
+            expect(base.cancelStagedAnnotation()).toBe(false);
+            expect(base.annotator.toggleAnnotationMode).not.toBeCalled();
+        });
+
+        test.each(['ba-PopupDrawingToolbar', 'ba-ReplyForm'])(
+            'should cancel the staged annotation and keep the current mode if a %s popup is open',
+            className => {
+                base.annotationControlsFSM.transition(AnnotationInput.CLICK, AnnotationMode.REGION);
+
+                const popupEl = document.createElement('div');
+                popupEl.className = className;
+                base.containerEl.appendChild(popupEl);
+
+                expect(base.cancelStagedAnnotation()).toBe(true);
+                expect(base.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.REGION);
+                expect(base.annotationControlsFSM.getMode()).toBe(AnnotationMode.REGION);
+            },
+        );
+
+        test('should cancel the staged annotation if a creation PopupV2 is open', () => {
+            base.annotationControlsFSM.transition(AnnotationInput.CLICK, AnnotationMode.HIGHLIGHT);
+
+            const popupEl = document.createElement('div');
+            popupEl.className = 'ba-PopupV2';
+            popupEl.setAttribute('data-resin-component', 'popupReplyV2');
+            base.containerEl.appendChild(popupEl);
+
+            expect(base.cancelStagedAnnotation()).toBe(true);
+            expect(base.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.HIGHLIGHT);
+        });
+
+        test('should ignore a PopupV2 that is viewing an existing thread', () => {
+            const popupEl = document.createElement('div');
+            popupEl.className = 'ba-PopupV2';
+            popupEl.setAttribute('data-resin-component', 'popupThreadV2');
+            base.containerEl.appendChild(popupEl);
+
+            expect(base.cancelStagedAnnotation()).toBe(false);
+            expect(base.annotator.toggleAnnotationMode).not.toBeCalled();
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -2125,6 +2125,10 @@ class DocBaseViewer extends BaseViewer {
             return;
         }
 
+        if (this.cancelStagedAnnotation()) {
+            return;
+        }
+
         if (this.options.enableAnnotationsDiscoverability) {
             this.annotator.toggleAnnotationMode(AnnotationMode.REGION);
             this.processAnnotationModeChange(this.annotationControlsFSM.transition(AnnotationInput.RESET));

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -4214,6 +4214,45 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.processAnnotationModeChange).not.toBeCalled();
                 expect(docBase.containerEl.getAttribute('data-resin-discoverability')).toBe('false');
             });
+
+            test('should stay in the current mode and only cancel the staged annotation if a creation popup is open', () => {
+                docBase.annotator = {
+                    emit: jest.fn(),
+                    toggleAnnotationMode: jest.fn(),
+                };
+                jest.spyOn(docBase, 'areNewAnnotationsEnabled').mockReturnValue(true);
+                docBase.annotationControlsFSM.transition(AnnotationInput.CLICK, AnnotationMode.HIGHLIGHT);
+
+                const popupEl = document.createElement('div');
+                popupEl.className = 'ba-ReplyForm';
+                docBase.containerEl.appendChild(popupEl);
+
+                docBase.handleAnnotationControlsEscape();
+
+                expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.HIGHLIGHT);
+                expect(docBase.annotator.toggleAnnotationMode).not.toBeCalledWith(AnnotationMode.NONE);
+                expect(docBase.annotationControlsFSM.getMode()).toBe(AnnotationMode.HIGHLIGHT);
+            });
+
+            test('should cancel a temp-state staged annotation and return to REGION when discoverability is enabled', () => {
+                docBase.annotator = {
+                    emit: jest.fn(),
+                    toggleAnnotationMode: jest.fn(),
+                };
+                jest.spyOn(docBase, 'areNewAnnotationsEnabled').mockReturnValue(true);
+                docBase.options.enableAnnotationsDiscoverability = true;
+                // Highlight staged via discoverability (no explicit mode click)
+                docBase.annotationControlsFSM.transition(AnnotationInput.CREATE, AnnotationMode.HIGHLIGHT);
+
+                const popupEl = document.createElement('div');
+                popupEl.className = 'ba-ReplyForm';
+                docBase.containerEl.appendChild(popupEl);
+
+                docBase.handleAnnotationControlsEscape();
+
+                expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.REGION);
+                expect(docBase.annotationControlsFSM.getMode()).toBe(AnnotationMode.NONE);
+            });
         });
 
         describe('handleAnnotationColorChange', () => {


### PR DESCRIPTION
## Problem

Pressing `Esc` while an annotation-creation comment popup is open (highlight comment, region comment, or drawing comment) exits the **entire annotation mode** — the toolbar button deselects — instead of just dismissing the comment box. Cancelling a mis-placed comment and immediately retrying is the most common reason to hit `Esc`, so kicking the user out of the mode each time is a papercut.

## Root cause

`AnnotationsControls` attaches a document-level `keydown` listener while a mode is active and calls `onAnnotationModeEscape()` on any Escape, unconditionally resetting the FSM and toggling the annotator to `NONE`.

The legacy `PopupReply`/`ReplyForm` in box-annotations worked around this by attaching its own real-DOM Escape handler that cancelled the draft and called `stopPropagation()` before the document listener saw the event. The threaded-annotations `PopupV2` (`isThreadedAnnotation: true`) has **no Escape handling at all**, so the keydown falls through to the document listener and tears down the mode.

## Fix

`handleAnnotationControlsEscape()` (both `BaseViewer` and the `DocBaseViewer` override) now first checks whether an annotation-creation popup is open inside the viewer container (`.ba-PopupDrawingToolbar`, `.ba-PopupV2[data-resin-component="popupReplyV2"]`, `.ba-ReplyForm`). If so, it:

1. transitions the FSM with `CANCEL` (explicit modes stay put; discoverability temp states resolve to `NONE` as before), and
2. re-toggles the annotator's current mode, which resets box-annotations' creator state — dismissing the popup and discarding the staged annotation — while keeping the mode active.

A second `Esc` with no popup open exits the mode exactly as before. Thread-viewing popups (`popupThreadV2`) are intentionally excluded, so `Esc` with an open thread still exits the mode.

This also acts as a safety net for the legacy popup path and any future popup that forgets its own Escape handler. A follow-up in box-annotations could additionally give `PopupV2` its own form-level handler to restore full parity with `ReplyForm`.

## Testing

- New unit tests for `cancelStagedAnnotation()` (all three popup selectors + thread-popup exclusion) and the new early-return in `handleAnnotationControlsEscape()` for both `BaseViewer` and `DocBaseViewer` (including the discoverability temp-state path).
- Full `BaseViewer`, `DocBaseViewer`, `ImageViewer`, `AnnotationsControls`, and `AnnotationControlsFSM` suites pass (686 tests).
- [ ] Runtime verification on devpod (highlight comment → Esc → popup closes, highlight mode stays active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)