### PR TITLE
fix(video): show account error for free-user video preview

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1329,6 +1329,13 @@ class Preview extends EventEmitter {
                 return;
             }
 
+            // Server file info is authoritative: a video with no dash/mp4 will never play for this
+            // account (HD video is paid). Instant Preview may have mounted a jpg-only viewer from
+            // cache; throw error_account instead of waiting forever on an empty player.
+            if (this.isVideoFileByExtension() && !this.hasPlayableVideoReps(file)) {
+                throw new PreviewError(ERROR_CODE.ACCOUNT, __('error_account'));
+            }
+
             // Should load viewer for first time if:
             //   - File isn't cached OR
             //   - Cached file doesn't have a valid structure

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1958,6 +1958,54 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
+        test('should trigger account error when video file has only preload rep and no playable reps', () => {
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
+            stubs.getCachedFile.mockReturnValue(null);
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
+            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
+            expect(stubs.triggerError.mock.calls[0][0].message).toBe(__('error_account'));
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should trigger account error when Instant Preview viewer is showing jpg but server file has no playable reps', () => {
+            preview.viewer = {
+                options: {
+                    viewer: { NAME: 'Dash' },
+                    representation: { representation: PRELOAD_REP_NAME },
+                },
+            };
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: stubs.file.file_version.sha1 },
+            });
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
+            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should not trigger account error when video file has pending dash rep', () => {
+            stubs.loadViewer.mockImplementation(() => {});
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [
+                { representation: PRELOAD_REP_NAME },
+                { representation: 'dash', status: { state: 'pending' } },
+            ];
+            stubs.getCachedFile.mockReturnValue(null);
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).not.toHaveBeenCalled();
+            expect(stubs.loadViewer).toHaveBeenCalled();
+        });
+
         test('should uncache the file if the file is watermarked', () => {
             stubs.isWatermarked.mockReturnValue(true);
             stubs.getCachedFile.mockReturnValue({


### PR DESCRIPTION
## Summary
- Fixes [PREVIEW-1512](https://jira.inside-box.net/browse/PREVIEW-1512): free users previewing video saw a blank player instead of the paid-account disclaimer.
- Instant Preview can still select a Dash/MP4 viewer from a jpg-only cached file so the poster paints. Once server file info is in, a video with no dash/mp4 throws `error_account` instead of waiting forever on an empty player.
- Paid accounts with dash/mp4 (including pending conversion) still get Instant Preview and playback.

## Test plan
- [ ] As a free / unpaid user, preview a video file — expect the account/upgrade message, not a blank player.
- [ ] As a paid user with dash/mp4, preview a video — Instant Preview poster then playback still works (V1 and V2).
- [ ] As a paid user whose dash/mp4 is still converting (pending rep), preview still waits/loads instead of showing `error_account`.
- [ ] `yarn jest src/lib/__tests__/Preview-test.js --watchman=false` passes.


Made with [Cursor](https://cursor.com)