### PR TITLE
Gallery resin tags

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -112,6 +112,13 @@ export const USER_DOCUMENT_THUMBNAIL_EVENTS = {
     OPEN: 'user_document_thumbnails_open',
 };
 
+// Events fired when using gallery view
+export const USER_DOCUMENT_GALLERY_EVENTS = {
+    DISMISS: 'user_document_gallery_dismiss', // The gallery closes without the user settling on a page
+    NAVIGATE: 'user_document_gallery_navigate', // The user picks a page, or closes on one they browsed to
+    OPEN: 'user_document_gallery_open', // The user opens the gallery
+};
+
 export const MISSING_EXTERNAL_REFS = 'missing_x_refs';
 
 export const MEDIA_METRIC = {

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -49,6 +49,7 @@ import {
     RENDER_EVENT,
     RENDER_METRIC,
     REPORT_ACI,
+    USER_DOCUMENT_GALLERY_EVENTS,
     USER_DOCUMENT_THUMBNAIL_EVENTS,
     VIEWER_EVENT,
 } from '../../events';
@@ -252,6 +253,7 @@ class DocBaseViewer extends BaseViewer {
             },
             onBeforeOpen: () => this.handleGalleryEnter(),
             onAfterClose: () => this.handleGalleryExit(),
+            onClose: landedPage => this.handleGalleryClose(landedPage),
         });
     }
 
