### PR TITLE
fix(video transcription): re-fetch transcription rep on cache hits

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -35,6 +35,7 @@ import {
     uncacheFile,
     isWatermarked,
     getCachedFile,
+    getRepresentation,
     normalizeFileVersion,
     canDownload,
     shouldDownloadWM,
@@ -1207,11 +1208,23 @@ class Preview extends EventEmitter {
         // Log cache hit
         this.logger.setCached();
 
-        // Finally load the viewer
-        this.loadViewer();
-
         const needsVideoReps = this.isVideoFileByExtension() && !this.hasPlayableVideoReps(this.file);
-        if (!this.options.skipServerUpdate || needsVideoReps) {
+        const needsTranscriptionRep =
+            isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
+            this.isVideoFileByExtension() &&
+            !this.hasTranscriptionRep(this.file);
+        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps || needsTranscriptionRep;
+
+        // When playable video reps are already cached but extracted_text is not, defer loading the
+        // viewer until handleFileInfoResponse can supply transcription metadata. Loading dash first
+        // races loadeddata (no captions) against the server refresh.
+        const deferViewerForTranscription = needsTranscriptionRep && !needsVideoReps && needsServerRefresh;
+
+        if (!deferViewerForTranscription) {
+            this.loadViewer();
+        }
+
+        if (needsServerRefresh) {
             this.loadFromServer();
         }
     }
@@ -1329,12 +1342,11 @@ class Preview extends EventEmitter {
                 return;
             }
 
-            // Server file info is authoritative: a video with no dash/mp4 will never play for this
-            // account (HD video is paid). Instant Preview may have mounted a jpg-only viewer from
-            // cache; throw error_account instead of waiting forever on an empty player.
-            if (this.isVideoFileByExtension() && !this.hasPlayableVideoReps(file)) {
-                throw new PreviewError(ERROR_CODE.ACCOUNT, __('error_account'));
-            }
+            const needsTranscriptionReload =
+                isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
+                this.isVideoFileByExtension() &&
+                !this.hasTranscriptionRep(cachedFile) &&
+                this.hasTranscriptionRep(file);
 
             // Should load viewer for first time if:
             //   - File isn't cached OR
@@ -1348,6 +1360,20 @@ class Preview extends EventEmitter {
             } else if (cachedFile.file_version.sha1 !== file.file_version.sha1 || isFileWatermarked) {
                 this.logger.setCacheStale(); // Log that cache is stale
                 this.reload(true); // Reload viewer without fetching updated file info from server
+            } else if (needsTranscriptionReload) {
+                // Cache was valid but lacked extracted_text (e.g. prefetch without the hint).
+                // Server refresh now has the rep — update the viewer so loadTranscription can run.
+                if (this.viewer) {
+                    this.viewer.options.file = this.file;
+                    if (typeof this.viewer.loadTranscription === 'function') {
+                        this.viewer.loadTranscription();
+                    }
+                } else {
+                    this.loadViewer();
+                }
+            } else if (!this.viewer) {
+                // Viewer load was deferred in loadFromCache() pending transcription metadata.
+                this.loadViewer();
             }
         } catch (err) {
             const error =
@@ -1476,6 +1502,18 @@ class Preview extends EventEmitter {
                 viewer => VIDEO_VIEWER_NAMES.indexOf(viewer.NAME) > -1 && viewer.EXT && viewer.EXT.indexOf(ext) > -1,
             );
         });
