### PR TITLE
feat(video): early-paint Instant Preview behind feature flag

### DIFF
--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -58,11 +58,6 @@ class Video360Viewer extends DashViewer {
         // Call super() to set up common layout
         super.setup();
 
-        // 360 videos do not support v2 video player yet, so remove the v2 classes
-        this.isVideoPlayerV2 = false;
-        this.wrapperEl.classList.remove('bp-media--v2');
-        this.mediaContainerEl.classList.remove('bp-media-container--v2');
-
         this.destroyed = false;
 
         // Hide video element

--- a/src/lib/viewers/box3d/video360/Video360Viewer.js
+++ b/src/lib/viewers/box3d/video360/Video360Viewer.js
@@ -45,6 +45,11 @@ class Video360Viewer extends DashViewer {
     }
 
     /** @inheritdoc */
+    supportsVideoPlayerV2() {
+        return false;
+    }
+
+    /** @inheritdoc */
     setup() {
         if (this.isSetup) {
             return;

--- a/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
+++ b/src/lib/viewers/box3d/video360/__tests__/Video360Viewer-test.js
@@ -68,6 +68,7 @@ describe('lib/viewers/box3d/video360/Video360Viewer', () => {
             viewer.isSetup = false;
             viewer.setup();
             expect(viewer.isVideoPlayerV2).toBe(false);
+            expect(viewer.mediaStageEl).toBeUndefined();
             expect(viewer.wrapperEl).not.toHaveClass('bp-media--v2');
             expect(viewer.mediaContainerEl).not.toHaveClass('bp-media-container--v2');
         });

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -174,7 +174,7 @@ class DashViewer extends VideoBaseViewer {
             this.showPreload();
             return Promise.resolve();
         }
-        if (!this.preloader?.wrapperEl) this.showPreload();
+        if (!this.preloader?.wrapperEl && !this.preloader?.showPreloadPromise) this.showPreload();
         this.mediaUrl = this.options.representation.content.url_template;
         this.watermarkCacheBust = Date.now();
 

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -112,8 +112,6 @@ class DashViewer extends VideoBaseViewer {
 
         // dash specific class
         this.wrapperEl.classList.add(CSS_CLASS_DASH);
-
-        this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled');
     }
 
     /**

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import {
-    CLASS_INVISIBLE,
     AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES,
     MEDIA_STATIC_ASSETS_VERSION,
     PRELOAD_REP_NAME,
@@ -870,11 +869,7 @@ class DashViewer extends VideoBaseViewer {
             return;
         }
 
-        if (!this.preloader?.wrapperEl) {
-            this.mediaEl.classList.remove(CLASS_INVISIBLE);
-        }
-        // Stop a late Instant Preview JPG from painting over the ready video.
-        this.preloader?.blockFuturePosterPaint();
+        this.syncInstantPreviewWithLoadedVideo();
         this.calculateVideoDimensions();
         if (this.useReactControls()) {
             this.loadUIReact();

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -873,6 +873,8 @@ class DashViewer extends VideoBaseViewer {
         if (!this.preloader?.wrapperEl) {
             this.mediaEl.classList.remove(CLASS_INVISIBLE);
         }
+        // Stop a late Instant Preview JPG from painting over the ready video.
+        this.preloader?.blockFuturePosterPaint();
         this.calculateVideoDimensions();
         if (this.useReactControls()) {
             this.loadUIReact();

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -64,6 +64,8 @@ class MP4Viewer extends VideoBaseViewer {
         if (!this.preloader?.wrapperEl) {
             this.mediaEl.classList.remove(CLASS_INVISIBLE);
         }
+        // Stop a late Instant Preview JPG from painting over the ready video.
+        this.preloader?.blockFuturePosterPaint();
         if (this.useReactControls()) {
             this.loadUIReact();
         } else {

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CLASS_INVISIBLE, DEFAULT_VIDEO_FPS, PRELOAD_REP_NAME } from '../../constants';
+import { DEFAULT_VIDEO_FPS, PRELOAD_REP_NAME } from '../../constants';
 import { VIEWER_EVENT } from '../../events';
 import VideoBaseViewer from './VideoBaseViewer';
 import VideoControls from './VideoControls';
@@ -61,11 +61,7 @@ class MP4Viewer extends VideoBaseViewer {
             return;
         }
 
-        if (!this.preloader?.wrapperEl) {
-            this.mediaEl.classList.remove(CLASS_INVISIBLE);
-        }
-        // Stop a late Instant Preview JPG from painting over the ready video.
-        this.preloader?.blockFuturePosterPaint();
+        this.syncInstantPreviewWithLoadedVideo();
         if (this.useReactControls()) {
             this.loadUIReact();
         } else {

--- a/src/lib/viewers/media/MP4Viewer.js
+++ b/src/lib/viewers/media/MP4Viewer.js
@@ -20,8 +20,6 @@ class MP4Viewer extends VideoBaseViewer {
         // Call super() first to set up common layout
         super.setup();
 
-        this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled');
-
         // mp4 specific class
         this.wrapperEl.classList.add(CSS_CLASS_MP4);
         this.wrapperEl.classList.add('bp-media-dash');

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -190,6 +190,9 @@ class VideoBaseViewer extends MediaBaseViewer {
         const options = {
             onImageClick: () => this.handlePlayRequest(),
         };
+        if (this.featureEnabled('videoPlayerV2.enabled')) {
+            options.sizeWrapperToViewport = true;
+        }
         if (this.wrapperEl) {
             const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             options.viewport = {

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -150,14 +150,23 @@ class VideoBaseViewer extends MediaBaseViewer {
     /**
      * Dismisses the preload thumbnail if it is currently visible. Safe to call
      * multiple times — hidePreload() guards on wrapperEl internally.
+     * Always reveals the video: the poster wrapper may already be gone after fade/cleanup
+     * while mediaEl is still bp-is-invisible from showPreload().
      *
      * @private
      * @return {void}
      */
     dismissPreload() {
-        if (this.preloader?.wrapperEl) {
+        const hadPoster = Boolean(this.preloader?.wrapperEl);
+        this.preloader?.blockFuturePosterPaint();
+        if (hadPoster) {
             this.hidePreload();
+        }
+        if (this.mediaEl) {
             this.mediaEl.classList.remove(CLASS_INVISIBLE);
+        }
+        // Avoid extra resize on no-op calls (e.g. play with no Instant Preview).
+        if (hadPoster) {
             this.resize();
         }
     }
@@ -380,6 +389,9 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     loadeddataHandler() {
         super.loadeddataHandler();
+
+        // Stop a late Instant Preview JPG from painting over the ready video.
+        this.preloader?.blockFuturePosterPaint();
 
         if (!this.preloader?.wrapperEl) {
             this.mediaEl.classList.remove(CLASS_INVISIBLE);

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -81,13 +81,16 @@ class VideoBaseViewer extends MediaBaseViewer {
         super.setup();
 
         this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled') && this.supportsVideoPlayerV2();
+        this.isVideoPosterEarlyPaint = this.isVideoPlayerV2 && this.featureEnabled('videoPosterEarlyPaint.enabled');
         if (this.isVideoPlayerV2) {
-            this.mediaStageEl = document.createElement('div');
-            this.mediaStageEl.classList.add('bp-media-stage--v2');
-            this.wrapperEl.insertBefore(this.mediaStageEl, this.mediaContainerEl);
-            this.mediaStageEl.appendChild(this.mediaContainerEl);
             this.wrapperEl.classList.add('bp-media--v2');
             this.mediaContainerEl.classList.add('bp-media-container--v2');
+            if (this.isVideoPosterEarlyPaint) {
+                this.mediaStageEl = document.createElement('div');
+                this.mediaStageEl.classList.add('bp-media-stage--v2');
+                this.wrapperEl.insertBefore(this.mediaStageEl, this.mediaContainerEl);
+                this.mediaStageEl.appendChild(this.mediaContainerEl);
+            }
         }
 
         this.videoAnnotationsEnabled = this.featureEnabled(VIDEO_ANNOTATIONS_ENABLED);
@@ -208,10 +211,11 @@ class VideoBaseViewer extends MediaBaseViewer {
         const options = {
             onImageClick: () => this.handlePlayRequest(),
         };
-        if (this.isVideoPlayerV2) {
+        if (this.isVideoPosterEarlyPaint) {
             // Resolve viewport at paint time so sidebar/layout changes after showPreload
             // don't leave the poster sized to a stale, oversized box.
             options.getViewport = () => this.getVideoViewport();
+            options.earlyPaint = true;
         } else if (this.wrapperEl) {
             const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             options.viewport = {
@@ -566,7 +570,7 @@ class VideoBaseViewer extends MediaBaseViewer {
         // Reset any prior set widths and heights
         // V1 only modifies widths: Chrome can't set a height larger than the current videoHeight
         this.mediaEl.style.width = '';
-        if (this.isVideoPlayerV2) {
+        if (this.isVideoPosterEarlyPaint) {
             this.mediaEl.style.height = '';
         }
         if (this.mediaContainerEl) {
@@ -644,16 +648,16 @@ class VideoBaseViewer extends MediaBaseViewer {
         let width = this.videoWidth || 0;
         let height = this.videoHeight || 0;
         const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
-        const viewport = this.isVideoPlayerV2
+        const viewport = this.isVideoPosterEarlyPaint
             ? this.getVideoViewport()
             : {
                   height: this.wrapperEl.clientHeight - controlsHeight,
                   width: this.wrapperEl.clientWidth,
               };
 
-        // V2: one contain-fit into the stage for poster and video so Instant Preview
+        // Early-paint V2: one contain-fit into the stage for poster and video so Instant Preview
         // and playback share the same frame (V2 controls overlay and do not change the stage).
-        if (this.isVideoPlayerV2) {
+        if (this.isVideoPosterEarlyPaint) {
             if (this.preloader?.isVisible()) {
                 this.preloader.sizeContainerToViewport(viewport);
                 this.mediaEl.style.width = this.mediaContainerEl.style.width;
@@ -706,6 +710,21 @@ class VideoBaseViewer extends MediaBaseViewer {
 
         if (this.mediaContainerEl && this.mediaEl.style.width) {
             this.mediaContainerEl.style.width = this.mediaEl.style.width;
+        }
+
+        // Legacy V2: let the padded container fill the stage; size Instant Preview to the video box.
+        if (this.isVideoPlayerV2) {
+            this.mediaContainerEl.style.width = '';
+
+            if (this.preloader?.wrapperEl && this.mediaEl.style.width) {
+                const videoWidth = parseInt(this.mediaEl.style.width, 10);
+                const videoHeight = videoWidth / this.aspect;
+                this.preloader.wrapperEl.style.width = `${videoWidth}px`;
+                this.preloader.wrapperEl.style.height = `${videoHeight}px`;
+                this.preloader.wrapperEl.style.left = '50%';
+                this.preloader.wrapperEl.style.top = '50%';
+                this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
+            }
         }
     }
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -355,7 +355,12 @@ class VideoBaseViewer extends MediaBaseViewer {
     destroy() {
         if (this.preloadBlobUrl) {
             URL.revokeObjectURL(this.preloadBlobUrl);
+            this.preloadBlobUrl = undefined;
         }
+
+        // Stop in-flight Instant Preview from painting after navigate-away, and drop any poster DOM.
+        this.preloader?.blockFuturePosterPaint?.();
+        this.preloader?.cleanupPreload?.();
 
         if (this.mediaEl) {
             this.mediaEl.removeEventListener('mousemove', this.mousemoveHandler);
@@ -382,6 +387,20 @@ class VideoBaseViewer extends MediaBaseViewer {
     }
 
     /**
+     * Once the video has data: stop late Instant Preview painting, and reveal the
+     * video element when no poster wrapper is covering it.
+     *
+     * @protected
+     * @return {void}
+     */
+    syncInstantPreviewWithLoadedVideo() {
+        this.preloader?.blockFuturePosterPaint?.();
+        if (this.mediaEl && !this.preloader?.wrapperEl) {
+            this.mediaEl.classList.remove(CLASS_INVISIBLE);
+        }
+    }
+
+    /**
      * Handler for meta data load for the media element.
      *
      * @override
@@ -390,12 +409,7 @@ class VideoBaseViewer extends MediaBaseViewer {
     loadeddataHandler() {
         super.loadeddataHandler();
 
-        // Stop a late Instant Preview JPG from painting over the ready video.
-        this.preloader?.blockFuturePosterPaint();
-
-        if (!this.preloader?.wrapperEl) {
-            this.mediaEl.classList.remove(CLASS_INVISIBLE);
-        }
+        this.syncInstantPreviewWithLoadedVideo();
         this.showPlayButton();
 
         if (this.userRequestedPlay) {

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -561,6 +561,7 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     resize() {
         // Reset any prior set widths and heights
+        // V1 only modifies widths: Chrome can't set a height larger than the current videoHeight
         this.mediaEl.style.width = '';
         if (this.isVideoPlayerV2) {
             this.mediaEl.style.height = '';
@@ -596,8 +597,9 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     getVideoViewport() {
         if (!this.mediaStageEl) {
+            const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             return {
-                height: this.wrapperEl.clientHeight,
+                height: this.wrapperEl.clientHeight - controlsHeight,
                 width: this.wrapperEl.clientWidth,
             };
         }

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -19,6 +19,7 @@ import { ICON_PLAY_LARGE, ICON_FORWARD, ICON_BACKWARD } from '../../icons';
 import ControlsRoot from '../controls';
 import MediaBaseViewer from './MediaBaseViewer';
 import VideoPreloader from './VideoPreloader';
+import fitFrameToViewport from './fitFrameToViewport';
 import { isWatermarked, getRepresentation } from '../../file';
 
 const MOUSE_MOVE_TIMEOUT_IN_MILLIS = 1000;
@@ -208,7 +209,9 @@ class VideoBaseViewer extends MediaBaseViewer {
             onImageClick: () => this.handlePlayRequest(),
         };
         if (this.isVideoPlayerV2) {
-            options.viewport = this.getVideoViewport();
+            // Resolve viewport at paint time so sidebar/layout changes after showPreload
+            // don't leave the poster sized to a stale, oversized box.
+            options.getViewport = () => this.getVideoViewport();
         } else if (this.wrapperEl) {
             const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             options.viewport = {
@@ -587,20 +590,20 @@ class VideoBaseViewer extends MediaBaseViewer {
     }
 
     /**
-     * Returns the usable V2 stage dimensions inside its padding.
+     * Returns the usable V2 stage content box (inside padding).
      *
-     * Before React controls mount, reserve their height so poster geometry
-     * matches the stage dimensions after metadata loads.
+     * Prefer the stage element's box over the wrapper: the stage is what actually
+     * clips/centers the shared media frame. V2 controls are position:absolute overlays
+     * and do not consume flex space, so do not reserve control-bar height here.
      *
      * @private
      * @return {Object} viewport width and height
      */
     getVideoViewport() {
         if (!this.mediaStageEl) {
-            const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             return {
-                height: this.wrapperEl.clientHeight - controlsHeight,
-                width: this.wrapperEl.clientWidth,
+                height: Math.max(0, this.wrapperEl.clientHeight),
+                width: Math.max(0, this.wrapperEl.clientWidth),
             };
         }
 
@@ -608,12 +611,26 @@ class VideoBaseViewer extends MediaBaseViewer {
         const horizontalPadding =
             (parseFloat(stageStyle.paddingLeft) || 0) + (parseFloat(stageStyle.paddingRight) || 0);
         const verticalPadding = (parseFloat(stageStyle.paddingTop) || 0) + (parseFloat(stageStyle.paddingBottom) || 0);
-        const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
 
         return {
-            height: Math.max(0, this.wrapperEl.clientHeight - verticalPadding - controlsHeight),
-            width: Math.max(0, this.wrapperEl.clientWidth - horizontalPadding),
+            width: Math.max(0, this.mediaStageEl.clientWidth - horizontalPadding),
+            height: Math.max(0, this.mediaStageEl.clientHeight - verticalPadding),
         };
+    }
+
+    /**
+     * Applies width/height to the shared V2 media frame (container + video element).
+     *
+     * @private
+     * @param {number} width
+     * @param {number} height
+     * @return {void}
+     */
+    applySharedMediaFrame(width, height) {
+        this.mediaEl.style.width = `${width}px`;
+        this.mediaEl.style.height = `${height}px`;
+        this.mediaContainerEl.style.width = `${width}px`;
+        this.mediaContainerEl.style.height = `${height}px`;
     }
 
     /**
@@ -634,10 +651,19 @@ class VideoBaseViewer extends MediaBaseViewer {
                   width: this.wrapperEl.clientWidth,
               };
 
-        if (this.isVideoPlayerV2 && this.preloader?.isVisible()) {
-            this.preloader.sizeContainerToViewport(viewport);
-            this.mediaEl.style.width = this.mediaContainerEl.style.width;
-            this.mediaEl.style.height = this.mediaContainerEl.style.height;
+        // V2: one contain-fit into the stage for poster and video so Instant Preview
+        // and playback share the same frame (V2 controls overlay and do not change the stage).
+        if (this.isVideoPlayerV2) {
+            if (this.preloader?.isVisible()) {
+                this.preloader.sizeContainerToViewport(viewport);
+                this.mediaEl.style.width = this.mediaContainerEl.style.width;
+                this.mediaEl.style.height = this.mediaContainerEl.style.height;
+                return;
+            }
+
+            const aspectRatio = this.aspect || width / (height || 1) || 1;
+            const frame = fitFrameToViewport(aspectRatio, viewport);
+            this.applySharedMediaFrame(frame.width, frame.height);
             return;
         }
 
@@ -680,13 +706,6 @@ class VideoBaseViewer extends MediaBaseViewer {
 
         if (this.mediaContainerEl && this.mediaEl.style.width) {
             this.mediaContainerEl.style.width = this.mediaEl.style.width;
-        }
-
-        if (this.isVideoPlayerV2 && this.mediaEl.style.width) {
-            const videoWidth = parseFloat(this.mediaEl.style.width);
-            const videoHeight = videoWidth / this.aspect;
-            this.mediaEl.style.height = `${videoHeight}px`;
-            this.mediaContainerEl.style.height = `${videoHeight}px`;
         }
     }
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -158,13 +158,11 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     dismissPreload() {
         const hadPoster = Boolean(this.preloader?.wrapperEl);
-        this.preloader?.blockFuturePosterPaint();
+        this.preloader?.blockFuturePosterPaint?.();
         if (hadPoster) {
             this.hidePreload();
         }
-        if (this.mediaEl) {
-            this.mediaEl.classList.remove(CLASS_INVISIBLE);
-        }
+        this.mediaEl?.classList.remove(CLASS_INVISIBLE);
         // Avoid extra resize on no-op calls (e.g. play with no Instant Preview).
         if (hadPoster) {
             this.resize();
@@ -177,9 +175,7 @@ class VideoBaseViewer extends MediaBaseViewer {
      * @return {void}
      */
     handlePlayRequest() {
-        if (this.preloader) {
-            this.preloader.showLoading();
-        }
+        this.preloader?.showLoading();
         this.userRequestedPlay = true;
         this.togglePlay();
     }
@@ -257,9 +253,7 @@ class VideoBaseViewer extends MediaBaseViewer {
      * @return {void}
      */
     hidePreload() {
-        if (this.preloader) {
-            this.preloader.hidePreload();
-        }
+        this.preloader?.hidePreload();
     }
 
     /**
@@ -395,8 +389,8 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     syncInstantPreviewWithLoadedVideo() {
         this.preloader?.blockFuturePosterPaint?.();
-        if (this.mediaEl && !this.preloader?.wrapperEl) {
-            this.mediaEl.classList.remove(CLASS_INVISIBLE);
+        if (!this.preloader?.wrapperEl) {
+            this.mediaEl?.classList.remove(CLASS_INVISIBLE);
         }
     }
 

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -38,6 +38,9 @@ class VideoBaseViewer extends MediaBaseViewer {
     /** @property {VideoPreloader} - Video preloader instance */
     preloader;
 
+    /** @property {HTMLElement} - Full-size padded stage around the shared V2 media frame */
+    mediaStageEl;
+
     /**
      * @inheritdoc
      */
@@ -76,6 +79,16 @@ class VideoBaseViewer extends MediaBaseViewer {
         // Call super() to set up common layout
         super.setup();
 
+        this.isVideoPlayerV2 = this.featureEnabled('videoPlayerV2.enabled') && this.supportsVideoPlayerV2();
+        if (this.isVideoPlayerV2) {
+            this.mediaStageEl = document.createElement('div');
+            this.mediaStageEl.classList.add('bp-media-stage--v2');
+            this.wrapperEl.insertBefore(this.mediaStageEl, this.mediaContainerEl);
+            this.mediaStageEl.appendChild(this.mediaContainerEl);
+            this.wrapperEl.classList.add('bp-media--v2');
+            this.mediaContainerEl.classList.add('bp-media-container--v2');
+        }
+
         this.videoAnnotationsEnabled = this.featureEnabled(VIDEO_ANNOTATIONS_ENABLED);
 
         this.isNarrowVideo = false;
@@ -100,17 +113,21 @@ class VideoBaseViewer extends MediaBaseViewer {
         this.bufferingSpinnerEl = this.mediaContainerEl.appendChild(document.createElement('div'));
         this.bufferingSpinnerEl.classList.add('bp-media-buffering-spinner');
         this.bufferingSpinnerEl.classList.add(CLASS_HIDDEN);
-        if (this.useReactControls() && !this.featureEnabled('videoPlayerV2.enabled')) {
+        if (this.useReactControls() && !this.isVideoPlayerV2) {
             // Shift up by half the control bar + half the spinner to visually center above the controls
             this.bufferingSpinnerEl.style.marginTop = `-${VIDEO_PLAYER_CONTROL_BAR_HEIGHT / 2 + SPINNER_HALF_SIZE}px`;
         }
 
-        if (this.featureEnabled('videoPlayerV2.enabled')) {
-            this.wrapperEl.classList.add('bp-media--v2');
-            this.mediaContainerEl.classList.add('bp-media-container--v2');
-        }
-
         this.lowerLights();
+    }
+
+    /**
+     * Whether this viewer supports the V2 video player structure.
+     *
+     * @return {boolean} true when V2 is supported
+     */
+    supportsVideoPlayerV2() {
+        return true;
     }
 
     /**
@@ -190,10 +207,9 @@ class VideoBaseViewer extends MediaBaseViewer {
         const options = {
             onImageClick: () => this.handlePlayRequest(),
         };
-        if (this.featureEnabled('videoPlayerV2.enabled')) {
-            options.sizeWrapperToViewport = true;
-        }
-        if (this.wrapperEl) {
+        if (this.isVideoPlayerV2) {
+            options.viewport = this.getVideoViewport();
+        } else if (this.wrapperEl) {
             const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
             options.viewport = {
                 width: this.wrapperEl.clientWidth,
@@ -398,9 +414,7 @@ class VideoBaseViewer extends MediaBaseViewer {
 
         // For the V2 player, mount the controls on the wrapper (above the media container)
         // so their width is constrained by the viewport rather than the video
-        const controlsContainerEl = this.featureEnabled('videoPlayerV2.enabled')
-            ? this.wrapperEl
-            : this.mediaContainerEl;
+        const controlsContainerEl = this.isVideoPlayerV2 ? this.wrapperEl : this.mediaContainerEl;
 
         this.controls = new ControlsRoot({
             className: 'bp-VideoControlsRoot',
@@ -547,10 +561,10 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     resize() {
         // Reset any prior set widths and heights
-        // We are only going to modify the widths and not heights
-        // This is because in Chrome its not possible to set a height
-        // that larger than the current videoHeight.
         this.mediaEl.style.width = '';
+        if (this.isVideoPlayerV2) {
+            this.mediaEl.style.height = '';
+        }
         if (this.mediaContainerEl) {
             this.mediaContainerEl.style.width = '';
             this.mediaContainerEl.style.height = '';
@@ -572,6 +586,35 @@ class VideoBaseViewer extends MediaBaseViewer {
     }
 
     /**
+     * Returns the usable V2 stage dimensions inside its padding.
+     *
+     * Before React controls mount, reserve their height so poster geometry
+     * matches the stage dimensions after metadata loads.
+     *
+     * @private
+     * @return {Object} viewport width and height
+     */
+    getVideoViewport() {
+        if (!this.mediaStageEl) {
+            return {
+                height: this.wrapperEl.clientHeight,
+                width: this.wrapperEl.clientWidth,
+            };
+        }
+
+        const stageStyle = window.getComputedStyle(this.mediaStageEl);
+        const horizontalPadding =
+            (parseFloat(stageStyle.paddingLeft) || 0) + (parseFloat(stageStyle.paddingRight) || 0);
+        const verticalPadding = (parseFloat(stageStyle.paddingTop) || 0) + (parseFloat(stageStyle.paddingBottom) || 0);
+        const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
+
+        return {
+            height: Math.max(0, this.wrapperEl.clientHeight - verticalPadding - controlsHeight),
+            width: Math.max(0, this.wrapperEl.clientWidth - horizontalPadding),
+        };
+    }
+
+    /**
      * Calculates and applies video dimensions based on viewport constraints.
      * Handles three cases: video fits in viewport, fullscreen mode, or overflow.
      *
@@ -582,14 +625,19 @@ class VideoBaseViewer extends MediaBaseViewer {
         let width = this.videoWidth || 0;
         let height = this.videoHeight || 0;
         const controlsHeight = this.useReactControls() ? VIDEO_PLAYER_CONTROL_BAR_HEIGHT : 0;
+        const viewport = this.isVideoPlayerV2
+            ? this.getVideoViewport()
+            : {
+                  height: this.wrapperEl.clientHeight - controlsHeight,
+                  width: this.wrapperEl.clientWidth,
+              };
 
-        // Calculate the viewport height minus the control bar height if using react controls
-        // This is necessary to prevent the control bar from overflowing the viewport when the video scale
-        // is expanded.
-        const viewport = {
-            height: this.wrapperEl.clientHeight - controlsHeight,
-            width: this.wrapperEl.clientWidth,
-        };
+        if (this.isVideoPlayerV2 && this.preloader?.isVisible()) {
+            this.preloader.sizeContainerToViewport(viewport);
+            this.mediaEl.style.width = this.mediaContainerEl.style.width;
+            this.mediaEl.style.height = this.mediaContainerEl.style.height;
+            return;
+        }
 
         // We need the width to be atleast wide enough for the controls
         // to not overflow and fit properly
@@ -632,18 +680,11 @@ class VideoBaseViewer extends MediaBaseViewer {
             this.mediaContainerEl.style.width = this.mediaEl.style.width;
         }
 
-        if (this.featureEnabled('videoPlayerV2.enabled')) {
-            this.mediaContainerEl.style.width = '';
-
-            if (this.preloader?.wrapperEl && this.mediaEl.style.width) {
-                const videoWidth = parseInt(this.mediaEl.style.width, 10);
-                const videoHeight = videoWidth / this.aspect;
-                this.preloader.wrapperEl.style.width = `${videoWidth}px`;
-                this.preloader.wrapperEl.style.height = `${videoHeight}px`;
-                this.preloader.wrapperEl.style.left = '50%';
-                this.preloader.wrapperEl.style.top = '50%';
-                this.preloader.wrapperEl.style.transform = 'translate(-50%, -50%)';
-            }
+        if (this.isVideoPlayerV2 && this.mediaEl.style.width) {
+            const videoWidth = parseFloat(this.mediaEl.style.width);
+            const videoHeight = videoWidth / this.aspect;
+            this.mediaEl.style.height = `${videoHeight}px`;
+            this.mediaContainerEl.style.height = `${videoHeight}px`;
         }
     }
 
@@ -656,7 +697,7 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     handleNarrowVideoUI() {
         if (this.useReactControls()) {
-            const widthNumber = this.featureEnabled('videoPlayerV2.enabled')
+            const widthNumber = this.isVideoPlayerV2
                 ? this.wrapperEl.clientWidth
                 : parseInt(this.mediaEl.style.width, 10);
 

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -65,7 +65,6 @@ class VideoPreloader extends EventEmitter {
      * @param {HTMLElement} containerEl - Container element to append preload to
      * @param {Object} [options] - Optional options
      * @param {Object} [options.viewport] - { width, height } to use for sizing (same as video viewport to avoid jump)
-     * @param {boolean} [options.sizeWrapperToViewport] - Whether to size the wrapper instead of the container
      * @param {Function} [options.onImageClick] - Called when user clicks the preload image
      * @return {Promise} Promise to show preload
      */
@@ -121,10 +120,7 @@ class VideoPreloader extends EventEmitter {
             return;
         }
 
-        // V1 sizes the media container, so restore its natural flexbox sizing.
-        // V2 sizes the wrapper, which is removed during cleanup and must retain
-        // its dimensions while the fade-out transition runs.
-        if (this.containerEl && !this.preloadOptions?.sizeWrapperToViewport) {
+        if (this.containerEl) {
             this.containerEl.style.width = '';
             this.containerEl.style.height = '';
         }
@@ -202,6 +198,15 @@ class VideoPreloader extends EventEmitter {
     }
 
     /**
+     * Whether the poster image is currently visible.
+     *
+     * @return {boolean} true when the poster has painted
+     */
+    isVisible() {
+        return !!this.preloadEl && !this.preloadEl.classList.contains(CLASS_INVISIBLE);
+    }
+
+    /**
      * Cleans up preload DOM.
      *
      * @private
@@ -266,20 +271,16 @@ class VideoPreloader extends EventEmitter {
             return;
         }
 
-        const shouldSizeWrapper = this.preloadOptions?.sizeWrapperToViewport;
-        const sizingTarget = shouldSizeWrapper ? this.wrapperEl : this.containerEl;
-        const hasVideoGeometry = shouldSizeWrapper && sizingTarget?.style.width && sizingTarget?.style.height;
-        if (!hasVideoGeometry) {
-            this.sizeContainerToViewport(this.preloadOptions?.viewport, sizingTarget);
+        if (this.checkVideoLoaded()) {
+            return;
         }
 
+        this.sizeContainerToViewport(this.preloadOptions?.viewport);
         this.preloadEl.classList.remove(CLASS_INVISIBLE);
 
-        if (this.containerEl && this.containerEl.parentNode) {
-            const mediaWrapper = this.containerEl.parentNode;
-            if (mediaWrapper && mediaWrapper.classList && mediaWrapper.classList.contains('bp-media')) {
-                mediaWrapper.classList.add(CLASS_IS_VISIBLE);
-            }
+        const mediaWrapper = this.containerEl?.closest('.bp-media');
+        if (mediaWrapper) {
+            mediaWrapper.classList.add(CLASS_IS_VISIBLE);
         }
 
         const onImageClick = this.preloadOptions?.onImageClick;
@@ -301,11 +302,10 @@ class VideoPreloader extends EventEmitter {
      * This prevents the thumbnail from appearing small and then jumping to the correct size.
      *
      * @param {Object} [viewportOverride] - Optional { width, height }; when provided, use instead of walking DOM (same as video viewport)
-     * @param {HTMLElement} [targetEl] - Element to size; defaults to the media container
      * @return {void}
      */
-    sizeContainerToViewport(viewportOverride, targetEl = this.containerEl) {
-        if (!this.containerEl || !this.imageEl || !targetEl) {
+    sizeContainerToViewport(viewportOverride) {
+        if (!this.containerEl || !this.imageEl) {
             return;
         }
 
@@ -342,16 +342,6 @@ class VideoPreloader extends EventEmitter {
             };
         }
 
-        if (targetEl === this.wrapperEl) {
-            const containerStyle = window.getComputedStyle(this.containerEl);
-            const horizontalPadding =
-                (parseFloat(containerStyle.paddingLeft) || 0) + (parseFloat(containerStyle.paddingRight) || 0);
-            const verticalPadding =
-                (parseFloat(containerStyle.paddingTop) || 0) + (parseFloat(containerStyle.paddingBottom) || 0);
-            viewport.width = Math.max(0, viewport.width - horizontalPadding);
-            viewport.height = Math.max(0, viewport.height - verticalPadding);
-        }
-
         // Apply minimum width to match video sizing logic
         // This ensures controls don't overflow
         const containerWidth = Math.max(MIN_VIDEO_WIDTH_PX, viewport.width);
@@ -378,14 +368,8 @@ class VideoPreloader extends EventEmitter {
             }
         }
 
-        targetEl.style.width = `${finalWidth}px`;
-        targetEl.style.height = `${containerHeight}px`;
-
-        if (targetEl === this.wrapperEl) {
-            targetEl.style.left = '50%';
-            targetEl.style.top = '50%';
-            targetEl.style.transform = 'translate(-50%, -50%)';
-        }
+        this.containerEl.style.width = `${finalWidth}px`;
+        this.containerEl.style.height = `${containerHeight}px`;
     }
 
     /**

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -482,13 +482,9 @@ class VideoPreloader extends EventEmitter {
             this.cleanupPreload();
         }
 
-        const videoEl = this.containerEl && this.containerEl.querySelector('video');
-        if (videoEl) {
-            videoEl.classList.remove(CLASS_INVISIBLE);
-        }
+        this.containerEl?.querySelector('video')?.classList.remove(CLASS_INVISIBLE);
 
         return true;
     }
 }
-
 export default VideoPreloader;

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -43,6 +43,9 @@ class VideoPreloader extends EventEmitter {
     /** @property {HTMLElement} - Preload wrapper element */
     wrapperEl;
 
+    /** @property {boolean} - When true, never create/paint a new Instant Preview poster */
+    blockPosterPaint = false;
+
     /**
      * [constructor]
      *
@@ -59,6 +62,17 @@ class VideoPreloader extends EventEmitter {
     }
 
     /**
+     * Stop any in-flight or future poster from painting. Used once the video is ready
+     * (or playback has dismissed Instant Preview) so a late JPG cannot overlay the video.
+     * Does not hide an Instant Preview that is already painted — play still dismisses that.
+     *
+     * @return {void}
+     */
+    blockFuturePosterPaint() {
+        this.blockPosterPaint = true;
+    }
+
+    /**
      * Shows a preload of the video by showing a thumbnail image. This should be called
      * while the full video loads to give the user visual feedback on the file as soon as possible.
      *
@@ -72,6 +86,10 @@ class VideoPreloader extends EventEmitter {
     showPreload(preloadUrlWithAuth, containerEl, options = {}) {
         this.containerEl = containerEl;
         this.preloadOptions = options;
+
+        if (this.shouldAbortPosterPaint()) {
+            return Promise.resolve();
+        }
 
         return this.api
             .get(preloadUrlWithAuth, { type: 'blob' })
@@ -93,6 +111,11 @@ class VideoPreloader extends EventEmitter {
                     </div>
                 </div>
             `.trim();
+
+                // Video may have become ready while we built the DOM — do not attach an unpainted poster.
+                if (this.checkVideoLoaded()) {
+                    return;
+                }
 
                 this.containerEl.appendChild(this.wrapperEl);
                 this.placeholderEl = this.wrapperEl.querySelector(`.${CLASS_BOX_PREVIEW_PRELOAD_PLACEHOLDER}`);
@@ -405,22 +428,66 @@ class VideoPreloader extends EventEmitter {
     };
 
     /**
-     * Check if video is already loaded - if so, hide the preload.
+     * Whether Instant Preview should stop creating/painting a poster.
+     * True once the viewer marks the video ready, while playing, or once metadata exists.
      *
      * @private
-     * @return {boolean} Whether video is already loaded
+     * @return {boolean}
      */
-    checkVideoLoaded() {
-        // If video element exists and has loaded metadata, hide the preload
-        if (this.containerEl) {
-            const videoEl = this.containerEl.querySelector('video');
-            if (videoEl && videoEl.readyState >= 1) {
-                this.hidePreload();
-                return true;
-            }
+    shouldAbortPosterPaint() {
+        if (this.blockPosterPaint) {
+            return true;
         }
 
-        return false;
+        if (!this.containerEl) {
+            return false;
+        }
+
+        const videoEl = this.containerEl.querySelector('video');
+        if (!videoEl) {
+            return false;
+        }
+
+        // Playing: never let a late poster land on top of playback.
+        if (videoEl.paused === false) {
+            return true;
+        }
+
+        // Metadata available: same gate Instant Preview has always used.
+        return videoEl.readyState >= 1;
+    }
+
+    /**
+     * Check if video is already loaded / poster paint should be aborted.
+     * Unpainted poster DOM is removed immediately; an already-visible Instant Preview is left
+     * for dismiss-on-play. Reveals the video when tearing down an unpainted poster.
+     *
+     * @private
+     * @return {boolean} Whether poster create/paint should abort
+     */
+    checkVideoLoaded() {
+        if (!this.shouldAbortPosterPaint()) {
+            return false;
+        }
+
+        const painted = this.wrapperEl && this.preloadEl && !this.preloadEl.classList.contains(CLASS_INVISIBLE);
+
+        if (painted) {
+            // Instant Preview is already up — play/dismiss owns hiding it.
+            return true;
+        }
+
+        // Never painted (or no DOM): drop it and make sure the video can show.
+        if (this.wrapperEl) {
+            this.cleanupPreload();
+        }
+
+        const videoEl = this.containerEl && this.containerEl.querySelector('video');
+        if (videoEl) {
+            videoEl.classList.remove(CLASS_INVISIBLE);
+        }
+
+        return true;
     }
 }
 

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -11,11 +11,11 @@ import {
     CLASS_INVISIBLE,
     CLASS_IS_TRANSPARENT,
     CLASS_IS_VISIBLE,
-    MIN_VIDEO_WIDTH_PX,
     VIDEO_PLAYER_CONTROL_BAR_HEIGHT,
 } from '../../constants';
 import { ICON_PLAY_LARGE } from '../../icons';
 import { handleRepresentationBlobFetch } from '../../util';
+import fitFrameToViewport from './fitFrameToViewport';
 
 class VideoPreloader extends EventEmitter {
     /** @property {Api} - Api layer used for XHR calls */
@@ -198,12 +198,18 @@ class VideoPreloader extends EventEmitter {
     }
 
     /**
-     * Whether the poster image is currently visible.
+     * Whether the poster is still the authoritative painted frame.
+     * False once hide/dismiss starts (transparent fade) so resize uses video geometry.
      *
-     * @return {boolean} true when the poster has painted
+     * @return {boolean} true when the poster has painted and is not dismissing
      */
     isVisible() {
-        return !!this.preloadEl && !this.preloadEl.classList.contains(CLASS_INVISIBLE);
+        return (
+            !!this.preloadEl &&
+            !!this.wrapperEl &&
+            !this.preloadEl.classList.contains(CLASS_INVISIBLE) &&
+            !this.wrapperEl.classList.contains(CLASS_IS_TRANSPARENT)
+        );
     }
 
     /**
@@ -275,7 +281,7 @@ class VideoPreloader extends EventEmitter {
             return;
         }
 
-        this.sizeContainerToViewport(this.preloadOptions?.viewport);
+        this.sizeContainerToViewport(this.resolveViewport());
         this.preloadEl.classList.remove(CLASS_INVISIBLE);
 
         const mediaWrapper = this.containerEl?.closest('.bp-media');
@@ -296,6 +302,21 @@ class VideoPreloader extends EventEmitter {
 
         this.emit('preload');
     };
+
+    /**
+     * Resolves the viewport to size against, preferring a live getter when provided
+     * so layout changes after showPreload() are reflected at paint time.
+     *
+     * @private
+     * @return {Object|undefined} viewport width/height
+     */
+    resolveViewport() {
+        const { getViewport, viewport } = this.preloadOptions || {};
+        if (typeof getViewport === 'function') {
+            return getViewport();
+        }
+        return viewport;
+    }
 
     /**
      * Sizes the target based on viewport dimensions and image aspect ratio to match video player sizing.
@@ -342,34 +363,13 @@ class VideoPreloader extends EventEmitter {
             };
         }
 
-        // Apply minimum width to match video sizing logic
-        // This ensures controls don't overflow
-        const containerWidth = Math.max(MIN_VIDEO_WIDTH_PX, viewport.width);
-
-        // Calculate container height based on image aspect ratio
         // Use natural dimensions if available (image has loaded), otherwise use current dimensions
         const imageWidth = this.imageEl.naturalWidth || this.imageEl.width || 1;
         const imageHeight = this.imageEl.naturalHeight || this.imageEl.height || 1;
-        const aspectRatio = imageWidth / imageHeight;
+        const { width, height } = fitFrameToViewport(imageWidth / imageHeight, viewport);
 
-        // Calculate height based on width and aspect ratio
-        let containerHeight = containerWidth / aspectRatio;
-        let finalWidth = containerWidth;
-
-        // Ensure height doesn't exceed viewport height
-        if (containerHeight > viewport.height) {
-            containerHeight = viewport.height;
-            // If height is constrained, recalculate width to maintain aspect ratio
-            finalWidth = containerHeight * aspectRatio;
-            // Ensure we still meet minimum width requirement
-            if (finalWidth < MIN_VIDEO_WIDTH_PX) {
-                finalWidth = MIN_VIDEO_WIDTH_PX;
-                containerHeight = finalWidth / aspectRatio;
-            }
-        }
-
-        this.containerEl.style.width = `${finalWidth}px`;
-        this.containerEl.style.height = `${containerHeight}px`;
+        this.containerEl.style.width = `${width}px`;
+        this.containerEl.style.height = `${height}px`;
     }
 
     /**

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -46,6 +46,12 @@ class VideoPreloader extends EventEmitter {
     /** @property {boolean} - When true, never create/paint a new Instant Preview poster */
     blockPosterPaint = false;
 
+    /** @property {number} - Monotonic id so overlapping showPreload fetches cannot append orphans */
+    preloadRequestId = 0;
+
+    /** @property {Promise|null} - In-flight showPreload promise (single-flight) */
+    showPreloadPromise = null;
+
     /**
      * [constructor]
      *
@@ -70,6 +76,26 @@ class VideoPreloader extends EventEmitter {
      */
     blockFuturePosterPaint() {
         this.blockPosterPaint = true;
+        // Invalidate in-flight showPreload work so a late fetch cannot append another wrapper.
+        this.preloadRequestId += 1;
+    }
+
+    /**
+     * Removes Instant Preview wrapper nodes in the container that are not the tracked wrapper.
+     * Overlapping showPreload calls can leave orphans that dismiss would otherwise miss.
+     *
+     * @private
+     * @return {void}
+     */
+    removeOrphanPreloadWrappers() {
+        if (!this.containerEl) {
+            return;
+        }
+        this.containerEl.querySelectorAll(`.${this.wrapperClassName}`).forEach(el => {
+            if (el !== this.wrapperEl) {
+                el.remove();
+            }
+        });
     }
 
     /**
@@ -91,19 +117,28 @@ class VideoPreloader extends EventEmitter {
             return Promise.resolve();
         }
 
-        return this.api
+        // load() may call showPreload again before wrapperEl is set (async fetch). Only one
+        // in-flight create is allowed so dismiss cannot leave an orphan wrapper behind.
+        if (this.wrapperEl || this.showPreloadPromise) {
+            return this.showPreloadPromise || Promise.resolve();
+        }
+
+        this.preloadRequestId += 1;
+        const requestId = this.preloadRequestId;
+
+        this.showPreloadPromise = this.api
             .get(preloadUrlWithAuth, { type: 'blob' })
             .then(handleRepresentationBlobFetch)
             .then(imgBlob => {
-                if (this.checkVideoLoaded()) {
+                if (requestId !== this.preloadRequestId || this.checkVideoLoaded()) {
                     return;
                 }
 
                 this.srcUrl = URL.createObjectURL(imgBlob);
 
-                this.wrapperEl = document.createElement('div');
-                this.wrapperEl.className = this.wrapperClassName;
-                this.wrapperEl.innerHTML = `
+                const wrapperEl = document.createElement('div');
+                wrapperEl.className = this.wrapperClassName;
+                wrapperEl.innerHTML = `
                 <div class="${CLASS_BOX_PREVIEW_PRELOAD} ${CLASS_INVISIBLE}">
                     <div class="${CLASS_BOX_PREVIEW_PRELOAD_PLACEHOLDER}">
                         <img class="${CLASS_BOX_PREVIEW_PRELOAD_CONTENT}" src="${this.srcUrl}" />
@@ -113,9 +148,15 @@ class VideoPreloader extends EventEmitter {
             `.trim();
 
                 // Video may have become ready while we built the DOM — do not attach an unpainted poster.
-                if (this.checkVideoLoaded()) {
+                if (requestId !== this.preloadRequestId || this.checkVideoLoaded()) {
+                    URL.revokeObjectURL(this.srcUrl);
+                    this.srcUrl = undefined;
                     return;
                 }
+
+                // Drop any stray Instant Preview nodes before attaching the tracked one.
+                this.wrapperEl = wrapperEl;
+                this.removeOrphanPreloadWrappers();
 
                 this.containerEl.appendChild(this.wrapperEl);
                 this.placeholderEl = this.wrapperEl.querySelector(`.${CLASS_BOX_PREVIEW_PRELOAD_PLACEHOLDER}`);
@@ -131,7 +172,12 @@ class VideoPreloader extends EventEmitter {
             })
             .catch(() => {
                 // Silently fail if preload image can't be loaded
+            })
+            .finally(() => {
+                this.showPreloadPromise = null;
             });
+
+        return this.showPreloadPromise;
     }
 
     /**
@@ -140,6 +186,9 @@ class VideoPreloader extends EventEmitter {
      * @return {void}
      */
     hidePreload() {
+        // Orphans are never faded via wrapperEl; remove them immediately on dismiss.
+        this.removeOrphanPreloadWrappers();
+
         if (!this.wrapperEl) {
             return;
         }
@@ -252,9 +301,13 @@ class VideoPreloader extends EventEmitter {
             this.wrapperEl = undefined;
         }
 
+        // Remove any Instant Preview wrappers left by overlapping showPreload races.
+        this.removeOrphanPreloadWrappers();
+
         this.preloadEl = undefined;
         this.imageEl = undefined;
         this.placeholderEl = undefined;
+        this.showPreloadPromise = null;
 
         if (this.srcUrl) {
             URL.revokeObjectURL(this.srcUrl);

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -65,6 +65,7 @@ class VideoPreloader extends EventEmitter {
      * @param {HTMLElement} containerEl - Container element to append preload to
      * @param {Object} [options] - Optional options
      * @param {Object} [options.viewport] - { width, height } to use for sizing (same as video viewport to avoid jump)
+     * @param {boolean} [options.sizeWrapperToViewport] - Whether to size the wrapper instead of the container
      * @param {Function} [options.onImageClick] - Called when user clicks the preload image
      * @return {Promise} Promise to show preload
      */
@@ -120,9 +121,10 @@ class VideoPreloader extends EventEmitter {
             return;
         }
 
-        // Clear inline styles we set on the container to restore natural flexbox sizing
-        // This prevents the video controls from being off-screen after video loads
-        if (this.containerEl) {
+        // V1 sizes the media container, so restore its natural flexbox sizing.
+        // V2 sizes the wrapper, which is removed during cleanup and must retain
+        // its dimensions while the fade-out transition runs.
+        if (this.containerEl && !this.preloadOptions?.sizeWrapperToViewport) {
             this.containerEl.style.width = '';
             this.containerEl.style.height = '';
         }
@@ -260,11 +262,16 @@ class VideoPreloader extends EventEmitter {
      * @return {void}
      */
     loadHandler = () => {
-        if (!this.preloadEl || !this.imageEl) {
+        if (!this.preloadEl || !this.imageEl || !this.preloadEl.classList.contains(CLASS_INVISIBLE)) {
             return;
         }
 
-        this.sizeContainerToViewport(this.preloadOptions?.viewport);
+        const shouldSizeWrapper = this.preloadOptions?.sizeWrapperToViewport;
+        const sizingTarget = shouldSizeWrapper ? this.wrapperEl : this.containerEl;
+        const hasVideoGeometry = shouldSizeWrapper && sizingTarget?.style.width && sizingTarget?.style.height;
+        if (!hasVideoGeometry) {
+            this.sizeContainerToViewport(this.preloadOptions?.viewport, sizingTarget);
+        }
 
         this.preloadEl.classList.remove(CLASS_INVISIBLE);
 
@@ -290,14 +297,15 @@ class VideoPreloader extends EventEmitter {
     };
 
     /**
-     * Sizes the container based on viewport dimensions and image aspect ratio to match video player sizing.
+     * Sizes the target based on viewport dimensions and image aspect ratio to match video player sizing.
      * This prevents the thumbnail from appearing small and then jumping to the correct size.
      *
      * @param {Object} [viewportOverride] - Optional { width, height }; when provided, use instead of walking DOM (same as video viewport)
+     * @param {HTMLElement} [targetEl] - Element to size; defaults to the media container
      * @return {void}
      */
-    sizeContainerToViewport(viewportOverride) {
-        if (!this.containerEl || !this.imageEl) {
+    sizeContainerToViewport(viewportOverride, targetEl = this.containerEl) {
+        if (!this.containerEl || !this.imageEl || !targetEl) {
             return;
         }
 
@@ -334,6 +342,16 @@ class VideoPreloader extends EventEmitter {
             };
         }
 
+        if (targetEl === this.wrapperEl) {
+            const containerStyle = window.getComputedStyle(this.containerEl);
+            const horizontalPadding =
+                (parseFloat(containerStyle.paddingLeft) || 0) + (parseFloat(containerStyle.paddingRight) || 0);
+            const verticalPadding =
+                (parseFloat(containerStyle.paddingTop) || 0) + (parseFloat(containerStyle.paddingBottom) || 0);
+            viewport.width = Math.max(0, viewport.width - horizontalPadding);
+            viewport.height = Math.max(0, viewport.height - verticalPadding);
+        }
+
         // Apply minimum width to match video sizing logic
         // This ensures controls don't overflow
         const containerWidth = Math.max(MIN_VIDEO_WIDTH_PX, viewport.width);
@@ -360,9 +378,14 @@ class VideoPreloader extends EventEmitter {
             }
         }
 
-        // Set container dimensions
-        this.containerEl.style.width = `${finalWidth}px`;
-        this.containerEl.style.height = `${containerHeight}px`;
+        targetEl.style.width = `${finalWidth}px`;
+        targetEl.style.height = `${containerHeight}px`;
+
+        if (targetEl === this.wrapperEl) {
+            targetEl.style.left = '50%';
+            targetEl.style.top = '50%';
+            targetEl.style.transform = 'translate(-50%, -50%)';
+        }
     }
 
     /**

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -11,6 +11,7 @@ import {
     CLASS_INVISIBLE,
     CLASS_IS_TRANSPARENT,
     CLASS_IS_VISIBLE,
+    MIN_VIDEO_WIDTH_PX,
     VIDEO_PLAYER_CONTROL_BAR_HEIGHT,
 } from '../../constants';
 import { ICON_PLAY_LARGE } from '../../icons';
@@ -366,10 +367,31 @@ class VideoPreloader extends EventEmitter {
         // Use natural dimensions if available (image has loaded), otherwise use current dimensions
         const imageWidth = this.imageEl.naturalWidth || this.imageEl.width || 1;
         const imageHeight = this.imageEl.naturalHeight || this.imageEl.height || 1;
-        const { width, height } = fitFrameToViewport(imageWidth / imageHeight, viewport);
 
-        this.containerEl.style.width = `${width}px`;
-        this.containerEl.style.height = `${height}px`;
+        if (this.preloadOptions?.earlyPaint) {
+            const { width, height } = fitFrameToViewport(imageWidth / imageHeight, viewport);
+            this.containerEl.style.width = `${width}px`;
+            this.containerEl.style.height = `${height}px`;
+            return;
+        }
+
+        // Legacy path: enforce minimum width to match V1 / pre-early-paint V2 video sizing
+        const containerWidth = Math.max(MIN_VIDEO_WIDTH_PX, viewport.width);
+        const aspectRatio = imageWidth / imageHeight;
+        let containerHeight = containerWidth / aspectRatio;
+        let finalWidth = containerWidth;
+
+        if (containerHeight > viewport.height) {
+            containerHeight = viewport.height;
+            finalWidth = containerHeight * aspectRatio;
+            if (finalWidth < MIN_VIDEO_WIDTH_PX) {
+                finalWidth = MIN_VIDEO_WIDTH_PX;
+                containerHeight = finalWidth / aspectRatio;
+            }
+        }
+
+        this.containerEl.style.width = `${finalWidth}px`;
+        this.containerEl.style.height = `${containerHeight}px`;
     }
 
     /**

--- a/src/lib/viewers/media/VideoPreloader.js
+++ b/src/lib/viewers/media/VideoPreloader.js
@@ -144,6 +144,8 @@ class VideoPreloader extends EventEmitter {
             return;
         }
 
+        // Clear inline styles we set on the container to restore natural flexbox sizing
+        // This prevents the video controls from being off-screen after video loads
         if (this.containerEl) {
             this.containerEl.style.width = '';
             this.containerEl.style.height = '';

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -727,9 +727,11 @@ describe('lib/viewers/media/DashViewer', () => {
             jest.spyOn(dash, 'loadTranscription').mockImplementation();
             jest.spyOn(dash, 'loadAlternateAudio').mockImplementation();
             jest.spyOn(dash, 'loadUI').mockImplementation();
+            jest.spyOn(dash, 'syncInstantPreviewWithLoadedVideo').mockImplementation();
 
             dash.options.autoFocus = true;
             dash.loadeddataHandler();
+            expect(dash.syncInstantPreviewWithLoadedVideo).toBeCalled();
             expect(dash.autoplay).toBeCalled();
             expect(dash.showMedia).toBeCalled();
             expect(dash.showPlayButton).toBeCalled();

--- a/src/lib/viewers/media/__tests__/MP4Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP4Viewer-test.js
@@ -99,6 +99,7 @@ describe('lib/viewers/media/MP4Viewer', () => {
             jest.spyOn(mp4, 'emit').mockImplementation();
             jest.spyOn(mp4, 'showAndHideReactControls').mockImplementation();
             jest.spyOn(mp4, 'setMediaTime').mockImplementation();
+            jest.spyOn(mp4, 'syncInstantPreviewWithLoadedVideo').mockImplementation();
         });
 
         test('should do nothing if the player is destroyed', () => {
@@ -106,12 +107,14 @@ describe('lib/viewers/media/MP4Viewer', () => {
             jest.spyOn(mp4, 'showMedia');
             mp4.loadeddataHandler();
             expect(mp4.showMedia).not.toHaveBeenCalled();
+            expect(mp4.syncInstantPreviewWithLoadedVideo).not.toHaveBeenCalled();
         });
 
         test('should load the metadata for the media element, show the media/play button, load subs, check for autoplay, and set focus without react controls', () => {
             mp4.options.autoFocus = true;
             mp4.startTimeInSeconds = 10;
             mp4.loadeddataHandler();
+            expect(mp4.syncInstantPreviewWithLoadedVideo).toHaveBeenCalled();
             expect(mp4.autoplay).toHaveBeenCalled();
             expect(mp4.showMedia).toHaveBeenCalled();
             expect(mp4.showPlayButton).toHaveBeenCalled();

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -5,7 +5,7 @@ import ControlsRoot from '../../controls';
 import MediaBaseViewer from '../MediaBaseViewer';
 import VideoBaseViewer from '../VideoBaseViewer';
 import VideoPreloader from '../VideoPreloader';
-import { CLASS_INVISIBLE } from '../../../constants';
+import { CLASS_INVISIBLE, CLASS_IS_TRANSPARENT } from '../../../constants';
 import * as fileUtil from '../../../file';
 
 let containerEl;
@@ -428,6 +428,38 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
             expect(videoBase.hidePreload).not.toBeCalled();
         });
+
+        test('should resize with video geometry after hide clears isVisible', () => {
+            videoBase.isVideoPlayerV2 = true;
+            videoBase.aspect = 1;
+            const wrapperEl = document.createElement('div');
+            const preloadEl = document.createElement('div');
+            videoBase.preloader = {
+                wrapperEl,
+                preloadEl,
+                hidePreload: jest.fn(() => {
+                    wrapperEl.classList.add(CLASS_IS_TRANSPARENT);
+                }),
+                isVisible() {
+                    return (
+                        !!this.preloadEl &&
+                        !!this.wrapperEl &&
+                        !this.preloadEl.classList.contains(CLASS_INVISIBLE) &&
+                        !this.wrapperEl.classList.contains(CLASS_IS_TRANSPARENT)
+                    );
+                },
+                sizeContainerToViewport: jest.fn(),
+            };
+            jest.spyOn(videoBase, 'getVideoViewport').mockReturnValue({ width: 600, height: 650 });
+            jest.spyOn(videoBase, 'applySharedMediaFrame');
+
+            videoBase.dismissPreload();
+
+            expect(videoBase.preloader.hidePreload).toHaveBeenCalled();
+            expect(videoBase.preloader.isVisible()).toBe(false);
+            expect(videoBase.preloader.sizeContainerToViewport).not.toHaveBeenCalled();
+            expect(videoBase.applySharedMediaFrame).toHaveBeenCalledWith(600, 600);
+        });
     });
 
     describe('playingHandler()', () => {
@@ -811,10 +843,12 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             test('should size mediaContainerEl as the shared frame when V2 is enabled', () => {
                 videoBase.isVideoPlayerV2 = true;
                 videoBase.aspect = 1;
-                videoBase.mediaContainerEl.style.width = '500px';
                 videoBase.setVideoDimensions();
-                expect(videoBase.mediaContainerEl.style.width).toBe('500px');
-                expect(videoBase.mediaContainerEl.style.height).toBe('500px');
+                // Contain-fit into wrapper viewport 600x650 → 600x600
+                expect(videoBase.mediaContainerEl.style.width).toBe('600px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('600px');
+                expect(videoBase.mediaEl.style.width).toBe('600px');
+                expect(videoBase.mediaEl.style.height).toBe('600px');
             });
 
             test('should preserve shared poster geometry after metadata when V2 is enabled', () => {
@@ -837,7 +871,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaEl.style.height).toBe('480px');
             });
 
-            test('should use video geometry when the V2 poster is not visible', () => {
+            test('should contain-fit video to the stage when the V2 poster is not visible', () => {
                 videoBase.isVideoPlayerV2 = true;
                 videoBase.aspect = 1;
                 videoBase.preloader = {
@@ -846,36 +880,75 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
                 videoBase.setVideoDimensions();
 
-                expect(videoBase.mediaEl.style.width).toBe('500px');
-                expect(videoBase.mediaEl.style.height).toBe('500px');
-                expect(videoBase.mediaContainerEl.style.width).toBe('500px');
-                expect(videoBase.mediaContainerEl.style.height).toBe('500px');
+                expect(videoBase.mediaEl.style.width).toBe('600px');
+                expect(videoBase.mediaEl.style.height).toBe('600px');
+                expect(videoBase.mediaContainerEl.style.width).toBe('600px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('600px');
+            });
+
+            test('should keep poster geometry when metadata arrives while Instant Preview is showing', () => {
+                // Simulates loadedmetadata → resize while poster is still up: must not
+                // replace the poster frame with video-aspect sizing yet.
+                videoBase.isVideoPlayerV2 = true;
+                videoBase.videoWidth = 1920;
+                videoBase.videoHeight = 1080;
+                videoBase.aspect = 16 / 9;
+                videoBase.preloader = {
+                    isVisible: jest.fn().mockReturnValue(true),
+                    sizeContainerToViewport: jest.fn(() => {
+                        videoBase.mediaContainerEl.style.width = '800px';
+                        videoBase.mediaContainerEl.style.height = '450px';
+                    }),
+                };
+                jest.spyOn(videoBase, 'applySharedMediaFrame');
+
+                videoBase.setVideoDimensions();
+
+                expect(videoBase.preloader.sizeContainerToViewport).toHaveBeenCalled();
+                expect(videoBase.applySharedMediaFrame).not.toHaveBeenCalled();
+                expect(videoBase.mediaContainerEl.style.width).toBe('800px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('450px');
             });
         });
     });
 
     describe('getVideoViewport()', () => {
-        test('should reserve React controls when the V2 stage is unavailable', () => {
+        test('should use the wrapper size when the V2 stage is unavailable', () => {
             Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
             Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 600 });
             videoBase.useReactControls.mockReturnValue(true);
 
             expect(videoBase.getVideoViewport()).toEqual({
-                height: 480,
+                height: 600,
                 width: 800,
             });
         });
 
-        test('should reserve V2 stage padding and React controls', () => {
+        test('should use the V2 stage content box without reserving overlay controls', () => {
             videoBase.mediaStageEl = document.createElement('div');
             videoBase.mediaStageEl.style.padding = '48px';
-            Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
-            Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 600 });
+            Object.defineProperty(videoBase.mediaStageEl, 'clientWidth', { value: 707 });
+            Object.defineProperty(videoBase.mediaStageEl, 'clientHeight', { value: 733 });
+            videoBase.useReactControls.mockReturnValue(true);
+
+            // V2 controls are position:absolute and do not shrink the stage
+            expect(videoBase.getVideoViewport()).toEqual({
+                height: 637,
+                width: 611,
+            });
+        });
+
+        test('should keep the same stage content box after controls mount', () => {
+            videoBase.mediaStageEl = document.createElement('div');
+            videoBase.mediaStageEl.style.padding = '48px';
+            Object.defineProperty(videoBase.mediaStageEl, 'clientWidth', { value: 707 });
+            Object.defineProperty(videoBase.mediaStageEl, 'clientHeight', { value: 733 });
+            videoBase.controls = { containerEl: document.createElement('div') };
             videoBase.useReactControls.mockReturnValue(true);
 
             expect(videoBase.getVideoViewport()).toEqual({
-                height: 384,
-                width: 704,
+                height: 637,
+                width: 611,
             });
         });
     });
@@ -1449,8 +1522,11 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         test('should size the shared media frame when V2 is enabled', () => {
             videoBase.isVideoPlayerV2 = true;
             videoBase.mediaStageEl = document.createElement('div');
-            Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
-            Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 450 });
+            videoBase.mediaStageEl.style.padding = '48px';
+            // Border-box stage: content 800x450 → client 896x546
+            Object.defineProperty(videoBase.mediaStageEl, 'clientWidth', { value: 896 });
+            Object.defineProperty(videoBase.mediaStageEl, 'clientHeight', { value: 546 });
+            videoBase.useReactControls.mockReturnValue(true);
             jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
 
             videoBase.showPreload();
@@ -1460,9 +1536,12 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 videoBase.mediaContainerEl,
                 expect.objectContaining({
                     onImageClick: expect.any(Function),
-                    viewport: { height: 450, width: 800 },
+                    getViewport: expect.any(Function),
                 }),
             );
+
+            const { getViewport } = VideoPreloader.prototype.showPreload.mock.calls[0][2];
+            expect(getViewport()).toEqual({ height: 450, width: 800 });
         });
 
         test('should preserve container sizing when V2 is disabled', () => {

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -135,6 +135,9 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.setup();
 
             expect(videoBase.wrapperEl.classList.contains('bp-media--v2')).toBe(true);
+            expect(videoBase.mediaStageEl.classList.contains('bp-media-stage--v2')).toBe(true);
+            expect(videoBase.mediaStageEl.parentNode).toBe(videoBase.wrapperEl);
+            expect(videoBase.mediaContainerEl.parentNode).toBe(videoBase.mediaStageEl);
             expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(true);
 
             Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
@@ -161,6 +164,8 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.setup();
 
             expect(videoBase.wrapperEl.classList.contains('bp-media--v2')).toBe(false);
+            expect(videoBase.mediaStageEl).toBeUndefined();
+            expect(videoBase.mediaContainerEl.parentNode).toBe(videoBase.wrapperEl);
             expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(false);
 
             Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
@@ -325,7 +330,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         test('should mount controls on wrapperEl when videoPlayerV2 is enabled', () => {
             videoBase.mediaContainerEl = document.createElement('div');
             videoBase.wrapperEl = document.createElement('div');
-            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBase.isVideoPlayerV2 = true;
             videoBase.loadUIReact();
 
             expect(videoBase.controls).toBeInstanceOf(ControlsRoot);
@@ -335,7 +340,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         test('should mount controls on mediaContainerEl when videoPlayerV2 is disabled', () => {
             videoBase.mediaContainerEl = document.createElement('div');
             videoBase.wrapperEl = document.createElement('div');
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            videoBase.isVideoPlayerV2 = false;
             videoBase.loadUIReact();
 
             expect(videoBase.controls).toBeInstanceOf(ControlsRoot);
@@ -687,7 +692,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         });
 
         test('should use wrapperEl.clientWidth when videoPlayerV2 is enabled', () => {
-            jest.spyOn(videoBaseViewer, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBaseViewer.isVideoPlayerV2 = true;
             videoBaseViewer.wrapperEl = document.createElement('div');
             Object.defineProperty(videoBaseViewer.wrapperEl, 'clientWidth', { value: 579 });
             videoBaseViewer.handleNarrowVideoUI();
@@ -696,7 +701,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         });
 
         test('should use wrapperEl.clientWidth >= threshold when videoPlayerV2 is enabled', () => {
-            jest.spyOn(videoBaseViewer, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            videoBaseViewer.isVideoPlayerV2 = true;
             videoBaseViewer.wrapperEl = document.createElement('div');
             Object.defineProperty(videoBaseViewer.wrapperEl, 'clientWidth', { value: 580 });
             videoBaseViewer.playContainerEl = document.createElement('div');
@@ -803,43 +808,63 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaContainerEl.style.width).toBe(videoBase.mediaEl.style.width);
             });
 
-            test('should reset mediaContainerEl width when V2 is enabled', () => {
-                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            test('should size mediaContainerEl as the shared frame when V2 is enabled', () => {
+                videoBase.isVideoPlayerV2 = true;
                 videoBase.aspect = 1;
                 videoBase.mediaContainerEl.style.width = '500px';
                 videoBase.setVideoDimensions();
-                expect(videoBase.mediaContainerEl.style.width).toBe('');
+                expect(videoBase.mediaContainerEl.style.width).toBe('500px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('500px');
             });
 
-            test('should reconcile provisional poster geometry after metadata when V2 is enabled', () => {
-                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            test('should preserve shared poster geometry after metadata when V2 is enabled', () => {
+                videoBase.isVideoPlayerV2 = true;
                 videoBase.aspect = 1;
                 videoBase.preloader = {
-                    wrapperEl: document.createElement('div'),
-                };
-                videoBase.preloader.wrapperEl.style.width = '480px';
-                videoBase.preloader.wrapperEl.style.height = '480px';
-
-                videoBase.setVideoDimensions();
-
-                expect(videoBase.preloader.wrapperEl.style.width).toBe('500px');
-                expect(videoBase.preloader.wrapperEl.style.height).toBe('500px');
-            });
-
-            test('should provide fallback poster geometry after metadata when V2 wrapper is unsized', () => {
-                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
-                videoBase.aspect = 1;
-                videoBase.preloader = {
-                    wrapperEl: document.createElement('div'),
+                    isVisible: jest.fn().mockReturnValue(true),
+                    sizeContainerToViewport: jest.fn(() => {
+                        videoBase.mediaContainerEl.style.width = '480px';
+                        videoBase.mediaContainerEl.style.height = '480px';
+                    }),
                 };
 
                 videoBase.setVideoDimensions();
 
-                expect(videoBase.preloader.wrapperEl.style.width).toBe('500px');
-                expect(videoBase.preloader.wrapperEl.style.height).toBe('500px');
-                expect(videoBase.preloader.wrapperEl.style.left).toBe('50%');
-                expect(videoBase.preloader.wrapperEl.style.top).toBe('50%');
-                expect(videoBase.preloader.wrapperEl.style.transform).toBe('translate(-50%, -50%)');
+                expect(videoBase.preloader.sizeContainerToViewport).toHaveBeenCalled();
+                expect(videoBase.mediaContainerEl.style.width).toBe('480px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('480px');
+                expect(videoBase.mediaEl.style.width).toBe('480px');
+                expect(videoBase.mediaEl.style.height).toBe('480px');
+            });
+
+            test('should use video geometry when the V2 poster is not visible', () => {
+                videoBase.isVideoPlayerV2 = true;
+                videoBase.aspect = 1;
+                videoBase.preloader = {
+                    isVisible: jest.fn().mockReturnValue(false),
+                };
+
+                videoBase.setVideoDimensions();
+
+                expect(videoBase.mediaEl.style.width).toBe('500px');
+                expect(videoBase.mediaEl.style.height).toBe('500px');
+                expect(videoBase.mediaContainerEl.style.width).toBe('500px');
+                expect(videoBase.mediaContainerEl.style.height).toBe('500px');
+            });
+        });
+    });
+
+    describe('getVideoViewport()', () => {
+        test('should reserve V2 stage padding and React controls', () => {
+            videoBase.mediaStageEl = document.createElement('div');
+            videoBase.mediaStageEl.style.padding = '48px';
+            Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
+            Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 600 });
+            videoBase.useReactControls.mockReturnValue(true);
+
+            expect(videoBase.getVideoViewport()).toEqual({
+                height: 384,
+                width: 704,
             });
         });
     });
@@ -1410,8 +1435,11 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             );
         });
 
-        test('should target the preload wrapper for sizing when V2 is enabled', () => {
-            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+        test('should size the shared media frame when V2 is enabled', () => {
+            videoBase.isVideoPlayerV2 = true;
+            videoBase.mediaStageEl = document.createElement('div');
+            Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
+            Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 450 });
             jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
 
             videoBase.showPreload();
@@ -1421,13 +1449,13 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 videoBase.mediaContainerEl,
                 expect.objectContaining({
                     onImageClick: expect.any(Function),
-                    sizeWrapperToViewport: true,
+                    viewport: { height: 450, width: 800 },
                 }),
             );
         });
 
         test('should preserve container sizing when V2 is disabled', () => {
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            videoBase.isVideoPlayerV2 = false;
             jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
 
             videoBase.showPreload();

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -855,6 +855,17 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
     });
 
     describe('getVideoViewport()', () => {
+        test('should reserve React controls when the V2 stage is unavailable', () => {
+            Object.defineProperty(videoBase.wrapperEl, 'clientWidth', { value: 800 });
+            Object.defineProperty(videoBase.wrapperEl, 'clientHeight', { value: 600 });
+            videoBase.useReactControls.mockReturnValue(true);
+
+            expect(videoBase.getVideoViewport()).toEqual({
+                height: 480,
+                width: 800,
+            });
+        });
+
         test('should reserve V2 stage padding and React controls', () => {
             videoBase.mediaStageEl = document.createElement('div');
             videoBase.mediaStageEl.style.padding = '48px';

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -430,33 +430,51 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
     describe('dismissPreload()', () => {
         test('should hide preload, remove CLASS_INVISIBLE, and resize when preload is visible', () => {
-            const mockPreloader = { wrapperEl: document.createElement('div'), hidePreload: jest.fn() };
+            const mockPreloader = {
+                wrapperEl: document.createElement('div'),
+                hidePreload: jest.fn(),
+                blockFuturePosterPaint: jest.fn(),
+            };
             videoBase.preloader = mockPreloader;
             videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
             jest.spyOn(videoBase, 'resize').mockImplementation();
 
             videoBase.dismissPreload();
 
+            expect(mockPreloader.blockFuturePosterPaint).toHaveBeenCalled();
             expect(mockPreloader.hidePreload).toHaveBeenCalled();
             expect(videoBase.mediaEl).not.toHaveClass(CLASS_INVISIBLE);
             expect(videoBase.resize).toHaveBeenCalled();
         });
 
         test('should not call hidePreload when no preloader is present', () => {
+            videoBase.preloader = null;
+            videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
             jest.spyOn(videoBase, 'hidePreload').mockImplementation();
+            jest.spyOn(videoBase, 'resize').mockImplementation();
 
             videoBase.dismissPreload();
 
             expect(videoBase.hidePreload).not.toBeCalled();
+            expect(videoBase.mediaEl).not.toHaveClass(CLASS_INVISIBLE);
+            expect(videoBase.resize).not.toHaveBeenCalled();
         });
 
-        test('should not call hidePreload when preloader has no wrapperEl', () => {
-            videoBase.preloader = { wrapperEl: undefined };
-            jest.spyOn(videoBase, 'hidePreload').mockImplementation();
+        test('should reveal the video even when the poster wrapper was already cleaned up', () => {
+            videoBase.preloader = {
+                wrapperEl: undefined,
+                hidePreload: jest.fn(),
+                blockFuturePosterPaint: jest.fn(),
+            };
+            videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
+            jest.spyOn(videoBase, 'resize').mockImplementation();
 
             videoBase.dismissPreload();
 
-            expect(videoBase.hidePreload).not.toBeCalled();
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
+            expect(videoBase.preloader.hidePreload).not.toHaveBeenCalled();
+            expect(videoBase.mediaEl).not.toHaveClass(CLASS_INVISIBLE);
+            expect(videoBase.resize).not.toHaveBeenCalled();
         });
 
         test('should resize with video geometry after hide clears isVisible', () => {
@@ -471,6 +489,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 hidePreload: jest.fn(() => {
                     wrapperEl.classList.add(CLASS_IS_TRANSPARENT);
                 }),
+                blockFuturePosterPaint: jest.fn(),
                 isVisible() {
                     return (
                         !!this.preloadEl &&
@@ -1735,13 +1754,28 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         });
 
         test('should not remove CLASS_INVISIBLE from mediaEl when preload is still visible', () => {
-            videoBase.preloader = { wrapperEl: document.createElement('div') };
+            videoBase.preloader = {
+                wrapperEl: document.createElement('div'),
+                blockFuturePosterPaint: jest.fn(),
+            };
             videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
             jest.spyOn(videoBase.mediaEl.classList, 'remove');
 
             videoBase.loadeddataHandler();
 
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
             expect(videoBase.mediaEl.classList.remove).not.toHaveBeenCalledWith(CLASS_INVISIBLE);
+        });
+
+        test('should block future poster paint when video data loads', () => {
+            videoBase.preloader = {
+                wrapperEl: undefined,
+                blockFuturePosterPaint: jest.fn(),
+            };
+
+            videoBase.loadeddataHandler();
+
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
         });
 
         test('should remove CLASS_INVISIBLE from mediaEl when preload is not showing', () => {

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -267,6 +267,18 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.mediaEl.removeEventListener).toBeCalledWith('waiting', videoBase.waitingHandler);
             expect(videoBase.playButtonEl.removeEventListener).toBeCalledWith('click', videoBase.handlePlayRequest);
         });
+
+        test('should block late Instant Preview paint and clean up the preloader', () => {
+            videoBase.preloader = {
+                blockFuturePosterPaint: jest.fn(),
+                cleanupPreload: jest.fn(),
+            };
+
+            videoBase.destroy();
+
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
+            expect(videoBase.preloader.cleanupPreload).toHaveBeenCalled();
+        });
     });
 
     describe('loadeddataHandler()', () => {
@@ -1701,6 +1713,34 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         });
     });
 
+    describe('syncInstantPreviewWithLoadedVideo()', () => {
+        test('should block future poster paint and reveal the video when no poster wrapper exists', () => {
+            videoBase.preloader = {
+                wrapperEl: undefined,
+                blockFuturePosterPaint: jest.fn(),
+            };
+            videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
+
+            videoBase.syncInstantPreviewWithLoadedVideo();
+
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
+            expect(videoBase.mediaEl).not.toHaveClass(CLASS_INVISIBLE);
+        });
+
+        test('should block future poster paint but keep the video invisible while a poster wrapper remains', () => {
+            videoBase.preloader = {
+                wrapperEl: document.createElement('div'),
+                blockFuturePosterPaint: jest.fn(),
+            };
+            videoBase.mediaEl.classList.add(CLASS_INVISIBLE);
+
+            videoBase.syncInstantPreviewWithLoadedVideo();
+
+            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
+            expect(videoBase.mediaEl).toHaveClass(CLASS_INVISIBLE);
+        });
+    });
+
     describe('hidePreload()', () => {
         test('should call preloader.hidePreload() if preloader exists', () => {
             const mockPreloader = {
@@ -1767,15 +1807,12 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.mediaEl.classList.remove).not.toHaveBeenCalledWith(CLASS_INVISIBLE);
         });
 
-        test('should block future poster paint when video data loads', () => {
-            videoBase.preloader = {
-                wrapperEl: undefined,
-                blockFuturePosterPaint: jest.fn(),
-            };
+        test('should sync Instant Preview when video data loads', () => {
+            jest.spyOn(videoBase, 'syncInstantPreviewWithLoadedVideo');
 
             videoBase.loadeddataHandler();
 
-            expect(videoBase.preloader.blockFuturePosterPaint).toHaveBeenCalled();
+            expect(videoBase.syncInstantPreviewWithLoadedVideo).toHaveBeenCalled();
         });
 
         test('should remove CLASS_INVISIBLE from mediaEl when preload is not showing', () => {

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -810,6 +810,37 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 videoBase.setVideoDimensions();
                 expect(videoBase.mediaContainerEl.style.width).toBe('');
             });
+
+            test('should reconcile provisional poster geometry after metadata when V2 is enabled', () => {
+                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+                videoBase.aspect = 1;
+                videoBase.preloader = {
+                    wrapperEl: document.createElement('div'),
+                };
+                videoBase.preloader.wrapperEl.style.width = '480px';
+                videoBase.preloader.wrapperEl.style.height = '480px';
+
+                videoBase.setVideoDimensions();
+
+                expect(videoBase.preloader.wrapperEl.style.width).toBe('500px');
+                expect(videoBase.preloader.wrapperEl.style.height).toBe('500px');
+            });
+
+            test('should provide fallback poster geometry after metadata when V2 wrapper is unsized', () => {
+                jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+                videoBase.aspect = 1;
+                videoBase.preloader = {
+                    wrapperEl: document.createElement('div'),
+                };
+
+                videoBase.setVideoDimensions();
+
+                expect(videoBase.preloader.wrapperEl.style.width).toBe('500px');
+                expect(videoBase.preloader.wrapperEl.style.height).toBe('500px');
+                expect(videoBase.preloader.wrapperEl.style.left).toBe('50%');
+                expect(videoBase.preloader.wrapperEl.style.top).toBe('50%');
+                expect(videoBase.preloader.wrapperEl.style.transform).toBe('translate(-50%, -50%)');
+            });
         });
     });
 
@@ -1376,6 +1407,35 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 'https://example.com/preview.jpg?auth=token',
                 videoBase.mediaContainerEl,
                 expect.objectContaining({ onImageClick: expect.any(Function) }),
+            );
+        });
+
+        test('should target the preload wrapper for sizing when V2 is enabled', () => {
+            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(flag => flag === 'videoPlayerV2.enabled');
+            jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
+
+            videoBase.showPreload();
+
+            expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
+                'https://example.com/preview.jpg?auth=token',
+                videoBase.mediaContainerEl,
+                expect.objectContaining({
+                    onImageClick: expect.any(Function),
+                    sizeWrapperToViewport: true,
+                }),
+            );
+        });
+
+        test('should preserve container sizing when V2 is disabled', () => {
+            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
+            jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
+
+            videoBase.showPreload();
+
+            expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
+                'https://example.com/preview.jpg?auth=token',
+                videoBase.mediaContainerEl,
+                expect.not.objectContaining({ sizeWrapperToViewport: expect.anything() }),
             );
         });
 

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -135,10 +135,40 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.setup();
 
             expect(videoBase.wrapperEl.classList.contains('bp-media--v2')).toBe(true);
+            expect(videoBase.mediaStageEl).toBeUndefined();
+            expect(videoBase.mediaContainerEl.parentNode).toBe(videoBase.wrapperEl);
+            expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(true);
+            expect(videoBase.isVideoPosterEarlyPaint).toBe(false);
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: lowerLights,
+            });
+        });
+
+        test('should add V2 stage when videoPosterEarlyPaint is enabled', () => {
+            const { lowerLights } = VideoBaseViewer.prototype;
+
+            Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
+                value: jest.fn(),
+            });
+            Object.defineProperty(BaseViewer.prototype, 'setup', { value: jest.fn() });
+            videoBase = new VideoBaseViewer({
+                file: {
+                    id: 1,
+                },
+                container: containerEl,
+            });
+            videoBase.useReactControls = jest.fn().mockReturnValue(false);
+            jest.spyOn(videoBase, 'featureEnabled').mockImplementation(
+                flag => flag === 'videoPlayerV2.enabled' || flag === 'videoPosterEarlyPaint.enabled',
+            );
+            videoBase.containerEl = containerEl;
+            videoBase.setup();
+
+            expect(videoBase.isVideoPosterEarlyPaint).toBe(true);
             expect(videoBase.mediaStageEl.classList.contains('bp-media-stage--v2')).toBe(true);
             expect(videoBase.mediaStageEl.parentNode).toBe(videoBase.wrapperEl);
             expect(videoBase.mediaContainerEl.parentNode).toBe(videoBase.mediaStageEl);
-            expect(videoBase.mediaContainerEl.classList.contains('bp-media-container--v2')).toBe(true);
 
             Object.defineProperty(VideoBaseViewer.prototype, 'lowerLights', {
                 value: lowerLights,
@@ -431,6 +461,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
         test('should resize with video geometry after hide clears isVisible', () => {
             videoBase.isVideoPlayerV2 = true;
+            videoBase.isVideoPosterEarlyPaint = true;
             videoBase.aspect = 1;
             const wrapperEl = document.createElement('div');
             const preloadEl = document.createElement('div');
@@ -840,8 +871,9 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaContainerEl.style.width).toBe(videoBase.mediaEl.style.width);
             });
 
-            test('should size mediaContainerEl as the shared frame when V2 is enabled', () => {
+            test('should size mediaContainerEl as the shared frame when early paint is enabled', () => {
                 videoBase.isVideoPlayerV2 = true;
+                videoBase.isVideoPosterEarlyPaint = true;
                 videoBase.aspect = 1;
                 videoBase.setVideoDimensions();
                 // Contain-fit into wrapper viewport 600x650 → 600x600
@@ -851,8 +883,17 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaEl.style.height).toBe('600px');
             });
 
-            test('should preserve shared poster geometry after metadata when V2 is enabled', () => {
+            test('should clear mediaContainerEl width for legacy V2 without early paint', () => {
                 videoBase.isVideoPlayerV2 = true;
+                videoBase.isVideoPosterEarlyPaint = false;
+                videoBase.aspect = 1;
+                videoBase.setVideoDimensions();
+                expect(videoBase.mediaContainerEl.style.width).toBe('');
+            });
+
+            test('should preserve shared poster geometry after metadata when early paint is enabled', () => {
+                videoBase.isVideoPlayerV2 = true;
+                videoBase.isVideoPosterEarlyPaint = true;
                 videoBase.aspect = 1;
                 videoBase.preloader = {
                     isVisible: jest.fn().mockReturnValue(true),
@@ -871,8 +912,9 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 expect(videoBase.mediaEl.style.height).toBe('480px');
             });
 
-            test('should contain-fit video to the stage when the V2 poster is not visible', () => {
+            test('should contain-fit video to the stage when the early-paint poster is not visible', () => {
                 videoBase.isVideoPlayerV2 = true;
+                videoBase.isVideoPosterEarlyPaint = true;
                 videoBase.aspect = 1;
                 videoBase.preloader = {
                     isVisible: jest.fn().mockReturnValue(false),
@@ -890,6 +932,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 // Simulates loadedmetadata → resize while poster is still up: must not
                 // replace the poster frame with video-aspect sizing yet.
                 videoBase.isVideoPlayerV2 = true;
+                videoBase.isVideoPosterEarlyPaint = true;
                 videoBase.videoWidth = 1920;
                 videoBase.videoHeight = 1080;
                 videoBase.aspect = 16 / 9;
@@ -1519,8 +1562,9 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             );
         });
 
-        test('should size the shared media frame when V2 is enabled', () => {
+        test('should size the shared media frame when early paint is enabled', () => {
             videoBase.isVideoPlayerV2 = true;
+            videoBase.isVideoPosterEarlyPaint = true;
             videoBase.mediaStageEl = document.createElement('div');
             videoBase.mediaStageEl.style.padding = '48px';
             // Border-box stage: content 800x450 → client 896x546
@@ -1536,6 +1580,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 videoBase.mediaContainerEl,
                 expect.objectContaining({
                     onImageClick: expect.any(Function),
+                    earlyPaint: true,
                     getViewport: expect.any(Function),
                 }),
             );

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -153,14 +153,6 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(videoPreloader.containerEl.style.height).toBe('');
         });
 
-        test('should preserve container styles when the V2 wrapper is the sizing target', () => {
-            videoPreloader.preloadOptions = { sizeWrapperToViewport: true };
-            videoPreloader.hidePreload();
-
-            expect(videoPreloader.containerEl.style.width).toBe('1000px');
-            expect(videoPreloader.containerEl.style.height).toBe('500px');
-        });
-
         test('should add transparent class and setup cleanup listeners', () => {
             videoPreloader.hidePreload();
 
@@ -292,6 +284,18 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(mediaWrapper).toHaveClass(CLASS_IS_VISIBLE);
         });
 
+        test('should make the media wrapper visible through the V2 stage', () => {
+            const mediaWrapper = containerEl.parentNode;
+            const mediaStageEl = document.createElement('div');
+            mediaWrapper.insertBefore(mediaStageEl, containerEl);
+            mediaStageEl.appendChild(containerEl);
+            mediaWrapper.classList.remove(CLASS_IS_VISIBLE);
+
+            videoPreloader.loadHandler();
+
+            expect(mediaWrapper).toHaveClass(CLASS_IS_VISIBLE);
+        });
+
         test('should call sizeContainerToViewport() and emit preload event', () => {
             videoPreloader.loadHandler();
 
@@ -303,43 +307,18 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.preloadOptions = { viewport: { width: 800, height: 450 } };
             videoPreloader.loadHandler();
 
-            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith(
-                { width: 800, height: 450 },
-                videoPreloader.containerEl,
-            );
+            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith({ width: 800, height: 450 });
         });
 
-        test('should size the V2 wrapper before making the preload visible', () => {
-            videoPreloader.preloadOptions = {
-                sizeWrapperToViewport: true,
-                viewport: { width: 800, height: 450 },
-            };
+        test('should size the shared media container before making the preload visible', () => {
+            videoPreloader.preloadOptions = { viewport: { width: 800, height: 450 } };
             videoPreloader.sizeContainerToViewport.mockImplementation(() => {
                 expect(videoPreloader.preloadEl).toHaveClass(CLASS_INVISIBLE);
             });
 
             videoPreloader.loadHandler();
 
-            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith(
-                { width: 800, height: 450 },
-                videoPreloader.wrapperEl,
-            );
-            expect(videoPreloader.preloadEl).not.toHaveClass(CLASS_INVISIBLE);
-        });
-
-        test('should preserve video geometry if metadata sizes the V2 wrapper before the image loads', () => {
-            videoPreloader.preloadOptions = {
-                sizeWrapperToViewport: true,
-                viewport: { width: 800, height: 450 },
-            };
-            videoPreloader.wrapperEl.style.width = '640px';
-            videoPreloader.wrapperEl.style.height = '360px';
-
-            videoPreloader.loadHandler();
-
-            expect(videoPreloader.sizeContainerToViewport).not.toBeCalled();
-            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
-            expect(videoPreloader.wrapperEl.style.height).toBe('360px');
+            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith({ width: 800, height: 450 });
             expect(videoPreloader.preloadEl).not.toHaveClass(CLASS_INVISIBLE);
         });
 
@@ -461,49 +440,6 @@ describe('lib/viewers/media/VideoPreloader', () => {
 
             // Height should be constrained to viewport height (400px)
             expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(400);
-        });
-
-        test('should size and center the V2 wrapper without changing the media container', () => {
-            videoPreloader.wrapperEl = document.createElement('div');
-
-            videoPreloader.sizeContainerToViewport({ width: 640, height: 360 }, videoPreloader.wrapperEl);
-
-            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
-            expect(parseFloat(videoPreloader.wrapperEl.style.height)).toBeCloseTo(360, 0);
-            expect(videoPreloader.wrapperEl.style.left).toBe('50%');
-            expect(videoPreloader.wrapperEl.style.top).toBe('50%');
-            expect(videoPreloader.wrapperEl.style.transform).toBe('translate(-50%, -50%)');
-            expect(videoPreloader.containerEl.style.width).toBe('');
-            expect(videoPreloader.containerEl.style.height).toBe('');
-        });
-
-        test('should fit a portrait V2 poster within the viewport', () => {
-            Object.defineProperty(videoPreloader.imageEl, 'naturalWidth', {
-                value: 1080,
-                configurable: true,
-            });
-            Object.defineProperty(videoPreloader.imageEl, 'naturalHeight', {
-                value: 1920,
-                configurable: true,
-            });
-            videoPreloader.wrapperEl = document.createElement('div');
-
-            videoPreloader.sizeContainerToViewport({ width: 1200, height: 800 }, videoPreloader.wrapperEl);
-
-            expect(parseFloat(videoPreloader.wrapperEl.style.width)).toBeCloseTo(450, 0);
-            expect(videoPreloader.wrapperEl.style.height).toBe('800px');
-            expect(videoPreloader.containerEl.style.width).toBe('');
-            expect(videoPreloader.containerEl.style.height).toBe('');
-        });
-
-        test('should keep the V2 wrapper inside the media container padding', () => {
-            videoPreloader.containerEl.style.padding = '48px';
-            videoPreloader.wrapperEl = document.createElement('div');
-
-            videoPreloader.sizeContainerToViewport({ width: 736, height: 456 }, videoPreloader.wrapperEl);
-
-            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
-            expect(parseFloat(videoPreloader.wrapperEl.style.height)).toBeCloseTo(360, 0);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -153,6 +153,14 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(videoPreloader.containerEl.style.height).toBe('');
         });
 
+        test('should preserve container styles when the V2 wrapper is the sizing target', () => {
+            videoPreloader.preloadOptions = { sizeWrapperToViewport: true };
+            videoPreloader.hidePreload();
+
+            expect(videoPreloader.containerEl.style.width).toBe('1000px');
+            expect(videoPreloader.containerEl.style.height).toBe('500px');
+        });
+
         test('should add transparent class and setup cleanup listeners', () => {
             videoPreloader.hidePreload();
 
@@ -256,6 +264,7 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
             videoPreloader.imageEl = document.createElement('img');
             videoPreloader.containerEl = containerEl;
+            videoPreloader.wrapperEl = document.createElement('div');
             jest.spyOn(videoPreloader, 'sizeContainerToViewport').mockImplementation();
             jest.spyOn(videoPreloader, 'emit').mockImplementation();
         });
@@ -294,7 +303,52 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.preloadOptions = { viewport: { width: 800, height: 450 } };
             videoPreloader.loadHandler();
 
-            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith({ width: 800, height: 450 });
+            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith(
+                { width: 800, height: 450 },
+                videoPreloader.containerEl,
+            );
+        });
+
+        test('should size the V2 wrapper before making the preload visible', () => {
+            videoPreloader.preloadOptions = {
+                sizeWrapperToViewport: true,
+                viewport: { width: 800, height: 450 },
+            };
+            videoPreloader.sizeContainerToViewport.mockImplementation(() => {
+                expect(videoPreloader.preloadEl).toHaveClass(CLASS_INVISIBLE);
+            });
+
+            videoPreloader.loadHandler();
+
+            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith(
+                { width: 800, height: 450 },
+                videoPreloader.wrapperEl,
+            );
+            expect(videoPreloader.preloadEl).not.toHaveClass(CLASS_INVISIBLE);
+        });
+
+        test('should preserve video geometry if metadata sizes the V2 wrapper before the image loads', () => {
+            videoPreloader.preloadOptions = {
+                sizeWrapperToViewport: true,
+                viewport: { width: 800, height: 450 },
+            };
+            videoPreloader.wrapperEl.style.width = '640px';
+            videoPreloader.wrapperEl.style.height = '360px';
+
+            videoPreloader.loadHandler();
+
+            expect(videoPreloader.sizeContainerToViewport).not.toBeCalled();
+            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
+            expect(videoPreloader.wrapperEl.style.height).toBe('360px');
+            expect(videoPreloader.preloadEl).not.toHaveClass(CLASS_INVISIBLE);
+        });
+
+        test('should handle a cached image load only once', () => {
+            videoPreloader.loadHandler();
+            videoPreloader.loadHandler();
+
+            expect(videoPreloader.sizeContainerToViewport).toHaveBeenCalledTimes(1);
+            expect(videoPreloader.emit).toHaveBeenCalledTimes(1);
         });
 
         test('should add click listener and invoke onImageClick when wrapper is clicked', () => {
@@ -314,8 +368,16 @@ describe('lib/viewers/media/VideoPreloader', () => {
         beforeEach(() => {
             videoPreloader.containerEl = containerEl;
             videoPreloader.imageEl = document.createElement('img');
-            Object.defineProperty(videoPreloader.imageEl, 'naturalWidth', { value: 1920, writable: false });
-            Object.defineProperty(videoPreloader.imageEl, 'naturalHeight', { value: 1080, writable: false });
+            Object.defineProperty(videoPreloader.imageEl, 'naturalWidth', {
+                value: 1920,
+                writable: false,
+                configurable: true,
+            });
+            Object.defineProperty(videoPreloader.imageEl, 'naturalHeight', {
+                value: 1080,
+                writable: false,
+                configurable: true,
+            });
         });
 
         test('should not do anything if containerEl or imageEl is missing', () => {
@@ -399,6 +461,49 @@ describe('lib/viewers/media/VideoPreloader', () => {
 
             // Height should be constrained to viewport height (400px)
             expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(400);
+        });
+
+        test('should size and center the V2 wrapper without changing the media container', () => {
+            videoPreloader.wrapperEl = document.createElement('div');
+
+            videoPreloader.sizeContainerToViewport({ width: 640, height: 360 }, videoPreloader.wrapperEl);
+
+            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
+            expect(parseFloat(videoPreloader.wrapperEl.style.height)).toBeCloseTo(360, 0);
+            expect(videoPreloader.wrapperEl.style.left).toBe('50%');
+            expect(videoPreloader.wrapperEl.style.top).toBe('50%');
+            expect(videoPreloader.wrapperEl.style.transform).toBe('translate(-50%, -50%)');
+            expect(videoPreloader.containerEl.style.width).toBe('');
+            expect(videoPreloader.containerEl.style.height).toBe('');
+        });
+
+        test('should fit a portrait V2 poster within the viewport', () => {
+            Object.defineProperty(videoPreloader.imageEl, 'naturalWidth', {
+                value: 1080,
+                configurable: true,
+            });
+            Object.defineProperty(videoPreloader.imageEl, 'naturalHeight', {
+                value: 1920,
+                configurable: true,
+            });
+            videoPreloader.wrapperEl = document.createElement('div');
+
+            videoPreloader.sizeContainerToViewport({ width: 1200, height: 800 }, videoPreloader.wrapperEl);
+
+            expect(parseFloat(videoPreloader.wrapperEl.style.width)).toBeCloseTo(450, 0);
+            expect(videoPreloader.wrapperEl.style.height).toBe('800px');
+            expect(videoPreloader.containerEl.style.width).toBe('');
+            expect(videoPreloader.containerEl.style.height).toBe('');
+        });
+
+        test('should keep the V2 wrapper inside the media container padding', () => {
+            videoPreloader.containerEl.style.padding = '48px';
+            videoPreloader.wrapperEl = document.createElement('div');
+
+            videoPreloader.sizeContainerToViewport({ width: 736, height: 456 }, videoPreloader.wrapperEl);
+
+            expect(videoPreloader.wrapperEl.style.width).toBe('640px');
+            expect(parseFloat(videoPreloader.wrapperEl.style.height)).toBeCloseTo(360, 0);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -66,18 +66,28 @@ describe('lib/viewers/media/VideoPreloader', () => {
         });
 
         test('should not do anything if video is already loaded', () => {
-            // checkVideoLoaded() is called after blob fetch, and it calls hidePreload() if video is loaded
-            jest.spyOn(videoPreloader, 'hidePreload').mockImplementation();
-            // Mock checkVideoLoaded to call hidePreload() and return true (matching real implementation)
+            // checkVideoLoaded() aborts create/paint (cleanup, not hide) when video is ready
+            jest.spyOn(videoPreloader, 'cleanupPreload').mockImplementation();
             jest.spyOn(videoPreloader, 'checkVideoLoaded').mockImplementation(function checkVideoLoadedMock() {
-                this.hidePreload();
+                this.cleanupPreload();
                 return true;
             });
 
             return videoPreloader.showPreload('someUrl', containerEl).then(() => {
-                // checkVideoLoaded() is called after blob fetch, and it should call hidePreload() if video is loaded
                 expect(videoPreloader.checkVideoLoaded).toBeCalled();
-                expect(videoPreloader.hidePreload).toBeCalled();
+                expect(videoPreloader.cleanupPreload).toBeCalled();
+                expect(videoPreloader.wrapperEl).toBeUndefined();
+            });
+        });
+
+        test('should resolve immediately when future poster paint is blocked', () => {
+            videoPreloader.blockFuturePosterPaint();
+            jest.spyOn(videoPreloader, 'checkVideoLoaded');
+
+            return videoPreloader.showPreload('someUrl', containerEl).then(() => {
+                expect(stubs.api.get).not.toHaveBeenCalled();
+                expect(videoPreloader.checkVideoLoaded).not.toHaveBeenCalled();
+                expect(videoPreloader.wrapperEl).toBeUndefined();
             });
         });
 
@@ -541,14 +551,35 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.preloadEl = document.createElement('div');
             videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
             videoPreloader.imageEl = document.createElement('img');
-            jest.spyOn(videoPreloader, 'hidePreload').mockImplementation();
+            jest.spyOn(videoPreloader, 'cleanupPreload').mockImplementation(() => {
+                videoPreloader.wrapperEl = undefined;
+                videoPreloader.preloadEl = undefined;
+            });
             jest.spyOn(videoPreloader, 'sizeContainerToViewport').mockImplementation();
 
             videoPreloader.loadHandler();
 
-            expect(videoPreloader.hidePreload).toHaveBeenCalled();
+            expect(videoPreloader.cleanupPreload).toHaveBeenCalled();
             expect(videoPreloader.sizeContainerToViewport).not.toHaveBeenCalled();
-            expect(videoPreloader.preloadEl).toHaveClass(CLASS_INVISIBLE);
+        });
+
+        test('should not paint when blockFuturePosterPaint was set after video ready', () => {
+            videoPreloader.containerEl = containerEl;
+            videoPreloader.wrapperEl = document.createElement('div');
+            videoPreloader.preloadEl = document.createElement('div');
+            videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
+            videoPreloader.imageEl = document.createElement('img');
+            videoPreloader.blockFuturePosterPaint();
+            jest.spyOn(videoPreloader, 'cleanupPreload').mockImplementation(() => {
+                videoPreloader.wrapperEl = undefined;
+                videoPreloader.preloadEl = undefined;
+            });
+            jest.spyOn(videoPreloader, 'sizeContainerToViewport').mockImplementation();
+
+            videoPreloader.loadHandler();
+
+            expect(videoPreloader.cleanupPreload).toHaveBeenCalled();
+            expect(videoPreloader.sizeContainerToViewport).not.toHaveBeenCalled();
         });
     });
 
@@ -597,6 +628,8 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.containerEl = containerEl;
             const videoEl = {
                 readyState: 1, // HAVE_METADATA
+                paused: true,
+                classList: { remove: jest.fn() },
             };
             jest.spyOn(containerEl, 'querySelector').mockReturnValue(videoEl);
 
@@ -604,6 +637,33 @@ describe('lib/viewers/media/VideoPreloader', () => {
 
             expect(result).toBe(true);
             expect(containerEl.querySelector).toBeCalledWith('video');
+        });
+
+        test('should return true if the video is already playing', () => {
+            videoPreloader.containerEl = containerEl;
+            const videoEl = {
+                readyState: 0,
+                paused: false,
+                classList: { remove: jest.fn() },
+            };
+            jest.spyOn(containerEl, 'querySelector').mockReturnValue(videoEl);
+
+            expect(videoPreloader.checkVideoLoaded()).toBe(true);
+        });
+
+        test('should return true after blockFuturePosterPaint without tearing down a painted poster', () => {
+            videoPreloader.containerEl = containerEl;
+            videoPreloader.wrapperEl = document.createElement('div');
+            videoPreloader.preloadEl = document.createElement('div');
+            // Already painted Instant Preview
+            jest.spyOn(videoPreloader, 'cleanupPreload').mockImplementation();
+            jest.spyOn(videoPreloader, 'hidePreload').mockImplementation();
+            videoPreloader.blockFuturePosterPaint();
+
+            expect(videoPreloader.checkVideoLoaded()).toBe(true);
+            expect(videoPreloader.cleanupPreload).not.toHaveBeenCalled();
+            expect(videoPreloader.hidePreload).not.toHaveBeenCalled();
+            expect(videoPreloader.wrapperEl).toBeTruthy();
         });
 
         test('should return false if video element does not exist', () => {

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -439,10 +439,23 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(videoPreloader.containerEl.style.width).toBe('853.3333333333333px');
         });
 
-        test('should contain-fit within a narrow viewport', () => {
+        test('should apply minimum width when viewport is smaller', () => {
             const contentWrapper = document.querySelector(`.${CLASS_BOX_PREVIEW_CONTENT}`);
             Object.defineProperty(contentWrapper, 'clientWidth', { value: 300, writable: false });
             Object.defineProperty(contentWrapper, 'clientHeight', { value: 400, writable: false });
+
+            videoPreloader.sizeContainerToViewport();
+
+            // Legacy path keeps MIN_VIDEO_WIDTH_PX (420px) when viewport is smaller
+            expect(videoPreloader.containerEl.style.width).toBe('420px');
+            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeGreaterThan(0);
+        });
+
+        test('should contain-fit within a narrow viewport when earlyPaint is enabled', () => {
+            const contentWrapper = document.querySelector(`.${CLASS_BOX_PREVIEW_CONTENT}`);
+            Object.defineProperty(contentWrapper, 'clientWidth', { value: 300, writable: false });
+            Object.defineProperty(contentWrapper, 'clientHeight', { value: 400, writable: false });
+            videoPreloader.preloadOptions = { earlyPaint: true };
 
             videoPreloader.sizeContainerToViewport();
 
@@ -474,8 +487,9 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(280);
         });
 
-        test('should not produce a frame wider than the viewport', () => {
+        test('should not produce a frame wider than the viewport when earlyPaint is enabled', () => {
             // Wide aspect + short viewport used to yield width > viewport.width after height clamp
+            videoPreloader.preloadOptions = { earlyPaint: true };
             videoPreloader.sizeContainerToViewport({ width: 611, height: 517 });
 
             expect(parseFloat(videoPreloader.containerEl.style.width)).toBeLessThanOrEqual(611);
@@ -502,6 +516,7 @@ describe('lib/viewers/media/VideoPreloader', () => {
                 value: 1080,
             });
             videoPreloader.preloadOptions = {
+                earlyPaint: true,
                 getViewport: () => ({ width: 800, height: 450 }),
             };
             jest.spyOn(videoPreloader, 'emit');

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -137,6 +137,58 @@ describe('lib/viewers/media/VideoPreloader', () => {
                 expect(videoPreloader.wrapperEl).toBeUndefined();
             });
         });
+
+        test('should single-flight overlapping showPreload calls so only one wrapper is appended', () => {
+            let resolveFetch;
+            stubs.api.get.mockReturnValue(
+                new Promise(resolve => {
+                    resolveFetch = resolve;
+                }),
+            );
+
+            const first = videoPreloader.showPreload('someUrl', containerEl);
+            const second = videoPreloader.showPreload('otherUrl', containerEl);
+
+            expect(stubs.api.get).toHaveBeenCalledTimes(1);
+            expect(second).toBe(first);
+
+            resolveFetch({ data: new Blob(['test'], { type: 'image/jpeg' }), status: 200 });
+
+            return first.then(() => {
+                expect(containerEl.querySelectorAll(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`)).toHaveLength(1);
+                expect(videoPreloader.wrapperEl).toBe(
+                    containerEl.querySelector(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`),
+                );
+            });
+        });
+
+        test('should not append a wrapper when blockFuturePosterPaint invalidates an in-flight fetch', () => {
+            let resolveFetch;
+            stubs.api.get.mockReturnValue(
+                new Promise(resolve => {
+                    resolveFetch = resolve;
+                }),
+            );
+
+            const pending = videoPreloader.showPreload('someUrl', containerEl);
+            videoPreloader.blockFuturePosterPaint();
+            resolveFetch({ data: new Blob(['test'], { type: 'image/jpeg' }), status: 200 });
+
+            return pending.then(() => {
+                expect(videoPreloader.wrapperEl).toBeUndefined();
+                expect(containerEl.querySelectorAll(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`)).toHaveLength(0);
+            });
+        });
+
+        test('should no-op a second showPreload once wrapperEl already exists', () => {
+            return videoPreloader.showPreload('someUrl', containerEl).then(() => {
+                stubs.api.get.mockClear();
+                return videoPreloader.showPreload('otherUrl', containerEl).then(() => {
+                    expect(stubs.api.get).not.toHaveBeenCalled();
+                    expect(containerEl.querySelectorAll(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`)).toHaveLength(1);
+                });
+            });
+        });
     });
 
     describe('hidePreload()', () => {
@@ -153,6 +205,18 @@ describe('lib/viewers/media/VideoPreloader', () => {
             videoPreloader.wrapperEl = null;
             videoPreloader.hidePreload();
 
+            expect(videoPreloader.unbindDOMListeners).not.toBeCalled();
+        });
+
+        test('should remove orphan wrappers even when wrapperEl is missing', () => {
+            const orphan = document.createElement('div');
+            orphan.className = CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO;
+            containerEl.appendChild(orphan);
+            videoPreloader.wrapperEl = null;
+
+            videoPreloader.hidePreload();
+
+            expect(containerEl.querySelectorAll(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`)).toHaveLength(0);
             expect(videoPreloader.unbindDOMListeners).not.toBeCalled();
         });
 
@@ -620,6 +684,17 @@ describe('lib/viewers/media/VideoPreloader', () => {
 
             const { wrapperEl } = videoPreloader;
             expect(wrapperEl).toBeUndefined();
+        });
+
+        test('should remove orphan wrappers left in the container', () => {
+            videoPreloader.containerEl = containerEl;
+            const orphan = document.createElement('div');
+            orphan.className = CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO;
+            containerEl.appendChild(orphan);
+
+            videoPreloader.cleanupPreload();
+
+            expect(containerEl.querySelectorAll(`.${CLASS_BOX_PREVIEW_PRELOAD_WRAPPER_VIDEO}`)).toHaveLength(0);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -439,17 +439,16 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(videoPreloader.containerEl.style.width).toBe('853.3333333333333px');
         });
 
-        test('should apply minimum width when viewport is smaller', () => {
+        test('should contain-fit within a narrow viewport', () => {
             const contentWrapper = document.querySelector(`.${CLASS_BOX_PREVIEW_CONTENT}`);
             Object.defineProperty(contentWrapper, 'clientWidth', { value: 300, writable: false });
             Object.defineProperty(contentWrapper, 'clientHeight', { value: 400, writable: false });
 
             videoPreloader.sizeContainerToViewport();
 
-            // Container width should be MIN_VIDEO_WIDTH_PX (420px) when viewport is smaller
-            expect(videoPreloader.containerEl.style.width).toBe('420px');
-            // Height should be calculated based on aspect ratio with minimum width constraint
-            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeGreaterThan(0);
+            // Fallback path subtracts control bar height: 400 - 120 = 280
+            expect(parseFloat(videoPreloader.containerEl.style.width)).toBeLessThanOrEqual(300);
+            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(280);
         });
 
         test('should calculate height based on image aspect ratio', () => {

--- a/src/lib/viewers/media/__tests__/VideoPreloader-test.js
+++ b/src/lib/viewers/media/__tests__/VideoPreloader-test.js
@@ -169,6 +169,27 @@ describe('lib/viewers/media/VideoPreloader', () => {
         });
     });
 
+    describe('isVisible()', () => {
+        beforeEach(() => {
+            videoPreloader.wrapperEl = document.createElement('div');
+            videoPreloader.preloadEl = document.createElement('div');
+        });
+
+        test('should be true when the poster has painted', () => {
+            expect(videoPreloader.isVisible()).toBe(true);
+        });
+
+        test('should be false while the poster is still invisible', () => {
+            videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
+            expect(videoPreloader.isVisible()).toBe(false);
+        });
+
+        test('should be false once hide/dismiss starts so resize uses video geometry', () => {
+            videoPreloader.wrapperEl.classList.add(CLASS_IS_TRANSPARENT);
+            expect(videoPreloader.isVisible()).toBe(false);
+        });
+    });
+
     describe('showLoading()', () => {
         beforeEach(() => {
             videoPreloader.wrapperEl = document.createElement('div');
@@ -310,6 +331,18 @@ describe('lib/viewers/media/VideoPreloader', () => {
             expect(videoPreloader.sizeContainerToViewport).toBeCalledWith({ width: 800, height: 450 });
         });
 
+        test('should prefer a live getViewport callback over a stale viewport snapshot', () => {
+            const getViewport = jest.fn().mockReturnValue({ width: 611, height: 517 });
+            videoPreloader.preloadOptions = {
+                viewport: { width: 800, height: 450 },
+                getViewport,
+            };
+            videoPreloader.loadHandler();
+
+            expect(getViewport).toHaveBeenCalled();
+            expect(videoPreloader.sizeContainerToViewport).toBeCalledWith({ width: 611, height: 517 });
+        });
+
         test('should size the shared media container before making the preload visible', () => {
             videoPreloader.preloadOptions = { viewport: { width: 800, height: 450 } };
             videoPreloader.sizeContainerToViewport.mockImplementation(() => {
@@ -438,8 +471,70 @@ describe('lib/viewers/media/VideoPreloader', () => {
 
             videoPreloader.sizeContainerToViewport();
 
-            // Height should be constrained to viewport height (400px)
-            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(400);
+            // Height should be constrained to viewport height (400px - control bar)
+            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(280);
+        });
+
+        test('should not produce a frame wider than the viewport', () => {
+            // Wide aspect + short viewport used to yield width > viewport.width after height clamp
+            videoPreloader.sizeContainerToViewport({ width: 611, height: 517 });
+
+            expect(parseFloat(videoPreloader.containerEl.style.width)).toBeLessThanOrEqual(611);
+            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeLessThanOrEqual(517);
+        });
+    });
+
+    describe('poster visibility before video metadata', () => {
+        test('should size and reveal the poster while video metadata is still pending', () => {
+            const videoEl = containerEl.querySelector('video');
+            Object.defineProperty(videoEl, 'readyState', { configurable: true, value: 0 });
+
+            videoPreloader.containerEl = containerEl;
+            videoPreloader.wrapperEl = document.createElement('div');
+            videoPreloader.preloadEl = document.createElement('div');
+            videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
+            videoPreloader.imageEl = document.createElement('img');
+            Object.defineProperty(videoPreloader.imageEl, 'naturalWidth', {
+                configurable: true,
+                value: 1920,
+            });
+            Object.defineProperty(videoPreloader.imageEl, 'naturalHeight', {
+                configurable: true,
+                value: 1080,
+            });
+            videoPreloader.preloadOptions = {
+                getViewport: () => ({ width: 800, height: 450 }),
+            };
+            jest.spyOn(videoPreloader, 'emit');
+
+            // Real sizeContainerToViewport — Instant Preview must not wait on loadedmetadata
+            videoPreloader.loadHandler();
+
+            expect(videoEl.readyState).toBe(0);
+            expect(videoPreloader.preloadEl).not.toHaveClass(CLASS_INVISIBLE);
+            expect(videoPreloader.isVisible()).toBe(true);
+            expect(videoPreloader.containerEl.style.width).toBe('800px');
+            expect(parseFloat(videoPreloader.containerEl.style.height)).toBeCloseTo(450, 5);
+            expect(videoPreloader.emit).toHaveBeenCalledWith('preload');
+        });
+
+        test('should keep the poster hidden when metadata is already available', () => {
+            const videoEl = containerEl.querySelector('video');
+            Object.defineProperty(videoEl, 'readyState', { configurable: true, value: 1 });
+
+            videoPreloader.containerEl = containerEl;
+            videoPreloader.wrapperEl = document.createElement('div');
+            videoPreloader.preloadEl = document.createElement('div');
+            videoPreloader.preloadEl.classList.add(CLASS_INVISIBLE);
+            videoPreloader.imageEl = document.createElement('img');
+            jest.spyOn(videoPreloader, 'hidePreload').mockImplementation();
+            jest.spyOn(videoPreloader, 'sizeContainerToViewport').mockImplementation();
+
+            videoPreloader.loadHandler();
+
+            expect(videoPreloader.hidePreload).toHaveBeenCalled();
+            expect(videoPreloader.sizeContainerToViewport).not.toHaveBeenCalled();
+            expect(videoPreloader.preloadEl).toHaveClass(CLASS_INVISIBLE);
         });
     });
 

--- a/src/lib/viewers/media/__tests__/fitFrameToViewport-test.js
+++ b/src/lib/viewers/media/__tests__/fitFrameToViewport-test.js
@@ -1,0 +1,23 @@
+import fitFrameToViewport from '../fitFrameToViewport';
+import { MIN_VIDEO_WIDTH_PX } from '../../../constants';
+
+describe('lib/viewers/media/fitFrameToViewport', () => {
+    test('should width-fit when the frame is shorter than the viewport height', () => {
+        expect(fitFrameToViewport(16 / 9, { width: 1600, height: 1200 })).toEqual({
+            width: 1600,
+            height: 900,
+        });
+    });
+
+    test('should height-fit without exceeding the viewport width', () => {
+        const { width, height } = fitFrameToViewport(16 / 9, { width: 800, height: 300 });
+        expect(height).toBeCloseTo(300, 5);
+        expect(width).toBeCloseTo(300 * (16 / 9), 5);
+        expect(width).toBeLessThanOrEqual(800);
+    });
+
+    test('should enforce the minimum video width', () => {
+        const { width } = fitFrameToViewport(1, { width: 200, height: 800 });
+        expect(width).toBe(MIN_VIDEO_WIDTH_PX);
+    });
+});

--- a/src/lib/viewers/media/__tests__/fitFrameToViewport-test.js
+++ b/src/lib/viewers/media/__tests__/fitFrameToViewport-test.js
@@ -1,5 +1,4 @@
 import fitFrameToViewport from '../fitFrameToViewport';
-import { MIN_VIDEO_WIDTH_PX } from '../../../constants';
 
 describe('lib/viewers/media/fitFrameToViewport', () => {
     test('should width-fit when the frame is shorter than the viewport height', () => {
@@ -16,8 +15,22 @@ describe('lib/viewers/media/fitFrameToViewport', () => {
         expect(width).toBeLessThanOrEqual(800);
     });
 
-    test('should enforce the minimum video width', () => {
-        const { width } = fitFrameToViewport(1, { width: 200, height: 800 });
-        expect(width).toBe(MIN_VIDEO_WIDTH_PX);
+    test('should not exceed a narrow viewport', () => {
+        const { width, height } = fitFrameToViewport(1, { width: 200, height: 800 });
+        expect(width).toBe(200);
+        expect(height).toBe(200);
+    });
+
+    test('should contain-fit a tall aspect without overflowing the stage', () => {
+        const { width, height } = fitFrameToViewport(9 / 16, { width: 800, height: 600 });
+        expect(height).toBeCloseTo(600, 5);
+        expect(width).toBeCloseTo(600 * (9 / 16), 5);
+        expect(width).toBeLessThanOrEqual(800);
+        expect(height).toBeLessThanOrEqual(600);
+    });
+
+    test('should return zeros for a non-positive viewport', () => {
+        expect(fitFrameToViewport(16 / 9, { width: 0, height: 400 })).toEqual({ width: 0, height: 0 });
+        expect(fitFrameToViewport(16 / 9, { width: 400, height: -1 })).toEqual({ width: 0, height: 0 });
     });
 });

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -183,14 +183,11 @@
     padding: 48px;
 
     video {
-        border: 1px solid rgba($white, .12);
+        border: 1px solid rgba($white, 0.12);
     }
 
     .bp-video-preload-wrapper {
-        top: 48px;
-        right: auto;
-        bottom: 48px;
-        left: 50%;
+        inset: 48px auto 48px 50%;
         transform: translateX(-50%);
 
         .bp-preload {
@@ -198,7 +195,7 @@
         }
 
         .bp-preload-content {
-            border: 1px solid rgba($white, .12);
+            border: 1px solid rgba($white, 0.12);
         }
     }
 }
@@ -229,13 +226,13 @@
     height: auto;
     padding: 0;
 
-    // Box aspect already matches media (JS contain-fit; poster aspect === video aspect).
+    // JS contain-fits the frame; use contain so a poster/video aspect mismatch does not stretch.
     video {
         width: 100%;
         max-width: none;
         height: 100%;
         max-height: none;
-        object-fit: fill;
+        object-fit: contain;
         border: 1px solid rgba($white, 0.12);
     }
 
@@ -248,7 +245,7 @@
         }
 
         .bp-preload-content {
-            object-fit: fill;
+            object-fit: contain;
             border: 1px solid rgba($white, 0.12);
         }
     }

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -196,6 +196,8 @@
 .bp-media-container--v2 {
     flex: 0 0 auto;
     width: auto;
+    max-width: 100%;
+    max-height: 100%;
     padding: 0;
 
     video {

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -189,6 +189,10 @@
     padding: 48px;
 }
 
+.bp-is-fullscreen .bp-media-stage--v2 {
+    padding: 0;
+}
+
 .bp-media-container--v2 {
     flex: 0 0 auto;
     width: auto;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -193,15 +193,23 @@
     padding: 0;
 }
 
-.bp-media-container--v2 {
+.bp-media--v2 .bp-media-container--v2 {
     flex: 0 0 auto;
     width: auto;
-    max-width: 100%;
-    max-height: 100%;
+
+    // Override .bp-media-container { min-width: 360px; width: 100%; flex: 1 } —
+    // those force a wider/taller box than the JS contain-fit and stretch the media.
+    min-width: 0;
+    height: auto;
     padding: 0;
 
+    // Box aspect already matches media (JS contain-fit; poster aspect === video aspect).
     video {
-        object-fit: contain;
+        width: 100%;
+        max-width: none;
+        height: 100%;
+        max-height: none;
+        object-fit: fill;
         border: 1px solid rgba($white, 0.12);
     }
 
@@ -214,6 +222,7 @@
         }
 
         .bp-preload-content {
+            object-fit: fill;
             border: 1px solid rgba($white, 0.12);
         }
     }

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -219,14 +219,10 @@
 .bp-media-stage--v2 .bp-media-container--v2 {
     flex: 0 0 auto;
     width: auto;
-
-    // Override .bp-media-container { min-width: 360px; width: 100%; flex: 1 } —
-    // those force a wider/taller box than the JS contain-fit and stretch the media.
     min-width: 0;
     height: auto;
     padding: 0;
 
-    // JS contain-fits the frame; use contain so a poster/video aspect mismatch does not stretch.
     video {
         width: 100%;
         max-width: none;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -178,16 +178,30 @@
     background: radial-gradient(ellipse at center, #2a2a2a 0%, #000 100%);
 }
 
-.bp-media-container--v2 {
+.bp-media-stage--v2 {
+    display: flex;
+    flex: 1 1 0;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 0;
     padding: 48px;
+}
+
+.bp-media-container--v2 {
+    flex: 0 0 auto;
+    width: auto;
+    padding: 0;
 
     video {
+        object-fit: contain;
         border: 1px solid rgba($white, 0.12);
     }
 
     .bp-video-preload-wrapper {
-        inset: 48px auto 48px 50%;
-        transform: translateX(-50%);
+        inset: 0;
+        transform: none;
 
         .bp-preload {
             transform: none;

--- a/src/lib/viewers/media/_mediaBase.scss
+++ b/src/lib/viewers/media/_mediaBase.scss
@@ -178,6 +178,32 @@
     background: radial-gradient(ellipse at center, #2a2a2a 0%, #000 100%);
 }
 
+// Legacy V2 (videoPosterEarlyPaint off): padded container owns the stage inset.
+.bp-media-container--v2 {
+    padding: 48px;
+
+    video {
+        border: 1px solid rgba($white, .12);
+    }
+
+    .bp-video-preload-wrapper {
+        top: 48px;
+        right: auto;
+        bottom: 48px;
+        left: 50%;
+        transform: translateX(-50%);
+
+        .bp-preload {
+            transform: none;
+        }
+
+        .bp-preload-content {
+            border: 1px solid rgba($white, .12);
+        }
+    }
+}
+
+// Early-paint V2: dedicated stage with a shared contain-fit media frame.
 .bp-media-stage--v2 {
     display: flex;
     flex: 1 1 0;
@@ -193,7 +219,7 @@
     padding: 0;
 }
 
-.bp-media--v2 .bp-media-container--v2 {
+.bp-media-stage--v2 .bp-media-container--v2 {
     flex: 0 0 auto;
     width: auto;
 

--- a/src/lib/viewers/media/fitFrameToViewport.js
+++ b/src/lib/viewers/media/fitFrameToViewport.js
@@ -1,7 +1,6 @@
-import { MIN_VIDEO_WIDTH_PX } from '../../constants';
-
 /**
  * Contain-fits a frame into the viewport (same model as object-fit: contain).
+ * Never exceeds the viewport; does not enforce a minimum width.
  *
  * @param {number} aspectRatio - width / height
  * @param {Object} viewport - { width, height }
@@ -11,7 +10,11 @@ export default function fitFrameToViewport(aspectRatio, viewport = {}) {
     const { width: viewportWidth = 0, height: viewportHeight = 0 } = viewport;
     const ratio = aspectRatio || 1;
 
-    let width = Math.max(MIN_VIDEO_WIDTH_PX, viewportWidth);
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return { width: 0, height: 0 };
+    }
+
+    let width = viewportWidth;
     let height = width / ratio;
 
     if (height > viewportHeight) {
@@ -21,11 +24,6 @@ export default function fitFrameToViewport(aspectRatio, viewport = {}) {
 
     if (width > viewportWidth) {
         width = viewportWidth;
-        height = width / ratio;
-    }
-
-    if (width < MIN_VIDEO_WIDTH_PX) {
-        width = MIN_VIDEO_WIDTH_PX;
         height = width / ratio;
     }
 

--- a/src/lib/viewers/media/fitFrameToViewport.js
+++ b/src/lib/viewers/media/fitFrameToViewport.js
@@ -1,0 +1,33 @@
+import { MIN_VIDEO_WIDTH_PX } from '../../constants';
+
+/**
+ * Contain-fits a frame into the viewport (same model as object-fit: contain).
+ *
+ * @param {number} aspectRatio - width / height
+ * @param {Object} viewport - { width, height }
+ * @return {{ width: number, height: number }}
+ */
+export default function fitFrameToViewport(aspectRatio, viewport = {}) {
+    const { width: viewportWidth = 0, height: viewportHeight = 0 } = viewport;
+    const ratio = aspectRatio || 1;
+
+    let width = Math.max(MIN_VIDEO_WIDTH_PX, viewportWidth);
+    let height = width / ratio;
+
+    if (height > viewportHeight) {
+        height = viewportHeight;
+        width = height * ratio;
+    }
+
+    if (width > viewportWidth) {
+        width = viewportWidth;
+        height = width / ratio;
+    }
+
+    if (width < MIN_VIDEO_WIDTH_PX) {
+        width = MIN_VIDEO_WIDTH_PX;
+        height = width / ratio;
+    }
+
+    return { width, height };
+}


### PR DESCRIPTION
## Summary
- Gate V2 Instant Preview early paint behind videoPosterEarlyPaint.enabled (requires videoPlayerV2.enabled).
- Flag on: paint/size poster before metadata on a shared .bp-media-stage--v2 contain-fit frame so poster and playback stay aligned; V2 controls stay full-width overlays.
- Flag off: keep legacy padded V2 Instant Preview sizing.
- Set V2 capability once in VideoBaseViewer.setup; 360 opts out via supportsVideoPlayerV2().
- Harden Instant Preview (not flag-gated): block late poster paint after video is ready, sync across VideoBase/Dash/MP4, tear down on destroy. Dismiss-on-playing unchanged.

## Test plan
- [x] Focused media viewer unit tests (VideoBase / VideoPreloader / Dash / MP4 / fitFrameToViewport / Video360)
- [x] ESLint / Stylelint (pre-push)
- [ ] Flag **off** (`videoPlayerV2` on, early paint off): legacy padded Instant Preview, no stage node
- [ ] Flag **on**: cold- and warm-cache poster paint before metadata; poster and video share one frame
- [ ] Poster → play → dismiss on `playing`; click before poster arrives
- [ ] Navigate away mid-load (no leftover Instant Preview / no late paint)
- [ ] 360 video stays off V2 structure
- [ ] Fullscreen padding behavior with early paint on