@@ -2076,7 +2078,24 @@ class DocBaseViewer extends BaseViewer {
         if (this.annotator) {
             this.annotator.toggleAnnotationMode(AnnotationMode.NONE);
         }
+        this.emitMetric({ name: USER_DOCUMENT_GALLERY_EVENTS.OPEN, data: this.pdfViewer?.pagesCount ?? 0 });
         this.emit(VIEWER_EVENT.galleryOpen);
+    }
+
+    /**
+     * Called as the gallery closes, with the page the user landed on or null if they left without
+     * settling on one. Reported as two distinct metrics so the pick-through rate is measurable.
+     *
+     * @protected
+     * @param {number|null} landedPage - Page the gallery left the document on, or null if unchanged
+     * @return {void}
+     */
+    handleGalleryClose(landedPage) {
+        if (landedPage !== null) {
+            this.emitMetric({ name: USER_DOCUMENT_GALLERY_EVENTS.NAVIGATE, data: landedPage });
+        } else {
+            this.emitMetric({ name: USER_DOCUMENT_GALLERY_EVENTS.DISMISS, data: this.pdfViewer?.pagesCount ?? 0 });
+        }
     }
 
     /**

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -36,7 +36,14 @@ import {
 } from '../../../constants';
 
 import { ICON_PRINT_CHECKMARK } from '../../../icons';
-import { LOAD_METRIC, RENDER_EVENT, REPORT_ACI, USER_DOCUMENT_THUMBNAIL_EVENTS, VIEWER_EVENT } from '../../../events';
+import {
+    LOAD_METRIC,
+    RENDER_EVENT,
+    REPORT_ACI,
+    USER_DOCUMENT_GALLERY_EVENTS,
+    USER_DOCUMENT_THUMBNAIL_EVENTS,
+    VIEWER_EVENT,
+} from '../../../events';
 import Timer from '../../../Timer';
 import Thumbnail from '../../../Thumbnail';
 import PageTracker from '../../../PageTracker';
@@ -342,6 +349,16 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
                 docBase.destroy();
                 expect(docBase.controls.destroy).toBeCalled();
+            });
+
+            test('should destroy the gallery controller before removing metric listeners', () => {
+                const order = [];
+                jest.spyOn(docBase.galleryController, 'destroy').mockImplementation(() => order.push('gallery'));
+                jest.spyOn(docBase, 'removeAllListeners').mockImplementation(() => order.push('listeners'));
+
+                docBase.destroy();
+
+                expect(order).toEqual(['gallery', 'listeners']);
             });
 
             test('should destroy the find bar', () => {
@@ -4564,6 +4581,76 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             test('should not throw if annotator is not initialized', () => {
                 docBase.annotator = undefined;
                 expect(() => docBase.handleGalleryEnter()).not.toThrow();
+            });
+
+            test('should emit the open metric with the page count', () => {
+                jest.spyOn(docBase, 'emitMetric').mockImplementation();
+                docBase.pdfViewer = { pagesCount: 42 };
+
+                docBase.handleGalleryEnter();
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.OPEN,
+                    data: 42,
+                });
+            });
+
+            test('should emit the open metric even when pdfViewer is not initialized', () => {
+                jest.spyOn(docBase, 'emitMetric').mockImplementation();
+                docBase.pdfViewer = undefined;
+
+                docBase.handleGalleryEnter();
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.OPEN,
+                    data: 0,
+                });
+            });
+        });
+
+        describe('handleGalleryClose()', () => {
+            beforeEach(() => {
+                jest.spyOn(docBase, 'emitMetric').mockImplementation();
+            });
+
+            test('should emit the navigate metric with the page landed on', () => {
+                docBase.handleGalleryClose(9);
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.NAVIGATE,
+                    data: 9,
+                });
+            });
+
+            test('should emit the dismiss metric with the page count when no page was landed on', () => {
+                docBase.pdfViewer = { pagesCount: 42 };
+
+                docBase.handleGalleryClose(null);
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.DISMISS,
+                    data: 42,
+                });
+            });
+
+            test('should emit the dismiss metric even when pdfViewer is not initialized', () => {
+                docBase.pdfViewer = undefined;
+
+                docBase.handleGalleryClose(null);
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.DISMISS,
+                    data: 0,
+                });
+            });
+
+            test('should treat landing on the first page as a navigation rather than a dismissal', () => {
+                docBase.handleGalleryClose(1);
+
+                expect(docBase.emitMetric).toBeCalledWith({
+                    name: USER_DOCUMENT_GALLERY_EVENTS.NAVIGATE,
+                    data: 1,
+                });
             });
         });
 

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -46,6 +46,7 @@ export type GalleryControllerOptions = {
     focusToggle: () => void;
     onBeforeOpen: () => void;
     onAfterClose: () => void;
+    onClose: (landedPage: number | null) => void;
 };
 
 export default class GalleryController {
@@ -71,6 +72,8 @@ export default class GalleryController {
 
     private onAfterClose: () => void;
 
+    private onClose: (landedPage: number | null) => void;
+
     private galleryRoot: Root | null = null;
 
     private galleryEl: HTMLDivElement | null = null;
@@ -87,6 +90,8 @@ export default class GalleryController {
 
     private isGalleryOpen = false;
 
+    private pickedPage: number | null = null;
+
     constructor(opts: GalleryControllerOptions) {
         this.containerEl = opts.containerEl;
         this.features = opts.features;
@@ -99,6 +104,7 @@ export default class GalleryController {
         this.focusToggle = opts.focusToggle;
         this.onBeforeOpen = opts.onBeforeOpen;
         this.onAfterClose = opts.onAfterClose;
+        this.onClose = opts.onClose;
     }
 
     get isOpen(): boolean {
@@ -176,6 +182,10 @@ export default class GalleryController {
                     }, THUMBNAILS_SIDEBAR_TRANSITION_TIME);
                 }
             }
+
+            const { pickedPage } = this;
+            this.pickedPage = null;
+            this.onClose(pickedPage ?? navigateToPage);
         }
 
         this.requestUiUpdate();
@@ -219,6 +229,13 @@ export default class GalleryController {
     }
 
     destroy(): void {
+        // Teardown with the gallery still open (file switch, preview closed) resolves the open
+        // instead of leaving it looking abandoned. Depends on the viewer destroying this controller
+        // before BaseViewer.destroy drops the metric listeners.
+        if (this.isGalleryOpen) {
+            this.onClose(null);
+        }
+
         if (this.galleryMountTimeoutId !== null) {
             clearTimeout(this.galleryMountTimeoutId);
             this.galleryMountTimeoutId = null;
@@ -263,6 +280,7 @@ export default class GalleryController {
 
     private handleGalleryNavigate = (pageNum: number): void => {
         this.galleryFocusedPage = pageNum;
+        this.pickedPage = pageNum;
         this.toggle();
     };
 

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -319,6 +319,7 @@ export default class GalleryController {
 
         const thumbnail = this.galleryThumbnail;
         this.galleryEl = document.createElement('div');
+        this.galleryEl.setAttribute('data-resin-component', 'gallery');
         this.containerEl.insertBefore(this.galleryEl, this.containerEl.querySelector('.bp-ControlsRoot'));
         this.galleryRoot = createRoot(this.galleryEl);
         this.galleryFocusedPage = pdfViewer.currentPageNumber;

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -56,6 +56,7 @@ const GalleryTile = React.memo(function GalleryTile({
             aria-selected={isFocused}
             className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
             data-page={pageNum}
+            data-resin-target="galleryTile"
             onClick={() => onClick(pageNum)}
             onFocus={() => onFocus(pageNum)}
             role="option"

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -35,6 +35,7 @@ interface Harness {
     focusToggle: jest.Mock;
     onBeforeOpen: jest.Mock;
     onAfterClose: jest.Mock;
+    onClose: jest.Mock;
 }
 
 function makeController(
@@ -63,6 +64,7 @@ function makeController(
     const focusToggle = jest.fn();
     const onBeforeOpen = jest.fn();
     const onAfterClose = jest.fn();
+    const onClose = jest.fn();
 
     const opts: GalleryControllerOptions = {
         containerEl,
@@ -76,6 +78,7 @@ function makeController(
         focusToggle,
         onBeforeOpen,
         onAfterClose,
+        onClose,
     };
 
     return {
@@ -89,6 +92,7 @@ function makeController(
         focusToggle,
         onBeforeOpen,
         onAfterClose,
+        onClose,
     };
 }
 
@@ -364,6 +368,94 @@ describe('GalleryController', () => {
 
             expect(setPage).toHaveBeenCalledWith(8);
             expect(controller.isOpen).toBe(false);
+        });
+    });
+
+    describe('outcome reporting', () => {
+        test('should report the picked page when one is chosen from the grid', () => {
+            const { controller, onClose } = makeController({ currentPage: 1, sidebarOpen: false });
+            controller.toggle();
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onPageNavigate(8);
+
+            expect(onClose).toHaveBeenCalledWith(8);
+        });
+
+        test('should report a pick when the chosen page is already the current page', () => {
+            const { controller, onClose, setPage } = makeController({ currentPage: 3 });
+            controller.toggle();
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onPageNavigate(3);
+
+            // No page change, but the user still found their page — that is a pick, not a bail
+            expect(setPage).not.toHaveBeenCalled();
+            expect(onClose).toHaveBeenCalledWith(3);
+        });
+
+        test('should report no landing on Escape', () => {
+            const { controller, onClose } = makeController();
+            controller.toggle();
+            controller.handleEscape();
+
+            expect(onClose).toHaveBeenCalledWith(null);
+        });
+
+        // Closing commits whichever page was browsed to, so the user has landed on it even though
+        // they never picked it outright — reported as a landing to match what the document does.
+        test('should report the browsed page when closed after arrowing to it', () => {
+            const { controller, onClose, setPage } = makeController({ currentPage: 1, sidebarOpen: false });
+            controller.toggle();
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onFocusChange(5);
+            controller.toggle();
+
+            expect(setPage).toHaveBeenCalledWith(5);
+            expect(onClose).toHaveBeenCalledWith(5);
+        });
+
+        test('should report no landing when closed without the page changing', () => {
+            const { controller, onClose, setPage } = makeController({ currentPage: 3, sidebarOpen: false });
+            controller.toggle();
+
+            // Focus starts on the current page and never moves off it
+            controller.toggle();
+
+            expect(setPage).not.toHaveBeenCalled();
+            expect(onClose).toHaveBeenCalledWith(null);
+        });
+
+        test('should report no landing when destroyed while open', () => {
+            const { controller, onClose } = makeController({ sidebarOpen: false });
+            controller.toggle();
+            controller.destroy();
+
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(onClose).toHaveBeenCalledWith(null);
+        });
+
+        test('should not report anything when destroyed while closed', () => {
+            const { controller, onClose } = makeController();
+            controller.destroy();
+
+            expect(onClose).not.toHaveBeenCalled();
+        });
+
+        test('should report exactly one outcome per open across repeated use', () => {
+            const { controller, onClose } = makeController({ currentPage: 1, sidebarOpen: false });
+
+            controller.toggle();
+            controller.toggle();
+
+            controller.toggle();
+            mockLastRoot.render.mock.calls[0][0].props.onPageNavigate(4);
+
+            controller.toggle();
+            controller.handleEscape();
+
+            expect(onClose.mock.calls).toEqual([[null], [4], [null]]);
         });
     });
 

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -153,6 +153,14 @@ describe('GalleryController', () => {
             expect(requestUiUpdate).toHaveBeenCalledTimes(1);
         });
 
+        test('should tag the gallery root with a resin component', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            controller.toggle();
+
+            const galleryEl = containerEl.firstElementChild as HTMLElement;
+            expect(galleryEl.getAttribute('data-resin-component')).toBe('gallery');
+        });
+
         test('should not call focusToggle on open', () => {
             const { controller, focusToggle } = makeController({ sidebarOpen: false });
             controller.toggle();

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -59,6 +59,15 @@ describe('GalleryGrid', () => {
         });
     });
 
+    describe('resin tagging', () => {
+        test('should set the resin target on every tile', () => {
+            getWrapper();
+            screen.getAllByRole('option').forEach(tile => {
+                expect(tile).toHaveAttribute('data-resin-target', 'galleryTile');
+            });
+        });
+    });
+
     describe('current page highlight', () => {
         test('should apply selected class to current page tile', () => {
             getWrapper();


### PR DESCRIPTION
Add Resin tagging and usage metrics to Gallery View so tile interactions are attributable and the open-to-navigate rate is measurable.

## What changed
### Resin tagging
- Tag gallery tiles with `data-resin-target="galleryTile"`, alongside the `galleryView` target the toggle already carried.
- Tag the gallery root with `data-resin-component="gallery"`. The grid mounts as a sibling of `.bp-ControlsRoot`, so tile clicks had no component ancestor and Resin could not attribute them.

### Usage metrics
- Add `user_document_gallery_open`, `_navigate`, and `_dismiss`, which Gallery had none of previously. Open and dismiss carry the document's page count; navigate carries the page landed on.
- Report outcomes from `GalleryController` through a single `onClose(landedPage)` callback, where a page number means the document ended up there and `null` means it never moved. One nullable argument makes "exactly one outcome per close" a property of the type rather than a convention.
- Count an outright pick and a close that commits the browsed page both as navigations, since closing commits the focused page either way. Picking the page already being viewed counts too.
- Report a dismissal when Preview is torn down with Gallery still open, so the open resolves instead of looking abandoned. A closed tab or crash cannot be observed.
- Leave these events out of `METRICS_WHITELIST`, unlike the thumbnail events, so every open is counted against its outcome rather than flattened to one of each.

## Test plan
- [ ] Open Gallery and click a tile, and verify `_open` then `_navigate` with the clicked page
- [ ] Open Gallery and press Escape, and verify `_open` then `_dismiss` with the page count
- [ ] Arrow to another page then press Escape, and verify `_navigate` with the browsed page rather than a dismissal
- [ ] Pick the page already being viewed and verify `_navigate`, not `_dismiss`
- [ ] Open and close Gallery twice and verify two `_open` events, confirming they are not de-duplicated
- [ ] Switch files with Gallery open and verify a dismissal is reported
- [ ] Click a tile and verify Resin no longer reports a missing component
- [ ] Verify tile clicks report component `gallery` and toggle clicks report component `toolbar`
- [x] 483 focused Jest tests pass
- [x] ESLint passes
- [x] `tsc --noEmit` passes