### PR TITLE
feat(gallery): add ARIA grid for 2D navigation

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -52,7 +52,7 @@ toggle_findbar=Toggle findbar
 toggle_thumbnails=Toggle thumbnails
 # Button tooltip for Gallery view
 gallery_view=Gallery view
-# Accessible name for the gallery page-thumbnail grid (listbox pre-V2)
+# Accessible name for the gallery of page thumbnails
 page_gallery=Page gallery
 # Accessible name for a single gallery tile; {1} is the page number
 page_gallery_tile=Page {1}

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -52,7 +52,7 @@ toggle_findbar=Toggle findbar
 toggle_thumbnails=Toggle thumbnails
 # Button tooltip for Gallery view
 gallery_view=Gallery view
-# Accessible name for the gallery page-thumbnail listbox
+# Accessible name for the gallery page-thumbnail grid (listbox pre-V2)
 page_gallery=Page gallery
 # Accessible name for a single gallery tile; {1} is the page number
 page_gallery_tile=Page {1}

--- a/src/lib/FocusTrap.ts
+++ b/src/lib/FocusTrap.ts
@@ -9,6 +9,7 @@ const FOCUSABLE_ELEMENT_SELECTORS = [
     'input[type="checkbox"]',
     'select',
     '[role="option"][tabindex="0"]',
+    '[role="gridcell"][tabindex="0"]',
 ];
 const EXCLUDED_SELECTOR_ATTRIBUTES = ['disabled', 'tabindex="-1"', 'aria-disabled="true"', 'aria-hidden="true"'];
 const FOCUSABLE_ELEMENTS_SELECTOR = FOCUSABLE_ELEMENT_SELECTORS.map(element => {

--- a/src/lib/__tests__/FocusTrap-test.ts
+++ b/src/lib/__tests__/FocusTrap-test.ts
@@ -188,12 +188,23 @@ describe('lib/FocusTrap', () => {
             tile.setAttribute('role', 'option');
             tile.setAttribute('tabindex', '0');
             container.appendChild(tile);
+            const gridTile = document.createElement('div');
+            gridTile.setAttribute('role', 'gridcell');
+            gridTile.setAttribute('tabindex', '0');
+            container.appendChild(gridTile);
+            // Roving tabindex: only the active gridcell is tabbable, the rest must stay out
+            const inactiveGridTile = document.createElement('div');
+            inactiveGridTile.setAttribute('role', 'gridcell');
+            inactiveGridTile.setAttribute('tabindex', '-1');
+            container.appendChild(inactiveGridTile);
 
             const focusTrap = getFocusTrap();
             focusTrap.enable();
 
             const focusable = focusTrap.getFocusableElements();
             expect(focusable).toContain(tile);
+            expect(focusable).toContain(gridTile);
+            expect(focusable).not.toContain(inactiveGridTile);
             expect(focusable.some(el => el.tagName.toLowerCase() === 'i')).toBe(false);
         });
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -936,7 +936,7 @@ class DocBaseViewer extends BaseViewer {
                 return true;
             }
 
-            if (this.galleryController.isZoomEnabled) {
+            if (this.galleryController.isEnhancedGalleryEnabled) {
                 if (key === 'Shift++') {
                     this.galleryController.zoomIn();
                     return true;
@@ -1518,7 +1518,7 @@ class DocBaseViewer extends BaseViewer {
         const isAnnotationsMode = this.currentAnnotatorViewMode === ANNOTATOR_VIEW_MODES.ANNOTATIONS;
         const canRotate = this.featureEnabled('rotate.enabled');
         const canGallery = !this.isMobile && this.galleryController.canRender(this.pdfViewer.pagesCount);
-        const isGalleryZoomActive = this.galleryController.isOpen && this.galleryController.isZoomEnabled;
+        const isGalleryZoomActive = this.galleryController.isOpen && this.galleryController.isEnhancedGalleryEnabled;
 
         this.controls.render(
             <DocControls
@@ -1526,7 +1526,7 @@ class DocBaseViewer extends BaseViewer {
                 annotationMode={this.annotationControlsFSM.getMode()}
                 experiences={this.experiences}
                 hasDrawing={canAnnotate && showAnnotationsDrawingCreate && isAnnotationsMode}
-                hasGalleryZoom={this.galleryController.isZoomEnabled}
+                hasGalleryZoom={this.galleryController.isEnhancedGalleryEnabled}
                 hasHighlight={canAnnotate && canDownload && isAnnotationsMode}
                 hasRegion={canAnnotate && isAnnotationsMode}
                 isGalleryOpen={this.galleryController.isOpen}

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -5,7 +5,8 @@ import Browser from '../../Browser';
 import ControlsRoot from '../controls/controls-root';
 import DocControls from './DocControls';
 import DocFindBar from './DocFindBar';
-import GalleryController, { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../gallery/GalleryController';
+import GalleryController from '../gallery/GalleryController';
+import { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../gallery/constants';
 import PageTracker from '../../PageTracker';
 import Popup from '../../Popup';
 import PreviewError from '../../PreviewError';
@@ -948,9 +949,9 @@ class DocBaseViewer extends BaseViewer {
             }
 
             // Swallow page-nav keys so they can't flip the doc page underneath the gallery
-            // or trigger the host's collection navigation. Arrows pressed outside the grid
-            // are redirected into it so the first press navigates the tiles.
-            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'].includes(key)) {
+            // or trigger the host's collection navigation. Arrows/Home/End pressed outside
+            // the grid are redirected into it so the first press navigates the tiles.
+            if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End', '[', ']'].includes(key)) {
                 this.galleryController.handleArrowKey(key);
                 return true;
             }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -17,7 +17,7 @@ import DocBaseViewer, {
 } from '../DocBaseViewer';
 import DocFindBar from '../DocFindBar';
 import DocPreloader from '../DocPreloader';
-import { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../../gallery/GalleryController';
+import { GALLERY_MAX_SCALE, GALLERY_MIN_SCALE } from '../../gallery/constants';
 import DocFirstPreloader from '../DocFirstPreloader';
 import fullscreen from '../../../Fullscreen';
 import {
@@ -1700,7 +1700,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect(consumed).toBe(true);
                 });
 
-                test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', '[', ']'])(
+                test.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End', '[', ']'])(
                     'should swallow %s without paging',
                     key => {
                         const consumed = docBase.onKeydown(key, { defaultPrevented: false });

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -1663,7 +1663,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 beforeEach(() => {
                     docBase.galleryController = {
                         isOpen: true,
-                        isZoomEnabled: true,
+                        isEnhancedGalleryEnabled: true,
                         handleArrowKey: jest.fn(),
                         handleEscape: jest.fn().mockReturnValue(true),
                         zoomIn: jest.fn(),
@@ -1687,7 +1687,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
 
                 test('should not consume the zoom shortcuts when gallery zoom is disabled', () => {
-                    docBase.galleryController.isZoomEnabled = false;
+                    docBase.galleryController.isEnhancedGalleryEnabled = false;
 
                     expect(docBase.onKeydown('Shift++', { defaultPrevented: false })).toBe(false);
                     expect(docBase.galleryController.zoomIn).not.toBeCalled();
@@ -2836,10 +2836,10 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test.each([true, false])(
                 'should route the zoom controls to the gallery scale, or the document scale, based on the zoom flag',
-                isZoomEnabled => {
+                isEnhancedGalleryEnabled => {
                     docBase.galleryController = {
                         isOpen: true,
-                        isZoomEnabled,
+                        isEnhancedGalleryEnabled,
                         canRender: jest.fn().mockReturnValue(true),
                         destroy: jest.fn(),
                         scale: 1.5,
@@ -2851,13 +2851,13 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     docBase.renderUI();
 
                     expect(getProps(docBase)).toMatchObject({
-                        hasGalleryZoom: isZoomEnabled,
+                        hasGalleryZoom: isEnhancedGalleryEnabled,
                         isGalleryOpen: true,
-                        maxScale: isZoomEnabled ? GALLERY_MAX_SCALE : 10,
-                        minScale: isZoomEnabled ? GALLERY_MIN_SCALE : 0.1,
-                        onZoomIn: isZoomEnabled ? docBase.galleryController.zoomIn : docBase.zoomIn,
-                        onZoomOut: isZoomEnabled ? docBase.galleryController.zoomOut : docBase.zoomOut,
-                        scale: isZoomEnabled ? 1.5 : 0.9,
+                        maxScale: isEnhancedGalleryEnabled ? GALLERY_MAX_SCALE : 10,
+                        minScale: isEnhancedGalleryEnabled ? GALLERY_MIN_SCALE : 0.1,
+                        onZoomIn: isEnhancedGalleryEnabled ? docBase.galleryController.zoomIn : docBase.zoomIn,
+                        onZoomOut: isEnhancedGalleryEnabled ? docBase.galleryController.zoomOut : docBase.zoomOut,
+                        scale: isEnhancedGalleryEnabled ? 1.5 : 0.9,
                     });
                 },
             );

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -230,7 +230,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
         test('should defer paging and zoom shortcuts to the gallery while it is open', () => {
             doc.galleryController = {
                 isOpen: true,
-                isZoomEnabled: true,
+                isEnhancedGalleryEnabled: true,
                 handleArrowKey: jest.fn(),
                 handleEscape: jest.fn(),
                 zoomIn: jest.fn(),

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -130,14 +130,10 @@ export default class GalleryController {
         return this.galleryScale;
     }
 
-    /** V2 requires the V1 flag: parent apps target the splits independently. */
-    get isV2Enabled(): boolean {
+    /** Both gallery flags must be on: parent apps target the splits independently. */
+    get isEnhancedGalleryEnabled(): boolean {
         const { features } = this;
         return isFeatureEnabled(features, 'galleryView.enabled') && isFeatureEnabled(features, 'galleryViewV2.enabled');
-    }
-
-    get isZoomEnabled(): boolean {
-        return this.isV2Enabled;
     }
 
     canRender(pageCount: number): boolean {
@@ -328,7 +324,7 @@ export default class GalleryController {
     };
 
     private commitScale = (scale: number): boolean => {
-        if (!this.isZoomEnabled || !Number.isFinite(scale)) {
+        if (!this.isEnhancedGalleryEnabled || !Number.isFinite(scale)) {
             return false;
         }
 
@@ -390,9 +386,11 @@ export default class GalleryController {
             <GalleryGrid
                 currentPage={pdfViewer.currentPageNumber}
                 getPageRatio={this.getPageRatio}
-                isAriaGridEnabled={this.isV2Enabled}
-                isPinchZoomEnabled={this.isZoomEnabled && isFeatureEnabled(this.features, 'pinchToZoom.enabled')}
-                isTouchZoomEnabled={this.isZoomEnabled && this.hasTouch}
+                isAriaGridEnabled={this.isEnhancedGalleryEnabled}
+                isPinchZoomEnabled={
+                    this.isEnhancedGalleryEnabled && isFeatureEnabled(this.features, 'pinchToZoom.enabled')
+                }
+                isTouchZoomEnabled={this.isEnhancedGalleryEnabled && this.hasTouch}
                 onClose={this.toggle}
                 onFocusChange={this.handleFocusChange}
                 onPageNavigate={this.handleGalleryNavigate}

--- a/src/lib/viewers/gallery/GalleryController.tsx
+++ b/src/lib/viewers/gallery/GalleryController.tsx
@@ -6,19 +6,19 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import Thumbnail from '../../Thumbnail';
 import { FeatureConfig, isFeatureEnabled } from '../../featureChecking';
+import {
+    GALLERY_MAX_PAGES,
+    GALLERY_MAX_SCALE,
+    GALLERY_MIN_SCALE,
+    GALLERY_SCALE_STEP,
+    THUMBNAILS_SIDEBAR_TRANSITION_TIME,
+} from './constants';
 import GalleryGrid, { GalleryThumbnail } from './GalleryGrid';
 import { PinchDirection } from './useGalleryPinch';
 
 // Controller-owned shape: GalleryGrid only sees the read surface (GalleryThumbnail),
 // but the controller also needs destroy() to invalidate the cache on rotate/teardown.
 type ManagedGalleryThumbnail = GalleryThumbnail & { destroy: () => void };
-
-const GALLERY_MAX_PAGES = 200; // Hide gallery toggle for files above this page count, will increase in V2
-const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301; // ms
-
-export const GALLERY_MAX_SCALE = 3;
-export const GALLERY_MIN_SCALE = 0.5;
-const GALLERY_SCALE_STEP = 0.1;
 
 // Minimal local shapes for untyped peer modules (pdfjs is JS-only, sidebar is JS-only).
 // Only the members the controller actually uses are declared — extend as needed.
@@ -130,9 +130,14 @@ export default class GalleryController {
         return this.galleryScale;
     }
 
-    get isZoomEnabled(): boolean {
+    /** V2 requires the V1 flag: parent apps target the splits independently. */
+    get isV2Enabled(): boolean {
         const { features } = this;
         return isFeatureEnabled(features, 'galleryView.enabled') && isFeatureEnabled(features, 'galleryViewV2.enabled');
+    }
+
+    get isZoomEnabled(): boolean {
+        return this.isV2Enabled;
     }
 
     canRender(pageCount: number): boolean {
@@ -235,18 +240,19 @@ export default class GalleryController {
     };
 
     /**
-     * Redirects an arrow key pressed outside the grid (e.g. focus parked on a toggle after
+     * Redirects a grid-nav key pressed outside the grid (e.g. focus parked on a toggle after
      * toggling fullscreen) back into it: refocuses the selected tile and replays the key so
      * the first press navigates, like the thumbnail sidebar. Keys pressed inside the grid
-     * never arrive here — GalleryGrid stops propagation on every arrow it handles.
+     * never arrive here — GalleryGrid stops propagation on every arrow/Home/End it handles.
      */
     handleArrowKey(key: string): void {
-        if (!this.isGalleryOpen || !key.startsWith('Arrow')) return;
+        if (!this.isGalleryOpen) return;
+        if (!key.startsWith('Arrow') && key !== 'Home' && key !== 'End') return;
 
         const grid = this.galleryEl;
         if (!grid) return;
 
-        const tile = grid.querySelector<HTMLElement>('[role="option"][tabindex="0"]');
+        const tile = grid.querySelector<HTMLElement>('[role="option"][tabindex="0"], [role="gridcell"][tabindex="0"]');
         if (tile) {
             tile.focus();
             tile.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
@@ -384,6 +390,7 @@ export default class GalleryController {
             <GalleryGrid
                 currentPage={pdfViewer.currentPageNumber}
                 getPageRatio={this.getPageRatio}
+                isAriaGridEnabled={this.isV2Enabled}
                 isPinchZoomEnabled={this.isZoomEnabled && isFeatureEnabled(this.features, 'pinchToZoom.enabled')}
                 isTouchZoomEnabled={this.isZoomEnabled && this.hasTouch}
                 onClose={this.toggle}

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -24,6 +24,12 @@
     align-items: start;
 }
 
+// V2 ARIA grid rows exist only for the accessibility tree: display: contents generates no
+// box, so tiles stay direct grid items of .bp-gallery-grid-inner and layout is unchanged.
+.bp-gallery-grid-row {
+    display: contents;
+}
+
 .bp-gallery-tile {
     position: relative;
     padding: 0;

--- a/src/lib/viewers/gallery/GalleryGrid.scss
+++ b/src/lib/viewers/gallery/GalleryGrid.scss
@@ -24,7 +24,7 @@
     align-items: start;
 }
 
-// V2 ARIA grid rows exist only for the accessibility tree: display: contents generates no
+// ARIA grid rows exist only for the accessibility tree: display: contents generates no
 // box, so tiles stay direct grid items of .bp-gallery-grid-inner and layout is unchanged.
 .bp-gallery-grid-row {
     display: contents;

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -137,6 +137,10 @@ export default function GalleryGrid({
     const highResStoreRef = useRef<HighResThumbnailStore | null>(null);
     const columnCountRef = useRef(1);
     const restoreFocusRef = useRef(false);
+    // Anchor tile's viewport top captured when a re-chunk is scheduled, so the post-commit effect
+    // can restore the scroll by delta instead of snapping the anchor to the top of the viewport.
+    const rechunkAnchorTopRef = useRef<number | null>(null);
+    const isFirstRechunkRef = useRef(true);
 
     const byDistanceFromAnchor = (a: number, b: number): number =>
         Math.abs(a - anchorPageRef.current) - Math.abs(b - anchorPageRef.current);
@@ -361,6 +365,10 @@ export default function GalleryGrid({
             // Re-chunking tiles into different rows recreates the focused tile's DOM node,
             // which would silently drop focus to <body>; remember to restore it post-render.
             restoreFocusRef.current = grid.contains(document.activeElement);
+            // Capture where the anchor tile sits now — after any zoom/resize scroll fixups that
+            // already ran — so the post-commit effect can put it back in exactly the same place.
+            const anchorTile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`);
+            rechunkAnchorTopRef.current = anchorTile ? anchorTile.getBoundingClientRect().top : null;
             columnCountRef.current = count;
             setColumnCount(count);
         }
@@ -475,15 +483,17 @@ export default function GalleryGrid({
             // always re-apply layout and re-measure; only the scroll-anchor restore is skipped
             // on that first delivery, since there is no viewed area to preserve yet.
             applyZoomLayout();
-            measureColumnCount();
             if (isFirstObservation) {
                 isFirstObservation = false;
+                measureColumnCount();
                 return;
             }
             const tile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
             if (tile) {
                 tile.scrollIntoView({ block: 'start' });
             }
+            // Measure after the anchor restore so a scheduled re-chunk captures the restored position.
+            measureColumnCount();
             // A larger viewport (fullscreen enter, window resize) can reveal unloaded tiles
             // without any scroll event, so run the same catch-up the scroll handler does.
             handleScrollRef.current();
@@ -517,9 +527,26 @@ export default function GalleryGrid({
             focusTile(focusedPage, { preventScroll: true });
         }
 
-        // Re-chunk replaced the tiles the zoom/resize scroll fixup used; re-anchor on the new ones.
-        const tile = gridRef.current?.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
-        if (tile) {
+        const anchorTop = rechunkAnchorTopRef.current;
+        rechunkAnchorTopRef.current = null;
+
+        // Skip the mount re-chunk: the mount effect centers the current page after the
+        // measurement captured its anchor, so restoring would undo that centering.
+        if (isFirstRechunkRef.current) {
+            isFirstRechunkRef.current = false;
+            return;
+        }
+
+        // Swapping the row DOM can clamp scrollTop. Restore the anchor tile to its captured
+        // position by delta, preserving the zoom focal-point and resize fixups that already ran.
+        const grid = gridRef.current;
+        const tile = grid && (grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null);
+        if (!grid || !tile) {
+            return;
+        }
+        if (anchorTop !== null) {
+            grid.scrollTop += tile.getBoundingClientRect().top - anchorTop;
+        } else {
             tile.scrollIntoView({ block: 'start' });
         }
     }, [columnCount, focusedPage, focusTile]);

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -137,10 +137,9 @@ export default function GalleryGrid({
     const highResStoreRef = useRef<HighResThumbnailStore | null>(null);
     const columnCountRef = useRef(1);
     const restoreFocusRef = useRef(false);
-    // Anchor tile's viewport top captured when a re-chunk is scheduled, so the post-commit effect
-    // can restore the scroll by delta instead of snapping the anchor to the top of the viewport.
-    const rechunkAnchorTopRef = useRef<number | null>(null);
-    const isFirstRechunkRef = useRef(true);
+    // Anchor tile and its viewport top, captured together when a re-chunk is scheduled so the
+    // post-commit effect restores against the same tile even if the anchor page changes meanwhile.
+    const rechunkAnchorRef = useRef<{ page: number; top: number } | null>(null);
 
     const byDistanceFromAnchor = (a: number, b: number): number =>
         Math.abs(a - anchorPageRef.current) - Math.abs(b - anchorPageRef.current);
@@ -366,9 +365,12 @@ export default function GalleryGrid({
             // which would silently drop focus to <body>; remember to restore it post-render.
             restoreFocusRef.current = grid.contains(document.activeElement);
             // Capture where the anchor tile sits now — after any zoom/resize scroll fixups that
-            // already ran — so the post-commit effect can put it back in exactly the same place.
-            const anchorTile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`);
-            rechunkAnchorTopRef.current = anchorTile ? anchorTile.getBoundingClientRect().top : null;
+            // already ran — so the post-commit effect can restore its position.
+            const anchorPage = anchorPageRef.current;
+            const anchorTile = grid.querySelector(`[data-page="${anchorPage}"]`);
+            rechunkAnchorRef.current = anchorTile
+                ? { page: anchorPage, top: anchorTile.getBoundingClientRect().top }
+                : null;
             columnCountRef.current = count;
             setColumnCount(count);
         }
@@ -426,6 +428,12 @@ export default function GalleryGrid({
             if (tile) {
                 tile.scrollIntoView({ block: 'center' });
                 tile.focus();
+                // The mount-time measurement may have captured this tile's position before this
+                // centering ran; refresh the capture so the re-chunk restore keeps the centering.
+                const anchor = rechunkAnchorRef.current;
+                if (anchor && anchor.page === currentPage) {
+                    anchor.top = tile.getBoundingClientRect().top;
+                }
             }
         }
 
@@ -512,7 +520,8 @@ export default function GalleryGrid({
         }
     }, []);
 
-    // Re-chunk unmounts tiles and drops focus; restore it after mount and resize/fullscreen.
+    // Re-chunk recreates the tile DOM nodes, which drops focus and can shift the scroll
+    // position; restore both after the new nodes commit.
     const committedColumnCountRef = useRef(columnCount);
     useLayoutEffect(() => {
         const isRechunk = committedColumnCountRef.current !== columnCount;
@@ -527,27 +536,18 @@ export default function GalleryGrid({
             focusTile(focusedPage, { preventScroll: true });
         }
 
-        const anchorTop = rechunkAnchorTopRef.current;
-        rechunkAnchorTopRef.current = null;
+        const anchor = rechunkAnchorRef.current;
+        rechunkAnchorRef.current = null;
 
-        // Skip the mount re-chunk: the mount effect centers the current page after the
-        // measurement captured its anchor, so restoring would undo that centering.
-        if (isFirstRechunkRef.current) {
-            isFirstRechunkRef.current = false;
-            return;
-        }
-
-        // Swapping the row DOM can clamp scrollTop. Restore the anchor tile to its captured
-        // position by delta, preserving the zoom focal-point and resize fixups that already ran.
+        // Swapping the row DOM out from under the scroller can shift scrollTop. Restore the
+        // captured anchor tile to its captured viewport position by delta, preserving the mount
+        // centering and the zoom focal-point / resize fixups that already ran.
         const grid = gridRef.current;
-        const tile = grid && (grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null);
-        if (!grid || !tile) {
-            return;
-        }
-        if (anchorTop !== null) {
-            grid.scrollTop += tile.getBoundingClientRect().top - anchorTop;
-        } else {
-            tile.scrollIntoView({ block: 'start' });
+        if (grid && anchor) {
+            const tile = grid.querySelector(`[data-page="${anchor.page}"]`) as HTMLElement | null;
+            if (tile) {
+                grid.scrollTop += tile.getBoundingClientRect().top - anchor.top;
+            }
         }
     }, [columnCount, focusedPage, focusTile]);
 

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -37,7 +37,7 @@ export type Props = {
     currentPage: number;
     /** Per-page width:height ratio (null while unknown). Falls back to the first-page ratio. */
     getPageRatio?: (pageNum: number) => number | null;
-    /** V2: swaps listbox/option semantics for an ARIA grid with 2D arrow navigation. */
+    /** When true, use ARIA grid roles and 2D arrow navigation instead of listbox/option. */
     isAriaGridEnabled?: boolean;
     isPinchZoomEnabled?: boolean;
     isTouchZoomEnabled?: boolean;
@@ -122,7 +122,7 @@ export default function GalleryGrid({
     const [highResImages, setHighResImages] = useState<Record<number, string>>({});
     const [focusedPage, setFocusedPage] = useState(currentPage);
     const [pageRatio, setPageRatio] = useState<number | null>(null);
-    // Measured from the rendered layout; drives ARIA grid metadata and 2D navigation (v2).
+    // Measured from the rendered layout; drives ARIA grid row/column numbers and 2D navigation.
     const [columnCount, setColumnCount] = useState(1);
     // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
     const anchorPageRef = useRef(currentPage);
@@ -502,12 +502,7 @@ export default function GalleryGrid({
         }
     }, []);
 
-    // Re-chunking on a column-count change unmounts and recreates tile DOM nodes, which drops
-    // focus to <body> when the focused tile is one of them. Two cases need it reclaimed:
-    //  - resize/fullscreen: flagged during measurement while the grid still held focus
-    //  - mount: the initial focus lands on a pre-measurement tile node, because React flushes
-    //    the pending mount effect before the sync re-render the measurement schedules
-    // Restoring focus also makes assistive tech re-announce the cell's new coordinates.
+    // Re-chunk unmounts tiles and drops focus; restore it after mount and resize/fullscreen.
     const committedColumnCountRef = useRef(columnCount);
     useLayoutEffect(() => {
         const isRechunk = committedColumnCountRef.current !== columnCount;
@@ -565,9 +560,8 @@ export default function GalleryGrid({
                     event.stopPropagation();
                     onClose();
                     return;
-                // V1 listbox is 1-D: every arrow moves ±1 page. The v2 ARIA grid keeps ±1 for
-                // Left/Right (wrapping across row edges, clamped at the first/last page) and
-                // moves Up/Down by one row, clamping Down to the last tile on a short final row.
+                // Listbox: every arrow moves ±1 page. ARIA grid: Left/Right stay ±1 (across row
+                // edges, clamped at first/last page); Up/Down move one row (Down clamps on a short last row).
                 case 'ArrowUp': {
                     event.preventDefault();
                     event.stopPropagation();

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -521,6 +521,12 @@ export default function GalleryGrid({
             restoreFocusRef.current = false;
             focusTile(focusedPage, { preventScroll: true });
         }
+
+        // Re-chunk replaced the tiles the zoom/resize scroll fixup used; re-anchor on the new ones.
+        const tile = gridRef.current?.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
+        if (tile) {
+            tile.scrollIntoView({ block: 'start' });
+        }
     }, [columnCount, focusedPage, focusTile]);
 
     const handleTileFocus = useCallback(

--- a/src/lib/viewers/gallery/GalleryGrid.tsx
+++ b/src/lib/viewers/gallery/GalleryGrid.tsx
@@ -3,22 +3,22 @@ import noop from 'lodash/noop';
 import throttle from 'lodash/throttle';
 import { decodeKeydown, replacePlaceholders } from '../../util';
 import HighResThumbnailStore, { HighResRenderTask } from './HighResThumbnailStore';
+import {
+    CONCURRENT_LOADS,
+    GALLERY_HIGH_RES_CONCURRENCY,
+    GALLERY_HIGH_RES_MAX_BYTES,
+    GALLERY_HIGH_RES_MAX_PAGES,
+    GALLERY_THUMB_MAX_DPR,
+    GALLERY_THUMB_MAX_TIER,
+    GALLERY_THUMB_MAX_WIDTH,
+    GALLERY_THUMB_WIDTH_TIERS,
+    GALLERY_TILE_GAP,
+    GALLERY_TILE_MIN_WIDTH,
+    SCROLL_THROTTLE_MS,
+} from './constants';
+import { getColumnIndex, getPageAbove, getPageBelow, getRowCount } from './galleryGridNavigation';
 import useGalleryPinch, { PinchDirection, PinchFocal } from './useGalleryPinch';
 import './GalleryGrid.scss';
-
-const GALLERY_THUMB_MAX_WIDTH = 440;
-const CONCURRENT_LOADS = 4;
-const SCROLL_THROTTLE_MS = 200;
-// Keep in sync with the 100% grid rule in GalleryGrid.scss
-const GALLERY_TILE_GAP = 16;
-const GALLERY_TILE_MIN_WIDTH = 220;
-const GALLERY_THUMB_WIDTH_TIERS = [GALLERY_THUMB_MAX_WIDTH, GALLERY_THUMB_MAX_WIDTH * 2, GALLERY_THUMB_MAX_WIDTH * 3];
-const GALLERY_THUMB_MAX_TIER = GALLERY_THUMB_WIDTH_TIERS[GALLERY_THUMB_WIDTH_TIERS.length - 1];
-const GALLERY_THUMB_MAX_DPR = 2;
-const GALLERY_HIGH_RES_MAX_BYTES = 64 * 1024 * 1024;
-const GALLERY_HIGH_RES_MAX_PAGES = 16;
-const GALLERY_HIGH_RES_CONCURRENCY = 2;
-const GALLERY_DEFAULT_PAGE_RATIO = 0.775;
 
 export interface GalleryThumbnail {
     init: () => Promise<unknown>;
@@ -37,6 +37,8 @@ export type Props = {
     currentPage: number;
     /** Per-page width:height ratio (null while unknown). Falls back to the first-page ratio. */
     getPageRatio?: (pageNum: number) => number | null;
+    /** V2: swaps listbox/option semantics for an ARIA grid with 2D arrow navigation. */
+    isAriaGridEnabled?: boolean;
     isPinchZoomEnabled?: boolean;
     isTouchZoomEnabled?: boolean;
     onFocusChange?: (pageNum: number) => void;
@@ -51,19 +53,23 @@ export type Props = {
 interface TileProps {
     pageNum: number;
     isFocused: boolean;
+    ariaColIndex?: number;
     imageSrc?: string;
     onClick: (pageNum: number) => void;
     onFocus: (pageNum: number) => void;
     pageRatio?: number | null;
+    role: 'option' | 'gridcell';
 }
 
 const GalleryTile = React.memo(function GalleryTile({
     pageNum,
     isFocused,
+    ariaColIndex,
     imageSrc,
     onClick,
     onFocus,
     pageRatio,
+    role,
 }: TileProps): JSX.Element {
     const ratio = pageRatio && Number.isFinite(pageRatio) && pageRatio > 0 ? pageRatio : null;
     const tileStyle = ratio ? { aspectRatio: String(ratio) } : undefined;
@@ -73,6 +79,7 @@ const GalleryTile = React.memo(function GalleryTile({
     return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <div
+            aria-colindex={ariaColIndex}
             aria-label={replacePlaceholders(__('page_gallery_tile'), [String(pageNum)])}
             aria-selected={isFocused}
             className={`bp-gallery-tile${isFocused ? ' bp-gallery-tile--selected' : ''}`}
@@ -80,11 +87,13 @@ const GalleryTile = React.memo(function GalleryTile({
             data-resin-target="galleryTile"
             onClick={() => onClick(pageNum)}
             onFocus={() => onFocus(pageNum)}
-            role="option"
+            role={role}
             style={tileStyle}
             tabIndex={isFocused ? 0 : -1}
         >
-            <span className="bp-gallery-tile-badge">{pageNum}</span>
+            <span aria-hidden="true" className="bp-gallery-tile-badge">
+                {pageNum}
+            </span>
             {imageSrc ? (
                 <img alt="" src={imageSrc} style={contentStyle} />
             ) : (
@@ -98,6 +107,7 @@ export default function GalleryGrid({
     pageCount,
     currentPage,
     getPageRatio,
+    isAriaGridEnabled = false,
     isPinchZoomEnabled = false,
     isTouchZoomEnabled = false,
     onClose,
@@ -112,6 +122,8 @@ export default function GalleryGrid({
     const [highResImages, setHighResImages] = useState<Record<number, string>>({});
     const [focusedPage, setFocusedPage] = useState(currentPage);
     const [pageRatio, setPageRatio] = useState<number | null>(null);
+    // Measured from the rendered layout; drives ARIA grid metadata and 2D navigation (v2).
+    const [columnCount, setColumnCount] = useState(1);
     // Topmost visible page — the scroll anchor used to restore the viewed area after a reflow.
     const anchorPageRef = useRef(currentPage);
     const gridRef = useRef<HTMLDivElement>(null);
@@ -123,6 +135,8 @@ export default function GalleryGrid({
     const isMountedRef = useRef(true);
     const inFlightRef = useRef<Set<number>>(new Set());
     const highResStoreRef = useRef<HighResThumbnailStore | null>(null);
+    const columnCountRef = useRef(1);
+    const restoreFocusRef = useRef(false);
 
     const byDistanceFromAnchor = (a: number, b: number): number =>
         Math.abs(a - anchorPageRef.current) - Math.abs(b - anchorPageRef.current);
@@ -170,14 +184,14 @@ export default function GalleryGrid({
 
     function syncHighRes() {
         const store = highResStoreRef.current;
-        if (!store) return;
+        const { pageRatio } = thumbnail;
+        if (!store || !pageRatio) return;
 
         const width = getNeededThumbWidth();
-        const ratio = thumbnail.pageRatio || GALLERY_DEFAULT_PAGE_RATIO;
         if (width === GALLERY_THUMB_MAX_WIDTH) {
-            store.setRetained([], width, ratio);
+            store.setRetained([], width, pageRatio);
         } else if (!isProcessingRef.current) {
-            store.setRetained(getPagesNearViewport(0.5), width, ratio);
+            store.setRetained(getPagesNearViewport(0.5), width, pageRatio);
         }
     }
 
@@ -317,6 +331,41 @@ export default function GalleryGrid({
         inner.style.justifyContent = 'center';
     }, []);
 
+    // Counts tiles sharing the first row's offsetTop instead of duplicating the CSS
+    // auto-fill math, so the stylesheet stays the only source of truth for the layout.
+    // Runs after every layout mutation: mount, container resize, and zoom changes.
+    const measureColumnCount = useCallback(() => {
+        const grid = gridRef.current;
+        const inner = innerRef.current;
+        if (!isAriaGridEnabled || !grid || !inner) {
+            return;
+        }
+
+        // Without a layout box (hidden host, zero-size container), offsetTop reads 0 for every
+        // tile and the count would balloon to the page count; keep the last measured value.
+        if (!inner.offsetWidth) {
+            return;
+        }
+
+        const tiles = inner.querySelectorAll<HTMLElement>('[data-page]');
+        if (tiles.length === 0) {
+            return;
+        }
+
+        let count = 1;
+        while (count < tiles.length && tiles[count].offsetTop === tiles[0].offsetTop) {
+            count += 1;
+        }
+
+        if (count !== columnCountRef.current) {
+            // Re-chunking tiles into different rows recreates the focused tile's DOM node,
+            // which would silently drop focus to <body>; remember to restore it post-render.
+            restoreFocusRef.current = grid.contains(document.activeElement);
+            columnCountRef.current = count;
+            setColumnCount(count);
+        }
+    }, [isAriaGridEnabled]);
+
     useLayoutEffect(() => {
         const grid = gridRef.current;
         const previousScale = scaleRef.current;
@@ -327,6 +376,7 @@ export default function GalleryGrid({
 
         if (!grid || previousScale === scale) {
             applyZoomLayout();
+            measureColumnCount();
             return;
         }
 
@@ -345,7 +395,8 @@ export default function GalleryGrid({
         }
 
         handleScrollRef.current();
-    }, [applyZoomLayout, scale]);
+        measureColumnCount();
+    }, [applyZoomLayout, measureColumnCount, scale]);
 
     useEffect(() => {
         const throttledScroll = handleScrollRef.current;
@@ -419,11 +470,16 @@ export default function GalleryGrid({
 
         let isFirstObservation = true;
         const observer = new ResizeObserver(() => {
+            // The initial fire on observe() can already report a size the mount-time layout
+            // effect never saw (e.g. a container that gained its size right after mount), so
+            // always re-apply layout and re-measure; only the scroll-anchor restore is skipped
+            // on that first delivery, since there is no viewed area to preserve yet.
+            applyZoomLayout();
+            measureColumnCount();
             if (isFirstObservation) {
-                isFirstObservation = false; // ResizeObserver always fires once on observe()
+                isFirstObservation = false;
                 return;
             }
-            applyZoomLayout();
             const tile = grid.querySelector(`[data-page="${anchorPageRef.current}"]`) as HTMLElement | null;
             if (tile) {
                 tile.scrollIntoView({ block: 'start' });
@@ -435,7 +491,7 @@ export default function GalleryGrid({
         observer.observe(grid);
 
         return () => observer.disconnect();
-    }, [applyZoomLayout]);
+    }, [applyZoomLayout, measureColumnCount]);
 
     const focusTile = useCallback((pageNum: number, options?: FocusOptions) => {
         const grid = gridRef.current;
@@ -445,6 +501,27 @@ export default function GalleryGrid({
             tile.focus(options);
         }
     }, []);
+
+    // Re-chunking on a column-count change unmounts and recreates tile DOM nodes, which drops
+    // focus to <body> when the focused tile is one of them. Two cases need it reclaimed:
+    //  - resize/fullscreen: flagged during measurement while the grid still held focus
+    //  - mount: the initial focus lands on a pre-measurement tile node, because React flushes
+    //    the pending mount effect before the sync re-render the measurement schedules
+    // Restoring focus also makes assistive tech re-announce the cell's new coordinates.
+    const committedColumnCountRef = useRef(columnCount);
+    useLayoutEffect(() => {
+        const isRechunk = committedColumnCountRef.current !== columnCount;
+        committedColumnCountRef.current = columnCount;
+        if (!isRechunk) {
+            return;
+        }
+
+        const active = document.activeElement;
+        if (restoreFocusRef.current || !active || active === document.body) {
+            restoreFocusRef.current = false;
+            focusTile(focusedPage, { preventScroll: true });
+        }
+    }, [columnCount, focusedPage, focusTile]);
 
     const handleTileFocus = useCallback(
         (pageNum: number) => {
@@ -482,8 +559,29 @@ export default function GalleryGrid({
                     event.stopPropagation();
                     onClose();
                     return;
-                // Listbox is 1-D — arrows move ±1; row-aware nav comes with v2 grid role.
-                case 'ArrowUp':
+                // V1 listbox is 1-D: every arrow moves ±1 page. The v2 ARIA grid keeps ±1 for
+                // Left/Right (wrapping across row edges, clamped at the first/last page) and
+                // moves Up/Down by one row, clamping Down to the last tile on a short final row.
+                case 'ArrowUp': {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const target = isAriaGridEnabled ? getPageAbove(focusedPage, columnCount) : focusedPage - 1;
+                    if (target !== null && target >= 1) {
+                        focusTile(target);
+                    }
+                    return;
+                }
+                case 'ArrowDown': {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const target = isAriaGridEnabled
+                        ? getPageBelow(focusedPage, columnCount, pageCount)
+                        : focusedPage + 1;
+                    if (target !== null && target <= pageCount) {
+                        focusTile(target);
+                    }
+                    return;
+                }
                 case 'ArrowLeft':
                     event.preventDefault();
                     event.stopPropagation();
@@ -491,7 +589,6 @@ export default function GalleryGrid({
                         focusTile(focusedPage - 1);
                     }
                     return;
-                case 'ArrowDown':
                 case 'ArrowRight':
                     event.preventDefault();
                     event.stopPropagation();
@@ -518,7 +615,7 @@ export default function GalleryGrid({
                 default:
             }
         },
-        [focusedPage, focusTile, onClose, onPageNavigate, pageCount],
+        [columnCount, focusedPage, focusTile, isAriaGridEnabled, onClose, onPageNavigate, pageCount],
     );
 
     const tiles = [];
@@ -526,29 +623,57 @@ export default function GalleryGrid({
         tiles.push(
             <GalleryTile
                 key={i}
+                ariaColIndex={isAriaGridEnabled ? getColumnIndex(i, columnCount) : undefined}
                 imageSrc={highResImages[i] || loadedImages[i]}
                 isFocused={i === focusedPage}
                 onClick={handleTileClick}
                 onFocus={handleTileFocus}
                 pageNum={i}
                 pageRatio={(getPageRatio && getPageRatio(i)) || pageRatio}
+                role={isAriaGridEnabled ? 'gridcell' : 'option'}
             />,
         );
+    }
+
+    // ARIA requires gridcells to live inside rows. The display: contents row wrappers add
+    // that level to the accessibility tree without generating boxes, so the tiles remain
+    // direct CSS-grid items and the visual layout is identical to the flat listbox.
+    let content: React.ReactNode = tiles;
+    if (isAriaGridEnabled) {
+        const rows = [];
+        for (let start = 0; start < tiles.length; start += columnCount) {
+            const rowIndex = start / columnCount + 1;
+            rows.push(
+                // Named with the row number so AT announces that instead of every tile in the row.
+                <div
+                    key={start}
+                    aria-label={String(rowIndex)}
+                    aria-rowindex={rowIndex}
+                    className="bp-gallery-grid-row"
+                    role="row"
+                >
+                    {tiles.slice(start, start + columnCount)}
+                </div>,
+            );
+        }
+        content = rows;
     }
 
     return (
         <div
             ref={gridRef}
+            aria-colcount={isAriaGridEnabled ? columnCount : undefined}
             aria-label={__('page_gallery')}
+            aria-rowcount={isAriaGridEnabled ? getRowCount(pageCount, columnCount) : undefined}
             className="bp-gallery-grid"
             onFocus={handleGridFocus}
             onKeyDown={handleGridKeyDown}
             onScroll={handleScroll}
-            role="listbox"
+            role={isAriaGridEnabled ? 'grid' : 'listbox'}
             tabIndex={-1}
         >
             <div ref={innerRef} className="bp-gallery-grid-inner" role="presentation">
-                {tiles}
+                {content}
             </div>
         </div>
     );

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -498,7 +498,7 @@ describe('GalleryController', () => {
         test('should step by exactly 10% from the current value and clamp to the gallery limits', () => {
             const { controller, requestUiUpdate } = makeController();
             controller.toggle();
-            expect(controller.isZoomEnabled).toBe(true);
+            expect(controller.isEnhancedGalleryEnabled).toBe(true);
             expect(controller.scale).toBe(1);
 
             controller.zoomIn();
@@ -537,13 +537,13 @@ describe('GalleryController', () => {
         });
 
         test('should disable zoom entirely unless both gallery flags are on', () => {
-            expect(makeController({ flagOn: false, zoomFlagOn: true }).controller.isZoomEnabled).toBe(false);
+            expect(makeController({ flagOn: false, zoomFlagOn: true }).controller.isEnhancedGalleryEnabled).toBe(false);
 
             const { controller, requestUiUpdate } = makeController({ hasTouch: true, zoomFlagOn: false });
             controller.toggle();
             requestUiUpdate.mockClear();
 
-            expect(controller.isZoomEnabled).toBe(false);
+            expect(controller.isEnhancedGalleryEnabled).toBe(false);
             controller.zoomIn();
             expect(controller.scale).toBe(1);
             expect(requestUiUpdate).not.toHaveBeenCalled();
@@ -574,16 +574,19 @@ describe('GalleryController', () => {
         });
     });
 
-    describe('isV2Enabled', () => {
+    describe('isEnhancedGalleryEnabled', () => {
         test.each`
-            v1       | v2       | expected
-            ${true}  | ${true}  | ${true}
-            ${true}  | ${false} | ${false}
-            ${false} | ${true}  | ${false}
-        `('should return $expected when v1=$v1 and v2=$v2', ({ v1, v2, expected }) => {
-            const { controller } = makeController({ flagOn: v1, zoomFlagOn: v2 });
-            expect(controller.isV2Enabled).toBe(expected);
-        });
+            flagOn   | zoomFlagOn | expected
+            ${true}  | ${true}    | ${true}
+            ${true}  | ${false}   | ${false}
+            ${false} | ${true}    | ${false}
+        `(
+            'should return $expected when flagOn=$flagOn and zoomFlagOn=$zoomFlagOn',
+            ({ flagOn, zoomFlagOn, expected }) => {
+                const { controller } = makeController({ flagOn, zoomFlagOn });
+                expect(controller.isEnhancedGalleryEnabled).toBe(expected);
+            },
+        );
     });
 
     describe('handleEscape', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -1,8 +1,10 @@
-import GalleryController, {
+import {
+    GALLERY_MAX_PAGES,
     GALLERY_MAX_SCALE,
     GALLERY_MIN_SCALE,
-    GalleryControllerOptions,
-} from '../GalleryController';
+    THUMBNAILS_SIDEBAR_TRANSITION_TIME,
+} from '../constants';
+import GalleryController, { GalleryControllerOptions } from '../GalleryController';
 
 jest.mock('../../../Thumbnail', () => {
     return jest.fn().mockImplementation(() => ({
@@ -23,8 +25,6 @@ jest.mock('react-dom/client', () => ({
         return mockLastRoot;
     }),
 }));
-
-const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301;
 
 type Sidebar = { isOpen: boolean; setCurrentPage: jest.Mock };
 
@@ -153,12 +153,12 @@ describe('GalleryController', () => {
 
     describe('canRender', () => {
         test.each`
-            pages  | flag     | expected
-            ${1}   | ${true}  | ${false}
-            ${2}   | ${true}  | ${true}
-            ${200} | ${true}  | ${true}
-            ${201} | ${true}  | ${false}
-            ${50}  | ${false} | ${false}
+            pages                    | flag     | expected
+            ${1}                     | ${true}  | ${false}
+            ${2}                     | ${true}  | ${true}
+            ${GALLERY_MAX_PAGES}     | ${true}  | ${true}
+            ${GALLERY_MAX_PAGES + 1} | ${true}  | ${false}
+            ${50}                    | ${false} | ${false}
         `('should return $expected when pages=$pages and flag=$flag', ({ pages, flag, expected }) => {
             const { controller } = makeController({ flagOn: flag });
             expect(controller.canRender(pages)).toBe(expected);
@@ -301,6 +301,7 @@ describe('GalleryController', () => {
             const grid = mockLastRoot.render.mock.calls[0][0];
             expect(grid.props.currentPage).toBe(3);
             expect(grid.props.pageCount).toBe(25);
+            expect(grid.props.isAriaGridEnabled).toBe(true);
             expect(grid.props.isPinchZoomEnabled).toBe(true);
             expect(grid.props.isTouchZoomEnabled).toBe(true);
             expect(grid.props.scale).toBe(1);
@@ -550,6 +551,7 @@ describe('GalleryController', () => {
             const grid = mockLastRoot.render.mock.calls[0][0];
             expect(grid.props.isPinchZoomEnabled).toBe(false);
             expect(grid.props.isTouchZoomEnabled).toBe(false);
+            expect(grid.props.isAriaGridEnabled).toBe(false);
 
             grid.props.onScaleChange(1.5);
             expect(controller.scale).toBe(1);
@@ -572,6 +574,18 @@ describe('GalleryController', () => {
         });
     });
 
+    describe('isV2Enabled', () => {
+        test.each`
+            v1       | v2       | expected
+            ${true}  | ${true}  | ${true}
+            ${true}  | ${false} | ${false}
+            ${false} | ${true}  | ${false}
+        `('should return $expected when v1=$v1 and v2=$v2', ({ v1, v2, expected }) => {
+            const { controller } = makeController({ flagOn: v1, zoomFlagOn: v2 });
+            expect(controller.isV2Enabled).toBe(expected);
+        });
+    });
+
     describe('handleEscape', () => {
         test('should return false when gallery is closed', () => {
             const { controller } = makeController();
@@ -590,10 +604,10 @@ describe('GalleryController', () => {
     describe('handleArrowKey', () => {
         // Adds the selected tile to the gallery root (mounted before .bp-ControlsRoot; with no
         // controls seeded it lands as containerEl's last child).
-        function seedSelectedTile(containerEl: HTMLElement): HTMLElement {
+        function seedSelectedTile(containerEl: HTMLElement, role = 'option'): HTMLElement {
             const galleryEl = containerEl.lastElementChild as HTMLElement;
             const tile = document.createElement('div');
-            tile.setAttribute('role', 'option');
+            tile.setAttribute('role', role);
             tile.setAttribute('tabindex', '0');
             galleryEl.appendChild(tile);
             return tile;
@@ -622,7 +636,19 @@ describe('GalleryController', () => {
             expect(tileKeydown.mock.calls[0][0].key).toBe('ArrowDown');
         });
 
-        test('should not redirect focus for non-arrow keys', () => {
+        test('should redirect into a v2 gridcell tile', () => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = seedToggle(containerEl);
+            controller.toggle();
+            const tile = seedSelectedTile(containerEl, 'gridcell');
+
+            toggle.focus();
+            controller.handleArrowKey('ArrowDown');
+
+            expect(document.activeElement).toBe(tile);
+        });
+
+        test('should not redirect focus for non-grid-nav keys', () => {
             const { controller, containerEl } = makeController({ sidebarOpen: false });
             const toggle = seedToggle(containerEl);
             controller.toggle();
@@ -632,6 +658,22 @@ describe('GalleryController', () => {
             controller.handleArrowKey('[');
 
             expect(document.activeElement).toBe(toggle);
+        });
+
+        test.each(['Home', 'End'])('should redirect %s into the selected tile', key => {
+            const { controller, containerEl } = makeController({ sidebarOpen: false });
+            const toggle = seedToggle(containerEl);
+            controller.toggle();
+            const tile = seedSelectedTile(containerEl);
+            const tileKeydown = jest.fn();
+            tile.addEventListener('keydown', tileKeydown);
+
+            toggle.focus();
+            controller.handleArrowKey(key);
+
+            expect(document.activeElement).toBe(tile);
+            expect(tileKeydown).toHaveBeenCalledTimes(1);
+            expect(tileKeydown.mock.calls[0][0].key).toBe(key);
         });
 
         test('should be a no-op when the gallery is closed', () => {

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -639,7 +639,7 @@ describe('GalleryController', () => {
             expect(tileKeydown.mock.calls[0][0].key).toBe('ArrowDown');
         });
 
-        test('should redirect into a v2 gridcell tile', () => {
+        test('should redirect into a gridcell tile', () => {
             const { controller, containerEl } = makeController({ sidebarOpen: false });
             const toggle = seedToggle(containerEl);
             controller.toggle();

--- a/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryController-test.tsx
@@ -50,7 +50,7 @@ function makeController(
         currentPage?: number;
         flagOn?: boolean;
         hasTouch?: boolean;
-        zoomFlagOn?: boolean;
+        enhancedGalleryEnabled?: boolean;
     } = {},
 ): Harness {
     const {
@@ -60,7 +60,7 @@ function makeController(
         currentPage = 1,
         flagOn = true,
         hasTouch = false,
-        zoomFlagOn = true,
+        enhancedGalleryEnabled = true,
     } = overrides;
 
     const containerEl = document.createElement('div');
@@ -85,7 +85,7 @@ function makeController(
         containerEl,
         features: {
             galleryView: { enabled: flagOn },
-            galleryViewV2: { enabled: zoomFlagOn },
+            galleryViewV2: { enabled: enhancedGalleryEnabled },
             pinchToZoom: { enabled: true },
         },
         hasTouch,
@@ -537,9 +537,11 @@ describe('GalleryController', () => {
         });
 
         test('should disable zoom entirely unless both gallery flags are on', () => {
-            expect(makeController({ flagOn: false, zoomFlagOn: true }).controller.isEnhancedGalleryEnabled).toBe(false);
+            expect(
+                makeController({ flagOn: false, enhancedGalleryEnabled: true }).controller.isEnhancedGalleryEnabled,
+            ).toBe(false);
 
-            const { controller, requestUiUpdate } = makeController({ hasTouch: true, zoomFlagOn: false });
+            const { controller, requestUiUpdate } = makeController({ hasTouch: true, enhancedGalleryEnabled: false });
             controller.toggle();
             requestUiUpdate.mockClear();
 
@@ -576,14 +578,14 @@ describe('GalleryController', () => {
 
     describe('isEnhancedGalleryEnabled', () => {
         test.each`
-            flagOn   | zoomFlagOn | expected
-            ${true}  | ${true}    | ${true}
-            ${true}  | ${false}   | ${false}
-            ${false} | ${true}    | ${false}
+            flagOn   | enhancedGalleryEnabled | expected
+            ${true}  | ${true}                | ${true}
+            ${true}  | ${false}               | ${false}
+            ${false} | ${true}                | ${false}
         `(
-            'should return $expected when flagOn=$flagOn and zoomFlagOn=$zoomFlagOn',
-            ({ flagOn, zoomFlagOn, expected }) => {
-                const { controller } = makeController({ flagOn, zoomFlagOn });
+            'should return $expected when flagOn=$flagOn and enhancedGalleryEnabled=$enhancedGalleryEnabled',
+            ({ flagOn, enhancedGalleryEnabled, expected }) => {
+                const { controller } = makeController({ flagOn, enhancedGalleryEnabled });
                 expect(controller.isEnhancedGalleryEnabled).toBe(expected);
             },
         );

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { GALLERY_THUMB_MAX_WIDTH, GALLERY_THUMB_WIDTH_TIERS } from '../constants';
 import GalleryGrid from '../GalleryGrid';
 
 const observeMock = jest.fn();
@@ -92,7 +93,9 @@ describe('GalleryGrid', () => {
             getWrapper();
             const allTiles = screen.getAllByRole('option');
             allTiles.forEach(tile => {
-                expect(tile.querySelector('.bp-gallery-tile-badge')).toBeInTheDocument();
+                const badge = tile.querySelector('.bp-gallery-tile-badge');
+                expect(badge).toBeInTheDocument();
+                expect(badge).toHaveAttribute('aria-hidden', 'true');
             });
         });
 
@@ -572,6 +575,7 @@ describe('GalleryGrid', () => {
                     image.src = `data:image/png;base-${pageIndex + 1}`;
                     return Promise.resolve(image);
                 }),
+                pageRatio: 1,
                 renderPageImage,
             };
             const { rerender } = getWrapper({ pageCount: 10, currentPage: 1, thumbnail });
@@ -582,7 +586,7 @@ describe('GalleryGrid', () => {
             });
             expect(thumbnail.createThumbnailImage).toHaveBeenCalledWith(0, {
                 createImgTag: true,
-                thumbMaxWidth: 440,
+                thumbMaxWidth: GALLERY_THUMB_MAX_WIDTH,
             });
             thumbnail.createThumbnailImage.mockClear();
 
@@ -592,7 +596,7 @@ describe('GalleryGrid', () => {
             rerender(<GalleryGrid {...defaultProps} currentPage={1} scale={2} thumbnail={thumbnail} />);
 
             await waitFor(() => {
-                expect(renderPageImage).toHaveBeenCalledWith(1, { thumbMaxWidth: 880 });
+                expect(renderPageImage).toHaveBeenCalledWith(1, { thumbMaxWidth: GALLERY_THUMB_WIDTH_TIERS[1] });
             });
             expect(thumbnail.createThumbnailImage).not.toHaveBeenCalled();
             expect(screen.getByLabelText('Page 1').querySelector('img')).toHaveAttribute(
@@ -607,6 +611,43 @@ describe('GalleryGrid', () => {
                     'src',
                     'data:image/png;base-1',
                 );
+            });
+        });
+
+        test('should wait for thumbnail initialization before rendering high-resolution pages', async () => {
+            let resolveInit!: (value: number) => void;
+            const initPromise = new Promise<number>(resolve => {
+                resolveInit = resolve;
+            });
+            const renderPageImage = jest.fn((pageNum: number, { thumbMaxWidth }: { thumbMaxWidth: number }) => ({
+                cancel: jest.fn(),
+                promise: Promise.resolve({
+                    dataUrl: `data:image/png;high-res-${pageNum}`,
+                    height: thumbMaxWidth,
+                    width: thumbMaxWidth,
+                }),
+            }));
+            const thumbnail = {
+                ...mockThumbnail,
+                createThumbnailImage: jest.fn().mockResolvedValue(null),
+                init: jest.fn(() => initPromise),
+                pageRatio: undefined as number | undefined,
+                renderPageImage,
+            };
+            const { rerender } = getWrapper({ pageCount: 10, currentPage: 1, thumbnail });
+            layoutGrid(500);
+            screen.getAllByRole('option').forEach(tile => {
+                Object.defineProperty(tile, 'offsetWidth', { configurable: true, value: 600 });
+            });
+
+            rerender(<GalleryGrid {...defaultProps} currentPage={1} scale={2} thumbnail={thumbnail} />);
+            expect(renderPageImage).not.toHaveBeenCalled();
+
+            thumbnail.pageRatio = 1;
+            resolveInit(100);
+
+            await waitFor(() => {
+                expect(renderPageImage).toHaveBeenCalledWith(1, { thumbMaxWidth: GALLERY_THUMB_WIDTH_TIERS[1] });
             });
         });
 
@@ -776,6 +817,284 @@ describe('GalleryGrid', () => {
             const placeholder = tile.querySelector('.bp-gallery-tile-placeholder') as HTMLElement;
             expect(tile.style.aspectRatio).toBeFalsy();
             expect(placeholder.style.paddingTop).toBe('');
+        });
+    });
+
+    describe('ARIA grid (v2)', () => {
+        // jsdom has no layout, so geometry is mocked at the prototype level: offsetTop lays the
+        // tiles out row by row from a mutable column count, and offsetWidth reports a layout box
+        // only while a column count is set (the component skips measurement without one).
+        // Prototype getters survive the tile-node recreation re-chunking causes, unlike per-node stubs.
+        let mockColumns: number | null = null;
+        const originalOffsetTop = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetTop');
+        const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+
+        beforeEach(() => {
+            mockColumns = null;
+            Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+                configurable: true,
+                get(this: HTMLElement): number {
+                    const page = this.dataset ? this.dataset.page : undefined;
+                    if (!page || mockColumns === null) {
+                        return 0;
+                    }
+                    return Math.floor((parseInt(page, 10) - 1) / mockColumns) * 300;
+                },
+            });
+            Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+                configurable: true,
+                get: (): number => (mockColumns === null ? 0 : 800),
+            });
+        });
+
+        afterEach(() => {
+            if (originalOffsetTop) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetTop', originalOffsetTop);
+            }
+            if (originalOffsetWidth) {
+                Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+            }
+        });
+
+        // Renders the default 10 pages (current page 3) laid out in the given column count;
+        // the mount-time measurement picks it up immediately.
+        const setupGrid = (columns: number, props = {}) => {
+            mockColumns = columns;
+            return getWrapper({ isAriaGridEnabled: true, ...props });
+        };
+
+        // Reflows to a new column count and fires a resize so the component re-measures.
+        const layoutColumns = (columns: number) => {
+            mockColumns = columns;
+            act(() => resizeCallback());
+        };
+
+        const focusPage = (page: number) => act(() => screen.getByLabelText(`Page ${page}`).focus());
+
+        describe('mount focus', () => {
+            // The mount-time measurement re-chunks the grid, which unmounts the tile node the
+            // mount effect focused (React flushes pending passive effects before the sync
+            // re-render a layout-effect state update schedules). Focus must be reclaimed or
+            // arrow keys go dead until the user clicks.
+            test('should keep focus on the current page tile after the mount re-measure re-chunks the grid', () => {
+                setupGrid(3);
+                // Guard against the mount re-chunk never happening, which would make this vacuous
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '3');
+                expect(screen.getByLabelText('Page 3')).toHaveFocus();
+            });
+        });
+
+        describe('semantics', () => {
+            test('should render grid, row, and gridcell structure with row/column metadata', () => {
+                setupGrid(3);
+
+                const grid = screen.getByRole('grid');
+                expect(grid).toHaveClass('bp-gallery-grid');
+                expect(grid).toHaveAttribute('aria-label', 'Page gallery');
+                expect(grid).toHaveAttribute('aria-rowcount', '4');
+                expect(grid).toHaveAttribute('aria-colcount', '3');
+                expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+                expect(screen.queryAllByRole('option')).toHaveLength(0);
+
+                const rows = screen.getAllByRole('row');
+                expect(rows).toHaveLength(4);
+                rows.forEach((row, index) => {
+                    expect(row).toHaveAttribute('aria-rowindex', String(index + 1));
+                    expect(row).toHaveAttribute('aria-label', String(index + 1));
+                    expect(row).toHaveClass('bp-gallery-grid-row');
+                });
+                expect(rows[0].querySelectorAll('[role="gridcell"]')).toHaveLength(3);
+                expect(rows[3].querySelectorAll('[role="gridcell"]')).toHaveLength(1);
+
+                expect(screen.getAllByRole('gridcell')).toHaveLength(10);
+                expect(screen.getByLabelText('Page 1')).toHaveAttribute('aria-colindex', '1');
+                expect(screen.getByLabelText('Page 5')).toHaveAttribute('aria-colindex', '2');
+                expect(screen.getByLabelText('Page 10')).toHaveAttribute('aria-colindex', '1');
+            });
+
+            test('should keep selection and roving tabindex semantics on gridcells', () => {
+                setupGrid(3);
+
+                expect(screen.getByLabelText('Page 3')).toHaveAttribute('aria-selected', 'true');
+                expect(screen.getByLabelText('Page 3')).toHaveAttribute('tabIndex', '0');
+                expect(screen.getByLabelText('Page 1')).toHaveAttribute('aria-selected', 'false');
+                expect(screen.getByLabelText('Page 1')).toHaveAttribute('tabIndex', '-1');
+            });
+
+            test('should not add grid metadata when the flag is off', () => {
+                getWrapper();
+
+                const listbox = screen.getByRole('listbox');
+                expect(listbox).not.toHaveAttribute('aria-rowcount');
+                expect(listbox).not.toHaveAttribute('aria-colcount');
+                expect(screen.queryAllByRole('row')).toHaveLength(0);
+                expect(screen.getByLabelText('Page 1')).not.toHaveAttribute('aria-colindex');
+            });
+        });
+
+        describe('2D keyboard navigation', () => {
+            // Rows at 3 columns: [1 2 3] [4 5 6] [7 8 9] [10]
+            test('should move down a row on ArrowDown', async () => {
+                setupGrid(3);
+                focusPage(2);
+                await userEvent.keyboard('{ArrowDown}');
+                expect(screen.getByLabelText('Page 5')).toHaveFocus();
+            });
+
+            test('should move up a row on ArrowUp', async () => {
+                setupGrid(3);
+                focusPage(5);
+                await userEvent.keyboard('{ArrowUp}');
+                expect(screen.getByLabelText('Page 2')).toHaveFocus();
+            });
+
+            test('should not move on ArrowUp in the first row', async () => {
+                setupGrid(3);
+                focusPage(2);
+                await userEvent.keyboard('{ArrowUp}');
+                expect(screen.getByLabelText('Page 2')).toHaveFocus();
+            });
+
+            test('should not move on ArrowDown in the last row', async () => {
+                setupGrid(3);
+                focusPage(10);
+                await userEvent.keyboard('{ArrowDown}');
+                expect(screen.getByLabelText('Page 10')).toHaveFocus();
+            });
+
+            test('should clamp ArrowDown to the last tile when no cell is directly below', async () => {
+                setupGrid(3);
+                focusPage(9); // directly below would be page 12, which does not exist
+                await userEvent.keyboard('{ArrowDown}');
+                expect(screen.getByLabelText('Page 10')).toHaveFocus();
+            });
+
+            test('should not move on ArrowDown in a full last row', async () => {
+                setupGrid(2); // rows: [1 2] [3 4] [5 6] [7 8] [9 10]
+                focusPage(9);
+                await userEvent.keyboard('{ArrowDown}');
+                expect(screen.getByLabelText('Page 9')).toHaveFocus();
+            });
+
+            test('should wrap to the next row on ArrowRight at a row edge', async () => {
+                setupGrid(3);
+                focusPage(3);
+                await userEvent.keyboard('{ArrowRight}');
+                expect(screen.getByLabelText('Page 4')).toHaveFocus();
+            });
+
+            test('should wrap to the previous row on ArrowLeft at a row start', async () => {
+                setupGrid(3);
+                focusPage(4);
+                await userEvent.keyboard('{ArrowLeft}');
+                expect(screen.getByLabelText('Page 3')).toHaveFocus();
+            });
+
+            test('should not move past the last page on ArrowRight', async () => {
+                setupGrid(3);
+                focusPage(10);
+                await userEvent.keyboard('{ArrowRight}');
+                expect(screen.getByLabelText('Page 10')).toHaveFocus();
+            });
+
+            test('should not move past the first page on ArrowLeft', async () => {
+                setupGrid(3);
+                focusPage(1);
+                await userEvent.keyboard('{ArrowLeft}');
+                expect(screen.getByLabelText('Page 1')).toHaveFocus();
+            });
+
+            test('should keep Home and End jumping to the first and last page of the grid', async () => {
+                setupGrid(3);
+                focusPage(5);
+                await userEvent.keyboard('{Home}');
+                expect(screen.getByLabelText('Page 1')).toHaveFocus();
+                await userEvent.keyboard('{End}');
+                expect(screen.getByLabelText('Page 10')).toHaveFocus();
+            });
+
+            test('should call onPageNavigate on Enter', async () => {
+                const onPageNavigate = jest.fn();
+                setupGrid(3, { onPageNavigate });
+                focusPage(5);
+                await userEvent.keyboard('{Enter}');
+                expect(onPageNavigate).toHaveBeenCalledWith(5);
+            });
+
+            test('should call onClose on Escape', async () => {
+                const onClose = jest.fn();
+                setupGrid(3, { onClose });
+                focusPage(5);
+                await userEvent.keyboard('{Escape}');
+                expect(onClose).toHaveBeenCalled();
+            });
+        });
+
+        describe('responsive column changes', () => {
+            test('should update metadata and keep focus on the same page when the column count changes', async () => {
+                setupGrid(3);
+                focusPage(5);
+                await waitFor(() => expect(screen.getByLabelText('Page 5')).toHaveFocus());
+                const nodeBeforeRechunk = screen.getByLabelText('Page 5');
+
+                layoutColumns(2); // rows become [1 2] [3 4] [5 6] [7 8] [9 10]
+
+                const grid = screen.getByRole('grid');
+                expect(grid).toHaveAttribute('aria-rowcount', '5');
+                expect(grid).toHaveAttribute('aria-colcount', '2');
+                expect(screen.getAllByRole('row')).toHaveLength(5);
+                expect(screen.getByLabelText('Page 5')).toHaveAttribute('aria-colindex', '1');
+                // Prove the re-chunk actually recreated the node, so a passing focus assertion
+                // demonstrates restoration across a node swap rather than surviving focus
+                expect(screen.getByLabelText('Page 5')).not.toBe(nodeBeforeRechunk);
+                expect(screen.getByLabelText('Page 5')).toHaveFocus();
+                expect(screen.getByLabelText('Page 5')).toHaveAttribute('aria-selected', 'true');
+            });
+
+            test('should keep 2D navigation in sync with the new column count', async () => {
+                setupGrid(3);
+                focusPage(5);
+                layoutColumns(2);
+
+                await userEvent.keyboard('{ArrowDown}');
+                expect(screen.getByLabelText('Page 7')).toHaveFocus();
+            });
+
+            test('should not steal focus from outside the grid when a resize re-chunks', () => {
+                setupGrid(3);
+                const outside = document.createElement('button');
+                document.body.appendChild(outside);
+                act(() => outside.focus());
+
+                layoutColumns(2);
+
+                // The re-chunk happened, but focus stays where the user put it
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '2');
+                expect(outside).toHaveFocus();
+
+                document.body.removeChild(outside);
+            });
+
+            test('should re-measure the column count when the zoom scale changes', () => {
+                const { rerender } = setupGrid(3);
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '3');
+
+                mockColumns = 2; // zoomed tiles are wider, so fewer fit per row
+                rerender(<GalleryGrid {...defaultProps} isAriaGridEnabled scale={1.5} />);
+
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '2');
+                expect(screen.getAllByRole('row')).toHaveLength(5);
+            });
+
+            test('should keep the last measured column count when the grid loses its layout box', () => {
+                setupGrid(3);
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '3');
+
+                mockColumns = null; // hidden host: no layout box, offsetTop reads 0 everywhere
+                act(() => resizeCallback());
+
+                expect(screen.getByRole('grid')).toHaveAttribute('aria-colcount', '3');
+            });
         });
     });
 });

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -820,7 +820,7 @@ describe('GalleryGrid', () => {
         });
     });
 
-    describe('ARIA grid (v2)', () => {
+    describe('ARIA grid', () => {
         // jsdom has no layout, so geometry is mocked at the prototype level: offsetTop lays the
         // tiles out row by row from a mutable column count, and offsetWidth reports a layout box
         // only while a column count is set (the component skips measurement without one).

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -884,6 +884,79 @@ describe('GalleryGrid', () => {
             });
         });
 
+        describe('scroll restore after re-chunk', () => {
+            // The component reads the anchor tile's getBoundingClientRect().top when it schedules
+            // a re-chunk (capture) and again after the new tile nodes commit (restore). jsdom
+            // returns all-zero rects, so feed each read from a per-page queue to simulate the
+            // tile drifting between the two reads; the last queue entry repeats.
+            const mockTileRectTops = (topsByPage: Record<string, number[]>) => {
+                jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function mockRect(
+                    this: Element,
+                ): DOMRect {
+                    const page = (this as HTMLElement).dataset?.page;
+                    const queue = page ? topsByPage[page] : undefined;
+                    let top = 0;
+                    if (queue && queue.length > 0) {
+                        top = queue.length > 1 ? (queue.shift() as number) : queue[0];
+                    }
+                    return {
+                        top,
+                        bottom: top,
+                        left: 0,
+                        right: 0,
+                        width: 0,
+                        height: 0,
+                        x: 0,
+                        y: top,
+                        toJSON: () => ({}),
+                    } as DOMRect;
+                });
+            };
+
+            afterEach(() => {
+                jest.restoreAllMocks();
+            });
+
+            test('should keep the mount-time centering instead of restoring the pre-centering capture', () => {
+                // Page 3 reads 0 at the pre-centering capture, then 300 once the mount effect has
+                // centered it; the restore after the mount re-chunk must see a zero delta.
+                mockTileRectTops({ '3': [0, 300] });
+                setupGrid(3);
+
+                const grid = screen.getByRole('grid');
+                // Guard against the mount re-chunk never happening, which would make this vacuous
+                expect(grid).toHaveAttribute('aria-colcount', '3');
+                expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+                expect(grid.scrollTop).toBe(0);
+            });
+
+            test('should restore the scroll on the first re-chunk after a single-column mount', () => {
+                // A single-column mount schedules no re-chunk, so the first one comes from a
+                // later resize and its restore must not be mistaken for the mount re-chunk
+                setupGrid(1);
+                const grid = screen.getByRole('grid');
+                expect(grid).toHaveAttribute('aria-colcount', '1');
+
+                // Anchor page 3: captured at 100, found at 250 after the new rows commit
+                mockTileRectTops({ '3': [100, 250] });
+                layoutColumns(2);
+
+                expect(grid).toHaveAttribute('aria-colcount', '2');
+                expect(grid.scrollTop).toBe(150);
+            });
+
+            test('should shift the scroll by the anchor tile drift across a later re-chunk', () => {
+                setupGrid(3);
+                const grid = screen.getByRole('grid');
+                grid.scrollTop = 400;
+
+                mockTileRectTops({ '3': [100, 250] });
+                layoutColumns(2);
+
+                expect(grid.scrollTop).toBe(550);
+            });
+        });
+
         describe('ARIA roles and row/column numbers', () => {
             test('should render grid, row, and gridcell structure with row/column numbers', () => {
                 setupGrid(3);

--- a/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
+++ b/src/lib/viewers/gallery/__tests__/GalleryGrid-test.tsx
@@ -884,8 +884,8 @@ describe('GalleryGrid', () => {
             });
         });
 
-        describe('semantics', () => {
-            test('should render grid, row, and gridcell structure with row/column metadata', () => {
+        describe('ARIA roles and row/column numbers', () => {
+            test('should render grid, row, and gridcell structure with row/column numbers', () => {
                 setupGrid(3);
 
                 const grid = screen.getByRole('grid');
@@ -921,7 +921,7 @@ describe('GalleryGrid', () => {
                 expect(screen.getByLabelText('Page 1')).toHaveAttribute('tabIndex', '-1');
             });
 
-            test('should not add grid metadata when the flag is off', () => {
+            test('should not add row/column numbers when the flag is off', () => {
                 getWrapper();
 
                 const listbox = screen.getByRole('listbox');

--- a/src/lib/viewers/gallery/constants.ts
+++ b/src/lib/viewers/gallery/constants.ts
@@ -1,0 +1,28 @@
+export const GALLERY_THUMB_MAX_WIDTH = 440;
+export const CONCURRENT_LOADS = 4;
+export const SCROLL_THROTTLE_MS = 200;
+
+// Keep in sync with the 100% grid rule in GalleryGrid.scss.
+export const GALLERY_TILE_GAP = 16;
+export const GALLERY_TILE_MIN_WIDTH = 220;
+
+export const GALLERY_THUMB_WIDTH_TIERS = [
+    GALLERY_THUMB_MAX_WIDTH,
+    GALLERY_THUMB_MAX_WIDTH * 2,
+    GALLERY_THUMB_MAX_WIDTH * 3,
+];
+export const GALLERY_THUMB_MAX_TIER = GALLERY_THUMB_WIDTH_TIERS[GALLERY_THUMB_WIDTH_TIERS.length - 1];
+export const GALLERY_THUMB_MAX_DPR = 2;
+export const GALLERY_HIGH_RES_MAX_BYTES = 64 * 1024 * 1024;
+export const GALLERY_HIGH_RES_MAX_PAGES = 16;
+export const GALLERY_HIGH_RES_CONCURRENCY = 2;
+
+// Gallery availability and zoom limits.
+// Hide the gallery toggle for files above this page count; expected to increase in V2.
+export const GALLERY_MAX_PAGES = 200;
+export const GALLERY_MAX_SCALE = 3;
+export const GALLERY_MIN_SCALE = 0.5;
+export const GALLERY_SCALE_STEP = 0.1;
+
+// Keep in sync with the thumbnails sidebar CSS transition.
+export const THUMBNAILS_SIDEBAR_TRANSITION_TIME = 301;

--- a/src/lib/viewers/gallery/constants.ts
+++ b/src/lib/viewers/gallery/constants.ts
@@ -18,7 +18,7 @@ export const GALLERY_HIGH_RES_MAX_PAGES = 16;
 export const GALLERY_HIGH_RES_CONCURRENCY = 2;
 
 // Gallery availability and zoom limits.
-// Hide the gallery toggle for files above this page count; expected to increase in V2.
+// Hide the gallery toggle for files above this page count.
 export const GALLERY_MAX_PAGES = 200;
 export const GALLERY_MAX_SCALE = 3;
 export const GALLERY_MIN_SCALE = 0.5;

--- a/src/lib/viewers/gallery/galleryGridNavigation.ts
+++ b/src/lib/viewers/gallery/galleryGridNavigation.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure math for the gallery's v2 ARIA grid: pages are laid out row-major, so page p
+ * (1-based) occupies row floor((p - 1) / columns) and column (p - 1) % columns.
+ * All indices returned here are 1-based, matching aria-rowindex / aria-colindex.
+ */
+
+export function getRowCount(pageCount: number, columnCount: number): number {
+    return Math.ceil(pageCount / columnCount);
+}
+
+export function getRowIndex(pageNum: number, columnCount: number): number {
+    return Math.floor((pageNum - 1) / columnCount) + 1;
+}
+
+export function getColumnIndex(pageNum: number, columnCount: number): number {
+    return ((pageNum - 1) % columnCount) + 1;
+}
+
+/** Page one row up in the same column, or null when already in the first row. */
+export function getPageAbove(pageNum: number, columnCount: number): number | null {
+    const target = pageNum - columnCount;
+    return target >= 1 ? target : null;
+}
+
+/**
+ * Page one row down in the same column, clamped to the last page when the final row is
+ * incomplete (so Down from a cell with no cell directly below lands on the last tile).
+ * Null when already in the last row.
+ */
+export function getPageBelow(pageNum: number, columnCount: number, pageCount: number): number | null {
+    if (getRowIndex(pageNum, columnCount) >= getRowCount(pageCount, columnCount)) {
+        return null;
+    }
+    return Math.min(pageNum + columnCount, pageCount);
+}

--- a/src/lib/viewers/gallery/galleryGridNavigation.ts
+++ b/src/lib/viewers/gallery/galleryGridNavigation.ts
@@ -1,6 +1,6 @@
 /**
- * Pure math for the gallery's v2 ARIA grid: pages are laid out row-major, so page p
- * (1-based) occupies row floor((p - 1) / columns) and column (p - 1) % columns.
+ * Pure math for the gallery ARIA grid: pages are laid out row-major, so page p
+ * (1-based) occupies row floor((p - 1) / columns) + 1 and column ((p - 1) % columns) + 1.
  * All indices returned here are 1-based, matching aria-rowindex / aria-colindex.
  */
 

--- a/test/integration/document/Gallery.e2e.test.js
+++ b/test/integration/document/Gallery.e2e.test.js
@@ -11,7 +11,7 @@ describe('Preview Document Gallery', () => {
         collection,
         enableThumbnailsSidebar = false,
         galleryEnabled = true,
-        galleryV2Enabled = true,
+        enhancedGalleryEnabled = true,
         pinchToZoomEnabled = false,
         targetFileId = fileId,
     } = {}) => {
@@ -23,7 +23,7 @@ describe('Preview Document Gallery', () => {
                     enabled: galleryEnabled,
                 },
                 galleryViewV2: {
-                    enabled: galleryV2Enabled,
+                    enabled: enhancedGalleryEnabled,
                 },
                 pinchToZoom: {
                     enabled: pinchToZoomEnabled,
@@ -92,7 +92,7 @@ describe('Preview Document Gallery', () => {
         cy.getByTitle('Gallery view').should('have.attr', 'aria-pressed', 'false');
     });
 
-    it('Should measure the responsive column count and clamp vertical navigation (v2)', () => {
+    it('Should measure the responsive column count and clamp vertical navigation', () => {
         // Default 1600px viewport: both pages fit side by side, so the measured grid is
         // 2 columns x 1 row — distinguishable from the pre-measurement default of 1 column.
         showDocumentPreview();
@@ -121,7 +121,7 @@ describe('Preview Document Gallery', () => {
         cy.focused().should('have.attr', 'aria-label', 'Page 2');
     });
 
-    it('Should stack rows on a narrow viewport and navigate vertically (v2)', () => {
+    it('Should stack rows on a narrow viewport and navigate vertically', () => {
         // Narrow viewport → single column → the 2-page doc stacks into 2 rows
         cy.viewport(500, 800);
         showDocumentPreview();
@@ -143,8 +143,8 @@ describe('Preview Document Gallery', () => {
         cy.focused().should('have.attr', 'aria-label', 'Page 2');
     });
 
-    it('Should keep listbox semantics and 1D arrows when the v2 flag is off', () => {
-        showDocumentPreview({ galleryV2Enabled: false });
+    it('Should keep listbox semantics and 1D arrows when the enhanced gallery flag is off', () => {
+        showDocumentPreview({ enhancedGalleryEnabled: false });
         openGallery();
 
         cy.get('.bp-gallery-grid[role="listbox"]').should('not.have.attr', 'aria-rowcount');
@@ -187,8 +187,8 @@ describe('Preview Document Gallery', () => {
             });
     });
 
-    it('Should hide gallery zoom controls when the v2 flag is off', () => {
-        showDocumentPreview({ galleryV2Enabled: false });
+    it('Should hide gallery zoom controls when the enhanced gallery flag is off', () => {
+        showDocumentPreview({ enhancedGalleryEnabled: false });
         openGallery();
 
         cy.getByTitle('Zoom in').should('not.exist');

--- a/test/integration/document/Gallery.e2e.test.js
+++ b/test/integration/document/Gallery.e2e.test.js
@@ -77,8 +77,8 @@ describe('Preview Document Gallery', () => {
         openGallery();
 
         cy.getByTitle('Gallery view').should('have.attr', 'aria-pressed', 'true');
-        cy.get('.bp-gallery-grid[role="listbox"]')
-            .find('[role="option"]')
+        cy.get('.bp-gallery-grid[role="grid"]')
+            .find('[role="gridcell"]')
             .should('have.length', 2);
         cy.get('.bp-gallery-tile[data-page="1"] img').should('be.visible');
         cy.getByTitle('Next page').should('not.exist');
@@ -90,6 +90,70 @@ describe('Preview Document Gallery', () => {
 
         cy.get('.bp-gallery-grid').should('not.exist');
         cy.getByTitle('Gallery view').should('have.attr', 'aria-pressed', 'false');
+    });
+
+    it('Should measure the responsive column count and clamp vertical navigation (v2)', () => {
+        // Default 1600px viewport: both pages fit side by side, so the measured grid is
+        // 2 columns x 1 row — distinguishable from the pre-measurement default of 1 column.
+        showDocumentPreview();
+        openGallery();
+
+        cy.get('.bp-gallery-grid[role="grid"]')
+            .should('have.attr', 'aria-colcount', '2')
+            .and('have.attr', 'aria-rowcount', '1');
+        cy.get('.bp-gallery-grid [role="row"]').should('have.length', 1);
+        cy.get('[role="gridcell"][aria-label="Page 1"]').should('have.attr', 'aria-colindex', '1');
+        cy.get('[role="gridcell"][aria-label="Page 2"]').should('have.attr', 'aria-colindex', '2');
+
+        // The display: contents row wrapper must not generate a box: tiles share a visual row
+        cy.get('.bp-gallery-tile[data-page="1"]').then($first => {
+            cy.get('.bp-gallery-tile[data-page="2"]').then($second => {
+                expect($first[0].getBoundingClientRect().top).to.equal($second[0].getBoundingClientRect().top);
+            });
+        });
+
+        // Single row: Down/Up are no-ops (the 1-D listbox would have moved); Right still moves ±1
+        cy.get('[role="gridcell"][aria-label="Page 1"]').type('{downArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 1');
+        cy.focused().type('{rightArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 2');
+        cy.focused().type('{upArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 2');
+    });
+
+    it('Should stack rows on a narrow viewport and navigate vertically (v2)', () => {
+        // Narrow viewport → single column → the 2-page doc stacks into 2 rows
+        cy.viewport(500, 800);
+        showDocumentPreview();
+        openGallery();
+
+        cy.get('.bp-gallery-grid[role="grid"]')
+            .should('have.attr', 'aria-colcount', '1')
+            .and('have.attr', 'aria-rowcount', '2');
+        cy.get('.bp-gallery-grid [role="row"]').should('have.length', 2);
+        cy.get('[role="gridcell"][aria-label="Page 1"]').should('have.attr', 'aria-colindex', '1');
+        cy.get('[role="gridcell"][aria-label="Page 2"]').should('have.attr', 'aria-colindex', '1');
+
+        // Down/Up move by a row; Right keeps moving ±1 page across row edges
+        cy.get('[role="gridcell"][aria-label="Page 1"]').type('{downArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 2');
+        cy.focused().type('{upArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 1');
+        cy.focused().type('{rightArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 2');
+    });
+
+    it('Should keep listbox semantics and 1D arrows when the v2 flag is off', () => {
+        showDocumentPreview({ galleryV2Enabled: false });
+        openGallery();
+
+        cy.get('.bp-gallery-grid[role="listbox"]').should('not.have.attr', 'aria-rowcount');
+        cy.get('.bp-gallery-grid[role="listbox"]')
+            .find('[role="option"]')
+            .should('have.length', 2);
+
+        cy.get('[role="option"][aria-label="Page 1"]').type('{downArrow}');
+        cy.focused().should('have.attr', 'aria-label', 'Page 2');
     });
 
     it('Should zoom the gallery independently of the document and persist across reopen', () => {
@@ -153,7 +217,7 @@ describe('Preview Document Gallery', () => {
             .should('have.text', '1 / 2');
         openGallery();
 
-        cy.get('[role="option"][aria-label="Page 2"]').click();
+        cy.get('.bp-gallery-tile[data-page="2"]').click();
 
         cy.get('.bp-gallery-grid').should('not.exist');
         cy.getPreviewPage(2).should('be.visible');
@@ -164,7 +228,7 @@ describe('Preview Document Gallery', () => {
         showDocumentPreview({ targetFileId: presentationFileId });
         openGallery();
 
-        cy.get('[role="option"][aria-label="Page 2"]').click();
+        cy.get('.bp-gallery-tile[data-page="2"]').click();
 
         cy.get('.bp-gallery-grid').should('not.exist');
         cy.getPreviewPage(2).should('be.visible');
@@ -180,7 +244,7 @@ describe('Preview Document Gallery', () => {
             .should('have.text', '1 / 2');
         openGallery();
 
-        cy.get('[role="option"][aria-label="Page 1"]').type('{esc}');
+        cy.get('.bp-gallery-tile[data-page="1"]').type('{esc}');
 
         cy.get('.bp-gallery-grid').should('not.exist');
         cy.get('@currentPage').should('have.text', '1 / 2');
@@ -223,7 +287,7 @@ describe('Preview Document Gallery', () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(301); // Wait for the thumbnails sidebar transition to complete
         cy.getByTestId('thumbnails-sidebar').should('not.be.visible');
-        cy.get('[role="option"][aria-label="Page 2"]').click();
+        cy.get('.bp-gallery-tile[data-page="2"]').click();
 
         cy.getPreviewPage(2).should('be.visible');
         cy.getByTestId('thumbnails-sidebar').should('be.visible');
@@ -264,7 +328,7 @@ describe('Preview Document Gallery', () => {
 
     it('Should release previous document resources when navigating to the next file', () => {
         showGalleryWithRenderedThumbnails({ collection: [fileId, singlePageFileId] });
-        cy.get('[role="option"][aria-label="Page 1"]').type('{esc}');
+        cy.get('.bp-gallery-tile[data-page="1"]').type('{esc}');
         cy.showControls();
 
         cy.window().then(win => {


### PR DESCRIPTION
## Summary

Upgrades Gallery View from 1D listbox semantics to a WAI-ARIA grid with 2D keyboard navigation, gated behind `galleryViewV2` (requires `galleryView`).

## ARIA grid (v2 flag only)

- `role="grid"` + `aria-rowcount`/`aria-colcount`; tiles become `gridcell`s with `aria-colindex`, chunked into `role="row"` wrappers with `aria-rowindex`
- Row wrappers use `display: contents` — tiles stay direct CSS-grid items, so layout and SCSS are unchanged
- Column count is measured from the rendered layout (not duplicated CSS math); re-measured on resize/fullscreen/zoom, guarded against zero-layout containers
- Keyboard: Left/Right stay ±1 wrapping across rows; Up/Down move by one row, with Down clamping on a short final row; Home/End/Enter/Space/Escape unchanged
- Focus survives re-chunks (column changes recreate tile nodes), including first open; restores with `preventScroll`
- Flag off → V1 listbox markup and behavior unchanged (pinned by tests)

## Scope note: memory fix removed

An earlier revision of this PR also included an unflagged `Thumbnail.js` change intended to release PDF.js per-page decoded resources after thumbnail renders. It was removed (`revert(doc): drop page memory release`) because the `isPageCached` guard it relied on does not exist in the bundled PDF.js (Box `2.107.0`, built from `pdfjs-dist` 4.3.136), so the cleanup never executed — and A/B verification on devpod with a 180-page image-heavy stress document showed no memory difference vs master (the bundled PDF.js already releases decoded bitmaps for thumbnail-only pages in Chrome). 

## Also

- Gallery constants extracted to `gallery/constants.ts` (follow-up from #1730 review)
- 2D nav math isolated in `galleryGridNavigation.ts`; FocusTrap recognizes gridcells

## Testing

- Unit tests, tsc, eslint, stylelint all green
- New unit coverage: grid semantics, keyboard boundaries (full + partial final rows), resize/zoom re-measure, focus retention across node recreation, no focus-stealing, zero-layout guard
- Cypress: v2 grid + 2D nav at wide/narrow viewports, v1 flag-off regression; existing specs made role-agnostic
- Manual on devpod EUA with both flag cookies: entry focus, arrows from first keypress, zoom + scroll
