### PR TITLE
fix(annotations): tint pencil scribble only while drawing mode is active

### DIFF
--- a/src/lib/viewers/controls/annotations/AnnotationsControls.tsx
+++ b/src/lib/viewers/controls/annotations/AnnotationsControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import noop from 'lodash/noop';
-import { bdlBoxBlue } from 'box-ui-elements/es/styles/variables';
+import { bdlBoxBlue, white } from 'box-ui-elements/es/styles/variables';
 import AnnotationsButton from './AnnotationsButton';
 import AnnotationsTargetedTooltip from './AnnotationsTargetedTooltip';
 import IconPencilScribbleMedium24 from '../icons/IconPencilScribbleMedium24';
@@ -112,7 +112,7 @@ export default function AnnotationsControls({
                 onClick={handleModeClick}
                 title={__('drawing_comment')}
             >
-                <IconPencilScribbleMedium24 style={{ color: annotationColor }} />
+                <IconPencilScribbleMedium24 style={{ color: isDrawingActive ? annotationColor : white }} />
             </AnnotationsButton>
             <AnnotationsTargetedTooltip isEnabled={showRegion}>
                 <AnnotationsButton

--- a/src/lib/viewers/controls/annotations/__tests__/AnnotationsControls-test.tsx
+++ b/src/lib/viewers/controls/annotations/__tests__/AnnotationsControls-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bdlBoxBlue } from 'box-ui-elements/es/styles/variables';
+import { white } from 'box-ui-elements/es/styles/variables';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AnnotationsControls from '../AnnotationsControls';
@@ -179,6 +179,26 @@ describe('AnnotationsControls', () => {
             expect(screen.getByTestId('IconPencilScribbleMedium24')).toBeInTheDocument();
             expect(screen.getByTestId('IconTextHighlightMedium24')).toBeInTheDocument();
             expect(screen.getByTestId('IconDashedSquareBubbleMedium24')).toBeInTheDocument();
+        });
+
+        test('should tint the pencil scribble with the annotation color while drawing mode is active', () => {
+            render(
+                <AnnotationsControls
+                    annotationColor="#f5b31b"
+                    annotationMode={AnnotationMode.DRAWING}
+                    hasDrawing
+                    hasHighlight
+                    hasRegion
+                />,
+            );
+
+            expect(screen.getByTestId('IconPencilScribbleMedium24')).toHaveStyle({ color: '#f5b31b' });
+        });
+
+        test('should render the pencil scribble in white when drawing mode is not active', () => {
+            render(<AnnotationsControls annotationColor="#f5b31b" hasDrawing hasHighlight hasRegion />);
+
+            expect(screen.getByTestId('IconPencilScribbleMedium24')).toHaveStyle({ color: white });
         });
     });
 });


### PR DESCRIPTION
## Human:
For the unselected state don't add the drawn-line color. Only on selection is it there.

|before|after|
|----|---|
|<img width="1206" height="187" alt="image" src="https://github.com/user-attachments/assets/29c8791f-28bc-43e2-8863-cce1806fe86f" />|<img width="525" height="124" alt="Screenshot 2026-07-21 at 1 25 46 PM" src="https://github.com/user-attachments/assets/10949782-5f28-482c-aafd-17513a9dcfb4" />|



## AI Summary

Follow-up to #1705, which tinted the pencil scribble icon with the selected annotation color unconditionally. This gates the tint on drawing mode being active:

- While the pen tool is selected, the scribble reflects the picked annotation color (unchanged from #1705).
- When the pen tool is not selected, the scribble renders plain white (`#fff`) like the other toolbar icons.

## Testing

- Added two render tests covering the tinted (drawing active) and white (drawing inactive) states.
- Full `AnnotationsControls` suite passes (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)