### PR TITLE
fix(doc): Keep PDF links above annotations overlay

### DIFF
--- a/src/lib/viewers/doc/_docBase.scss
+++ b/src/lib/viewers/doc/_docBase.scss
@@ -363,6 +363,14 @@ $thumbnail-sidebar-width: 191px; // Extra pixel to account for sidebar border
     }
 
     .annotationLayer {
+        // box-annotations inserts its region-creation layer as a sibling inside .page with no
+        // z-index, and its full-page creator div captures pointer events. Since this layer is
+        // also z-index: auto, paint order follows DOM order and whichever layer pdf.js inserts
+        // last wins the click -- which varies by pdf.js version (vendored vs npm). Pin the link
+        // layer into the stack explicitly: above .textLayer (1) and the region-creation overlay
+        // (auto), below the region/highlight/drawing layers (3) and popups (4).
+        z-index: 2;
+
         h1,
         h2,
         h3,

--- a/test/integration/document/PresentationViewer.e2e.test.js
+++ b/test/integration/document/PresentationViewer.e2e.test.js
@@ -39,4 +39,24 @@ describe('Presentation Viewer', () => {
 
         cy.getPreviewPage(3).should('be.visible');
     });
+
+    it('Should keep links clickable when PDF.js inserts the annotation layer before the text layer', () => {
+        cy.showPreview(token, fileWithLinksId, {
+            enableAnnotationsDiscoverability: true,
+            showAnnotations: true,
+            showAnnotationsControls: true,
+        });
+
+        cy.get('.ba-RegionCreation-creator').should('exist');
+        cy.get('.annotationLayer .linkAnnotation > a').then($link => {
+            const annotationLayer = $link[0].closest('.annotationLayer');
+            const textLayer = annotationLayer.parentElement.querySelector('.textLayer');
+
+            // npm PDF.js inserts the annotation layer earlier than the vendored build.
+            annotationLayer.parentElement.insertBefore(annotationLayer, textLayer);
+        });
+        cy.get('.annotationLayer .linkAnnotation > a').click();
+
+        cy.getPreviewPage(3).should('be.visible');
+    });
 });


### PR DESCRIPTION
### JIRA ticket link

https://jira.inside-box.net/browse/PREVIEW-1372

### Description

Pins the PDF.js annotation layer at `z-index: 2` so link annotations remain above the unnumbered region-creation overlay while staying below annotation targets and popups. The explicit stacking order applies to both vendored and npm PDF.js builds regardless of their DOM insertion order.

A Cypress regression test recreates npm PDF.js's earlier layer insertion order with the vendored build so the stacking behavior runs in CI's Electron browser.

### Test plan

- [x] Run the pre-push checks (lint and changed-file tests)
- [x] Preview a PDF with external links while `use_npm_for_pdfjs` is on and annotations are enabled; verify the link opens in a new tab
- [x] Verify the regression test fails without the stacking rule because the text layer covers the PDF link
- [x] Verify `PresentationViewer.e2e.test.js` passes with the stacking rule (3 passing)
