### PR TITLE
fix(video): prevent V2 filmstrip thumbnail drift on non-standard aspect ratios

### DIFF
--- a/src/lib/viewers/controls/media/FilmstripV2.scss
+++ b/src/lib/viewers/controls/media/FilmstripV2.scss
@@ -20,6 +20,7 @@
     align-items: center;
     justify-content: center;
     overflow: hidden;
+    background-repeat: no-repeat;
     border-radius: 10px;
 }
 

--- a/src/lib/viewers/controls/media/FilmstripV2.scss
+++ b/src/lib/viewers/controls/media/FilmstripV2.scss
@@ -16,12 +16,26 @@
 }
 
 .bp-FilmstripV2-frame {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    background-repeat: no-repeat;
     border-radius: 10px;
+}
+
+.bp-FilmstripV2-frameImage {
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow: hidden;
+    background-repeat: no-repeat;
+    transform-origin: top left;
+}
+
+.bp-FilmstripV2-frame .bp-crawler {
+    position: relative;
+    z-index: 1;
 }
 
 .bp-FilmstripV2-time {

--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -32,7 +32,6 @@ export default function FilmstripV2({
 }: Props): JSX.Element | null {
     const [isLoading, setIsLoading] = React.useState(true);
     const [imageWidth, setImageWidth] = React.useState<number>(0);
-    const [imageHeight, setImageHeight] = React.useState<number>(0);
     const frameNumber = Math.floor(time / interval);
     const frameRow = Math.floor(frameNumber / FILMSTRIP_FRAMES_PER_ROW);
     const sourceFrameWidth = imageWidth
@@ -41,16 +40,11 @@ export default function FilmstripV2({
           Math.floor(FILMSTRIP_DISPLAY_WIDTH * (FILMSTRIP_SOURCE_FRAME_HEIGHT / FILMSTRIP_DISPLAY_HEIGHT));
     const scale = FILMSTRIP_DISPLAY_HEIGHT / FILMSTRIP_SOURCE_FRAME_HEIGHT;
     const displayWidth = Math.floor(sourceFrameWidth * scale) || FILMSTRIP_DISPLAY_WIDTH;
-    const rowCount = imageHeight ? imageHeight / FILMSTRIP_SOURCE_FRAME_HEIGHT : 0;
-    // Paint each row 1px taller than the window and clip. Subpixel rounding otherwise
-    // samples the next row (often a black letterbox) as a line under the thumbnail.
-    const scaledRowHeight = FILMSTRIP_DISPLAY_HEIGHT + 1;
-    const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * displayWidth;
-    const backgroundTop = -(frameRow * (rowCount ? scaledRowHeight : FILMSTRIP_DISPLAY_HEIGHT));
-    const backgroundWidth = displayWidth * FILMSTRIP_FRAMES_PER_ROW;
-    const backgroundHeight = rowCount ? rowCount * scaledRowHeight : undefined;
+    // Pan in native JPEG pixels (same as Filmstrip.tsx) so 1.5x scale cannot leak the next cell.
+    const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * sourceFrameWidth;
+    const backgroundTop = -(frameRow * FILMSTRIP_SOURCE_FRAME_HEIGHT);
     const cardWidth = displayWidth + 24;
-    const filmstripLeft = Math.round(Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth));
+    const filmstripLeft = Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth);
 
     React.useEffect((): void => {
         if (!imageUrl) return;
@@ -58,7 +52,6 @@ export default function FilmstripV2({
         const filmstripImage = document.createElement('img');
         filmstripImage.onload = (): void => {
             setImageWidth(filmstripImage.naturalWidth);
-            setImageHeight(filmstripImage.naturalHeight);
             setIsLoading(false);
         };
         filmstripImage.src = imageUrl;
@@ -74,16 +67,24 @@ export default function FilmstripV2({
                 className="bp-FilmstripV2-frame"
                 data-testid="bp-FilmstripV2-frame"
                 style={{
-                    backgroundImage: imageUrl ? `url('${imageUrl}')` : '',
-                    backgroundPositionX: backgroundLeft,
-                    backgroundPositionY: backgroundTop,
-                    backgroundSize: backgroundHeight
-                        ? `${backgroundWidth}px ${backgroundHeight}px`
-                        : `${backgroundWidth}px auto`,
                     height: FILMSTRIP_DISPLAY_HEIGHT,
                     width: displayWidth,
                 }}
             >
+                {!!imageUrl && (
+                    <div
+                        className="bp-FilmstripV2-frameImage"
+                        data-testid="bp-FilmstripV2-frameImage"
+                        style={{
+                            backgroundImage: `url('${imageUrl}')`,
+                            backgroundPositionX: backgroundLeft,
+                            backgroundPositionY: backgroundTop,
+                            height: FILMSTRIP_SOURCE_FRAME_HEIGHT,
+                            transform: `scale(${scale})`,
+                            width: sourceFrameWidth,
+                        }}
+                    />
+                )}
                 {isLoading && (
                     <div className="bp-crawler" data-testid="bp-FilmstripV2-crawler">
                         <div />

--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -41,13 +41,16 @@ export default function FilmstripV2({
           Math.floor(FILMSTRIP_DISPLAY_WIDTH * (FILMSTRIP_SOURCE_FRAME_HEIGHT / FILMSTRIP_DISPLAY_HEIGHT));
     const scale = FILMSTRIP_DISPLAY_HEIGHT / FILMSTRIP_SOURCE_FRAME_HEIGHT;
     const displayWidth = Math.floor(sourceFrameWidth * scale) || FILMSTRIP_DISPLAY_WIDTH;
+    const rowCount = imageHeight ? imageHeight / FILMSTRIP_SOURCE_FRAME_HEIGHT : 0;
+    // Paint each row 1px taller than the window and clip. Subpixel rounding otherwise
+    // samples the next row (often a black letterbox) as a line under the thumbnail.
+    const scaledRowHeight = FILMSTRIP_DISPLAY_HEIGHT + 1;
     const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * displayWidth;
-    const backgroundTop = -(frameRow * FILMSTRIP_DISPLAY_HEIGHT);
-    // Width snaps to displayWidth so frames cannot drift; height is 1.5x so rows fill the 135px window.
+    const backgroundTop = -(frameRow * (rowCount ? scaledRowHeight : FILMSTRIP_DISPLAY_HEIGHT));
     const backgroundWidth = displayWidth * FILMSTRIP_FRAMES_PER_ROW;
-    const backgroundHeight = imageHeight ? imageHeight * scale : undefined;
+    const backgroundHeight = rowCount ? rowCount * scaledRowHeight : undefined;
     const cardWidth = displayWidth + 24;
-    const filmstripLeft = Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth);
+    const filmstripLeft = Math.round(Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth));
 
     React.useEffect((): void => {
         if (!imageUrl) return;

--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -8,6 +8,7 @@ const FILMSTRIP_FRAMES_PER_ROW = 100;
 const FILMSTRIP_SOURCE_FRAME_HEIGHT = 90;
 const FILMSTRIP_DISPLAY_HEIGHT = 135;
 const FILMSTRIP_DISPLAY_WIDTH = 240;
+const FILMSTRIP_DISPLAY_SCALE = FILMSTRIP_DISPLAY_HEIGHT / FILMSTRIP_SOURCE_FRAME_HEIGHT;
 
 export type Props = {
     aspectRatio?: number;
@@ -32,17 +33,17 @@ export default function FilmstripV2({
 }: Props): JSX.Element | null {
     const [isLoading, setIsLoading] = React.useState(true);
     const [imageWidth, setImageWidth] = React.useState<number>(0);
-    const frameNumber = Math.floor(time / interval);
-    const frameRow = Math.floor(frameNumber / FILMSTRIP_FRAMES_PER_ROW);
+
+    const frameNumber = Math.floor(time / interval); // Current frame based on current time
+    const frameRow = Math.floor(frameNumber / FILMSTRIP_FRAMES_PER_ROW); // Row number if there is more than one row
     const sourceFrameWidth = imageWidth
         ? Math.floor(imageWidth / FILMSTRIP_FRAMES_PER_ROW)
         : Math.floor(aspectRatio * FILMSTRIP_SOURCE_FRAME_HEIGHT) ||
           Math.floor(FILMSTRIP_DISPLAY_WIDTH * (FILMSTRIP_SOURCE_FRAME_HEIGHT / FILMSTRIP_DISPLAY_HEIGHT));
-    const scale = FILMSTRIP_DISPLAY_HEIGHT / FILMSTRIP_SOURCE_FRAME_HEIGHT;
-    const displayWidth = Math.floor(sourceFrameWidth * scale) || FILMSTRIP_DISPLAY_WIDTH;
-    // Pan in native JPEG pixels (same as Filmstrip.tsx) so 1.5x scale cannot leak the next cell.
-    const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * sourceFrameWidth;
-    const backgroundTop = -(frameRow * FILMSTRIP_SOURCE_FRAME_HEIGHT);
+    const frameBackgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * sourceFrameWidth; // Frame position in its row
+    const frameBackgroundTop = -(frameRow * FILMSTRIP_SOURCE_FRAME_HEIGHT); // Row position in its filmstrip
+
+    const displayWidth = Math.floor(sourceFrameWidth * FILMSTRIP_DISPLAY_SCALE) || FILMSTRIP_DISPLAY_WIDTH;
     const cardWidth = displayWidth + 24;
     const filmstripLeft = Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth);
 
@@ -77,10 +78,10 @@ export default function FilmstripV2({
                         data-testid="bp-FilmstripV2-frameImage"
                         style={{
                             backgroundImage: `url('${imageUrl}')`,
-                            backgroundPositionX: backgroundLeft,
-                            backgroundPositionY: backgroundTop,
+                            backgroundPositionX: frameBackgroundLeft,
+                            backgroundPositionY: frameBackgroundTop,
                             height: FILMSTRIP_SOURCE_FRAME_HEIGHT,
-                            transform: `scale(${scale})`,
+                            transform: `scale(${FILMSTRIP_DISPLAY_SCALE})`,
                             width: sourceFrameWidth,
                         }}
                     />

--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -42,7 +42,8 @@ export default function FilmstripV2({
     const displayWidth = Math.floor(sourceFrameWidth * scale) || FILMSTRIP_DISPLAY_WIDTH;
     const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * displayWidth;
     const backgroundTop = -(frameRow * FILMSTRIP_DISPLAY_HEIGHT);
-    const backgroundWidth = imageWidth ? imageWidth * scale : undefined;
+    // Sprite width must be a multiple of displayWidth so 1.5x scale cannot drift across frames.
+    const backgroundWidth = displayWidth * FILMSTRIP_FRAMES_PER_ROW;
     const cardWidth = displayWidth + 24;
     const filmstripLeft = Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth);
 
@@ -70,7 +71,7 @@ export default function FilmstripV2({
                     backgroundImage: imageUrl ? `url('${imageUrl}')` : '',
                     backgroundPositionX: backgroundLeft,
                     backgroundPositionY: backgroundTop,
-                    backgroundSize: backgroundWidth ? `${backgroundWidth}px auto` : undefined,
+                    backgroundSize: `${backgroundWidth}px auto`,
                     height: FILMSTRIP_DISPLAY_HEIGHT,
                     width: displayWidth,
                 }}

--- a/src/lib/viewers/controls/media/FilmstripV2.tsx
+++ b/src/lib/viewers/controls/media/FilmstripV2.tsx
@@ -32,6 +32,7 @@ export default function FilmstripV2({
 }: Props): JSX.Element | null {
     const [isLoading, setIsLoading] = React.useState(true);
     const [imageWidth, setImageWidth] = React.useState<number>(0);
+    const [imageHeight, setImageHeight] = React.useState<number>(0);
     const frameNumber = Math.floor(time / interval);
     const frameRow = Math.floor(frameNumber / FILMSTRIP_FRAMES_PER_ROW);
     const sourceFrameWidth = imageWidth
@@ -42,8 +43,9 @@ export default function FilmstripV2({
     const displayWidth = Math.floor(sourceFrameWidth * scale) || FILMSTRIP_DISPLAY_WIDTH;
     const backgroundLeft = -(frameNumber % FILMSTRIP_FRAMES_PER_ROW) * displayWidth;
     const backgroundTop = -(frameRow * FILMSTRIP_DISPLAY_HEIGHT);
-    // Sprite width must be a multiple of displayWidth so 1.5x scale cannot drift across frames.
+    // Width snaps to displayWidth so frames cannot drift; height is 1.5x so rows fill the 135px window.
     const backgroundWidth = displayWidth * FILMSTRIP_FRAMES_PER_ROW;
+    const backgroundHeight = imageHeight ? imageHeight * scale : undefined;
     const cardWidth = displayWidth + 24;
     const filmstripLeft = Math.min(Math.max(0, position - cardWidth / 2), positionMax - cardWidth);
 
@@ -53,6 +55,7 @@ export default function FilmstripV2({
         const filmstripImage = document.createElement('img');
         filmstripImage.onload = (): void => {
             setImageWidth(filmstripImage.naturalWidth);
+            setImageHeight(filmstripImage.naturalHeight);
             setIsLoading(false);
         };
         filmstripImage.src = imageUrl;
@@ -71,7 +74,9 @@ export default function FilmstripV2({
                     backgroundImage: imageUrl ? `url('${imageUrl}')` : '',
                     backgroundPositionX: backgroundLeft,
                     backgroundPositionY: backgroundTop,
-                    backgroundSize: `${backgroundWidth}px auto`,
+                    backgroundSize: backgroundHeight
+                        ? `${backgroundWidth}px ${backgroundHeight}px`
+                        : `${backgroundWidth}px auto`,
                     height: FILMSTRIP_DISPLAY_HEIGHT,
                     width: displayWidth,
                 }}

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -110,7 +110,7 @@ describe('FilmstripV2', () => {
     });
 
     describe('frame width', () => {
-        const mockFilmstripLoad = (naturalWidth: number): (() => void) => {
+        const mockFilmstripLoad = (naturalWidth: number, naturalHeight = 90): (() => void) => {
             let capturedImg: HTMLImageElement | null = null;
             const originalCreateElement = document.createElement.bind(document);
             jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
@@ -123,6 +123,7 @@ describe('FilmstripV2', () => {
                 act(() => {
                     if (capturedImg?.onload) {
                         Object.defineProperty(capturedImg, 'naturalWidth', { value: naturalWidth });
+                        Object.defineProperty(capturedImg, 'naturalHeight', { value: naturalHeight });
                         (capturedImg.onload as (this: GlobalEventHandlers, ev: Event) => void).call(
                             capturedImg,
                             new Event('load'),
@@ -163,11 +164,11 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 127, display = floor(190.5) = 190, sprite = 190 * 100, frame 53 offset = -10070
+            // source = 127, display = floor(190.5) = 190; width = 190*100, height = 90*1.5 so the window fills
             expect(frame).toHaveStyle({
                 width: '190px',
                 backgroundPositionX: '-10070px',
-                backgroundSize: '19000px auto',
+                backgroundSize: '19000px 135px',
             });
         });
 
@@ -185,11 +186,31 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 128, display = 192, sprite = 19200, frame 53 offset = -10176
+            // source = 128, display = 192, sprite = 19200x135, frame 53 offset = -10176
             expect(frame).toHaveStyle({
                 width: '192px',
                 backgroundPositionX: '-10176px',
-                backgroundSize: '19200px auto',
+                backgroundSize: '19200px 135px',
+            });
+        });
+
+        test('should scale multi-row filmstrip height to fill each 135px row', () => {
+            const triggerLoad = mockFilmstripLoad(12800, 180);
+            render(
+                <FilmstripV2
+                    aspectRatio={1.4167}
+                    imageUrl="https://example.com/filmstrip.jpg"
+                    interval={1}
+                    time={110}
+                />,
+            );
+
+            triggerLoad();
+
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            expect(frame).toHaveStyle({
+                backgroundPositionY: '-135px',
+                backgroundSize: '19200px 270px',
             });
         });
     });

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -27,25 +27,18 @@ describe('FilmstripV2', () => {
             const el = screen.getByTestId('bp-FilmstripV2');
             expect(el.style.left).toBe('0px');
         });
-
-        test('should snap filmstrip position to whole pixels', () => {
-            render(<FilmstripV2 position={200.4} positionMax={800} />);
-            const el = screen.getByTestId('bp-FilmstripV2');
-            expect(el.style.left).toBe('68px');
-        });
     });
 
     describe('frame display', () => {
         test('should set background image when imageUrl is provided', () => {
             render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" interval={1} time={5} />);
-            const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            expect(frame.style.backgroundImage).toContain('https://example.com/filmstrip.jpg');
+            const frameImage = screen.getByTestId('bp-FilmstripV2-frameImage');
+            expect(frameImage.style.backgroundImage).toContain('https://example.com/filmstrip.jpg');
         });
 
-        test('should not set background image when imageUrl is empty', () => {
+        test('should not render the filmstrip image when imageUrl is empty', () => {
             render(<FilmstripV2 interval={1} time={5} />);
-            const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            expect(frame.style.backgroundImage).toBe('');
+            expect(screen.queryByTestId('bp-FilmstripV2-frameImage')).not.toBeInTheDocument();
         });
 
         test('should set frame height to 135px', () => {
@@ -56,8 +49,8 @@ describe('FilmstripV2', () => {
 
         test('should calculate background position based on time and interval', () => {
             render(<FilmstripV2 imageUrl="https://example.com/filmstrip.jpg" interval={1} time={10} />);
-            const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            expect(frame.style.backgroundPositionX).toBeDefined();
+            const frameImage = screen.getByTestId('bp-FilmstripV2-frameImage');
+            expect(frameImage.style.backgroundPositionX).toBeDefined();
         });
     });
 
@@ -116,7 +109,7 @@ describe('FilmstripV2', () => {
     });
 
     describe('frame width', () => {
-        const mockFilmstripLoad = (naturalWidth: number, naturalHeight = 90): (() => void) => {
+        const mockFilmstripLoad = (naturalWidth: number): (() => void) => {
             let capturedImg: HTMLImageElement | null = null;
             const originalCreateElement = document.createElement.bind(document);
             jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
@@ -129,7 +122,6 @@ describe('FilmstripV2', () => {
                 act(() => {
                     if (capturedImg?.onload) {
                         Object.defineProperty(capturedImg, 'naturalWidth', { value: naturalWidth });
-                        Object.defineProperty(capturedImg, 'naturalHeight', { value: naturalHeight });
                         (capturedImg.onload as (this: GlobalEventHandlers, ev: Event) => void).call(
                             capturedImg,
                             new Event('load'),
@@ -156,7 +148,7 @@ describe('FilmstripV2', () => {
             expect(frame).toHaveStyle({ width: '192px' });
         });
 
-        test('should align background size to display width so scaled frames do not drift', () => {
+        test('should pan in native JPEG pixels so scaled frames do not drift', () => {
             const triggerLoad = mockFilmstripLoad(12700);
             render(
                 <FilmstripV2
@@ -170,12 +162,11 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 127, display = floor(190.5) = 190; height overscans 1px (136) and is clipped
-            expect(frame).toHaveStyle({
-                width: '190px',
-                backgroundPositionX: '-10070px',
-                backgroundSize: '19000px 136px',
-            });
+            const frameImage = screen.getByTestId('bp-FilmstripV2-frameImage');
+            expect(frame).toHaveStyle({ width: '190px' });
+            expect(frameImage).toHaveStyle({ width: '127px', height: '90px' });
+            expect(frameImage.style.backgroundPositionX).toBe('-6731px');
+            expect(Number.parseInt(frameImage.style.backgroundPositionY, 10)).toBe(0);
         });
 
         test('should keep even source frames aligned after 1.5x scale', () => {
@@ -192,16 +183,15 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 128, display = 192, sprite = 19200x136, frame 53 offset = -10176
-            expect(frame).toHaveStyle({
-                width: '192px',
-                backgroundPositionX: '-10176px',
-                backgroundSize: '19200px 136px',
-            });
+            const frameImage = screen.getByTestId('bp-FilmstripV2-frameImage');
+            expect(frame).toHaveStyle({ width: '192px' });
+            expect(frameImage).toHaveStyle({ width: '128px', height: '90px', transform: 'scale(1.5)' });
+            expect(frameImage.style.backgroundPositionX).toBe('-6784px');
+            expect(Number.parseInt(frameImage.style.backgroundPositionY, 10)).toBe(0);
         });
 
-        test('should scale multi-row filmstrip height to fill each 135px row', () => {
-            const triggerLoad = mockFilmstripLoad(12800, 180);
+        test('should pan to the next native row after 100 frames', () => {
+            const triggerLoad = mockFilmstripLoad(12800);
             render(
                 <FilmstripV2
                     aspectRatio={1.4167}
@@ -213,11 +203,9 @@ describe('FilmstripV2', () => {
 
             triggerLoad();
 
-            const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            expect(frame).toHaveStyle({
-                backgroundPositionY: '-136px',
-                backgroundSize: '19200px 272px',
-            });
+            const frameImage = screen.getByTestId('bp-FilmstripV2-frameImage');
+            expect(frameImage.style.backgroundPositionX).toBe('-1280px');
+            expect(frameImage.style.backgroundPositionY).toBe('-90px');
         });
     });
 });

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -108,4 +108,89 @@ describe('FilmstripV2', () => {
             (document.createElement as jest.Mock).mockRestore();
         });
     });
+
+    describe('frame width', () => {
+        const mockFilmstripLoad = (naturalWidth: number): (() => void) => {
+            let capturedImg: HTMLImageElement | null = null;
+            const originalCreateElement = document.createElement.bind(document);
+            jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+                const el = originalCreateElement(tag);
+                if (tag === 'img') capturedImg = el as HTMLImageElement;
+                return el;
+            });
+
+            return (): void => {
+                act(() => {
+                    if (capturedImg?.onload) {
+                        Object.defineProperty(capturedImg, 'naturalWidth', { value: naturalWidth });
+                        (capturedImg.onload as (this: GlobalEventHandlers, ev: Event) => void).call(
+                            capturedImg,
+                            new Event('load'),
+                        );
+                    }
+                });
+                (document.createElement as jest.Mock).mockRestore();
+            };
+        };
+
+        test('should derive display width from filmstrip image width after load', () => {
+            const triggerLoad = mockFilmstripLoad(12800);
+            render(
+                <FilmstripV2 aspectRatio={1.4167} imageUrl="https://example.com/filmstrip.jpg" interval={1} time={1} />,
+            );
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+
+            // Before load: source = floor(1.4167 * 90) = 127, display = floor(127 * 1.5) = 190
+            expect(frame).toHaveStyle({ width: '190px' });
+
+            triggerLoad();
+
+            // After load: source = floor(12800 / 100) = 128, display = floor(128 * 1.5) = 192
+            expect(frame).toHaveStyle({ width: '192px' });
+        });
+
+        test('should align background size to display width so scaled frames do not drift', () => {
+            const triggerLoad = mockFilmstripLoad(12700);
+            render(
+                <FilmstripV2
+                    aspectRatio={1.4167}
+                    imageUrl="https://example.com/filmstrip.jpg"
+                    interval={1}
+                    time={53}
+                />,
+            );
+
+            triggerLoad();
+
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            // source = 127, display = floor(190.5) = 190, sprite = 190 * 100, frame 53 offset = -10070
+            expect(frame).toHaveStyle({
+                width: '190px',
+                backgroundPositionX: '-10070px',
+                backgroundSize: '19000px auto',
+            });
+        });
+
+        test('should keep even source frames aligned after 1.5x scale', () => {
+            const triggerLoad = mockFilmstripLoad(12800);
+            render(
+                <FilmstripV2
+                    aspectRatio={1.4167}
+                    imageUrl="https://example.com/filmstrip.jpg"
+                    interval={1}
+                    time={53}
+                />,
+            );
+
+            triggerLoad();
+
+            const frame = screen.getByTestId('bp-FilmstripV2-frame');
+            // source = 128, display = 192, sprite = 19200, frame 53 offset = -10176
+            expect(frame).toHaveStyle({
+                width: '192px',
+                backgroundPositionX: '-10176px',
+                backgroundSize: '19200px auto',
+            });
+        });
+    });
 });

--- a/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx
@@ -27,6 +27,12 @@ describe('FilmstripV2', () => {
             const el = screen.getByTestId('bp-FilmstripV2');
             expect(el.style.left).toBe('0px');
         });
+
+        test('should snap filmstrip position to whole pixels', () => {
+            render(<FilmstripV2 position={200.4} positionMax={800} />);
+            const el = screen.getByTestId('bp-FilmstripV2');
+            expect(el.style.left).toBe('68px');
+        });
     });
 
     describe('frame display', () => {
@@ -164,11 +170,11 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 127, display = floor(190.5) = 190; width = 190*100, height = 90*1.5 so the window fills
+            // source = 127, display = floor(190.5) = 190; height overscans 1px (136) and is clipped
             expect(frame).toHaveStyle({
                 width: '190px',
                 backgroundPositionX: '-10070px',
-                backgroundSize: '19000px 135px',
+                backgroundSize: '19000px 136px',
             });
         });
 
@@ -186,11 +192,11 @@ describe('FilmstripV2', () => {
             triggerLoad();
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
-            // source = 128, display = 192, sprite = 19200x135, frame 53 offset = -10176
+            // source = 128, display = 192, sprite = 19200x136, frame 53 offset = -10176
             expect(frame).toHaveStyle({
                 width: '192px',
                 backgroundPositionX: '-10176px',
-                backgroundSize: '19200px 135px',
+                backgroundSize: '19200px 136px',
             });
         });
 
@@ -209,8 +215,8 @@ describe('FilmstripV2', () => {
 
             const frame = screen.getByTestId('bp-FilmstripV2-frame');
             expect(frame).toHaveStyle({
-                backgroundPositionY: '-135px',
-                backgroundSize: '19200px 270px',
+                backgroundPositionY: '-136px',
+                backgroundSize: '19200px 272px',
             });
         });
     });


### PR DESCRIPTION
## Summary
- `FilmstripV2.tsx` drifted out of sync because it stretched the whole sheet 1.5× (`background-size`) and panned in those scaled coordinates, so frame width and position could disagree.
- Crop one native cell first (90px tall, pan with `-frameIndex * sourceFrameWidth` / `-row * 90`, `overflow: hidden`), then `transform: scale(1.5)` that crop to 135px. Scale never participates in which cell is shown, so later timestamps cannot leak the next row (the black sliver under the thumbnail).
- Adds unit tests for the ticket’s 12800px sheet, odd source widths at `time=53`, and row 2 at `time=110`.

BEFORE

<img width="244" height="199" alt="Screenshot 2026-08-18 at 2 56 24 PM" src="https://github.com/user-attachments/assets/384661f1-4716-4c9b-bc04-3a22f7b9a142" />

AFTER

<img width="247" height="198" alt="Screenshot 2026-08-18 at 2 55 42 PM" src="https://github.com/user-attachments/assets/f9746a55-4431-4464-bbf3-75dbb5acd664" />

## Test plan
- [ ] Hover the V2 player scrubber on a 16:9 video and confirm filmstrip thumbnails still look correct
- [ ] Reproduce with the PREVIEW-1354 test clip (or another non-standard ratio such as 3060×2160): scrub past ~0:50 and confirm each thumbnail is a single frame, not split
- [ ] Scrub toward the end of a longer video and confirm there is no black sliver under the thumbnail
- [ ] Confirm the filmstrip still appears while the JPEG is loading (crawler, then thumbnail) without a split frame
- [ ] `NODE_ENV=test yarn jest src/lib/viewers/controls/media/__tests__/FilmstripV2-test.tsx --watchman=false`