### PR TITLE
fix(preview): release PDF memory

### DIFF
--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -65,6 +65,10 @@ class Thumbnail {
         }
 
         return pdfDocument.getPage(1).then(page => {
+            if (!this.thumbnailImageCache) {
+                return null;
+            }
+
             const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
             const viewport = page.getViewport({ scale: 1, rotation });
             if (!viewport) {
@@ -120,6 +124,10 @@ class Thumbnail {
      * @return {Promise} - promise reolves with the image HTMLElement or null if generation is in progress
      */
     createThumbnailImage(itemIndex, thumbOptions) {
+        if (!this.thumbnailImageCache) {
+            return Promise.resolve(null);
+        }
+
         const cacheEntry = this.getImageFromCache(itemIndex);
         // If this thumbnail has already been cached, use it
         if (cacheEntry && cacheEntry.image) {
@@ -135,15 +143,21 @@ class Thumbnail {
         this.thumbnailImageCache.set(itemIndex, { ...cacheEntry, inProgress: true });
         return this.getThumbnailDataURL(itemIndex + 1, thumbOptions)
             .then(dataUrl => {
-                return this.createImageEl(dataUrl, thumbOptions);
-            })
-            .then(imageEl => {
+                if (!this.thumbnailImageCache) {
+                    return null;
+                }
+
+                const imageEl = this.createImageEl(dataUrl, thumbOptions);
                 // Cache this image element for future use
                 this.thumbnailImageCache.set(itemIndex, { inProgress: false, image: imageEl });
 
                 return imageEl;
             })
             .catch(() => {
+                if (!this.thumbnailImageCache) {
+                    return null;
+                }
+
                 this.thumbnailImageCache.set(itemIndex, { ...this.getImageFromCache(itemIndex), inProgress: false });
                 throw new Error('Thumbnail generation failed');
             });
@@ -156,7 +170,7 @@ class Thumbnail {
      * @return {Promise} - promise reolves with the image HTMLElement or null if generation is in progress
      */
     getImageFromCache(itemIndex) {
-        return this.thumbnailImageCache.get(itemIndex);
+        return this.thumbnailImageCache?.get(itemIndex) || null;
     }
 
     /**
@@ -181,6 +195,10 @@ class Thumbnail {
         return pdfDocument
             .getPage(pageNum)
             .then(page => {
+                if (!this.thumbnailImageCache) {
+                    return null;
+                }
+
                 const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
                 const viewport = page.getViewport({ scale: 1, rotation });
                 if (!viewport || !isFinite(viewport.width) || !isFinite(viewport.height)) {

--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -137,6 +137,11 @@ class ThumbnailsSidebar {
             this.virtualScroller = null;
         }
 
+        if (this.thumbnail) {
+            this.thumbnail.destroy();
+            this.thumbnail = null;
+        }
+
         this.pdfViewer = null;
         this.currentThumbnails = [];
         this.currentPage = null;
@@ -211,6 +216,10 @@ class ThumbnailsSidebar {
      * @return {void}
      */
     renderNextThumbnailImage() {
+        if (!this.thumbnail || !this.virtualScroller) {
+            return;
+        }
+
         const scrollerNotInited =
             this.virtualScroller &&
             this.virtualScroller instanceof VirtualScroller &&
@@ -293,8 +302,13 @@ class ThumbnailsSidebar {
      * @return {void}
      */
     requestThumbnailImage(itemIndex, thumbnailEl) {
+        if (!this.thumbnail) {
+            return;
+        }
+
         const requestId = requestAnimationFrame(() => {
             this.animationFrameRequestIds = this.animationFrameRequestIds.filter(id => id !== requestId);
+
             this.thumbnail
                 .createThumbnailImage(itemIndex)
                 .then(imageEl => {
@@ -407,7 +421,7 @@ class ThumbnailsSidebar {
 
     refresh() {
         if (!this.virtualScroller) {
-            return;
+            return Promise.resolve();
         }
 
         this.virtualScroller.destroy();
@@ -421,7 +435,11 @@ class ThumbnailsSidebar {
         const savedPreloader = this.thumbnail.preloader;
         this.thumbnail.preloader = null;
 
-        this.thumbnail.init().then(thumbnailHeight => {
+        return this.thumbnail.init().then(thumbnailHeight => {
+            if (!this.thumbnail || !this.virtualScroller) {
+                return;
+            }
+
             this.thumbnail.preloader = savedPreloader;
 
             if (thumbnailHeight) {

--- a/src/lib/ThumbnailsSidebar.js
+++ b/src/lib/ThumbnailsSidebar.js
@@ -147,6 +147,7 @@ class ThumbnailsSidebar {
         this.currentPage = null;
         this.preloader = null;
         this.anchorEl.removeEventListener('click', this.thumbnailClickHandler);
+        this.anchorEl.removeEventListener('keydown', this.onKeydown);
     }
 
     /**

--- a/src/lib/__tests__/Thumbnail-test.js
+++ b/src/lib/__tests__/Thumbnail-test.js
@@ -128,6 +128,49 @@ describe('Thumbnail', () => {
         test('should clean up the instance properties', () => {
             thumbnail.destroy();
             expect(thumbnail.thumbnailImageCache).toBeNull();
+            expect(thumbnail.pdfViewer).toBeNull();
+            expect(thumbnail.preloader).toBeNull();
+        });
+
+        test('should safely handle repeated calls', () => {
+            thumbnail.destroy();
+            expect(() => thumbnail.destroy()).not.toThrow();
+        });
+
+        test('should not initialize after being destroyed', async () => {
+            thumbnail.destroy();
+
+            await expect(thumbnail.init()).resolves.toBeNull();
+            expect(stubs.getPage).not.toBeCalled();
+        });
+
+        test('should ignore an in-flight initialization after being destroyed', async () => {
+            let resolvePage;
+            pagePromise = new Promise(resolve => {
+                resolvePage = resolve;
+            });
+
+            const initPromise = thumbnail.init();
+            thumbnail.destroy();
+            resolvePage(page);
+
+            await expect(initPromise).resolves.toBeNull();
+            expect(stubs.getViewport).not.toBeCalled();
+        });
+
+        test('should ignore an in-flight thumbnail render after being destroyed', async () => {
+            let resolvePage;
+            pagePromise = new Promise(resolve => {
+                resolvePage = resolve;
+            });
+
+            const dataUrlPromise = thumbnail.getThumbnailDataURL(1);
+            thumbnail.destroy();
+            resolvePage(page);
+            await dataUrlPromise;
+
+            expect(stubs.getViewport).not.toBeCalled();
+            expect(stubs.render).not.toBeCalled();
         });
     });
 
@@ -183,6 +226,31 @@ describe('Thumbnail', () => {
                 expect(stubs.createImageEl).not.toBeCalled();
                 expect(imageEl).toBeNull();
             });
+        });
+
+        test('should resolve with null after being destroyed', async () => {
+            thumbnail.destroy();
+
+            await expect(thumbnail.createThumbnailImage(0)).resolves.toBeNull();
+            expect(stubs.getThumbnailDataURL).not.toBeCalled();
+        });
+
+        test('should ignore an in-flight image after being destroyed', async () => {
+            let resolveDataUrl;
+            stubs.getThumbnailDataURL.mockReturnValue(
+                new Promise(resolve => {
+                    resolveDataUrl = resolve;
+                }),
+            );
+
+            const imagePromise = thumbnail.createThumbnailImage(0);
+            thumbnail.destroy();
+            stubs.setCacheEntry.mockClear();
+            resolveDataUrl('image');
+
+            await expect(imagePromise).resolves.toBeNull();
+            expect(stubs.createImageEl).not.toBeCalled();
+            expect(stubs.setCacheEntry).not.toBeCalled();
         });
     });
 

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -98,6 +98,15 @@ describe('ThumbnailsSidebar', () => {
             expect(thumbnailsSidebar.preloader).toBeNull();
         });
 
+        test('should remove event listeners from the anchor element', () => {
+            const removeEventListener = jest.spyOn(anchorEl, 'removeEventListener');
+
+            thumbnailsSidebar.destroy();
+
+            expect(removeEventListener).toBeCalledWith('click', thumbnailsSidebar.thumbnailClickHandler);
+            expect(removeEventListener).toBeCalledWith('keydown', thumbnailsSidebar.onKeydown);
+        });
+
         test('should destroy virtualScroller if it exists', () => {
             thumbnailsSidebar.virtualScroller = virtualScroller;
             thumbnailsSidebar.destroy();

--- a/src/lib/__tests__/ThumbnailsSidebar-test.js
+++ b/src/lib/__tests__/ThumbnailsSidebar-test.js
@@ -84,8 +84,14 @@ describe('ThumbnailsSidebar', () => {
 
     describe('destroy()', () => {
         test('should clean up the instance properties', () => {
+            const thumbnailDestroy = jest.spyOn(thumbnailsSidebar.thumbnail, 'destroy');
+
             thumbnailsSidebar.destroy();
+
+            expect(thumbnailDestroy).toBeCalled();
+            expect(thumbnailsSidebar.thumbnail).toBeNull();
             expect(thumbnailsSidebar.pdfViewer).toBeNull();
+
             const preloader = { retrievedPagesCount: 3 };
             thumbnailsSidebar = new ThumbnailsSidebar(anchorEl, pdfViewer, preloader);
             thumbnailsSidebar.destroy();
@@ -99,6 +105,33 @@ describe('ThumbnailsSidebar', () => {
             expect(stubs.vsDestroy).toBeCalled();
             expect(thumbnailsSidebar.virtualScroller).toBeNull();
             expect(thumbnailsSidebar.pdfViewer).toBeNull();
+        });
+
+        test('should safely handle repeated calls and delayed rendering', () => {
+            thumbnailsSidebar.destroy();
+
+            expect(() => thumbnailsSidebar.destroy()).not.toThrow();
+            expect(() => thumbnailsSidebar.renderNextThumbnailImage()).not.toThrow();
+            expect(() => thumbnailsSidebar.requestThumbnailImage(0, document.createElement('div'))).not.toThrow();
+        });
+
+        test('should ignore an in-flight refresh after being destroyed', async () => {
+            let resolveThumbnailHeight;
+            thumbnailsSidebar.virtualScroller = virtualScroller;
+            jest.spyOn(thumbnailsSidebar.thumbnail, 'init').mockReturnValue(
+                new Promise(resolve => {
+                    resolveThumbnailHeight = resolve;
+                }),
+            );
+
+            const refreshPromise = thumbnailsSidebar.refresh();
+            const refreshedScroller = thumbnailsSidebar.virtualScroller;
+            const refreshedScrollerInit = jest.spyOn(refreshedScroller, 'init');
+            thumbnailsSidebar.destroy();
+            resolveThumbnailHeight(100);
+
+            await expect(refreshPromise).resolves.toBeUndefined();
+            expect(refreshedScrollerInit).not.toBeCalled();
         });
     });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -289,6 +289,11 @@ class DocBaseViewer extends BaseViewer {
             this.thumbnailsSidebar.destroy();
         }
 
+        if (this.advancedInsightsThumbs) {
+            this.advancedInsightsThumbs.destroy();
+            this.advancedInsightsThumbs = null;
+        }
+
         // Clean up PDF network requests
         if (this.pdfLoadingTask) {
             try {
@@ -308,6 +313,8 @@ class DocBaseViewer extends BaseViewer {
         if (this.pdfLinkService) {
             this.pdfLinkService.setDocument(null);
         }
+
+        this.doc = null;
 
         if (this.printPopup) {
             this.printPopup.destroy();
@@ -2330,9 +2337,13 @@ class DocBaseViewer extends BaseViewer {
      * Get a thumbnail image element
      *
      * @param {number} pageNumber - the page number
-     * @return {Promise} - promise resolves with the image HTMLElement or null if generation is in progress
+     * @return {Promise} - promise resolves with the image HTMLElement or null if unavailable or in progress
      */
     getThumbnail(pageNumber) {
+        if (this.isDestroyed()) {
+            return Promise.resolve(null);
+        }
+
         if (!this.advancedInsightsThumbs) {
             this.advancedInsightsThumbs = new Thumbnail(this.pdfViewer);
         }

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -285,6 +285,10 @@ class DocBaseViewer extends BaseViewer {
             this.galleryController.destroy();
         }
 
+        if (this.thumbnailsSidebar) {
+            this.thumbnailsSidebar.destroy();
+        }
+
         // Clean up PDF network requests
         if (this.pdfLoadingTask) {
             try {
@@ -294,17 +298,19 @@ class DocBaseViewer extends BaseViewer {
             }
         }
 
-        // Clean up viewer
+        // Clean up and detach the PDF.js document so retained viewer instances
+        // do not keep page views and document resources alive.
         if (this.pdfViewer) {
             this.pdfViewer.cleanup();
+            this.pdfViewer.setDocument(null);
+        }
+
+        if (this.pdfLinkService) {
+            this.pdfLinkService.setDocument(null);
         }
 
         if (this.printPopup) {
             this.printPopup.destroy();
-        }
-
-        if (this.thumbnailsSidebar) {
-            this.thumbnailsSidebar.destroy();
         }
 
         if (this.thumbnailsSidebarEl) {
@@ -1076,6 +1082,10 @@ class DocBaseViewer extends BaseViewer {
 
         return this.pdfLoadingTask.promise
             .then(doc => {
+                if (this.isDestroyed()) {
+                    return null;
+                }
+
                 // Only check operations for .numbers and .xlsx files
                 if (file.extension === 'numbers' || file.extension === 'xlsx') {
                     return countPdfOperations(doc, MAX_OPERATION_PAGES).then(opCount => {
@@ -1088,6 +1098,10 @@ class DocBaseViewer extends BaseViewer {
                 return doc;
             })
             .then(doc => {
+                if (this.isDestroyed()) {
+                    return;
+                }
+
                 this.pdfLinkService.setDocument(doc, pdfUrl);
                 this.pdfViewer.setDocument(doc);
                 if (this.shouldThumbnailsBeToggled()) {
@@ -1099,6 +1113,10 @@ class DocBaseViewer extends BaseViewer {
                 this.doc = doc;
             })
             .catch(err => {
+                if (this.isDestroyed()) {
+                    return;
+                }
+
                 console.error(err); // eslint-disable-line
 
                 // pdf.js gives us the status code in their error message

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -383,6 +383,14 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.pdfLinkService.setDocument).toBeCalledWith(null);
             });
 
+            test('should release the stored PDF document', () => {
+                docBase.doc = {};
+
+                docBase.destroy();
+
+                expect(docBase.doc).toBeNull();
+            });
+
             test('should safely handle repeated destruction', () => {
                 docBase.pdfViewer = {
                     cleanup: jest.fn(),
@@ -408,6 +416,18 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.thumbnailsSidebar.destroy).toBeCalled();
                 expect(docBase.rootEl.removeChild).toBeCalled();
                 expect(stubs.classListRemove).toBeCalled();
+            });
+
+            test('should clean up the advanced insights thumbnails', () => {
+                const advancedInsightsThumbs = {
+                    destroy: jest.fn(),
+                };
+                docBase.advancedInsightsThumbs = advancedInsightsThumbs;
+
+                docBase.destroy();
+
+                expect(advancedInsightsThumbs.destroy).toBeCalled();
+                expect(docBase.advancedInsightsThumbs).toBeNull();
             });
 
             test('should destroy the page tracker object', () => {
@@ -4726,9 +4746,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
         describe('getThumbnail()', () => {
             beforeEach(() => {
                 docBase.pdfViewer = {
+                    cleanup: jest.fn(),
                     pdfDocument: {
                         getPage: jest.fn(),
                     },
+                    setDocument: jest.fn(),
                 };
                 stubs.promiseResolve = Promise.resolve({
                     getViewport: jest.fn().mockReturnValue({ width: 0, height: 0 }),
@@ -4750,6 +4772,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(docBase.advancedInsightsThumbs).toBe(undefined);
                 docBase.getThumbnail();
                 expect(docBase.advancedInsightsThumbs).toBeInstanceOf(Thumbnail);
+            });
+
+            test('should not create a new Thumbnail after being destroyed', async () => {
+                docBase.advancedInsightsThumbs = {
+                    destroy: jest.fn(),
+                };
+                docBase.destroy();
+
+                await expect(docBase.getThumbnail(1)).resolves.toBeNull();
+                expect(docBase.advancedInsightsThumbs).toBeNull();
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -366,10 +366,36 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             test('should clean up the viewer', () => {
                 docBase.pdfViewer = {
                     cleanup: jest.fn(),
+                    setDocument: jest.fn(),
                 };
 
                 docBase.destroy();
                 expect(docBase.pdfViewer.cleanup).toBeCalled();
+                expect(docBase.pdfViewer.setDocument).toBeCalledWith(null);
+            });
+
+            test('should detach the document from the link service', () => {
+                docBase.pdfLinkService = {
+                    setDocument: jest.fn(),
+                };
+
+                docBase.destroy();
+                expect(docBase.pdfLinkService.setDocument).toBeCalledWith(null);
+            });
+
+            test('should safely handle repeated destruction', () => {
+                docBase.pdfViewer = {
+                    cleanup: jest.fn(),
+                    setDocument: jest.fn(),
+                };
+                docBase.pdfLinkService = {
+                    setDocument: jest.fn(),
+                };
+
+                expect(() => {
+                    docBase.destroy();
+                    docBase.destroy();
+                }).not.toThrow();
             });
 
             test('should clean up the thumbnails sidebar instance and DOM element', () => {
@@ -1725,6 +1751,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     on: jest.fn(),
                 };
                 stubs.pdfViewer = {
+                    cleanup: jest.fn(),
                     setDocument: jest.fn(),
                 };
                 stubs.pdfViewerClass = jest.fn(() => stubs.pdfViewer);
@@ -1756,6 +1783,85 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     })),
                     PDFViewer: stubs.pdfViewerClass,
                 };
+            });
+
+            test('should not attach a PDF document after the viewer is destroyed', async () => {
+                let resolveDocument;
+                const pdfDocument = {
+                    numPages: 1,
+                    getPage: jest.fn(),
+                };
+                docBase.options.file.extension = 'xlsx';
+                stubs.getDocument.mockReturnValue({
+                    destroy: jest.fn(),
+                    promise: new Promise(resolve => {
+                        resolveDocument = resolve;
+                    }),
+                });
+
+                const initPromise = docBase.initViewer('');
+                docBase.destroy();
+                resolveDocument(pdfDocument);
+                await initPromise;
+
+                expect(stubs.pdfViewer.setDocument).toBeCalledWith(null);
+                expect(stubs.pdfViewer.setDocument).not.toBeCalledWith(pdfDocument);
+                expect(docBase.pdfLinkService.setDocument).toBeCalledWith(null);
+                expect(docBase.pdfLinkService.setDocument).not.toBeCalledWith(pdfDocument, expect.anything());
+                expect(pdfDocument.getPage).not.toBeCalled();
+            });
+
+            test('should not attach a PDF document if destroyed while counting operations', async () => {
+                let resolveOperatorList;
+                let signalOperatorList;
+                const operatorListCalled = new Promise(resolve => {
+                    signalOperatorList = resolve;
+                });
+                const getOperatorList = jest.fn(() => {
+                    signalOperatorList();
+                    return new Promise(resolve => {
+                        resolveOperatorList = resolve;
+                    });
+                });
+                const pdfDocument = {
+                    numPages: 1,
+                    getPage: jest.fn().mockResolvedValue({ getOperatorList }),
+                };
+                docBase.options.file.extension = 'xlsx';
+                stubs.getDocument.mockReturnValue({
+                    destroy: jest.fn(),
+                    promise: Promise.resolve(pdfDocument),
+                });
+
+                const initPromise = docBase.initViewer('');
+                await operatorListCalled;
+
+                docBase.destroy();
+                resolveOperatorList({ fnArray: [] });
+                await initPromise;
+
+                expect(stubs.pdfViewer.setDocument).not.toBeCalledWith(pdfDocument);
+                expect(docBase.pdfLinkService.setDocument).not.toBeCalledWith(pdfDocument, expect.anything());
+            });
+
+            test('should ignore PDF load errors after the viewer is destroyed', async () => {
+                let rejectDocument;
+                stubs.getDocument.mockReturnValue({
+                    destroy: jest.fn(),
+                    promise: new Promise((resolve, reject) => {
+                        rejectDocument = reject;
+                    }),
+                });
+                stubs.consoleError = jest.spyOn(console, 'error').mockImplementation();
+                stubs.handleDownloadError = jest.spyOn(docBase, 'handleDownloadError').mockImplementation();
+
+                const initPromise = docBase.initViewer('');
+                docBase.destroy();
+                rejectDocument(new Error('PDF load aborted'));
+                await initPromise;
+
+                expect(stubs.consoleError).not.toBeCalled();
+                expect(stubs.handleDownloadError).not.toBeCalled();
             });
 
             test('should create an event bus and subscribe to relevant events', () => {

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -38,6 +38,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
         doc.pdfViewer = {
             currentPageNumber: 0,
             cleanup: jest.fn(),
+            setDocument: jest.fn(),
         };
         doc.controls = {
             add: jest.fn(),

--- a/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/PresentationViewer-test.js
@@ -42,6 +42,7 @@ describe('lib/viewers/doc/PresentationViewer', () => {
             currentPageNumber: 1,
             update: jest.fn(),
             cleanup: jest.fn(),
+            setDocument: jest.fn(),
         };
 
         presentation.controls = {
@@ -111,6 +112,19 @@ describe('lib/viewers/doc/PresentationViewer', () => {
                 removeAllListeners: jest.fn(),
             };
             presentation.destroy();
+            presentation = null; // Don't call destroy again during cleanup
+        });
+
+        test('should detach the PDF document when destroyed', () => {
+            presentation.pdfLinkService = {
+                setDocument: jest.fn(),
+            };
+
+            presentation.destroy();
+
+            expect(presentation.pdfViewer.cleanup).toBeCalled();
+            expect(presentation.pdfViewer.setDocument).toBeCalledWith(null);
+            expect(presentation.pdfLinkService.setDocument).toBeCalledWith(null);
             presentation = null; // Don't call destroy again during cleanup
         });
     });

--- a/test/integration/document/Gallery.e2e.test.js
+++ b/test/integration/document/Gallery.e2e.test.js
@@ -8,6 +8,7 @@ describe('Preview Document Gallery', () => {
     const THUMBNAIL_SELECTED_CLASS = 'bp-thumbnail-is-selected';
 
     const showDocumentPreview = ({
+        collection,
         enableThumbnailsSidebar = false,
         galleryEnabled = true,
         targetFileId = fileId,
@@ -24,6 +25,9 @@ describe('Preview Document Gallery', () => {
         if (enableThumbnailsSidebar) {
             options.enableThumbnailsSidebar = true;
         }
+        if (collection) {
+            options.collection = collection;
+        }
 
         cy.showPreview(token, targetFileId, options);
         cy.getPreviewPage(1);
@@ -36,6 +40,23 @@ describe('Preview Document Gallery', () => {
             .click();
 
         cy.get('.bp-gallery-grid').should('be.visible');
+    };
+
+    const showGalleryWithRenderedThumbnails = (options = {}) => {
+        showDocumentPreview({ ...options, enableThumbnailsSidebar: true });
+        cy.get('.bp-thumbnail[data-bp-page-num="1"] .bp-thumbnail-image').should('exist');
+        openGallery();
+        cy.get('.bp-gallery-tile img').should('have.length', 2);
+    };
+
+    const expectReleasedResources = viewer => {
+        expect(viewer.destroyed).to.be.true;
+        expect(viewer.pdfViewer.pdfDocument).to.be.null;
+        // PDF.js private state is asserted intentionally: this retained page-view array caused the regression.
+        expect(viewer.pdfViewer._pages).to.be.empty;
+        expect(viewer.pdfLinkService.pdfDocument).to.be.null;
+        expect(viewer.galleryController.galleryThumbnail).to.be.null;
+        expect(viewer.thumbnailsSidebar.thumbnail).to.be.null;
     };
 
     beforeEach(() => {
@@ -147,5 +168,52 @@ describe('Preview Document Gallery', () => {
             .should('have.class', THUMBNAIL_SELECTED_CLASS)
             .find('.bp-thumbnail-image')
             .should('exist');
+    });
+
+    it('Should release document and thumbnail resources when Preview is destroyed', () => {
+        showGalleryWithRenderedThumbnails();
+
+        cy.window().then(win => {
+            const viewer = win.preview.getCurrentViewer();
+
+            expect(viewer.pdfViewer.pdfDocument).to.exist;
+            expect(viewer.pdfViewer._pages).to.have.length(2);
+            expect(viewer.galleryController.galleryThumbnail).to.exist;
+            expect(viewer.thumbnailsSidebar.thumbnail).to.exist;
+
+            win.preview.hide();
+
+            expectReleasedResources(viewer);
+        });
+    });
+
+    it('Should release previous document resources when Preview reloads', () => {
+        showGalleryWithRenderedThumbnails();
+
+        cy.window().then(win => {
+            const viewer = win.preview.getCurrentViewer();
+            win.preview.reload(true);
+            expectReleasedResources(viewer);
+        });
+
+        cy.getPreviewPage(1).should('be.visible');
+    });
+
+    it('Should release previous document resources when navigating to the next file', () => {
+        showGalleryWithRenderedThumbnails({ collection: [fileId, singlePageFileId] });
+        cy.get('[role="option"][aria-label="Page 1"]').type('{esc}');
+        cy.showControls();
+
+        cy.window().then(win => {
+            cy.wrap(win.preview.getCurrentViewer()).as('previousViewer');
+        });
+        cy.getByTitle('Next file').click();
+        cy.get('@previousViewer').then(viewer => {
+            expectReleasedResources(viewer);
+        });
+
+        cy.window()
+            .its('preview.file.id')
+            .should('equal', singlePageFileId);
     });
 });

--- a/test/integration/document/Gallery.e2e.test.js
+++ b/test/integration/document/Gallery.e2e.test.js
@@ -55,6 +55,7 @@ describe('Preview Document Gallery', () => {
         // PDF.js private state is asserted intentionally: this retained page-view array caused the regression.
         expect(viewer.pdfViewer._pages).to.be.empty;
         expect(viewer.pdfLinkService.pdfDocument).to.be.null;
+        expect(viewer.doc).to.be.null;
         expect(viewer.galleryController.galleryThumbnail).to.be.null;
         expect(viewer.thumbnailsSidebar.thumbnail).to.be.null;
     };


### PR DESCRIPTION
Fix document Preview memory retention that is amplified by Gallery View: closing, reloading, or navigating away now releases PDF.js page resources and thumbnail caches instead of retaining them after Preview exits.

## What changed
**PDF.js teardown**
- Call `pdfViewer.setDocument(null)` during `DocBaseViewer.destroy()` so PDF.js releases the previous document, page-view array, rendered canvases, text layers, and associated page resources.
- Call `pdfLinkService.setDocument(null)` so the link service no longer retains the previous PDF document.
- Destroy Gallery and sidebar resources before detaching PDF.js, ensuring owned thumbnail resources are released first.
- Keep teardown safe when called repeatedly.

**Thumbnail cleanup**
- Destroy the `Thumbnail` instance owned by `ThumbnailsSidebar` instead of only destroying its virtual scroller.
- Release the sidebar’s bounded thumbnail cache and clear references to its PDF viewer and preloader.
- Ignore thumbnail initialization, rendering, and cache updates that complete after the thumbnail has been destroyed.
- Ignore delayed sidebar rendering and refresh callbacks after teardown.

**Async document loading**
- Check whether the viewer was destroyed before counting spreadsheet PDF operations or attaching a loaded document.
- Prevent delayed PDF loading from calling `setDocument()` on a destroyed viewer.
- Ignore expected PDF loading failures after teardown instead of logging or retrying them.
- Preserve normal loading behavior for active document and presentation viewers.

**Impact and compatibility**
- The underlying retention affected document Preview independently of Gallery View; Gallery amplified it by rendering thumbnails across many pages.
- During investigation with a complex 198-page document, repeated Gallery usage peaked around 4.5 GB and retained approximately 2.6 GB after leaving Preview. Explicit teardown reduced the footprint to approximately 895 MB.
- Gallery remains controlled by its existing feature flag. Users without Gallery access receive the same Preview behavior with improved document cleanup.
- Sidebar cleanup is conditional, so documents without the thumbnails sidebar are unaffected.

## Test plan
- [ ] Open a large document, render Gallery thumbnails, close Preview, and verify memory drops after garbage collection
- [ ] Reload Preview in place and verify the previous PDF.js document and page views are released
- [ ] Navigate to the next file and verify the previous viewer releases its resources
- [ ] Close Preview without opening Gallery and verify normal document teardown
- [ ] Verify Gallery remains hidden when its feature flag is omitted or disabled
- [ ] Verify documents without the thumbnails sidebar continue to open and close normally
- [ ] Destroy Preview while PDF loading is pending and verify the document is never attached
- [ ] Destroy Preview while spreadsheet operation counting is pending and verify loading does not resume
- [ ] Destroy thumbnails while initialization or rendering is pending and verify no cache or DOM work resumes
- [ ] Rotate a document and verify sidebar and Gallery thumbnails continue to refresh normally
- [ ] Verify repeated destruction does not throw
- [ ] Verify document and presentation viewers both detach their PDF.js documents
- [x] 499 focused Jest tests pass
- [x] 12 Gallery Cypress tests pass
- [x] ESLint passes
- [x] `git diff --check` passes