### PR TITLE
feat(gallery): add pinch to zoom

### DIFF
--- a/src/lib/viewers/controls/zoom/ZoomControls.tsx
+++ b/src/lib/viewers/controls/zoom/ZoomControls.tsx
@@ -9,6 +9,8 @@ export type Props = {
     minScale?: number;
     onZoomIn: () => void;
     onZoomOut: () => void;
+    resinTargetZoomIn?: string;
+    resinTargetZoomOut?: string;
     scale?: number;
 };
 
@@ -20,6 +22,8 @@ export default function ZoomControls({
     minScale = MIN_SCALE,
     onZoomIn,
     onZoomOut,
+    resinTargetZoomIn = 'zoomIn',
+    resinTargetZoomOut = 'zoomOut',
     scale = 1,
 }: Props): JSX.Element {
     const currentScale = Math.round((scale + Number.EPSILON) * 100) / 100;
@@ -30,7 +34,7 @@ export default function ZoomControls({
         <div className="bp-ZoomControls">
             <button
                 className="bp-ZoomControls-button"
-                data-resin-target="zoomOut"
+                data-resin-target={resinTargetZoomOut}
                 data-testid="bp-ZoomControls-out"
                 disabled={currentScale <= minScaleValue}
                 onClick={onZoomOut}
@@ -46,7 +50,7 @@ export default function ZoomControls({
             >{`${Math.round(currentScale * 100)}%`}</div>
             <button
                 className="bp-ZoomControls-button"
-                data-resin-target="zoomIn"
+                data-resin-target={resinTargetZoomIn}
                 data-testid="bp-ZoomControls-in"
                 disabled={currentScale >= maxScaleValue}
                 onClick={onZoomIn}

--- a/src/lib/viewers/controls/zoom/__tests__/ZoomControls-test.tsx
+++ b/src/lib/viewers/controls/zoom/__tests__/ZoomControls-test.tsx
@@ -102,5 +102,17 @@ describe('ZoomControls', () => {
             expect(zoomOut).toBeInTheDocument();
             expect(currentZoom).toBeInTheDocument();
         });
+
+        test('should default the resin targets', async () => {
+            getWrapper();
+            expect(await getZoomIn()).toHaveAttribute('data-resin-target', 'zoomIn');
+            expect(await getZoomOut()).toHaveAttribute('data-resin-target', 'zoomOut');
+        });
+
+        test('should allow hosts to override the resin targets', async () => {
+            getWrapper({ resinTargetZoomIn: 'galleryZoomIn', resinTargetZoomOut: 'galleryZoomOut' });
+            expect(await getZoomIn()).toHaveAttribute('data-resin-target', 'galleryZoomIn');
+            expect(await getZoomOut()).toHaveAttribute('data-resin-target', 'galleryZoomOut');
+        });
     });
 });

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -5,7 +5,7 @@ import Browser from '../../Browser';
 import ControlsRoot from '../controls/controls-root';
 import DocControls from './DocControls';
 import DocFindBar from './DocFindBar';
-import GalleryController from '../gallery/GalleryController';
+import GalleryController, { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../gallery/GalleryController';
 import PageTracker from '../../PageTracker';
 import Popup from '../../Popup';
 import PreviewError from '../../PreviewError';
@@ -158,6 +158,7 @@ class DocBaseViewer extends BaseViewer {
         this.handleAnnotationCreateEvent = this.handleAnnotationCreateEvent.bind(this);
         this.handleAnnotationCreatorChangeEvent = this.handleAnnotationCreatorChangeEvent.bind(this);
         this.handleDocElKeydown = this.handleDocElKeydown.bind(this);
+        this.handleGalleryZoomGesture = this.handleGalleryZoomGesture.bind(this);
         this.handlePageSubmit = this.handlePageSubmit.bind(this);
         this.onThumbnailSelectHandler = this.onThumbnailSelectHandler.bind(this);
         this.pagechangingHandler = this.pagechangingHandler.bind(this);
@@ -239,6 +240,7 @@ class DocBaseViewer extends BaseViewer {
         this.galleryController = new GalleryController({
             containerEl: this.containerEl,
             features: this.options.features,
+            hasTouch: this.hasTouch,
             getPdfViewer: () => this.pdfViewer,
             getPreloader: () => this.preloader,
             getThumbnailsSidebar: () => this.thumbnailsSidebar,
@@ -254,6 +256,7 @@ class DocBaseViewer extends BaseViewer {
             onBeforeOpen: () => this.handleGalleryEnter(),
             onAfterClose: () => this.handleGalleryExit(),
             onClose: landedPage => this.handleGalleryClose(landedPage),
+            onZoomGesture: this.handleGalleryZoomGesture,
         });
     }
 
@@ -955,6 +958,18 @@ class DocBaseViewer extends BaseViewer {
                 return true;
             }
 
+            if (this.galleryController.isZoomEnabled) {
+                if (key === 'Shift++') {
+                    this.galleryController.zoomIn();
+                    return true;
+                }
+
+                if (key === 'Shift+_') {
+                    this.galleryController.zoomOut();
+                    return true;
+                }
+            }
+
             // Swallow page-nav keys so they can't flip the doc page underneath the gallery
             // or trigger the host's collection navigation. Arrows pressed outside the grid
             // are redirected into it so the first press navigates the tiles.
@@ -1531,6 +1546,7 @@ class DocBaseViewer extends BaseViewer {
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
         const canRotate = this.featureEnabled('rotate.enabled');
         const canGallery = !this.isMobile && this.galleryController.canRender(this.pdfViewer.pagesCount);
+        const isGalleryZoomActive = this.galleryController.isOpen && this.galleryController.isZoomEnabled;
 
         this.controls.render(
             <DocControls
@@ -1538,12 +1554,13 @@ class DocBaseViewer extends BaseViewer {
                 annotationMode={this.annotationControlsFSM.getMode()}
                 experiences={this.experiences}
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
+                hasGalleryZoom={this.galleryController.isZoomEnabled}
                 hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
                 hasRegion={canAnnotate && isAnnotationsMode}
                 isGalleryOpen={this.galleryController.isOpen}
                 isThumbnailsOpen={this.thumbnailsSidebar && this.thumbnailsSidebar.isOpen}
-                maxScale={MAX_SCALE}
-                minScale={MIN_SCALE}
+                maxScale={isGalleryZoomActive ? GALLERY_MAX_SCALE : MAX_SCALE}
+                minScale={isGalleryZoomActive ? GALLERY_MIN_SCALE : MIN_SCALE}
                 onAnnotationColorChange={this.handleAnnotationColorChange}
                 onAnnotationModeClick={this.handleAnnotationControlsClick}
                 onAnnotationModeEscape={this.handleAnnotationControlsEscape}
@@ -1554,11 +1571,11 @@ class DocBaseViewer extends BaseViewer {
                 onPageSubmit={this.handlePageSubmit}
                 onRotateLeft={canRotate ? this.rotateLeft : undefined}
                 onThumbnailsToggle={enableThumbnailsSidebar ? this.toggleThumbnails : undefined}
-                onZoomIn={this.zoomIn}
-                onZoomOut={this.zoomOut}
+                onZoomIn={isGalleryZoomActive ? this.galleryController.zoomIn : this.zoomIn}
+                onZoomOut={isGalleryZoomActive ? this.galleryController.zoomOut : this.zoomOut}
                 pageCount={this.pdfViewer.pagesCount}
                 pageNumber={this.pdfViewer.currentPageNumber}
-                scale={this.pdfViewer.currentScale}
+                scale={isGalleryZoomActive ? this.galleryController.scale : this.pdfViewer.currentScale}
             />,
         );
     }
@@ -2061,6 +2078,21 @@ class DocBaseViewer extends BaseViewer {
     toggleFindBar(findBarToggleEl) {
         this.findBarToggleEl = findBarToggleEl;
         this.findBar.toggle();
+    }
+
+    /**
+     * @protected
+     * @param {string} direction - 'zoomIn' or 'zoomOut'
+     * @return {void}
+     */
+    handleGalleryZoomGesture(direction) {
+        this.options.resin?.recordAction({
+            action: 'programmatic',
+            component: 'galleryView',
+            target: direction,
+            fileId: this.options.file.id,
+            fileExtension: this.options.file.extension,
+        });
     }
 
     /**

--- a/src/lib/viewers/doc/DocControls.tsx
+++ b/src/lib/viewers/doc/DocControls.tsx
@@ -20,13 +20,16 @@ export type Props = AnnotationsControlsProps &
     PageControlsProps &
     Partial<RotateControlProps> &
     ThumbnailsToggleProps &
-    ZoomControlsProps;
+    ZoomControlsProps & {
+        hasGalleryZoom?: boolean;
+    };
 
 export default function DocControls({
     annotationColor,
     annotationMode,
     experiences,
     hasDrawing,
+    hasGalleryZoom = false,
     hasHighlight,
     hasRegion,
     isGalleryOpen,
@@ -69,21 +72,25 @@ export default function DocControls({
                                 pageNumber={pageNumber}
                             />
                         </ControlsBarGroup>
-                        <ControlsBarGroup isDistinct>
-                            <ZoomControls
-                                maxScale={maxScale}
-                                minScale={minScale}
-                                onZoomIn={onZoomIn}
-                                onZoomOut={onZoomOut}
-                                scale={scale}
-                            />
-                        </ControlsBarGroup>
-                        {onRotateLeft && (
-                            <ControlsBarGroup>
-                                <RotateControl onRotateLeft={onRotateLeft} />
-                            </ControlsBarGroup>
-                        )}
                     </>
+                )}
+                {(!isGalleryOpen || hasGalleryZoom) && (
+                    <ControlsBarGroup isDistinct>
+                        <ZoomControls
+                            maxScale={maxScale}
+                            minScale={minScale}
+                            onZoomIn={onZoomIn}
+                            onZoomOut={onZoomOut}
+                            resinTargetZoomIn={isGalleryOpen ? 'galleryZoomIn' : undefined}
+                            resinTargetZoomOut={isGalleryOpen ? 'galleryZoomOut' : undefined}
+                            scale={scale}
+                        />
+                    </ControlsBarGroup>
+                )}
+                {!isGalleryOpen && onRotateLeft && (
+                    <ControlsBarGroup>
+                        <RotateControl onRotateLeft={onRotateLeft} />
+                    </ControlsBarGroup>
                 )}
                 <ControlsBarGroup>
                     <GalleryToggle isGalleryOpen={isGalleryOpen} onGalleryToggle={onGalleryToggle} />

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -17,6 +17,7 @@ import DocBaseViewer, {
 } from '../DocBaseViewer';
 import DocFindBar from '../DocFindBar';
 import DocPreloader from '../DocPreloader';
+import { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../../gallery/GalleryController';
 import DocFirstPreloader from '../DocFirstPreloader';
 import fullscreen from '../../../Fullscreen';
 import {
@@ -1733,10 +1734,34 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 beforeEach(() => {
                     docBase.galleryController = {
                         isOpen: true,
+                        isZoomEnabled: true,
                         handleArrowKey: jest.fn(),
                         handleEscape: jest.fn().mockReturnValue(true),
+                        zoomIn: jest.fn(),
+                        zoomOut: jest.fn(),
                         destroy: jest.fn(),
                     };
+                });
+
+                test('should route the zoom shortcuts to the gallery zoom, never the document zoom', () => {
+                    const zoomIn = jest.spyOn(docBase, 'zoomIn').mockImplementation();
+                    const zoomOut = jest.spyOn(docBase, 'zoomOut').mockImplementation();
+
+                    expect(docBase.onKeydown('Shift++', { defaultPrevented: false })).toBe(true);
+                    expect(docBase.galleryController.zoomIn).toBeCalledTimes(1);
+
+                    expect(docBase.onKeydown('Shift+_', { defaultPrevented: false })).toBe(true);
+                    expect(docBase.galleryController.zoomOut).toBeCalledTimes(1);
+
+                    expect(zoomIn).not.toBeCalled();
+                    expect(zoomOut).not.toBeCalled();
+                });
+
+                test('should not consume the zoom shortcuts when gallery zoom is disabled', () => {
+                    docBase.galleryController.isZoomEnabled = false;
+
+                    expect(docBase.onKeydown('Shift++', { defaultPrevented: false })).toBe(false);
+                    expect(docBase.galleryController.zoomIn).not.toBeCalled();
                 });
 
                 test('should close the gallery and consume Escape', () => {
@@ -2914,6 +2939,34 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     onThumbnailsToggle: option ? docBase.toggleThumbnails : undefined,
                 });
             });
+
+            test.each([true, false])(
+                'should route the zoom controls to the gallery scale, or the document scale, based on the zoom flag',
+                isZoomEnabled => {
+                    docBase.galleryController = {
+                        isOpen: true,
+                        isZoomEnabled,
+                        canRender: jest.fn().mockReturnValue(true),
+                        destroy: jest.fn(),
+                        scale: 1.5,
+                        toggle: jest.fn(),
+                        zoomIn: jest.fn(),
+                        zoomOut: jest.fn(),
+                    };
+
+                    docBase.renderUI();
+
+                    expect(getProps(docBase)).toMatchObject({
+                        hasGalleryZoom: isZoomEnabled,
+                        isGalleryOpen: true,
+                        maxScale: isZoomEnabled ? GALLERY_MAX_SCALE : 10,
+                        minScale: isZoomEnabled ? GALLERY_MIN_SCALE : 0.1,
+                        onZoomIn: isZoomEnabled ? docBase.galleryController.zoomIn : docBase.zoomIn,
+                        onZoomOut: isZoomEnabled ? docBase.galleryController.zoomOut : docBase.zoomOut,
+                        scale: isZoomEnabled ? 1.5 : 0.9,
+                    });
+                },
+            );
 
             test.each([true, false])('should enable or disable the gallery toggle based on mobile', isMobile => {
                 docBase.isMobile = isMobile;
@@ -4543,6 +4596,23 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.handleAnnotationControlsClick({ mode: AnnotationMode.NONE });
                 expect(docBase.annotator.toggleAnnotationMode).toBeCalledWith(AnnotationMode.REGION);
                 expect(docBase.containerEl.getAttribute('data-resin-discoverability')).toBe('true');
+            });
+        });
+
+        describe('handleGalleryZoomGesture()', () => {
+            test('should record a resin action distinct from document zoom', () => {
+                docBase.options.resin = { recordAction: jest.fn() };
+                docBase.options.file = { id: '0', extension: 'pdf' };
+
+                docBase.handleGalleryZoomGesture('zoomIn');
+
+                expect(docBase.options.resin.recordAction).toBeCalledWith({
+                    action: 'programmatic',
+                    component: 'galleryView',
+                    target: 'zoomIn',
+                    fileId: '0',
+                    fileExtension: 'pdf',
+                });
             });
         });
 

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -227,11 +227,14 @@ describe('lib/viewers/doc/DocumentViewer', () => {
             expect(docbaseStub).toBeCalledTimes(2);
         });
 
-        test('should defer to the gallery key policy instead of paging or zooming while the gallery is open', () => {
+        test('should defer paging and zoom shortcuts to the gallery while it is open', () => {
             doc.galleryController = {
                 isOpen: true,
+                isZoomEnabled: true,
                 handleArrowKey: jest.fn(),
                 handleEscape: jest.fn(),
+                zoomIn: jest.fn(),
+                zoomOut: jest.fn(),
                 destroy: jest.fn(),
             };
 
@@ -241,7 +244,8 @@ describe('lib/viewers/doc/DocumentViewer', () => {
 
             const zoomResult = doc.onKeydown('Shift++', { defaultPrevented: false });
             expect(stubs.zoomIn).not.toBeCalled();
-            expect(zoomResult).toBe(false);
+            expect(doc.galleryController.zoomIn).toBeCalledTimes(1);
+            expect(zoomResult).toBe(true);
         });
     });
 

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -384,8 +384,8 @@ export default class GalleryController {
             <GalleryGrid
                 currentPage={pdfViewer.currentPageNumber}
                 getPageRatio={this.getPageRatio}
-                hasTouch={this.isZoomEnabled && this.hasTouch}
                 isPinchZoomEnabled={this.isZoomEnabled && isFeatureEnabled(this.features, 'pinchToZoom.enabled')}
+                isTouchZoomEnabled={this.isZoomEnabled && this.hasTouch}
                 onClose={this.toggle}
                 onFocusChange={this.handleFocusChange}
                 onPageNavigate={this.handleGalleryNavigate}

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -226,9 +226,13 @@ export default class GalleryController {
         return true;
     }
 
-    zoomIn = (): void => this.commitScale(this.galleryScale + GALLERY_SCALE_STEP);
+    zoomIn = (): void => {
+        this.commitScale(this.galleryScale + GALLERY_SCALE_STEP);
+    };
 
-    zoomOut = (): void => this.commitScale(this.galleryScale - GALLERY_SCALE_STEP);
+    zoomOut = (): void => {
+        this.commitScale(this.galleryScale - GALLERY_SCALE_STEP);
+    };
 
     /**
      * Redirects an arrow key pressed outside the grid (e.g. focus parked on a toggle after
@@ -317,19 +321,20 @@ export default class GalleryController {
         this.galleryFocusedPage = pageNum;
     };
 
-    private commitScale = (scale: number): void => {
+    private commitScale = (scale: number): boolean => {
         if (!this.isZoomEnabled || !Number.isFinite(scale)) {
-            return;
+            return false;
         }
 
         const clamped = Math.min(GALLERY_MAX_SCALE, Math.max(GALLERY_MIN_SCALE, Math.round(scale * 1000) / 1000));
         if (clamped === this.galleryScale) {
-            return;
+            return false;
         }
 
         this.galleryScale = clamped;
         this.renderGrid();
         this.requestUiUpdate();
+        return true;
     };
 
     // Per-page width:height ratio from PDF.js page metadata; null until the page's metadata

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -7,6 +7,7 @@ import { createRoot, Root } from 'react-dom/client';
 import Thumbnail from '../../Thumbnail';
 import { FeatureConfig, isFeatureEnabled } from '../../featureChecking';
 import GalleryGrid, { GalleryThumbnail } from './GalleryGrid';
+import { PinchDirection } from './useGalleryPinch';
 
 // Controller-owned shape: GalleryGrid only sees the read surface (GalleryThumbnail),
 // but the controller also needs destroy() to invalidate the cache on rotate/teardown.
@@ -14,6 +15,10 @@ type ManagedGalleryThumbnail = GalleryThumbnail & { destroy: () => void };
 
 const GALLERY_MAX_PAGES = 200; // Hide gallery toggle for files above this page count, will increase in V2
 const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // ms
+
+export const GALLERY_MAX_SCALE = 3;
+export const GALLERY_MIN_SCALE = 0.5;
+const GALLERY_SCALE_STEP = 0.1;
 
 // Minimal local shapes for untyped peer modules (pdfjs is JS-only, sidebar is JS-only).
 // Only the members the controller actually uses are declared — extend as needed.
@@ -37,6 +42,7 @@ type PreloaderLike = ConstructorParameters<typeof Thumbnail>[1];
 export type GalleryControllerOptions = {
     containerEl: HTMLElement;
     features: FeatureConfig;
+    hasTouch: boolean;
     getPdfViewer: () => PdfViewerLike;
     getPreloader: () => PreloaderLike;
     getThumbnailsSidebar: () => ThumbnailsSidebarLike | null;
@@ -47,12 +53,15 @@ export type GalleryControllerOptions = {
     onBeforeOpen: () => void;
     onAfterClose: () => void;
     onClose: (landedPage: number | null) => void;
+    onZoomGesture: (direction: PinchDirection) => void;
 };
 
 export default class GalleryController {
     private containerEl: HTMLElement;
 
     private features: FeatureConfig;
+
+    private hasTouch: boolean;
 
     private getPdfViewer: () => PdfViewerLike;
 
@@ -74,6 +83,8 @@ export default class GalleryController {
 
     private onClose: (landedPage: number | null) => void;
 
+    private onZoomGesture: (direction: PinchDirection) => void;
+
     private galleryRoot: Root | null = null;
 
     private galleryEl: HTMLDivElement | null = null;
@@ -92,9 +103,12 @@ export default class GalleryController {
 
     private pickedPage: number | null = null;
 
+    private galleryScale = 1;
+
     constructor(opts: GalleryControllerOptions) {
         this.containerEl = opts.containerEl;
         this.features = opts.features;
+        this.hasTouch = opts.hasTouch;
         this.getPdfViewer = opts.getPdfViewer;
         this.getPreloader = opts.getPreloader;
         this.getThumbnailsSidebar = opts.getThumbnailsSidebar;
@@ -105,10 +119,20 @@ export default class GalleryController {
         this.onBeforeOpen = opts.onBeforeOpen;
         this.onAfterClose = opts.onAfterClose;
         this.onClose = opts.onClose;
+        this.onZoomGesture = opts.onZoomGesture;
     }
 
     get isOpen(): boolean {
         return this.isGalleryOpen;
+    }
+
+    get scale(): number {
+        return this.galleryScale;
+    }
+
+    get isZoomEnabled(): boolean {
+        const { features } = this;
+        return isFeatureEnabled(features, 'galleryView.enabled') && isFeatureEnabled(features, 'galleryViewV2.enabled');
     }
 
     canRender(pageCount: number): boolean {
@@ -202,6 +226,10 @@ export default class GalleryController {
         return true;
     }
 
+    zoomIn = (): void => this.commitScale(this.galleryScale + GALLERY_SCALE_STEP);
+
+    zoomOut = (): void => this.commitScale(this.galleryScale - GALLERY_SCALE_STEP);
+
     /**
      * Redirects an arrow key pressed outside the grid (e.g. focus parked on a toggle after
      * toggling fullscreen) back into it: refocuses the selected tile and replays the key so
@@ -266,6 +294,7 @@ export default class GalleryController {
         this.isGalleryOpen = false;
         this.sidebarWasOpen = false;
         this.galleryFocusedPage = null;
+        this.galleryScale = 1;
     }
 
     private applyGalleryOpenState(): void {
@@ -286,6 +315,21 @@ export default class GalleryController {
 
     private handleFocusChange = (pageNum: number): void => {
         this.galleryFocusedPage = pageNum;
+    };
+
+    private commitScale = (scale: number): void => {
+        if (!this.isZoomEnabled || !Number.isFinite(scale)) {
+            return;
+        }
+
+        const clamped = Math.min(GALLERY_MAX_SCALE, Math.max(GALLERY_MIN_SCALE, Math.round(scale * 1000) / 1000));
+        if (clamped === this.galleryScale) {
+            return;
+        }
+
+        this.galleryScale = clamped;
+        this.renderGrid();
+        this.requestUiUpdate();
     };
 
     // Per-page width:height ratio from PDF.js page metadata; null until the page's metadata
@@ -317,21 +361,34 @@ export default class GalleryController {
             ) as unknown) as ManagedGalleryThumbnail;
         }
 
-        const thumbnail = this.galleryThumbnail;
         this.galleryEl = document.createElement('div');
         this.galleryEl.setAttribute('data-resin-component', 'gallery');
         this.containerEl.insertBefore(this.galleryEl, this.containerEl.querySelector('.bp-ControlsRoot'));
         this.galleryRoot = createRoot(this.galleryEl);
         this.galleryFocusedPage = pdfViewer.currentPageNumber;
+        this.renderGrid();
+    }
+
+    private renderGrid(): void {
+        if (!this.galleryRoot || !this.galleryThumbnail) {
+            return;
+        }
+
+        const pdfViewer = this.getPdfViewer();
         this.galleryRoot.render(
             <GalleryGrid
                 currentPage={pdfViewer.currentPageNumber}
                 getPageRatio={this.getPageRatio}
+                hasTouch={this.isZoomEnabled && this.hasTouch}
+                isPinchZoomEnabled={this.isZoomEnabled && isFeatureEnabled(this.features, 'pinchToZoom.enabled')}
                 onClose={this.toggle}
                 onFocusChange={this.handleFocusChange}
                 onPageNavigate={this.handleGalleryNavigate}
+                onPinchStart={this.onZoomGesture}
+                onScaleChange={this.commitScale}
                 pageCount={pdfViewer.pagesCount}
-                thumbnail={thumbnail}
+                scale={this.galleryScale}
+                thumbnail={this.galleryThumbnail}
             />,
         );
     }

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -8,16 +8,22 @@
     left: 0;
     // Sits above annotation layers and find bar (z=3); toolbar (ControlsRoot z=5) stays on top.
     z-index: 4;
-    display: grid;
-    grid-auto-rows: min-content;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 16px;
-    align-items: start;
     padding: 40px;
     padding-bottom: 100px;
     overflow-y: auto;
     overscroll-behavior: none;
     background-color: $white;
+}
+
+// Keep 220px/16px in sync with GalleryGrid's GALLERY_TILE_MIN_WIDTH/GALLERY_TILE_GAP.
+.bp-gallery-grid-inner {
+    --bp-gallery-hover-scale: 1.02;
+
+    display: grid;
+    grid-auto-rows: min-content;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+    align-items: start;
 }
 
 .bp-gallery-tile {
@@ -32,7 +38,7 @@
 
     &:hover {
         box-shadow: 0 0 0 3px $seventy-sixers, 0 4px 5px 0 rgba(0, 0, 0, .15);
-        transform: translateY(-1px) scale(1.02);
+        transform: translateY(-1px) scale(var(--bp-gallery-hover-scale));
 
         .bp-gallery-tile-badge {
             opacity: 1;
@@ -67,14 +73,14 @@
 
 .bp-gallery-tile-badge {
     position: absolute;
-    top: 0;
-    left: 0;
+    top: -2px;
+    left: -2px;
     z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 28px;
-    height: 24px;
+    min-width: 30px;
+    height: 26px;
     padding: 0 4px;
     color: $white;
     font-size: 13px;

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -53,6 +53,7 @@
         display: block;
         width: 100%;
         height: auto;
+        object-fit: contain;
         border-radius: 12px;
     }
 }

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -1,11 +1,16 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import noop from 'lodash/noop';
 import throttle from 'lodash/throttle';
 import { decodeKeydown, replacePlaceholders } from '../../util';
+import useGalleryPinch, { PinchDirection, PinchFocal } from './useGalleryPinch';
 import './GalleryGrid.scss';
 
 const GALLERY_THUMB_MAX_WIDTH = 440;
 const CONCURRENT_LOADS = 4;
 const SCROLL_THROTTLE_MS = 200;
+// Keep in sync with the 100% grid rule in GalleryGrid.scss
+const GALLERY_TILE_GAP = 16;
+const GALLERY_TILE_MIN_WIDTH = 220;
 
 export interface GalleryThumbnail {
     init: () => Promise<unknown>;
@@ -23,9 +28,14 @@ export type Props = {
     currentPage: number;
     /** Per-page width:height ratio (null while unknown). Falls back to the first-page ratio. */
     getPageRatio?: (pageNum: number) => number | null;
+    hasTouch?: boolean;
+    isPinchZoomEnabled?: boolean;
     onFocusChange?: (pageNum: number) => void;
     onPageNavigate: (n: number) => void;
     onClose: () => void;
+    onPinchStart?: (direction: PinchDirection) => void;
+    onScaleChange?: (scale: number) => void;
+    scale?: number;
     thumbnail: GalleryThumbnail;
 };
 
@@ -76,9 +86,14 @@ export default function GalleryGrid({
     pageCount,
     currentPage,
     getPageRatio,
+    hasTouch = false,
+    isPinchZoomEnabled = false,
     onClose,
     onFocusChange,
     onPageNavigate,
+    onPinchStart = noop,
+    onScaleChange = noop,
+    scale = 1,
     thumbnail,
 }: Props): JSX.Element {
     const [loadedImages, setLoadedImages] = useState<Record<number, string>>({});
@@ -87,6 +102,9 @@ export default function GalleryGrid({
     // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
     const anchorPageRef = useRef(currentPage);
     const gridRef = useRef<HTMLDivElement>(null);
+    const innerRef = useRef<HTMLDivElement>(null);
+    const focalRef = useRef<PinchFocal | null>(null);
+    const scaleRef = useRef(scale);
     const queueRef = useRef<number[]>([]);
     const isProcessingRef = useRef(false);
     const isMountedRef = useRef(true);
@@ -222,6 +240,69 @@ export default function GalleryGrid({
         handleScrollRef.current();
     }, []);
 
+    useGalleryPinch({
+        focalRef,
+        gridRef,
+        hasTouch,
+        isPinchZoomEnabled,
+        onGestureStart: onPinchStart,
+        onZoom: onScaleChange,
+        scaleRef,
+    });
+
+    const applyZoomLayout = useCallback(() => {
+        const inner = innerRef.current;
+        if (!inner) {
+            return;
+        }
+
+        const currentScale = scaleRef.current;
+        inner.style.setProperty('--bp-gallery-hover-scale', String(1 + 0.02 / currentScale));
+
+        if (currentScale === 1) {
+            inner.style.gridTemplateColumns = '';
+            inner.style.justifyContent = '';
+            return;
+        }
+
+        const width = inner.clientWidth;
+        const columnPitch = GALLERY_TILE_MIN_WIDTH + GALLERY_TILE_GAP;
+        const columns = Math.max(1, Math.floor((width + GALLERY_TILE_GAP) / columnPitch));
+        const baseWidth = (width - (columns - 1) * GALLERY_TILE_GAP) / columns;
+        inner.style.gridTemplateColumns = `repeat(auto-fill, ${Math.min(width, baseWidth * currentScale)}px)`;
+        inner.style.justifyContent = 'center';
+    }, []);
+
+    useLayoutEffect(() => {
+        const grid = gridRef.current;
+        const previousScale = scaleRef.current;
+        scaleRef.current = scale;
+
+        const focal = focalRef.current;
+        focalRef.current = null;
+
+        if (!grid || previousScale === scale) {
+            applyZoomLayout();
+            return;
+        }
+
+        const focalTile = focal
+            ? document.elementFromPoint?.(focal.x, focal.y)?.closest<HTMLElement>('[data-page]')
+            : null;
+        const anchorTile = focalTile || grid.querySelector<HTMLElement>(`[data-page="${anchorPageRef.current}"]`);
+        const beforeRect = anchorTile && anchorTile.getBoundingClientRect();
+
+        applyZoomLayout();
+
+        if (anchorTile && beforeRect) {
+            const afterRect = anchorTile.getBoundingClientRect();
+            grid.scrollLeft += afterRect.left - beforeRect.left;
+            grid.scrollTop += afterRect.top - beforeRect.top;
+        }
+
+        handleScrollRef.current();
+    }, [applyZoomLayout, scale]);
+
     useEffect(() => {
         const throttledScroll = handleScrollRef.current;
 
@@ -283,6 +364,7 @@ export default function GalleryGrid({
                 isFirstObservation = false; // ResizeObserver always fires once on observe()
                 return;
             }
+            applyZoomLayout();
             const tile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
             if (tile) {
                 tile.scrollIntoView({ block: 'start' });
@@ -294,7 +376,7 @@ export default function GalleryGrid({
         observer.observe(grid);
 
         return () => observer.disconnect();
-    }, []);
+    }, [applyZoomLayout]);
 
     const focusTile = useCallback((pageNum: number) => {
         const grid = gridRef.current;
@@ -406,7 +488,9 @@ export default function GalleryGrid({
             role="listbox"
             tabIndex={-1}
         >
-            {tiles}
+            <div ref={innerRef} className="bp-gallery-grid-inner" role="presentation">
+                {tiles}
+            </div>
         </div>
     );
 }

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -34,7 +34,7 @@ export type Props = {
     onPageNavigate: (n: number) => void;
     onClose: () => void;
     onPinchStart?: (direction: PinchDirection) => void;
-    onScaleChange?: (scale: number) => void;
+    onScaleChange?: (scale: number) => boolean | void;
     scale?: number;
     thumbnail: GalleryThumbnail;
 };
@@ -56,8 +56,10 @@ const GalleryTile = React.memo(function GalleryTile({
     onFocus,
     pageRatio,
 }: TileProps): JSX.Element {
-    // Match the placeholder to the real page shape so tiles don't resize (reflow/jitter) as images arrive
-    const placeholderStyle = pageRatio ? { paddingTop: `${100 / pageRatio}%` } : undefined;
+    const ratio = pageRatio && Number.isFinite(pageRatio) && pageRatio > 0 ? pageRatio : null;
+    const tileStyle = ratio ? { aspectRatio: String(ratio) } : undefined;
+    const contentStyle = ratio ? { height: '100%' } : undefined;
+    const placeholderStyle = ratio ? { ...contentStyle, paddingTop: 0 } : undefined;
 
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
@@ -70,11 +72,12 @@ const GalleryTile = React.memo(function GalleryTile({
             onClick={() => onClick(pageNum)}
             onFocus={() => onFocus(pageNum)}
             role="option"
+            style={tileStyle}
             tabIndex={isFocused ? 0 : -1}
         >
             <span className="bp-gallery-tile-badge">{pageNum}</span>
             {imageSrc ? (
-                <img alt="" src={imageSrc} />
+                <img alt="" src={imageSrc} style={contentStyle} />
             ) : (
                 <span className="bp-gallery-tile-placeholder" style={placeholderStyle} />
             )}

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -28,8 +28,8 @@ export type Props = {
     currentPage: number;
     /** Per-page width:height ratio (null while unknown). Falls back to the first-page ratio. */
     getPageRatio?: (pageNum: number) => number | null;
-    hasTouch?: boolean;
     isPinchZoomEnabled?: boolean;
+    isTouchZoomEnabled?: boolean;
     onFocusChange?: (pageNum: number) => void;
     onPageNavigate: (n: number) => void;
     onClose: () => void;
@@ -89,8 +89,8 @@ export default function GalleryGrid({
     pageCount,
     currentPage,
     getPageRatio,
-    hasTouch = false,
     isPinchZoomEnabled = false,
+    isTouchZoomEnabled = false,
     onClose,
     onFocusChange,
     onPageNavigate,
@@ -246,8 +246,8 @@ export default function GalleryGrid({
     useGalleryPinch({
         focalRef,
         gridRef,
-        hasTouch,
         isPinchZoomEnabled,
+        isTouchZoomEnabled,
         onGestureStart: onPinchStart,
         onZoom: onScaleChange,
         scaleRef,

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -1,4 +1,8 @@
-import GalleryController, { GalleryControllerOptions } from '../GalleryController';
+import GalleryController, {
+    GALLERY_MAX_SCALE,
+    GALLERY_MIN_SCALE,
+    GalleryControllerOptions,
+} from '../GalleryController';
 
 jest.mock('../../../Thumbnail', () => {
     return jest.fn().mockImplementation(() => ({
@@ -45,9 +49,19 @@ function makeController(
         pageCount?: number;
         currentPage?: number;
         flagOn?: boolean;
+        hasTouch?: boolean;
+        zoomFlagOn?: boolean;
     } = {},
 ): Harness {
-    const { sidebarOpen = false, sidebarPresent = true, pageCount = 10, currentPage = 1, flagOn = true } = overrides;
+    const {
+        sidebarOpen = false,
+        sidebarPresent = true,
+        pageCount = 10,
+        currentPage = 1,
+        flagOn = true,
+        hasTouch = false,
+        zoomFlagOn = true,
+    } = overrides;
 
     const containerEl = document.createElement('div');
     document.body.appendChild(containerEl);
@@ -65,10 +79,16 @@ function makeController(
     const onBeforeOpen = jest.fn();
     const onAfterClose = jest.fn();
     const onClose = jest.fn();
+    const onZoomGesture = jest.fn();
 
     const opts: GalleryControllerOptions = {
         containerEl,
-        features: { galleryView: { enabled: flagOn } },
+        features: {
+            galleryView: { enabled: flagOn },
+            galleryViewV2: { enabled: zoomFlagOn },
+            pinchToZoom: { enabled: true },
+        },
+        hasTouch,
         getPdfViewer: () => pdfViewer,
         getPreloader: () => null,
         getThumbnailsSidebar: () => sidebar,
@@ -79,6 +99,7 @@ function makeController(
         onBeforeOpen,
         onAfterClose,
         onClose,
+        onZoomGesture,
     };
 
     return {
@@ -273,17 +294,22 @@ describe('GalleryController', () => {
         });
 
         test('should wire the correct props into GalleryGrid', () => {
-            const { controller } = makeController({ currentPage: 3, pageCount: 25, sidebarOpen: false });
+            const { controller } = makeController({ currentPage: 3, hasTouch: true, pageCount: 25 });
             controller.toggle();
 
             expect(mockLastRoot.render).toHaveBeenCalledTimes(1);
             const grid = mockLastRoot.render.mock.calls[0][0];
             expect(grid.props.currentPage).toBe(3);
             expect(grid.props.pageCount).toBe(25);
+            expect(grid.props.hasTouch).toBe(true);
+            expect(grid.props.isPinchZoomEnabled).toBe(true);
+            expect(grid.props.scale).toBe(1);
             expect(grid.props.thumbnail).toBeDefined();
             expect(grid.props.onClose).toBe(controller.toggle);
             expect(typeof grid.props.onPageNavigate).toBe('function');
             expect(typeof grid.props.onFocusChange).toBe('function');
+            expect(typeof grid.props.onPinchStart).toBe('function');
+            expect(typeof grid.props.onScaleChange).toBe('function');
             expect(typeof grid.props.getPageRatio).toBe('function');
         });
 
@@ -464,6 +490,84 @@ describe('GalleryController', () => {
             controller.handleEscape();
 
             expect(onClose.mock.calls).toEqual([[null], [4], [null]]);
+        });
+    });
+
+    describe('zoom', () => {
+        test('should step by exactly 10% from the current value and clamp to the gallery limits', () => {
+            const { controller, requestUiUpdate } = makeController();
+            controller.toggle();
+            expect(controller.isZoomEnabled).toBe(true);
+            expect(controller.scale).toBe(1);
+
+            controller.zoomIn();
+            expect(controller.scale).toBe(1.1);
+            expect(requestUiUpdate).toHaveBeenCalledTimes(2); // open + zoom
+
+            for (let i = 0; i < 40; i += 1) controller.zoomIn();
+            expect(controller.scale).toBe(GALLERY_MAX_SCALE);
+
+            for (let i = 0; i < 40; i += 1) controller.zoomOut();
+            expect(controller.scale).toBe(GALLERY_MIN_SCALE);
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            grid.props.onScaleChange(0.83);
+            controller.zoomIn();
+            expect(controller.scale).toBe(0.93);
+            controller.zoomOut();
+            controller.zoomOut();
+            expect(controller.scale).toBe(0.73);
+        });
+
+        test('should clamp continuous pinch updates from the grid and re-render it', () => {
+            const { controller } = makeController();
+            controller.toggle();
+            const grid = mockLastRoot.render.mock.calls[0][0];
+
+            grid.props.onScaleChange(1.234);
+            expect(controller.scale).toBe(1.234);
+
+            grid.props.onScaleChange(99);
+            expect(controller.scale).toBe(GALLERY_MAX_SCALE);
+
+            const lastRenderCalls = mockLastRoot.render.mock.calls;
+            expect(lastRenderCalls[lastRenderCalls.length - 1][0].props.scale).toBe(GALLERY_MAX_SCALE);
+        });
+
+        test('should disable zoom entirely unless both gallery flags are on', () => {
+            expect(makeController({ flagOn: false, zoomFlagOn: true }).controller.isZoomEnabled).toBe(false);
+
+            const { controller, requestUiUpdate } = makeController({ hasTouch: true, zoomFlagOn: false });
+            controller.toggle();
+            requestUiUpdate.mockClear();
+
+            expect(controller.isZoomEnabled).toBe(false);
+            controller.zoomIn();
+            expect(controller.scale).toBe(1);
+            expect(requestUiUpdate).not.toHaveBeenCalled();
+
+            const grid = mockLastRoot.render.mock.calls[0][0];
+            expect(grid.props.hasTouch).toBe(false);
+            expect(grid.props.isPinchZoomEnabled).toBe(false);
+
+            grid.props.onScaleChange(1.5);
+            expect(controller.scale).toBe(1);
+        });
+
+        test('should persist scale across close and reopen but reset on destroy', () => {
+            const { controller } = makeController();
+            controller.toggle();
+            controller.zoomIn();
+            controller.zoomIn();
+            expect(controller.scale).toBe(1.2);
+
+            controller.toggle();
+            controller.toggle();
+            const renderCalls = mockLastRoot.render.mock.calls;
+            expect(renderCalls[renderCalls.length - 1][0].props.scale).toBe(1.2);
+
+            controller.destroy();
+            expect(controller.scale).toBe(1);
         });
     });
 

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -301,8 +301,8 @@ describe('GalleryController', () => {
             const grid = mockLastRoot.render.mock.calls[0][0];
             expect(grid.props.currentPage).toBe(3);
             expect(grid.props.pageCount).toBe(25);
-            expect(grid.props.hasTouch).toBe(true);
             expect(grid.props.isPinchZoomEnabled).toBe(true);
+            expect(grid.props.isTouchZoomEnabled).toBe(true);
             expect(grid.props.scale).toBe(1);
             expect(grid.props.thumbnail).toBeDefined();
             expect(grid.props.onClose).toBe(controller.toggle);
@@ -548,8 +548,8 @@ describe('GalleryController', () => {
             expect(requestUiUpdate).not.toHaveBeenCalled();
 
             const grid = mockLastRoot.render.mock.calls[0][0];
-            expect(grid.props.hasTouch).toBe(false);
             expect(grid.props.isPinchZoomEnabled).toBe(false);
+            expect(grid.props.isTouchZoomEnabled).toBe(false);
 
             grid.props.onScaleChange(1.5);
             expect(controller.scale).toBe(1);

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -524,11 +524,12 @@ describe('GalleryController', () => {
             controller.toggle();
             const grid = mockLastRoot.render.mock.calls[0][0];
 
-            grid.props.onScaleChange(1.234);
+            expect(grid.props.onScaleChange(1.234)).toBe(true);
             expect(controller.scale).toBe(1.234);
 
-            grid.props.onScaleChange(99);
+            expect(grid.props.onScaleChange(99)).toBe(true);
             expect(controller.scale).toBe(GALLERY_MAX_SCALE);
+            expect(grid.props.onScaleChange(99)).toBe(false);
 
             const lastRenderCalls = mockLastRoot.render.mock.calls;
             expect(lastRenderCalls[lastRenderCalls.length - 1][0].props.scale).toBe(GALLERY_MAX_SCALE);

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -430,6 +430,24 @@ describe('GalleryGrid', () => {
                 expect(grid.scrollTop).toBe(80);
             });
 
+            test('should clear the pinch focal point when the scale change is rejected', () => {
+                const onScaleChange = jest.fn().mockReturnValue(false);
+                const { rerender } = getWrapper({ isPinchZoomEnabled: true, onScaleChange });
+                const grid = screen.getByRole('listbox');
+
+                act(() => {
+                    grid.dispatchEvent(wheelEvent({ clientX: 300, clientY: 200, ctrlKey: true, deltaY: -20 }));
+                });
+                act(() => rafCallback!(0));
+
+                document.elementFromPoint = jest.fn();
+                rerender(
+                    <GalleryGrid {...defaultProps} isPinchZoomEnabled onScaleChange={onScaleChange} scale={1.1} />,
+                );
+
+                expect(document.elementFromPoint).not.toHaveBeenCalled();
+            });
+
             test('should update scale from a two-finger touch pinch', () => {
                 const onScaleChange = jest.fn();
                 getWrapper({ hasTouch: true, onScaleChange });
@@ -636,9 +654,10 @@ describe('GalleryGrid', () => {
             expect(mockThumbnail.getImageFromCache).toHaveBeenCalledTimes(10);
         });
 
-        test('should use cached images when available', () => {
+        test('should use cached images while preserving the page ratio', async () => {
             const cachedThumbnail = {
                 ...mockThumbnail,
+                pageRatio: 4 / 3,
                 getImageFromCache: jest.fn(pageIndex => {
                     if (pageIndex === 2) {
                         return { image: { src: 'data:image/png;cached-page-3' }, inProgress: false };
@@ -652,6 +671,10 @@ describe('GalleryGrid', () => {
             const img = tile3.querySelector('img');
             expect(img).toBeInTheDocument();
             expect(img).toHaveAttribute('src', 'data:image/png;cached-page-3');
+            await waitFor(() => {
+                expect(tile3.style.aspectRatio).toBe(String(4 / 3));
+                expect(img?.style.height).toBe('100%');
+            });
         });
 
         test('should show placeholder for uncached pages', () => {
@@ -661,20 +684,18 @@ describe('GalleryGrid', () => {
             expect(tile1.querySelector('img')).not.toBeInTheDocument();
         });
 
-        test('should size placeholders from the page ratio once init resolves', async () => {
-            // 16:9 landscape page: ratio 16/9 -> padding-top 56.25%
+        test('should size tiles from the page ratio once init resolves', async () => {
             const thumbnail = { ...mockThumbnail, pageRatio: 16 / 9 };
             getWrapper({ thumbnail });
 
             await waitFor(() => {
-                const placeholder = screen
-                    .getByLabelText('Page 1')
-                    .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
-                expect(placeholder.style.paddingTop).toBe('56.25%');
+                const tile = screen.getByLabelText('Page 1');
+                expect(tile.style.aspectRatio).toBe(String(16 / 9));
+                expect((tile.querySelector('.bp-gallery-tile-placeholder') as HTMLElement).style.height).toBe('100%');
             });
         });
 
-        test('should size each placeholder from its own page ratio when getPageRatio provides one', async () => {
+        test('should size each tile from its own page ratio when getPageRatio provides one', async () => {
             // First page portrait (3:4), page 2 landscape (16:9); pages beyond have no
             // metadata yet and fall back to the first-page ratio.
             const thumbnail = { ...mockThumbnail, pageRatio: 3 / 4 };
@@ -682,16 +703,10 @@ describe('GalleryGrid', () => {
             getWrapper({ thumbnail, getPageRatio });
 
             await waitFor(() => {
-                const landscape = screen
-                    .getByLabelText('Page 2')
-                    .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
-                expect(landscape.style.paddingTop).toBe('56.25%');
+                expect(screen.getByLabelText('Page 2').style.aspectRatio).toBe(String(16 / 9));
             });
 
-            const fallback = screen
-                .getByLabelText('Page 5')
-                .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
-            expect(parseFloat(fallback.style.paddingTop)).toBeCloseTo(133.333);
+            expect(screen.getByLabelText('Page 5').style.aspectRatio).toBe(String(3 / 4));
         });
 
         test('should leave placeholder sizing to the stylesheet when no page ratio is available', async () => {
@@ -700,9 +715,9 @@ describe('GalleryGrid', () => {
                 expect(mockThumbnail.init).toHaveBeenCalled();
             });
 
-            const placeholder = screen
-                .getByLabelText('Page 1')
-                .querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+            const tile = screen.getByLabelText('Page 1');
+            const placeholder = tile.querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
+            expect(tile.style.aspectRatio).toBeFalsy();
             expect(placeholder.style.paddingTop).toBe('');
         });
     });

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -450,7 +450,7 @@ describe('GalleryGrid', () => {
 
             test('should update scale from a two-finger touch pinch', () => {
                 const onScaleChange = jest.fn();
-                getWrapper({ hasTouch: true, onScaleChange });
+                getWrapper({ isTouchZoomEnabled: true, onScaleChange });
                 const grid = screen.getByRole('listbox');
 
                 act(() => {

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -325,6 +325,173 @@ describe('GalleryGrid', () => {
         });
     });
 
+    describe('zoom', () => {
+        test('should scale and clamp the tile width while keeping the listbox structure untouched', () => {
+            const { rerender } = getWrapper();
+            const inner = screen.getByRole('presentation');
+            Object.defineProperty(inner, 'clientWidth', { configurable: true, value: 920 });
+
+            expect(inner).toHaveClass('bp-gallery-grid-inner');
+            expect(inner.style.gridTemplateColumns).toBe('');
+            expect(inner.style.getPropertyValue('--bp-gallery-hover-scale')).toBe('1.02');
+            expect(screen.getByRole('listbox')).toContainElement(inner);
+            expect(screen.getAllByRole('option')).toHaveLength(10);
+
+            rerender(<GalleryGrid {...defaultProps} scale={1.5} />);
+
+            expect(inner.style.gridTemplateColumns).toBe('repeat(auto-fill, 444px)');
+            expect(inner.style.justifyContent).toBe('center');
+            expect(inner.style.getPropertyValue('--bp-gallery-hover-scale')).toBe(String(1 + 0.02 / 1.5));
+            expect(screen.getAllByRole('option')).toHaveLength(10);
+
+            rerender(<GalleryGrid {...defaultProps} scale={1} />);
+
+            expect(inner.style.gridTemplateColumns).toBe('');
+            expect(inner.style.justifyContent).toBe('');
+            expect(inner.style.getPropertyValue('--bp-gallery-hover-scale')).toBe('1.02');
+
+            Object.defineProperty(inner, 'clientWidth', { configurable: true, value: 200 });
+            rerender(<GalleryGrid {...defaultProps} scale={2} />);
+
+            expect(inner.style.gridTemplateColumns).toBe('repeat(auto-fill, 200px)');
+            expect(inner.style.getPropertyValue('--bp-gallery-hover-scale')).toBe('1.01');
+        });
+
+        test('should keep the topmost visible tile anchored when the scale changes', () => {
+            const { rerender } = getWrapper();
+            const grid = screen.getByRole('listbox');
+            Object.defineProperty(grid, 'scrollLeft', { configurable: true, value: 0, writable: true });
+            Object.defineProperty(grid, 'scrollTop', { configurable: true, value: 100, writable: true });
+            const anchorTile = screen.getByLabelText('Page 3');
+            jest.spyOn(anchorTile, 'getBoundingClientRect')
+                .mockReturnValueOnce({ left: 0, top: 150 } as DOMRect)
+                .mockReturnValueOnce({ left: 30, top: 390 } as DOMRect);
+
+            rerender(<GalleryGrid {...defaultProps} scale={2} />);
+
+            expect(grid.scrollLeft).toBe(30);
+            expect(grid.scrollTop).toBe(340);
+        });
+
+        describe('pinch gestures', () => {
+            let rafCallback: FrameRequestCallback | null = null;
+
+            const wheelEvent = (init: WheelEventInit): WheelEvent =>
+                new WheelEvent('wheel', { bubbles: true, cancelable: true, ...init });
+
+            const touchEvent = (type: string, xPositions: number[]): TouchEvent => {
+                const touches = xPositions.map(
+                    x => (({ clientX: x, clientY: 0, pageX: x, pageY: 0 } as unknown) as Touch),
+                );
+                return new TouchEvent(type, { bubbles: true, cancelable: true, touches });
+            };
+
+            beforeEach(() => {
+                rafCallback = null;
+                jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+                    rafCallback = callback;
+                    return 1;
+                });
+            });
+
+            afterEach(() => {
+                jest.restoreAllMocks();
+                delete (document as { elementFromPoint?: unknown }).elementFromPoint;
+            });
+
+            test('should update scale from a ctrl+wheel trackpad pinch anchored on the cursor', () => {
+                const onScaleChange = jest.fn();
+                const { rerender } = getWrapper({ isPinchZoomEnabled: true, onScaleChange });
+                const grid = screen.getByRole('listbox');
+                Object.defineProperty(grid, 'scrollLeft', { configurable: true, value: 0, writable: true });
+                Object.defineProperty(grid, 'scrollTop', { configurable: true, value: 0, writable: true });
+                const event = wheelEvent({ clientX: 300, clientY: 200, ctrlKey: true, deltaY: -20 });
+
+                act(() => {
+                    grid.dispatchEvent(event);
+                });
+                expect(event.defaultPrevented).toBe(true);
+
+                act(() => rafCallback!(0));
+                expect(onScaleChange).toHaveBeenCalledWith(1.2);
+
+                const pinchTile = screen.getByLabelText('Page 5');
+                document.elementFromPoint = jest.fn().mockReturnValue(pinchTile);
+                jest.spyOn(pinchTile, 'getBoundingClientRect')
+                    .mockReturnValueOnce({ left: 250, top: 180 } as DOMRect)
+                    .mockReturnValueOnce({ left: 310, top: 260 } as DOMRect);
+
+                rerender(
+                    <GalleryGrid {...defaultProps} isPinchZoomEnabled onScaleChange={onScaleChange} scale={1.2} />,
+                );
+
+                expect(document.elementFromPoint).toHaveBeenCalledWith(300, 200);
+                expect(grid.scrollLeft).toBe(60);
+                expect(grid.scrollTop).toBe(80);
+            });
+
+            test('should update scale from a two-finger touch pinch', () => {
+                const onScaleChange = jest.fn();
+                getWrapper({ hasTouch: true, onScaleChange });
+                const grid = screen.getByRole('listbox');
+
+                act(() => {
+                    grid.dispatchEvent(touchEvent('touchstart', [0, 100]));
+                    grid.dispatchEvent(touchEvent('touchmove', [0, 200]));
+                });
+
+                act(() => rafCallback!(0));
+                expect(onScaleChange).toHaveBeenCalledWith(2);
+            });
+
+            test('should report one pinch session per burst of trackpad wheel events', () => {
+                let now = 1000;
+                jest.spyOn(Date, 'now').mockImplementation(() => now);
+                const onPinchStart = jest.fn();
+                getWrapper({ isPinchZoomEnabled: true, onPinchStart });
+                const grid = screen.getByRole('listbox');
+
+                act(() => {
+                    grid.dispatchEvent(wheelEvent({ ctrlKey: true, deltaY: -20 }));
+                    now += 50; // Within the same gesture
+                    grid.dispatchEvent(wheelEvent({ ctrlKey: true, deltaY: -20 }));
+                });
+
+                expect(onPinchStart).toHaveBeenCalledTimes(1);
+                expect(onPinchStart).toHaveBeenCalledWith('zoomIn');
+
+                act(() => {
+                    now += 500; // A pause starts a new gesture
+                    grid.dispatchEvent(wheelEvent({ ctrlKey: true, deltaY: 20 }));
+                });
+
+                expect(onPinchStart).toHaveBeenCalledTimes(2);
+                expect(onPinchStart).toHaveBeenLastCalledWith('zoomOut');
+            });
+
+            test('should ignore plain wheel scrolling and ctrl+wheel when pinch zoom is disabled', () => {
+                const onScaleChange = jest.fn();
+                const { rerender } = getWrapper({ isPinchZoomEnabled: true, onScaleChange });
+                const grid = screen.getByRole('listbox');
+
+                const plainWheel = wheelEvent({ deltaY: -20 });
+                act(() => {
+                    grid.dispatchEvent(plainWheel);
+                });
+                expect(plainWheel.defaultPrevented).toBe(false);
+
+                rerender(<GalleryGrid {...defaultProps} isPinchZoomEnabled={false} onScaleChange={onScaleChange} />);
+                const ctrlWheel = wheelEvent({ ctrlKey: true, deltaY: -20 });
+                act(() => {
+                    grid.dispatchEvent(ctrlWheel);
+                });
+
+                expect(ctrlWheel.defaultPrevented).toBe(false);
+                expect(onScaleChange).not.toHaveBeenCalled();
+            });
+        });
+    });
+
     describe('viewport-aware loading', () => {
         // Lay the grid out as a single column of 100px-tall tiles so getUnloadedNearViewport
         // has real geometry to work with (jsdom defaults all dimensions to 0).

--- a/src/lib/viewers/gallery/useGalleryPinch.ts
+++ b/src/lib/viewers/gallery/useGalleryPinch.ts
@@ -1,0 +1,144 @@
+import { MutableRefObject, RefObject, useEffect, useRef } from 'react';
+import { getDistance, getMidpoint } from '../../util';
+
+const WHEEL_ZOOM_SCALE_FACTOR = 0.01;
+const WHEEL_SESSION_GAP_MS = 200;
+
+export type PinchDirection = 'zoomIn' | 'zoomOut';
+
+export interface PinchFocal {
+    x: number;
+    y: number;
+}
+
+interface Props {
+    focalRef: MutableRefObject<PinchFocal | null>;
+    gridRef: RefObject<HTMLDivElement>;
+    hasTouch: boolean;
+    isPinchZoomEnabled: boolean;
+    onGestureStart: (direction: PinchDirection) => void;
+    onZoom: (scale: number) => void;
+    scaleRef: MutableRefObject<number>;
+}
+
+// Native non-passive listeners: React's synthetic wheel/touch handlers are passive and cannot preventDefault.
+export default function useGalleryPinch({
+    focalRef,
+    gridRef,
+    hasTouch,
+    isPinchZoomEnabled,
+    onGestureStart,
+    onZoom,
+    scaleRef,
+}: Props): void {
+    const frameRef = useRef<number | null>(null);
+    const pendingRef = useRef<{ focal: PinchFocal; scale: number } | null>(null);
+    const touchStartRef = useRef<{ distance: number; scale: number } | null>(null);
+    const lastWheelAtRef = useRef(0);
+    const onGestureStartRef = useRef(onGestureStart);
+    const onZoomRef = useRef(onZoom);
+
+    useEffect(() => {
+        onGestureStartRef.current = onGestureStart;
+        onZoomRef.current = onZoom;
+    }, [onGestureStart, onZoom]);
+
+    useEffect(() => {
+        const grid = gridRef.current;
+        if (!grid || (!hasTouch && !isPinchZoomEnabled)) {
+            return undefined;
+        }
+
+        const scheduleZoom = (nextScale: number, clientX: number, clientY: number): void => {
+            pendingRef.current = { focal: { x: clientX, y: clientY }, scale: nextScale };
+
+            if (frameRef.current === null) {
+                frameRef.current = requestAnimationFrame(() => {
+                    frameRef.current = null;
+                    const pending = pendingRef.current;
+                    pendingRef.current = null;
+                    if (pending) {
+                        focalRef.current = pending.focal;
+                        onZoomRef.current(pending.scale);
+                    }
+                });
+            }
+        };
+
+        const handleWheel = (event: WheelEvent): void => {
+            if (!event.ctrlKey) {
+                return;
+            }
+
+            event.preventDefault();
+            const now = Date.now();
+            if (now - lastWheelAtRef.current > WHEEL_SESSION_GAP_MS) {
+                onGestureStartRef.current(event.deltaY > 0 ? 'zoomOut' : 'zoomIn');
+            }
+            lastWheelAtRef.current = now;
+
+            const baseScale = pendingRef.current?.scale ?? scaleRef.current;
+            scheduleZoom(baseScale - event.deltaY * WHEEL_ZOOM_SCALE_FACTOR, event.clientX, event.clientY);
+        };
+
+        const getTouchDistance = (touches: TouchList): number =>
+            getDistance(touches[0].pageX, touches[0].pageY, touches[1].pageX, touches[1].pageY);
+
+        const handleTouchStart = (event: TouchEvent): void => {
+            if (event.touches.length < 2) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            touchStartRef.current = {
+                distance: getTouchDistance(event.touches),
+                scale: pendingRef.current?.scale ?? scaleRef.current,
+            };
+        };
+
+        const handleTouchMove = (event: TouchEvent): void => {
+            const start = touchStartRef.current;
+            if (!start || start.distance <= 0 || event.touches.length < 2) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            const distance = getTouchDistance(event.touches);
+            const [midpointX, midpointY] = getMidpoint(
+                event.touches[0].clientX,
+                event.touches[0].clientY,
+                event.touches[1].clientX,
+                event.touches[1].clientY,
+            );
+            scheduleZoom(start.scale * (distance / start.distance), midpointX, midpointY);
+        };
+
+        const handleTouchEnd = (): void => {
+            touchStartRef.current = null;
+        };
+
+        if (isPinchZoomEnabled) {
+            grid.addEventListener('wheel', handleWheel, { passive: false });
+        }
+        if (hasTouch) {
+            grid.addEventListener('touchstart', handleTouchStart, { passive: false });
+            grid.addEventListener('touchmove', handleTouchMove, { passive: false });
+            grid.addEventListener('touchend', handleTouchEnd);
+            grid.addEventListener('touchcancel', handleTouchEnd);
+        }
+
+        return () => {
+            if (frameRef.current !== null) {
+                cancelAnimationFrame(frameRef.current);
+                frameRef.current = null;
+            }
+            grid.removeEventListener('wheel', handleWheel);
+            grid.removeEventListener('touchstart', handleTouchStart);
+            grid.removeEventListener('touchmove', handleTouchMove);
+            grid.removeEventListener('touchend', handleTouchEnd);
+            grid.removeEventListener('touchcancel', handleTouchEnd);
+        };
+    }, [focalRef, gridRef, hasTouch, isPinchZoomEnabled, scaleRef]);
+}

--- a/src/lib/viewers/gallery/useGalleryPinch.ts
+++ b/src/lib/viewers/gallery/useGalleryPinch.ts
@@ -14,8 +14,8 @@ export interface PinchFocal {
 interface Props {
     focalRef: MutableRefObject<PinchFocal | null>;
     gridRef: RefObject<HTMLDivElement>;
-    hasTouch: boolean;
     isPinchZoomEnabled: boolean;
+    isTouchZoomEnabled: boolean;
     onGestureStart: (direction: PinchDirection) => void;
     onZoom: (scale: number) => boolean | void;
     scaleRef: MutableRefObject<number>;
@@ -25,8 +25,8 @@ interface Props {
 export default function useGalleryPinch({
     focalRef,
     gridRef,
-    hasTouch,
     isPinchZoomEnabled,
+    isTouchZoomEnabled,
     onGestureStart,
     onZoom,
     scaleRef,
@@ -45,7 +45,7 @@ export default function useGalleryPinch({
 
     useEffect(() => {
         const grid = gridRef.current;
-        if (!grid || (!hasTouch && !isPinchZoomEnabled)) {
+        if (!grid || (!isTouchZoomEnabled && !isPinchZoomEnabled)) {
             return undefined;
         }
 
@@ -124,7 +124,7 @@ export default function useGalleryPinch({
         if (isPinchZoomEnabled) {
             grid.addEventListener('wheel', handleWheel, { passive: false });
         }
-        if (hasTouch) {
+        if (isTouchZoomEnabled) {
             grid.addEventListener('touchstart', handleTouchStart, { passive: false });
             grid.addEventListener('touchmove', handleTouchMove, { passive: false });
             grid.addEventListener('touchend', handleTouchEnd);
@@ -142,5 +142,5 @@ export default function useGalleryPinch({
             grid.removeEventListener('touchend', handleTouchEnd);
             grid.removeEventListener('touchcancel', handleTouchEnd);
         };
-    }, [focalRef, gridRef, hasTouch, isPinchZoomEnabled, scaleRef]);
+    }, [focalRef, gridRef, isPinchZoomEnabled, isTouchZoomEnabled, scaleRef]);
 }

--- a/src/lib/viewers/gallery/useGalleryPinch.ts
+++ b/src/lib/viewers/gallery/useGalleryPinch.ts
@@ -17,7 +17,7 @@ interface Props {
     hasTouch: boolean;
     isPinchZoomEnabled: boolean;
     onGestureStart: (direction: PinchDirection) => void;
-    onZoom: (scale: number) => void;
+    onZoom: (scale: number) => boolean | void;
     scaleRef: MutableRefObject<number>;
 }
 
@@ -59,7 +59,9 @@ export default function useGalleryPinch({
                     pendingRef.current = null;
                     if (pending) {
                         focalRef.current = pending.focal;
-                        onZoomRef.current(pending.scale);
+                        if (onZoomRef.current(pending.scale) === false) {
+                            focalRef.current = null;
+                        }
                     }
                 });
             }

--- a/test/integration/document/Gallery.e2e.test.js
+++ b/test/integration/document/Gallery.e2e.test.js
@@ -11,6 +11,8 @@ describe('Preview Document Gallery', () => {
         collection,
         enableThumbnailsSidebar = false,
         galleryEnabled = true,
+        galleryV2Enabled = true,
+        pinchToZoomEnabled = false,
         targetFileId = fileId,
     } = {}) => {
         const options = {};
@@ -19,6 +21,12 @@ describe('Preview Document Gallery', () => {
             options.features = {
                 galleryView: {
                     enabled: galleryEnabled,
+                },
+                galleryViewV2: {
+                    enabled: galleryV2Enabled,
+                },
+                pinchToZoom: {
+                    enabled: pinchToZoomEnabled,
                 },
             };
         }
@@ -82,6 +90,60 @@ describe('Preview Document Gallery', () => {
 
         cy.get('.bp-gallery-grid').should('not.exist');
         cy.getByTitle('Gallery view').should('have.attr', 'aria-pressed', 'false');
+    });
+
+    it('Should zoom the gallery independently of the document and persist across reopen', () => {
+        showDocumentPreview();
+        cy.showControls();
+        cy.getByTestId('bp-ZoomControls-current')
+            .invoke('text')
+            .then(documentScale => {
+                openGallery();
+                cy.getByTestId('bp-ZoomControls-current').should('have.text', '100%');
+
+                cy.get('.bp-gallery-tile[data-page="1"]').then($tile => {
+                    const initialWidth = $tile[0].getBoundingClientRect().width;
+                    cy.get('.bp-gallery-tile[data-page="1"] img')
+                        .invoke('attr', 'src')
+                        .then(initialSrc => {
+                            cy.getByTitle('Zoom in').click();
+                            cy.getByTestId('bp-ZoomControls-current').should('have.text', '110%');
+                            cy.get('.bp-gallery-tile[data-page="1"]').should($zoomedTile => {
+                                expect($zoomedTile[0].getBoundingClientRect().width).to.be.greaterThan(initialWidth);
+                            });
+                            cy.get('.bp-gallery-tile[data-page="1"] img').should('have.attr', 'src', initialSrc);
+                        });
+                });
+
+                cy.getByTitle('Gallery view').click();
+                cy.getByTestId('bp-ZoomControls-current').should('have.text', documentScale);
+
+                openGallery();
+                cy.getByTestId('bp-ZoomControls-current').should('have.text', '110%');
+            });
+    });
+
+    it('Should hide gallery zoom controls when the v2 flag is off', () => {
+        showDocumentPreview({ galleryV2Enabled: false });
+        openGallery();
+
+        cy.getByTitle('Zoom in').should('not.exist');
+        cy.getByTitle('Zoom out').should('not.exist');
+    });
+
+    it('Should update gallery zoom from a trackpad pinch gesture', () => {
+        showDocumentPreview({ pinchToZoomEnabled: true });
+        openGallery();
+
+        cy.get('.bp-gallery-grid').trigger('wheel', {
+            clientX: 300,
+            clientY: 300,
+            ctrlKey: true,
+            deltaY: -10,
+            eventConstructor: 'WheelEvent',
+        });
+
+        cy.getByTestId('bp-ZoomControls-current').should('have.text', '110%');
     });
 
     it('Should navigate to a selected page and close gallery view', () => {


### PR DESCRIPTION
## Summary

- Add zoom controls to the document gallery.
- Support toolbar, keyboard, trackpad, and touch pinch zooming.
- Preserve the viewed tile while the gallery grid reflows.
- Keep gallery zoom independent from document zoom.
- Record gallery zoom Resin events.
- Keep thumbnails at their existing resolution; adaptive quality will follow in a separate stacked PR.

## Test plan

- [x] 542 affected unit tests pass.
- [x] TypeScript typecheck passes.
- [x] ESLint passes.
- [ ] Verify toolbar and keyboard zoom controls.
- [ ] Verify trackpad and touch pinch zoom.
- [ ] Verify scroll position remains anchored during zoom.
- [ ] Verify gallery scale persists after reopening and resets after teardown.
- [ ] Verify zoom controls remain hidden when Gallery V2 is disabled.