### PR TITLE
fix(doc): disable native pinch-to-zoom on touch devices via passive false

### DIFF
--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1551,13 +1551,16 @@ class DocBaseViewer extends BaseViewer {
         this.docEl.addEventListener('scroll', this.throttledScrollHandler);
 
         if (this.hasTouch) {
-            this.docEl.addEventListener('touchstart', this.pinchToZoomStartHandler);
-            this.docEl.addEventListener('touchmove', this.pinchToZoomChangeHandler);
+            const disableNativePinchToZoom = new URLSearchParams(window.location.search).has(
+                'disableNativePinchToZoom',
+            );
+            const passiveOption = disableNativePinchToZoom ? { passive: false } : undefined;
+            this.docEl.addEventListener('touchstart', this.pinchToZoomStartHandler, passiveOption);
+            this.docEl.addEventListener('touchmove', this.pinchToZoomChangeHandler, passiveOption);
             this.docEl.addEventListener('touchend', this.pinchToZoomEndHandler);
         }
 
-        const disableMobileWheelZoom = new URLSearchParams(window.location.search).has('disableMobileWheelZoom');
-        if (this.featureEnabled('pinchToZoom.enabled') && !(this.isMobile && disableMobileWheelZoom)) {
+        if (this.featureEnabled('pinchToZoom.enabled')) {
             this.docEl.addEventListener('wheel', this.trackpadPinchToZoomHandler, { passive: false });
         }
     }
@@ -1579,8 +1582,7 @@ class DocBaseViewer extends BaseViewer {
                 this.docEl.removeEventListener('touchend', this.pinchToZoomEndHandler);
             }
 
-            const disableMobileWheelZoom = new URLSearchParams(window.location.search).has('disableMobileWheelZoom');
-            if (this.featureEnabled('pinchToZoom.enabled') && !(this.isMobile && disableMobileWheelZoom)) {
+            if (this.featureEnabled('pinchToZoom.enabled')) {
                 this.docEl.removeEventListener('wheel', this.trackpadPinchToZoomHandler);
             }
         }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1551,10 +1551,15 @@ class DocBaseViewer extends BaseViewer {
         this.docEl.addEventListener('scroll', this.throttledScrollHandler);
 
         if (this.hasTouch) {
-            const disableNativePinchToZoom = new URLSearchParams(window.location.search).has(
-                'disableNativePinchToZoom',
-            );
-            const passiveOption = disableNativePinchToZoom ? { passive: false } : undefined;
+            const searchParams = new URLSearchParams(window.location.search);
+            const disableNativePinchToZoom = searchParams.has('disableNativePinchToZoom');
+            const forceNonPassiveTouchListeners = searchParams.has('forceNonPassiveTouchListeners');
+
+            if (disableNativePinchToZoom) {
+                this.docEl.style.touchAction = 'pan-x pan-y';
+            }
+
+            const passiveOption = forceNonPassiveTouchListeners ? { passive: false } : undefined;
             this.docEl.addEventListener('touchstart', this.pinchToZoomStartHandler, passiveOption);
             this.docEl.addEventListener('touchmove', this.pinchToZoomChangeHandler, passiveOption);
             this.docEl.addEventListener('touchend', this.pinchToZoomEndHandler);

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -1553,9 +1553,12 @@ class DocBaseViewer extends BaseViewer {
         if (this.hasTouch) {
             const searchParams = new URLSearchParams(window.location.search);
             const disableNativePinchToZoom = searchParams.has('disableNativePinchToZoom');
+            const disableAllTouchActions = searchParams.has('disableAllTouchActions');
             const forceNonPassiveTouchListeners = searchParams.has('forceNonPassiveTouchListeners');
 
-            if (disableNativePinchToZoom) {
+            if (disableAllTouchActions) {
+                this.docEl.style.touchAction = 'none';
+            } else if (disableNativePinchToZoom) {
                 this.docEl.style.touchAction = 'pan-x pan-y';
             }
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2965,10 +2965,34 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 );
             });
 
-            test('should add touch listeners with passive false when disableNativePinchToZoom query param is present', () => {
+            test('should set touch-action to pan-x pan-y when disableNativePinchToZoom query param is present', () => {
                 docBase.hasTouch = true;
                 delete window.location;
                 window.location = { search: '?disableNativePinchToZoom' };
+
+                docBase.bindDOMListeners();
+
+                expect(docBase.docEl.style.touchAction).toBe('pan-x pan-y');
+
+                window.location = originalLocation;
+            });
+
+            test('should not set touch-action when disableNativePinchToZoom query param is absent', () => {
+                docBase.hasTouch = true;
+                delete window.location;
+                window.location = { search: '' };
+
+                docBase.bindDOMListeners();
+
+                expect(docBase.docEl.style.touchAction).not.toBe('pan-x pan-y');
+
+                window.location = originalLocation;
+            });
+
+            test('should add touch listeners with passive false when forceNonPassiveTouchListeners query param is present', () => {
+                docBase.hasTouch = true;
+                delete window.location;
+                window.location = { search: '?forceNonPassiveTouchListeners' };
 
                 docBase.bindDOMListeners();
 
@@ -2982,7 +3006,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 window.location = originalLocation;
             });
 
-            test('should add touch listeners without passive false when disableNativePinchToZoom query param is absent', () => {
+            test('should add touch listeners without passive false when forceNonPassiveTouchListeners query param is absent', () => {
                 docBase.hasTouch = true;
                 delete window.location;
                 window.location = { search: '' };

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2940,8 +2940,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.hasTouch = true;
                 docBase.bindDOMListeners();
 
-                expect(stubs.addEventListener).toBeCalledWith('touchstart', docBase.pinchToZoomStartHandler);
-                expect(stubs.addEventListener).toBeCalledWith('touchmove', docBase.pinchToZoomChangeHandler);
+                expect(stubs.addEventListener).toBeCalledWith('touchstart', docBase.pinchToZoomStartHandler, undefined);
+                expect(stubs.addEventListener).toBeCalledWith('touchmove', docBase.pinchToZoomChangeHandler, undefined);
                 expect(stubs.addEventListener).toBeCalledWith('touchend', docBase.pinchToZoomEndHandler);
             });
 
@@ -2965,42 +2965,38 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 );
             });
 
-            test('should not add wheel listener on mobile when disableMobileWheelZoom query param is present', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
-                docBase.isMobile = true;
+            test('should add touch listeners with passive false when disableNativePinchToZoom query param is present', () => {
+                docBase.hasTouch = true;
                 delete window.location;
-                window.location = { search: '?disableMobileWheelZoom' };
+                window.location = { search: '?disableNativePinchToZoom' };
 
                 docBase.bindDOMListeners();
 
-                expect(stubs.addEventListener).not.toBeCalledWith(
-                    'wheel',
-                    docBase.trackpadPinchToZoomHandler,
-                    expect.anything(),
-                );
+                expect(stubs.addEventListener).toBeCalledWith('touchstart', docBase.pinchToZoomStartHandler, {
+                    passive: false,
+                });
+                expect(stubs.addEventListener).toBeCalledWith('touchmove', docBase.pinchToZoomChangeHandler, {
+                    passive: false,
+                });
 
                 window.location = originalLocation;
             });
 
-            test('should still add wheel listener on mobile when disableMobileWheelZoom query param is absent', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
-                docBase.isMobile = true;
+            test('should add touch listeners without passive false when disableNativePinchToZoom query param is absent', () => {
+                docBase.hasTouch = true;
                 delete window.location;
                 window.location = { search: '' };
 
                 docBase.bindDOMListeners();
 
-                expect(stubs.addEventListener).toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler, {
-                    passive: false,
-                });
+                expect(stubs.addEventListener).toBeCalledWith('touchstart', docBase.pinchToZoomStartHandler, undefined);
+                expect(stubs.addEventListener).toBeCalledWith('touchmove', docBase.pinchToZoomChangeHandler, undefined);
 
                 window.location = originalLocation;
             });
         });
 
         describe('unbindDOMListeners()', () => {
-            const originalLocation = window.location;
-
             beforeEach(() => {
                 stubs.removeEventListener = jest.spyOn(docBase.docEl, 'removeEventListener').mockImplementation();
                 stubs.removeFullscreenListener = jest.spyOn(fullscreen, 'removeListener').mockImplementation();
@@ -3046,19 +3042,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.unbindDOMListeners();
 
                 expect(stubs.removeEventListener).toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler);
-            });
-
-            test('should not remove wheel listener on mobile when disableMobileWheelZoom query param is present', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockImplementation(feature => feature === 'pinchToZoom.enabled');
-                docBase.isMobile = true;
-                delete window.location;
-                window.location = { search: '?disableMobileWheelZoom' };
-
-                docBase.unbindDOMListeners();
-
-                expect(stubs.removeEventListener).not.toBeCalledWith('wheel', docBase.trackpadPinchToZoomHandler);
-
-                window.location = originalLocation;
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -2977,6 +2977,18 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 window.location = originalLocation;
             });
 
+            test('should set touch-action to none when disableAllTouchActions query param is present', () => {
+                docBase.hasTouch = true;
+                delete window.location;
+                window.location = { search: '?disableAllTouchActions' };
+
+                docBase.bindDOMListeners();
+
+                expect(docBase.docEl.style.touchAction).toBe('none');
+
+                window.location = originalLocation;
+            });
+
             test('should not set touch-action when disableNativePinchToZoom query param is absent', () => {
                 docBase.hasTouch = true;
                 delete window.location;


### PR DESCRIPTION
## Summary

- Users have reported a bug where pinching to zoom on documents in mobile browsers can trigger an unintended page refresh.
- I previously attempted to fix this in #1710, but that approach did not resolve the issue because mobile browsers do not emit `wheel` events for pinch gestures.
- This PR reverts the changes from #1710 and introduces three potential fixes, each gated behind a URL query parameter so they can be evaluated independently before a full rollout:
    - `disableNativePinchToZoom` — Sets `touch-action: pan-x pan-y` on the document element, disabling native pinch-to-zoom while preserving scrolling.
     - `disableAllTouchActions` — Sets `touch-action: none` on the document element, disabling all native touch gestures (including pinch-to-zoom and scrolling).
    - `forceNonPassiveTouchListeners` — Registers `touchstart` and `touchmove` listeners with `{ passive: false }`, allowing `preventDefault()` to suppress native gesture handling.

Note: These changes are gated behind URL query parameters because I currently can't reproduce or validate the issue in my local development environment. My personal mobile device has restrictions that prevent testing against local builds, and I have been unable to reproduce the issue using mobile browser emulators. Once this code reaches production, I'll be able to test each approach independently on my device and remove the experimental code after identifying the correct fix. I'm using URL query parameters instead of a traditional feature flag because I can't configure the required feature flag cookies on my personal mobile browser.

## Suspected root cause
- Modern mobile browsers ignore `user-scalable=no` in the viewport meta tag for accessibility reasons, so native pinch-to-zoom is no longer reliably disabled.
- As a result, native browser pinch-to-zoom can conflict with our custom pinch-to-zoom implementation, potentially causing the browser to refresh the page.

 ## Test plan
  - [ ] Open a document preview on mobile browser without query params — behavior unchanged
  - [ ] Open with `?disableNativePinchToZoom` — browser no longer handles pinch-zoom natively, custom zoom works without page refresh, scrolling still works
  - [ ] Open with `?disableAllTouchActions` — all native gestures disabled, JS handles everything
  - [ ] Open with `?forceNonPassiveTouchListeners` — `preventDefault()` blocks native gesture handling
  - [ ] Open with params combined to compare approaches
  - [ ] Open on desktop — behavior unchanged regardless of query params (no touch events)
  - [ ] Verify wheel-based trackpad pinch-to-zoom still works on desktop