+    }
+
+    /**
+     * Returns true if file has an extracted_text transcription rep with a content URL.
+     *
+     * @private
+     * @param {Object} file - File object
+     * @return {boolean}
+     */
+    hasTranscriptionRep(file) {
+        const extractedText = getRepresentation(file, 'extracted_text');
+        return !!extractedText?.content?.url_template;
     }
 
     /**

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -10,7 +10,12 @@ import PreviewError from '../PreviewError';
 import PreviewPerf from '../PreviewPerf';
 import Timer from '../Timer';
 import loaders from '../loaders';
-import { API_HOST, CLASS_NAVIGATION_VISIBILITY, PRELOAD_REP_NAME } from '../constants';
+import {
+    API_HOST,
+    CLASS_NAVIGATION_VISIBILITY,
+    PRELOAD_REP_NAME,
+    AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES,
+} from '../constants';
 import {
     VIEWER_EVENT,
     ERROR_CODE,
@@ -1774,6 +1779,40 @@ describe('lib/Preview', () => {
             expect(preview.loadFromServer).not.toHaveBeenCalled();
         });
 
+        test('should refresh from server when skipServerUpdate but video lacks transcription rep', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(true);
+            preview.options.skipServerUpdate = true;
+            preview.file = {
+                id: '123',
+                extension: 'avi',
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            };
+
+            preview.loadFromCache();
+
+            expect(stubs.loadFromServer).toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should load the viewer immediately when video reps are also missing', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(false);
+            preview.options.skipServerUpdate = true;
+            preview.file = { id: '123', extension: 'avi' };
+
+            preview.loadFromCache();
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
+            expect(stubs.loadFromServer).toHaveBeenCalled();
+        });
+
         test('should refresh the file from the server to update the cache', () => {
             preview.loadFromCache();
             expect(preview.loadFromServer).toHaveBeenCalled();
@@ -1958,54 +1997,6 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
-        test('should trigger account error when video file has only preload rep and no playable reps', () => {
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
-            stubs.getCachedFile.mockReturnValue(null);
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
-            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
-            expect(stubs.triggerError.mock.calls[0][0].message).toBe(__('error_account'));
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
-        });
-
-        test('should trigger account error when Instant Preview viewer is showing jpg but server file has no playable reps', () => {
-            preview.viewer = {
-                options: {
-                    viewer: { NAME: 'Dash' },
-                    representation: { representation: PRELOAD_REP_NAME },
-                },
-            };
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
-            stubs.getCachedFile.mockReturnValue({
-                file_version: { sha1: stubs.file.file_version.sha1 },
-            });
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
-            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
-        });
-
-        test('should not trigger account error when video file has pending dash rep', () => {
-            stubs.loadViewer.mockImplementation(() => {});
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [
-                { representation: PRELOAD_REP_NAME },
-                { representation: 'dash', status: { state: 'pending' } },
-            ];
-            stubs.getCachedFile.mockReturnValue(null);
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).not.toHaveBeenCalled();
-            expect(stubs.loadViewer).toHaveBeenCalled();
-        });
-
         test('should uncache the file if the file is watermarked', () => {
             stubs.isWatermarked.mockReturnValue(true);
             stubs.getCachedFile.mockReturnValue({
@@ -2046,6 +2037,53 @@ describe('lib/Preview', () => {
             preview.handleFileInfoResponse(stubs.file);
             expect(preview.logger.setCacheStale).toHaveBeenCalled();
             expect(stubs.reload).toHaveBeenCalled();
+        });
+
+        test('should update viewer and load transcription when cache lacked extracted_text', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.file.extension = 'avi';
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+                { representation: 'extracted_text', content: { url_template: 'https://example.com/vtt' } },
+            ];
+            const loadTranscription = jest.fn();
+            preview.viewer = {
+                options: { file: {} },
+                player: {},
+                loadTranscription,
+            };
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(preview.viewer.options.file).toBe(stubs.file);
+            expect(loadTranscription).toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should load the deferred viewer when transcription is still unavailable on the server', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.viewer = undefined;
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+            ];
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
         test('should set the cache stale and re-load the viewer if the file is watermarked', () => {


### PR DESCRIPTION
## Summary
- When `skipServerUpdate` is set and a cached video file lacks an `extracted_text` rep, refresh file metadata from the server (same pattern as missing playable video reps).
- Defer loading the Dash viewer until that server refresh completes when playable video reps are already cached but `extracted_text` is not — avoids a race where `loadeddata` fires before transcription metadata arrives.
- After the server response includes `extracted_text`, update the active Dash viewer and call `loadTranscription()` instead of treating the cache hit as complete.

Fixes: on dev, subtitles only appeared on the first video preview because reopening reused cached metadata without `extracted_text`.

## Test plan
- [x] Unit tests for `loadFromCache` server refresh when transcription rep is missing
- [x] Unit tests for deferred viewer load when playable reps exist but transcription is missing
- [x] Unit tests for `handleFileInfoResponse` calling `loadTranscription` when cache lacked `extracted_text`
- [ ] Preview a video with AI transcription enabled, close preview, reopen same video — subtitles should still appear
- [ ] Preview a video, navigate away, return — subtitles should still appear