### PR TITLE
feat(image-preview): enable preview for cr3 and avif formats

### DIFF
--- a/src/lib/viewers/image/ImageLoader.js
+++ b/src/lib/viewers/image/ImageLoader.js
@@ -31,14 +31,14 @@ const VIEWERS = [
         NAME: 'Image',
         CONSTRUCTOR: ImageViewer,
         REP: 'jpg',
-        EXT: ['jpeg', 'jpg', 'cr2', 'crw', 'dng', 'nef', 'raf', 'raw'],
+        EXT: ['jpeg', 'jpg', 'cr2', 'cr3', 'crw', 'dng', 'nef', 'raf', 'raw'],
         ASSET: '1.jpg',
     },
     {
         NAME: 'Image',
         CONSTRUCTOR: ImageViewer,
         REP: 'png',
-        EXT: ['ai', 'bmp', 'dcm', 'eps', 'gif', 'heic', 'png', 'ps', 'psd', 'tga', 'tif', 'tiff', 'webp'],
+        EXT: ['ai', 'avif', 'bmp', 'dcm', 'eps', 'gif', 'heic', 'png', 'ps', 'psd', 'tga', 'tif', 'tiff', 'webp'],
         ASSET: '1.png',
     },
 ];


### PR DESCRIPTION
Enable preview for new image formats cr3 and avif. Reps for these formats are already supported in prod.

| | |
| :--- | :--- |
|  thumbnail view | <img width="785" height="359" alt="Screenshot 2026-07-21 at 4 47 02 PM" src="https://github.com/user-attachments/assets/314b4b99-5407-4ef0-97c4-ce3ace4e7499" />|
| cr3 preview | <img width="1336" height="981" alt="Screenshot 2026-07-21 at 4 47 19 PM" src="https://github.com/user-attachments/assets/1cd6946d-9401-460a-b3ae-8c2580f9cef9" />|
| avif preview | <img width="1331" height="979" alt="Screenshot 2026-07-21 at 4 47 29 PM" src="https://github.com/user-attachments/assets/5a8b0e69-2bf5-4f63-9caf-b13933b695b8" /> |