### PR TITLE
feat(gallery): sharpen thumbs

### DIFF
--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -1,9 +1,14 @@
 import isFinite from 'lodash/isFinite';
+import noop from 'lodash/noop';
 import BoundedCache from './BoundedCache';
 
 export const CLASS_BOX_PREVIEW_THUMBNAIL_IMAGE = 'bp-thumbnail-image';
 export const THUMBNAIL_TOTAL_WIDTH = 150; // 190px sidebar width - 40px margins
 export const THUMBNAIL_IMAGE_WIDTH = THUMBNAIL_TOTAL_WIDTH * 2; // Multiplied by a scaling factor so that we render the image at a higher resolution
+
+function createRejectedTask(message) {
+    return { cancel: noop, promise: Promise.reject(new Error(message)) };
+}
 
 class Thumbnail {
     /** @property {PDfViewer} - The PDFJS viewer instance */
@@ -11,6 +16,9 @@ class Thumbnail {
 
     /** @property {Object} - Cache for the thumbnail image elements */
     thumbnailImageCache;
+
+    /** @property {Set} - Active PDF.js render tasks */
+    renderTasks;
 
     preloader;
 
@@ -24,8 +32,10 @@ class Thumbnail {
         this.createImageEl = this.createImageEl.bind(this);
         this.createThumbnailImage = this.createThumbnailImage.bind(this);
         this.getThumbnailDataURL = this.getThumbnailDataURL.bind(this);
+        this.renderPageImage = this.renderPageImage.bind(this);
         this.pdfViewer = pdfViewer;
         this.thumbnailImageCache = new BoundedCache();
+        this.renderTasks = new Set();
     }
 
     /**
@@ -34,6 +44,11 @@ class Thumbnail {
      * @return {void}
      */
     destroy() {
+        if (this.renderTasks) {
+            this.renderTasks.forEach(task => task.cancel());
+            this.renderTasks.clear();
+            this.renderTasks = null;
+        }
         if (this.thumbnailImageCache) {
             this.thumbnailImageCache.destroy();
             this.thumbnailImageCache = null;
@@ -146,6 +161,10 @@ class Thumbnail {
                 if (!this.thumbnailImageCache) {
                     return null;
                 }
+                if (!dataUrl) {
+                    this.thumbnailImageCache.set(itemIndex, { ...cacheEntry, inProgress: false });
+                    return null;
+                }
 
                 const imageEl = this.createImageEl(dataUrl, thumbOptions);
                 // Cache this image element for future use
@@ -174,6 +193,102 @@ class Thumbnail {
     }
 
     /**
+     * Renders a page image without caching it.
+     * @param {number} pageNum - The page number of the document (1 indexed)
+     * @param {Object} thumbOptions - Thumbnail render options
+     * @return {Object} A cancellable render task
+     */
+    renderPageImage(pageNum, thumbOptions) {
+        const pdfDocument = this.pdfViewer?.pdfDocument;
+        if (!pdfDocument) {
+            return createRejectedTask('PDF document not ready');
+        }
+
+        const thumbnailImageWidth =
+            thumbOptions && thumbOptions.thumbMaxWidth ? thumbOptions.thumbMaxWidth : THUMBNAIL_IMAGE_WIDTH;
+        if (!isFinite(thumbnailImageWidth) || thumbnailImageWidth <= 0) {
+            return createRejectedTask('Invalid thumbnail render dimensions');
+        }
+
+        const canvas = document.createElement('canvas');
+        let isCancelled = false;
+        let pdfRenderTask = null;
+        const task = {
+            cancel: () => {
+                if (isCancelled) {
+                    return;
+                }
+                isCancelled = true;
+                pdfRenderTask?.cancel();
+            },
+            promise: null,
+        };
+
+        task.promise = pdfDocument
+            .getPage(pageNum)
+            .then(page => {
+                if (isCancelled || !this.thumbnailImageCache) {
+                    return null;
+                }
+
+                const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
+                const viewport = page.getViewport({ scale: 1, rotation });
+                if (
+                    !viewport ||
+                    !isFinite(viewport.width) ||
+                    viewport.width <= 0 ||
+                    !isFinite(viewport.height) ||
+                    viewport.height <= 0
+                ) {
+                    return Promise.reject(new Error('Invalid page viewport'));
+                }
+                const { width, height } = viewport;
+                const currentPageRatio = width / height;
+
+                // More-portrait pages are constrained by the first page's height budget.
+                if (currentPageRatio < this.pageRatio) {
+                    canvas.height = Math.ceil(thumbnailImageWidth / this.pageRatio);
+                    canvas.width = canvas.height * currentPageRatio;
+                } else {
+                    canvas.width = thumbnailImageWidth;
+                    canvas.height = Math.ceil(thumbnailImageWidth / currentPageRatio);
+                }
+                const { width: canvasWidth } = canvas;
+                const scale = canvasWidth / width;
+                pdfRenderTask = page.render({
+                    canvasContext: canvas.getContext('2d'),
+                    viewport: page.getViewport({ scale, rotation }),
+                });
+
+                return pdfRenderTask.promise.then(() => {
+                    if (isCancelled || !this.thumbnailImageCache) {
+                        return null;
+                    }
+
+                    return {
+                        dataUrl: canvas.toDataURL(),
+                        height: canvas.height,
+                        width: canvas.width,
+                    };
+                });
+            })
+            .catch(error => {
+                if (isCancelled) {
+                    return null;
+                }
+                throw error;
+            })
+            .finally(() => {
+                canvas.width = 0;
+                canvas.height = 0;
+                this.renderTasks?.delete(task);
+            });
+
+        this.renderTasks.add(task);
+        return task;
+    }
+
+    /**
      * Given a page number, generates the image data URL for the image of the page
      * @param {number} pageNum  - The page number of the document
      * @return {string} The data URL of the page image
@@ -183,56 +298,7 @@ class Thumbnail {
             return Promise.resolve(this.preloader.preloadedImages[pageNum]);
         }
 
-        const pdfDocument = this.pdfViewer?.pdfDocument;
-        if (!pdfDocument) {
-            return Promise.reject(new Error('PDF document not ready'));
-        }
-
-        const canvas = document.createElement('canvas');
-        const thumbnailImageWidth =
-            thumbOptions && thumbOptions.thumbMaxWidth ? thumbOptions.thumbMaxWidth : THUMBNAIL_IMAGE_WIDTH;
-
-        return pdfDocument
-            .getPage(pageNum)
-            .then(page => {
-                if (!this.thumbnailImageCache) {
-                    return null;
-                }
-
-                const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
-                const viewport = page.getViewport({ scale: 1, rotation });
-                if (!viewport || !isFinite(viewport.width) || !isFinite(viewport.height)) {
-                    return Promise.reject(new Error('Invalid page viewport'));
-                }
-                const { width, height } = viewport;
-                // Get the current page w:h ratio in case it differs from the first page
-                const curPageRatio = width / height;
-
-                // Handle the case where the current page's w:h ratio is less than the
-                // `pageRatio` which means that this page is probably more portrait than
-                // landscape
-                if (curPageRatio < this.pageRatio) {
-                    // Set the canvas height to that of the thumbnail max height
-                    canvas.height = Math.ceil(thumbnailImageWidth / this.pageRatio);
-                    // Find the canvas width based on the current page ratio
-                    canvas.width = canvas.height * curPageRatio;
-                } else {
-                    // In case the current page ratio is same as the first page
-                    // or in case it's larger (which means that it's wider), keep
-                    // the width at the max thumbnail width
-                    canvas.width = thumbnailImageWidth;
-                    // Find the height based on the current page ratio
-                    canvas.height = Math.ceil(thumbnailImageWidth / curPageRatio);
-                }
-                // The amount for which to scale down the current page
-                const { width: canvasWidth } = canvas;
-                const scale = canvasWidth / width;
-                return page.render({
-                    canvasContext: canvas.getContext('2d'),
-                    viewport: page.getViewport({ scale, rotation }),
-                }).promise;
-            })
-            .then(() => canvas.toDataURL());
+        return this.renderPageImage(pageNum, thumbOptions).promise.then(result => result?.dataUrl || null);
     }
 }
 

--- a/src/lib/__tests__/Thumbnail-test.js
+++ b/src/lib/__tests__/Thumbnail-test.js
@@ -12,7 +12,9 @@ describe('Thumbnail', () => {
 
     beforeEach(() => {
         stubs.getViewport = jest.fn();
+        stubs.cancelRender = jest.fn();
         stubs.render = jest.fn(() => ({
+            cancel: stubs.cancelRender,
             promise: Promise.resolve(),
         }));
         page = {
@@ -43,6 +45,7 @@ describe('Thumbnail', () => {
         test('should initialize properties', () => {
             expect(thumbnail.pdfViewer).toBe(pdfViewer);
             expect(thumbnail.thumbnailImageCache.cache).toEqual({});
+            expect(thumbnail.renderTasks).toEqual(new Set());
             expect(thumbnail.scale).toBeUndefined();
             expect(thumbnail.pageRatio).toBeUndefined();
         });
@@ -130,6 +133,7 @@ describe('Thumbnail', () => {
             expect(thumbnail.thumbnailImageCache).toBeNull();
             expect(thumbnail.pdfViewer).toBeNull();
             expect(thumbnail.preloader).toBeNull();
+            expect(thumbnail.renderTasks).toBeNull();
         });
 
         test('should safely handle repeated calls', () => {
@@ -192,7 +196,7 @@ describe('Thumbnail', () => {
 
     describe('createThumbnailImage', () => {
         beforeEach(() => {
-            stubs.getThumbnailDataURL = jest.spyOn(thumbnail, 'getThumbnailDataURL').mockResolvedValue(undefined);
+            stubs.getThumbnailDataURL = jest.spyOn(thumbnail, 'getThumbnailDataURL').mockResolvedValue('dataurl');
             stubs.createImageEl = jest.spyOn(thumbnail, 'createImageEl').mockImplementation();
             stubs.getCacheEntry = jest.spyOn(thumbnail.thumbnailImageCache, 'get').mockImplementation();
             stubs.setCacheEntry = jest.spyOn(thumbnail.thumbnailImageCache, 'set').mockImplementation();
@@ -213,7 +217,10 @@ describe('Thumbnail', () => {
 
             return thumbnail.createThumbnailImage(0).then(imageEl => {
                 expect(stubs.createImageEl).toBeCalled();
-                expect(stubs.setCacheEntry).toBeCalledWith(0, { inProgress: false, image: imageEl });
+                expect(stubs.setCacheEntry).toBeCalledWith(0, {
+                    image: imageEl,
+                    inProgress: false,
+                });
             });
         });
 
@@ -226,6 +233,14 @@ describe('Thumbnail', () => {
                 expect(stubs.createImageEl).not.toBeCalled();
                 expect(imageEl).toBeNull();
             });
+        });
+
+        test('should clear the in-progress entry when rendering is cancelled', async () => {
+            stubs.getThumbnailDataURL.mockResolvedValue(null);
+
+            await expect(thumbnail.createThumbnailImage(0)).resolves.toBeNull();
+            expect(stubs.setCacheEntry).toHaveBeenLastCalledWith(0, { inProgress: false });
+            expect(stubs.createImageEl).not.toHaveBeenCalled();
         });
 
         test('should resolve with null after being destroyed', async () => {
@@ -332,6 +347,57 @@ describe('Thumbnail', () => {
                 expect(stubs.getPage).not.toHaveBeenCalled();
                 expect(stubs.getViewport).not.toHaveBeenCalled();
             });
+        });
+    });
+
+    describe('renderPageImage()', () => {
+        beforeEach(() => {
+            thumbnail.pageRatio = 1;
+            stubs.getViewport.mockReturnValue({ width: 10, height: 10 });
+        });
+
+        test('should return dimensions and release the canvas backing store', async () => {
+            const canvas = document.createElement('canvas');
+            const createElement = jest.spyOn(document, 'createElement').mockReturnValue(canvas);
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await expect(task.promise).resolves.toMatchObject({
+                dataUrl: expect.stringContaining('data:image/png'),
+                height: 20,
+                width: 20,
+            });
+            expect(canvas.width).toBe(0);
+            expect(canvas.height).toBe(0);
+            expect(thumbnail.renderTasks.size).toBe(0);
+            createElement.mockRestore();
+        });
+
+        test('should cancel an active PDF render and discard its result', async () => {
+            let rejectRender;
+            stubs.render.mockReturnValue({
+                cancel: stubs.cancelRender,
+                promise: new Promise((resolve, reject) => {
+                    rejectRender = reject;
+                }),
+            });
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await pagePromise;
+            await Promise.resolve();
+            task.cancel();
+            rejectRender(new Error('Rendering cancelled'));
+
+            expect(stubs.cancelRender).toHaveBeenCalled();
+            await expect(task.promise).resolves.toBeNull();
+        });
+
+        test('should bypass preloaded images for an uncached high-resolution render', async () => {
+            thumbnail = new Thumbnail(pdfViewer, { preloadedImages: { 1: 'dataurl' } });
+            thumbnail.pageRatio = 1;
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await expect(task.promise).resolves.toMatchObject({ width: 20 });
+            expect(stubs.getPage).toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import noop from 'lodash/noop';
 import throttle from 'lodash/throttle';
 import { decodeKeydown, replacePlaceholders } from '../../util';
+import HighResThumbnailStore, { HighResRenderTask } from './HighResThumbnailStore';
 import useGalleryPinch, { PinchDirection, PinchFocal } from './useGalleryPinch';
 import './GalleryGrid.scss';
 
@@ -11,6 +12,13 @@ const SCROLL_THROTTLE_MS = 200;
 // Keep in sync with the 100% grid rule in GalleryGrid.scss
 const GALLERY_TILE_GAP = 16;
 const GALLERY_TILE_MIN_WIDTH = 220;
+const GALLERY_THUMB_WIDTH_TIERS = [GALLERY_THUMB_MAX_WIDTH, GALLERY_THUMB_MAX_WIDTH * 2, GALLERY_THUMB_MAX_WIDTH * 3];
+const GALLERY_THUMB_MAX_TIER = GALLERY_THUMB_WIDTH_TIERS[GALLERY_THUMB_WIDTH_TIERS.length - 1];
+const GALLERY_THUMB_MAX_DPR = 2;
+const GALLERY_HIGH_RES_MAX_BYTES = 64 * 1024 * 1024;
+const GALLERY_HIGH_RES_MAX_PAGES = 16;
+const GALLERY_HIGH_RES_CONCURRENCY = 2;
+const GALLERY_DEFAULT_PAGE_RATIO = 0.775;
 
 export interface GalleryThumbnail {
     init: () => Promise<unknown>;
@@ -19,6 +27,7 @@ export interface GalleryThumbnail {
         itemIndex: number,
         options: { createImgTag: boolean; thumbMaxWidth: number },
     ) => Promise<HTMLImageElement | null>;
+    renderPageImage: (pageNum: number, options: { thumbMaxWidth: number }) => HighResRenderTask;
     /** First-page width:height ratio, populated by init(). Used to size placeholders to the real page shape. */
     pageRatio?: number;
 }
@@ -100,6 +109,7 @@ export default function GalleryGrid({
     thumbnail,
 }: Props): JSX.Element {
     const [loadedImages, setLoadedImages] = useState<Record<number, string>>({});
+    const [highResImages, setHighResImages] = useState<Record<number, string>>({});
     const [focusedPage, setFocusedPage] = useState(currentPage);
     const [pageRatio, setPageRatio] = useState<number | null>(null);
     // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
@@ -112,41 +122,70 @@ export default function GalleryGrid({
     const isProcessingRef = useRef(false);
     const isMountedRef = useRef(true);
     const inFlightRef = useRef<Set<number>>(new Set());
+    const highResStoreRef = useRef<HighResThumbnailStore | null>(null);
 
     const byDistanceFromAnchor = (a: number, b: number): number =>
         Math.abs(a - anchorPageRef.current) - Math.abs(b - anchorPageRef.current);
 
-    // Unloaded tiles within viewport + buffer, on-screen tiles first so the user never
-    // watches a visible hole while off-screen pages load. Pages already being rendered
-    // (in flight) are excluded so re-derives can't waste loader slots on them.
-    function getUnloadedNearViewport(): number[] {
+    function getNeededThumbWidth(): number {
+        if (scaleRef.current === 1) {
+            return GALLERY_THUMB_MAX_WIDTH;
+        }
+
+        const tile = gridRef.current?.querySelector<HTMLElement>('[data-page]');
+        const neededWidth = (tile?.offsetWidth || 0) * Math.min(window.devicePixelRatio || 1, GALLERY_THUMB_MAX_DPR);
+        return GALLERY_THUMB_WIDTH_TIERS.find(tier => tier >= neededWidth) || GALLERY_THUMB_MAX_TIER;
+    }
+
+    // Prioritize visible pages before spending work on the surrounding buffer.
+    function getPagesNearViewport(
+        marginRatio: number,
+        isEligible?: (tile: HTMLElement, pageNum: number) => boolean,
+    ): number[] {
         const grid = gridRef.current;
         if (!grid) return [];
 
         const { scrollTop, clientHeight } = grid;
-        const bufferZone = clientHeight * 3;
         const viewportBottom = scrollTop + clientHeight;
+        const margin = clientHeight * marginRatio;
+        const visible: number[] = [];
+        const nearby: number[] = [];
 
-        const visibleUnloaded: number[] = [];
-        const bufferedUnloaded: number[] = [];
-        const tiles = grid.querySelectorAll('[data-page]');
-
-        tiles.forEach(tile => {
-            const el = tile as HTMLElement;
-            if (!el.dataset.page) return;
-            const pageNum = parseInt(el.dataset.page, 10);
-            if (inFlightRef.current.has(pageNum) || el.querySelector('img')) return;
-            const tileTop = el.offsetTop;
-            const tileBottom = tileTop + el.offsetHeight;
+        grid.querySelectorAll<HTMLElement>('[data-page]').forEach(tile => {
+            if (!tile.dataset.page) return;
+            const pageNum = parseInt(tile.dataset.page, 10);
+            if (isEligible && !isEligible(tile, pageNum)) return;
+            const tileTop = tile.offsetTop;
+            const tileBottom = tileTop + tile.offsetHeight;
 
             if (tileBottom > scrollTop && tileTop < viewportBottom) {
-                visibleUnloaded.push(pageNum);
-            } else if (tileBottom > scrollTop - bufferZone && tileTop < viewportBottom + bufferZone) {
-                bufferedUnloaded.push(pageNum);
+                visible.push(pageNum);
+            } else if (tileBottom > scrollTop - margin && tileTop < viewportBottom + margin) {
+                nearby.push(pageNum);
             }
         });
 
-        return [...visibleUnloaded.sort(byDistanceFromAnchor), ...bufferedUnloaded.sort(byDistanceFromAnchor)];
+        return [...visible.sort(byDistanceFromAnchor), ...nearby.sort(byDistanceFromAnchor)];
+    }
+
+    function syncHighRes() {
+        const store = highResStoreRef.current;
+        if (!store) return;
+
+        const width = getNeededThumbWidth();
+        const ratio = thumbnail.pageRatio || GALLERY_DEFAULT_PAGE_RATIO;
+        if (width === GALLERY_THUMB_MAX_WIDTH) {
+            store.setRetained([], width, ratio);
+        } else if (!isProcessingRef.current) {
+            store.setRetained(getPagesNearViewport(0.5), width, ratio);
+        }
+    }
+
+    function getUnloadedNearViewport(): number[] {
+        return getPagesNearViewport(
+            3,
+            (tile, pageNum) => !inFlightRef.current.has(pageNum) && !tile.querySelector('img'),
+        );
     }
 
     function processQueue() {
@@ -182,6 +221,7 @@ export default function GalleryGrid({
                 queueRef.current = getUnloadedNearViewport().filter(p => remaining.has(p));
                 if (queueRef.current.length === 0) {
                     isProcessingRef.current = false;
+                    syncHighRes();
                     return;
                 }
                 processQueue();
@@ -222,6 +262,7 @@ export default function GalleryGrid({
                 queueRef.current = [...toAdd, ...queueRef.current];
                 startProcessing();
             }
+            syncHighRes();
         }, SCROLL_THROTTLE_MS),
     );
 
@@ -308,6 +349,18 @@ export default function GalleryGrid({
 
     useEffect(() => {
         const throttledScroll = handleScrollRef.current;
+        const highResStore = new HighResThumbnailStore({
+            maxBytes: GALLERY_HIGH_RES_MAX_BYTES,
+            maxConcurrent: GALLERY_HIGH_RES_CONCURRENCY,
+            maxPages: GALLERY_HIGH_RES_MAX_PAGES,
+            onChange: images => {
+                if (isMountedRef.current) {
+                    setHighResImages(images);
+                }
+            },
+            render: (pageNum, width) => thumbnail.renderPageImage(pageNum, { thumbMaxWidth: width }),
+        });
+        highResStoreRef.current = highResStore;
 
         if (gridRef.current) {
             const tile = gridRef.current.querySelector(`[data-page="${currentPage}"]`) as HTMLElement;
@@ -344,12 +397,15 @@ export default function GalleryGrid({
             // Guarded start: the mount scrollIntoView can fire the scroll handler first, and a
             // second unguarded pump would double the concurrent thumbnail renders.
             startProcessing();
+            syncHighRes();
         });
 
         return () => {
             isMountedRef.current = false;
             queueRef.current = [];
             isProcessingRef.current = false;
+            highResStore.destroy();
+            highResStoreRef.current = null;
             throttledScroll.cancel();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -381,12 +437,12 @@ export default function GalleryGrid({
         return () => observer.disconnect();
     }, [applyZoomLayout]);
 
-    const focusTile = useCallback((pageNum: number) => {
+    const focusTile = useCallback((pageNum: number, options?: FocusOptions) => {
         const grid = gridRef.current;
         if (!grid) return;
         const tile = grid.querySelector(`[data-page="${pageNum}"]`) as HTMLElement | null;
         if (tile) {
-            tile.focus();
+            tile.focus(options);
         }
     }, []);
 
@@ -410,7 +466,7 @@ export default function GalleryGrid({
     const handleGridFocus = useCallback(
         (event: React.FocusEvent) => {
             if (event.target === gridRef.current) {
-                focusTile(focusedPage);
+                focusTile(focusedPage, { preventScroll: true });
             }
         },
         [focusedPage, focusTile],
@@ -470,7 +526,7 @@ export default function GalleryGrid({
         tiles.push(
             <GalleryTile
                 key={i}
-                imageSrc={loadedImages[i]}
+                imageSrc={highResImages[i] || loadedImages[i]}
                 isFocused={i === focusedPage}
                 onClick={handleTileClick}
                 onFocus={handleTileFocus}

--- a/src/lib/viewers/gallery/HighResThumbnailStore.ts
+++ b/src/lib/viewers/gallery/HighResThumbnailStore.ts
@@ -1,0 +1,234 @@
+export interface HighResRenderResult {
+    dataUrl: string;
+    height: number;
+    width: number;
+}
+
+export interface HighResRenderTask {
+    cancel: () => void;
+    promise: Promise<HighResRenderResult | null>;
+}
+
+interface HighResThumbnailStoreOptions {
+    maxBytes: number;
+    maxConcurrent: number;
+    maxPages: number;
+    onChange: (images: Record<number, string>) => void;
+    render: (pageNum: number, width: number) => HighResRenderTask;
+}
+
+interface CachedImage extends HighResRenderResult {
+    bytes: number;
+    requestedWidth: number;
+}
+
+interface PendingRender {
+    task: HighResRenderTask;
+    width: number;
+}
+
+export default class HighResThumbnailStore {
+    private activeCount = 0;
+
+    private cache = new Map<number, CachedImage>();
+
+    private currentBytes = 0;
+
+    private failed = new Set<number>();
+
+    private inFlight = new Map<number, PendingRender>();
+
+    private isDestroyed = false;
+
+    private maxBytes: number;
+
+    private maxConcurrent: number;
+
+    private maxPages: number;
+
+    private onChange: ((images: Record<number, string>) => void) | null;
+
+    private queue: number[] = [];
+
+    private render: ((pageNum: number, width: number) => HighResRenderTask) | null;
+
+    private retained = new Set<number>();
+
+    private targetWidth = 0;
+
+    constructor({ maxBytes, maxConcurrent, maxPages, onChange, render }: HighResThumbnailStoreOptions) {
+        this.maxBytes = maxBytes;
+        this.maxConcurrent = maxConcurrent;
+        this.maxPages = maxPages;
+        this.onChange = onChange;
+        this.render = render;
+    }
+
+    setRetained(pages: number[], width: number, pageRatio: number): void {
+        if (this.isDestroyed) {
+            return;
+        }
+
+        const previousWidth = this.targetWidth;
+        this.targetWidth = width;
+        if (previousWidth !== width) {
+            this.failed.clear();
+        }
+
+        const ratio = Number.isFinite(pageRatio) && pageRatio > 0 ? pageRatio : 1;
+        const estimatedBytes = width * Math.ceil(width / ratio) * 4;
+        const pageLimit = Math.min(this.maxPages, Math.floor(this.maxBytes / estimatedBytes));
+        const retainedPages = Array.from(new Set(pages)).slice(0, pageLimit);
+        const retainedSet = new Set(retainedPages);
+        this.retained = retainedSet;
+        this.failed.forEach(pageNum => {
+            if (!retainedSet.has(pageNum)) {
+                this.failed.delete(pageNum);
+            }
+        });
+        let didEvict = false;
+
+        this.cache.forEach((entry, pageNum) => {
+            if (!this.retained.has(pageNum) || entry.requestedWidth !== width) {
+                this.cache.delete(pageNum);
+                this.currentBytes -= entry.bytes;
+                didEvict = true;
+            }
+        });
+
+        this.inFlight.forEach((pending, pageNum) => {
+            if (!this.retained.has(pageNum) || pending.width !== width) {
+                pending.task.cancel();
+                this.inFlight.delete(pageNum);
+            }
+        });
+
+        this.queue = retainedPages.filter(
+            pageNum => !this.cache.has(pageNum) && !this.inFlight.has(pageNum) && !this.failed.has(pageNum),
+        );
+
+        if (didEvict) {
+            this.emit();
+        }
+        this.pump();
+    }
+
+    destroy(): void {
+        if (this.isDestroyed) {
+            return;
+        }
+
+        this.isDestroyed = true;
+        this.inFlight.forEach(({ task }) => task.cancel());
+        this.inFlight.clear();
+        this.cache.clear();
+        this.failed.clear();
+        this.queue = [];
+        this.retained.clear();
+        this.currentBytes = 0;
+        this.onChange = null;
+        this.render = null;
+    }
+
+    private emit(): void {
+        if (!this.onChange) {
+            return;
+        }
+
+        const images: Record<number, string> = {};
+        this.cache.forEach((entry, pageNum) => {
+            images[pageNum] = entry.dataUrl;
+        });
+        this.onChange(images);
+    }
+
+    private pump(): void {
+        if (this.isDestroyed || !this.render) {
+            return;
+        }
+
+        while (this.activeCount < this.maxConcurrent && this.queue.length > 0) {
+            const pageNum = this.queue.shift();
+            if (pageNum && this.retained.has(pageNum)) {
+                this.startRender(pageNum);
+            }
+        }
+    }
+
+    private startRender(pageNum: number): void {
+        if (!this.render) {
+            return;
+        }
+
+        const width = this.targetWidth;
+        let task: HighResRenderTask;
+        try {
+            task = this.render(pageNum, width);
+        } catch {
+            this.failed.add(pageNum);
+            return;
+        }
+
+        const pending = { task, width };
+        this.activeCount += 1;
+        this.inFlight.set(pageNum, pending);
+
+        task.promise
+            .then(
+                result => this.handleRenderResult(pageNum, pending, result),
+                () => this.handleRenderFailure(pageNum, pending),
+            )
+            .then(
+                () => this.finishRender(),
+                () => this.finishRender(),
+            );
+    }
+
+    private clearInFlight(pageNum: number, pending: PendingRender): boolean {
+        if (this.inFlight.get(pageNum) !== pending) {
+            return false;
+        }
+
+        this.inFlight.delete(pageNum);
+        return true;
+    }
+
+    private finishRender(): void {
+        this.activeCount -= 1;
+        this.pump();
+    }
+
+    private handleRenderFailure(pageNum: number, pending: PendingRender): void {
+        if (this.clearInFlight(pageNum, pending) && this.isStillWanted(pageNum, pending)) {
+            this.failed.add(pageNum);
+        }
+    }
+
+    private handleRenderResult(pageNum: number, pending: PendingRender, result: HighResRenderResult | null): void {
+        if (!this.clearInFlight(pageNum, pending) || !result || !this.isStillWanted(pageNum, pending)) {
+            return;
+        }
+
+        const { height, width } = result;
+        if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
+            this.failed.add(pageNum);
+            return;
+        }
+
+        const bytes = width * height * 4;
+        const existing = this.cache.get(pageNum);
+        const nextBytes = this.currentBytes - (existing?.bytes || 0) + bytes;
+        if (nextBytes > this.maxBytes) {
+            this.failed.add(pageNum);
+            return;
+        }
+
+        this.cache.set(pageNum, { ...result, bytes, requestedWidth: pending.width });
+        this.currentBytes = nextBytes;
+        this.emit();
+    }
+
+    private isStillWanted(pageNum: number, pending: PendingRender): boolean {
+        return !this.isDestroyed && this.targetWidth === pending.width && this.retained.has(pageNum);
+    }
+}

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -18,6 +18,7 @@ describe('GalleryGrid', () => {
         init: jest.fn().mockResolvedValue(100),
         getImageFromCache: jest.fn().mockReturnValue(null),
         createThumbnailImage: jest.fn().mockResolvedValue(null),
+        renderPageImage: jest.fn(() => ({ cancel: jest.fn(), promise: Promise.resolve(null) })),
         destroy: jest.fn(),
     };
 
@@ -263,12 +264,14 @@ describe('GalleryGrid', () => {
         test('should redirect focus to focused tile when grid container is clicked', async () => {
             getWrapper();
             const grid = screen.getByRole('listbox');
+            const focusedTile = screen.getByLabelText('Page 3');
+            const focus = jest.spyOn(focusedTile, 'focus');
             grid.focus();
 
             await waitFor(() => {
-                const focusedTile = screen.getByLabelText('Page 3');
                 expect(focusedTile).toHaveFocus();
             });
+            expect(focus).toHaveBeenCalledWith({ preventScroll: true });
         });
     });
 
@@ -551,6 +554,60 @@ describe('GalleryGrid', () => {
             // Pages beyond the viewport + buffer stay lazy
             expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(48);
             expect(screen.getByLabelText('Page 49').querySelector('img')).not.toBeInTheDocument();
+        });
+
+        test('should temporarily sharpen visible tiles after zooming in', async () => {
+            const renderPageImage = jest.fn((pageNum: number, { thumbMaxWidth }: { thumbMaxWidth: number }) => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve({
+                    dataUrl: `data:image/png;high-res-${pageNum}`,
+                    height: thumbMaxWidth,
+                    width: thumbMaxWidth,
+                }),
+            }));
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn((pageIndex: number) => {
+                    const image = document.createElement('img');
+                    image.src = `data:image/png;base-${pageIndex + 1}`;
+                    return Promise.resolve(image);
+                }),
+                renderPageImage,
+            };
+            const { rerender } = getWrapper({ pageCount: 10, currentPage: 1, thumbnail });
+            layoutGrid(500);
+
+            await waitFor(() => {
+                expect(thumbnail.createThumbnailImage).toHaveBeenCalledTimes(10);
+            });
+            expect(thumbnail.createThumbnailImage).toHaveBeenCalledWith(0, {
+                createImgTag: true,
+                thumbMaxWidth: 440,
+            });
+            thumbnail.createThumbnailImage.mockClear();
+
+            screen.getAllByRole('option').forEach(tile => {
+                Object.defineProperty(tile, 'offsetWidth', { configurable: true, value: 600 });
+            });
+            rerender(<GalleryGrid {...defaultProps} currentPage={1} scale={2} thumbnail={thumbnail} />);
+
+            await waitFor(() => {
+                expect(renderPageImage).toHaveBeenCalledWith(1, { thumbMaxWidth: 880 });
+            });
+            expect(thumbnail.createThumbnailImage).not.toHaveBeenCalled();
+            expect(screen.getByLabelText('Page 1').querySelector('img')).toHaveAttribute(
+                'src',
+                'data:image/png;high-res-1',
+            );
+
+            rerender(<GalleryGrid {...defaultProps} currentPage={1} scale={1} thumbnail={thumbnail} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Page 1').querySelector('img')).toHaveAttribute(
+                    'src',
+                    'data:image/png;base-1',
+                );
+            });
         });
 
         test('should load radiating outward from the viewed area', async () => {

--- a/src/lib/viewers/gallery/__tests__/HighResThumbnailStore-test.ts
+++ b/src/lib/viewers/gallery/__tests__/HighResThumbnailStore-test.ts
@@ -1,0 +1,210 @@
+import HighResThumbnailStore, { HighResRenderResult, HighResRenderTask } from '../HighResThumbnailStore';
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    reject: (reason?: unknown) => void;
+    resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+}
+
+describe('HighResThumbnailStore', () => {
+    const createResult = (pageNum: number, width: number): HighResRenderResult => ({
+        dataUrl: `high-res-${pageNum}-${width}`,
+        height: width,
+        width,
+    });
+
+    test('should admit pages in priority order within the byte budget', async () => {
+        const onChange = jest.fn();
+        const render = jest.fn(
+            (pageNum: number, width: number): HighResRenderTask => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve(createResult(pageNum, width)),
+            }),
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 800,
+            maxConcurrent: 2,
+            maxPages: 10,
+            onChange,
+            render,
+        });
+
+        store.setRetained([3, 2, 1], 10, 1);
+        await flushPromises();
+
+        expect(render.mock.calls.map(([pageNum]) => pageNum)).toEqual([3, 2]);
+        expect(onChange).toHaveBeenLastCalledWith({
+            2: 'high-res-2-10',
+            3: 'high-res-3-10',
+        });
+    });
+
+    test('should evict pages immediately when the retained viewport changes', async () => {
+        const onChange = jest.fn();
+        const render = jest.fn(
+            (pageNum: number, width: number): HighResRenderTask => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve(createResult(pageNum, width)),
+            }),
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 800,
+            maxConcurrent: 1,
+            maxPages: 2,
+            onChange,
+            render,
+        });
+
+        store.setRetained([1], 10, 1);
+        await flushPromises();
+        store.setRetained([2], 10, 1);
+
+        expect(onChange).toHaveBeenLastCalledWith({});
+        await flushPromises();
+        expect(onChange).toHaveBeenLastCalledWith({ 2: 'high-res-2-10' });
+    });
+
+    test('should keep cancelled work counted until it settles', async () => {
+        const renders = new Map<number, { cancel: jest.Mock; result: Deferred<HighResRenderResult | null> }>();
+        const render = jest.fn(
+            (pageNum: number): HighResRenderTask => {
+                const result = deferred<HighResRenderResult | null>();
+                const cancel = jest.fn();
+                renders.set(pageNum, { cancel, result });
+                return { cancel, promise: result.promise };
+            },
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 800,
+            maxConcurrent: 1,
+            maxPages: 2,
+            onChange: jest.fn(),
+            render,
+        });
+
+        store.setRetained([1], 10, 1);
+        store.setRetained([2], 10, 1);
+
+        expect(renders.get(1)?.cancel).toHaveBeenCalled();
+        expect(render).toHaveBeenCalledTimes(1);
+        renders.get(1)?.result.reject(new Error('cancelled'));
+        await flushPromises();
+        expect(render).toHaveBeenLastCalledWith(2, 10);
+    });
+
+    test('should not let a stale completion untrack its replacement render', async () => {
+        const renders: Array<{
+            cancel: jest.Mock;
+            result: Deferred<HighResRenderResult | null>;
+            width: number;
+        }> = [];
+        const render = jest.fn(
+            (_pageNum: number, width: number): HighResRenderTask => {
+                const result = deferred<HighResRenderResult | null>();
+                const cancel = jest.fn();
+                renders.push({ cancel, result, width });
+                return { cancel, promise: result.promise };
+            },
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 2000,
+            maxConcurrent: 2,
+            maxPages: 2,
+            onChange: jest.fn(),
+            render,
+        });
+
+        store.setRetained([1], 10, 1);
+        store.setRetained([1], 20, 1);
+
+        expect(renders).toHaveLength(2);
+        expect(renders[0].cancel).toHaveBeenCalled();
+        renders[0].result.reject(new Error('cancelled'));
+        await flushPromises();
+
+        store.setRetained([], 20, 1);
+        expect(renders[1].cancel).toHaveBeenCalled();
+        expect(render).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not repeatedly render results that exceed the byte budget', async () => {
+        const render = jest.fn(
+            (): HighResRenderTask => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve(createResult(1, 20)),
+            }),
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 400,
+            maxConcurrent: 1,
+            maxPages: 1,
+            onChange: jest.fn(),
+            render,
+        });
+
+        store.setRetained([1], 10, 1);
+        await flushPromises();
+        store.setRetained([1], 10, 1);
+
+        expect(render).toHaveBeenCalledTimes(1);
+    });
+
+    test('should retain a narrower canvas rendered for the requested tier', async () => {
+        const render = jest.fn(
+            (): HighResRenderTask => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve({
+                    dataUrl: 'portrait-page',
+                    height: 10,
+                    width: 6,
+                }),
+            }),
+        );
+        const store = new HighResThumbnailStore({
+            maxBytes: 400,
+            maxConcurrent: 1,
+            maxPages: 1,
+            onChange: jest.fn(),
+            render,
+        });
+
+        store.setRetained([1], 10, 1);
+        await flushPromises();
+        store.setRetained([1], 10, 1);
+
+        expect(render).toHaveBeenCalledTimes(1);
+    });
+
+    test('should cancel work and ignore late results after destroy', async () => {
+        const result = deferred<HighResRenderResult | null>();
+        const cancel = jest.fn();
+        const onChange = jest.fn();
+        const store = new HighResThumbnailStore({
+            maxBytes: 800,
+            maxConcurrent: 1,
+            maxPages: 2,
+            onChange,
+            render: () => ({ cancel, promise: result.promise }),
+        });
+
+        store.setRetained([1], 10, 1);
+        store.destroy();
+        result.resolve(createResult(1, 10));
+        await flushPromises();
+
+        expect(cancel).toHaveBeenCalled();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Depends on [#1729](https://github.com/box/box-content-preview/pull/1729).

- Render sharper gallery thumbnails at 880px and 1320px as tiles grow.
- Keep persistent 440px thumbnails as a fallback.
- Limit high-resolution thumbnails to visible and nearby pages.
- Enforce a 64MiB decoded-pixel budget, 16-page limit, and two concurrent renders.
- Cancel stale PDF renders and release canvas backing stores.
- Evict offscreen high-resolution images back to base quality.
- Prevent scrollbar interaction from jumping to the highlighted tile.

## Test plan

- [x] Affected unit tests pass.
- [x] TypeScript typecheck passes.
- [x] ESLint passes.
- [ ] Verify visible thumbnails sharpen when zooming.
- [ ] Verify nearby thumbnails sharpen before entering the viewport.
- [ ] Verify offscreen pages return to base quality.
- [ ] Aggressively zoom and scroll through a large document and confirm memory plateaus.
- [ ] Verify closing and reopening the gallery releases high-resolution resources.
- [ ] Verify dragging the gallery scrollbar does not jump to the highlighted tile.