### PR TITLE
fix(npm): expose the PDF.js worker asset

### DIFF
--- a/build/verifyLibBundle.js
+++ b/build/verifyLibBundle.js
@@ -8,6 +8,9 @@ const path = require('path');
 // files. output.chunkLoading: false and optimization.splitChunks: false in
 // webpack.config.lib.js prevent it; this check keeps that from silently regressing.
 const bundlePath = path.resolve(__dirname, '../dist/lib/index.js');
+const packagePath = path.resolve(__dirname, '../package.json');
+const pdfjsWorkerPath = path.resolve(__dirname, '../node_modules/pdfjs-dist/build/pdf.worker.min.mjs');
+const emittedWorkerPath = path.resolve(__dirname, '../dist/lib/pdf.worker.min.mjs');
 
 if (!fs.existsSync(bundlePath)) {
     console.error(`verifyLibBundle: ${bundlePath} not found. Run yarn build:lib:js first.`);
@@ -44,4 +47,51 @@ try {
     process.exit(1);
 }
 
-console.log('verifyLibBundle: OK, no chunk-loading runtime in dist/lib/index.js and CJS resolution works');
+const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+const workerExport = pkg.exports['./pdf.worker.min.mjs'];
+
+if (workerExport !== './dist/lib/pdf.worker.min.mjs') {
+    console.error(
+        'verifyLibBundle: package.json must export "./pdf.worker.min.mjs" as "./dist/lib/pdf.worker.min.mjs".',
+    );
+    process.exit(1);
+}
+
+if (!fs.existsSync(emittedWorkerPath)) {
+    console.error('verifyLibBundle: dist/lib/pdf.worker.min.mjs was not emitted.');
+    process.exit(1);
+}
+
+let resolvedWorkerPath;
+
+try {
+    resolvedWorkerPath = require.resolve('box-content-preview/pdf.worker.min.mjs');
+} catch (error) {
+    console.error('verifyLibBundle: require.resolve("box-content-preview/pdf.worker.min.mjs") failed.');
+    console.error(error.message);
+    process.exit(1);
+}
+
+if (resolvedWorkerPath !== emittedWorkerPath) {
+    console.error(`verifyLibBundle: PDF worker resolved to ${resolvedWorkerPath}, expected ${emittedWorkerPath}.`);
+    process.exit(1);
+}
+
+const pdfjsWorker = fs.readFileSync(pdfjsWorkerPath);
+
+if (!fs.readFileSync(emittedWorkerPath).equals(pdfjsWorker)) {
+    console.error('verifyLibBundle: emitted PDF worker does not match the pinned pdfjs-dist worker.');
+    process.exit(1);
+}
+
+const emittedWorkerCopies = fs
+    .readdirSync(path.dirname(emittedWorkerPath))
+    .filter(filename => filename.endsWith('.mjs'))
+    .filter(filename => fs.readFileSync(path.join(path.dirname(emittedWorkerPath), filename)).equals(pdfjsWorker));
+
+if (emittedWorkerCopies.length !== 1 || emittedWorkerCopies[0] !== path.basename(emittedWorkerPath)) {
+    console.error(`verifyLibBundle: expected one PDF worker asset, found ${emittedWorkerCopies.join(', ') || 'none'}.`);
+    process.exit(1);
+}
+
+console.log('verifyLibBundle: OK, library bundle is self-contained and package exports resolve to verified assets');

--- a/build/webpack.config.lib.js
+++ b/build/webpack.config.lib.js
@@ -110,6 +110,14 @@ module.exports = {
                     filename: 'assets/[name][ext]',
                 },
             },
+            {
+                test: /pdf\.worker\.min\.mjs$/,
+                type: 'asset/resource',
+                include: [path.resolve('node_modules/pdfjs-dist/build')],
+                generator: {
+                    filename: 'pdf.worker.min.mjs',
+                },
+            },
         ],
     },
     optimization: {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
             "default": "./dist/lib/index.js"
         },
         "./styles.css": "./dist/lib/index.css",
+        "./pdf.worker.min.mjs": "./dist/lib/pdf.worker.min.mjs",
         "./package.json": "./package.json"
     },
     "files": [


### PR DESCRIPTION
A quick hello from the Box alumni crew 👋, and thanks for keeping this project moving.

I took a pass at #1722. The npm build already emits the pinned PDF.js worker, but only under a generated filename that consumers cannot access through the package exports.

This gives the existing worker a stable `pdf.worker.min.mjs` filename and exports it through the package.

For Vite consumers:

```js
import workerUrl from 'box-content-preview/pdf.worker.min.mjs?url';
```

The build verifier now checks that the export resolves, the emitted worker exactly matches the pinned `pdfjs-dist` worker, and no duplicate worker is shipped.

Tested with:

- the library build and verifier
- 171 Jest suites and 4,205 tests
- ESLint and `git diff --check`
- the real npm tarball installed in a clean Vite app using the import above

Fixes #1722.

Meow. 🐈
