### PR TITLE
fix(video transcription): re-fetch transcription rep on cache hits

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -35,6 +35,7 @@ import {
     uncacheFile,
     isWatermarked,
     getCachedFile,
+    getRepresentation,
     normalizeFileVersion,
     canDownload,
     shouldDownloadWM,
@@ -1207,11 +1208,23 @@ class Preview extends EventEmitter {
         // Log cache hit
         this.logger.setCached();
 
-        // Finally load the viewer
-        this.loadViewer();
-
         const needsVideoReps = this.isVideoFileByExtension() && !this.hasPlayableVideoReps(this.file);
-        if (!this.options.skipServerUpdate || needsVideoReps) {
+        const needsTranscriptionRep =
+            isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
+            this.isVideoFileByExtension() &&
+            !this.hasTranscriptionRep(this.file);
+        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps || needsTranscriptionRep;
+
+        // When playable video reps are already cached but extracted_text is not, defer loading the
+        // viewer until handleFileInfoResponse can supply transcription metadata. Loading dash first
+        // races loadeddata (no captions) against the server refresh.
+        const deferViewerForTranscription = needsTranscriptionRep && !needsVideoReps && needsServerRefresh;
+
+        if (!deferViewerForTranscription) {
+            this.loadViewer();
+        }
+
+        if (needsServerRefresh) {
             this.loadFromServer();
         }
     }
@@ -1336,6 +1349,12 @@ class Preview extends EventEmitter {
                 throw new PreviewError(ERROR_CODE.ACCOUNT, __('error_account'));
             }
 
+            const needsTranscriptionReload =
+                isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
+                this.isVideoFileByExtension() &&
+                !this.hasTranscriptionRep(cachedFile) &&
+                this.hasTranscriptionRep(file);
+
             // Should load viewer for first time if:
             //   - File isn't cached OR
             //   - Cached file doesn't have a valid structure
@@ -1348,6 +1367,20 @@ class Preview extends EventEmitter {
             } else if (cachedFile.file_version.sha1 !== file.file_version.sha1 || isFileWatermarked) {
                 this.logger.setCacheStale(); // Log that cache is stale
                 this.reload(true); // Reload viewer without fetching updated file info from server
+            } else if (needsTranscriptionReload) {
+                // Cache was valid but lacked extracted_text (e.g. prefetch without the hint).
+                // Server refresh now has the rep — update the viewer so loadTranscription can run.
+                if (this.viewer) {
+                    this.viewer.options.file = this.file;
+                    if (typeof this.viewer.loadTranscription === 'function') {
+                        this.viewer.loadTranscription();
+                    }
+                } else {
+                    this.loadViewer();
+                }
+            } else if (!this.viewer) {
+                // Viewer load was deferred in loadFromCache() pending transcription metadata.
+                this.loadViewer();
             }
         } catch (err) {
             const error =
@@ -1476,6 +1509,18 @@ class Preview extends EventEmitter {
                 viewer => VIDEO_VIEWER_NAMES.indexOf(viewer.NAME) > -1 && viewer.EXT && viewer.EXT.indexOf(ext) > -1,
             );
         });
+    }
+
+    /**
+     * Returns true if file has an extracted_text transcription rep with a content URL.
+     *
+     * @private
+     * @param {Object} file - File object
+     * @return {boolean}
+     */
+    hasTranscriptionRep(file) {
+        const extractedText = getRepresentation(file, 'extracted_text');
+        return !!extractedText?.content?.url_template;
     }
 
     /**

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1209,10 +1209,14 @@ class Preview extends EventEmitter {
         this.logger.setCached();
 
         const needsVideoReps = this.isVideoFileByExtension() && !this.hasPlayableVideoReps(this.file);
+        const needsTranscriptionRep =
+            isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
+            this.isVideoFileByExtension() &&
+            !this.hasTranscriptionRep(this.file);
         // Captions are optional — do not treat a missing extracted_text rep like missing
         // dash/mp4. skipServerUpdate should still skip the refresh; default reopen already
         // calls loadFromServer() because skipServerUpdate is false.
-        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps;
+        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps || needsTranscriptionRep;
 
         // Play from cache immediately. Default reopen still refreshes file info in the
         // background; handleFileInfoResponse then updates the live viewer if extracted_text

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1801,17 +1801,23 @@ class Preview extends EventEmitter {
             return;
         }
 
+        // Transcription is optional. If we deferred the viewer only to refresh
+        // extracted_text and still have dash/mp4 in memory, play now. Uncache +
+        // load(id) would replace this.file with { id } and stick on the spinner.
+        if (this.viewerLoadDeferredForTranscription && !this.viewer && this.hasPlayableVideoReps(this.file)) {
+            try {
+                this.loadViewer();
+                return;
+            } catch {
+                // Fall through to uncache / retry / error viewer
+            }
+        }
+
         // Nuke the cache
         uncacheFile(this.cache, this.file);
 
         // Check if we hit the retry limit for fetching file info
         if (this.retryCount > RETRY_COUNT) {
-            // Viewer load was deferred for transcription refresh; fall back to cached playback.
-            if (this.viewerLoadDeferredForTranscription && !this.viewer) {
-                this.loadViewer();
-                return;
-            }
-
             let errorCode = ERROR_CODE.EXCEEDED_RETRY_LIMIT;
             let errorMessage = __('error_refresh');
 

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -1209,17 +1209,14 @@ class Preview extends EventEmitter {
         this.logger.setCached();
 
         const needsVideoReps = this.isVideoFileByExtension() && !this.hasPlayableVideoReps(this.file);
-        const needsTranscriptionRep =
-            this.canUseDash() &&
-            isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
-            this.isVideoFileByExtension() &&
-            !this.hasTranscriptionRep(this.file);
-        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps || needsTranscriptionRep;
+        // Captions are optional — do not treat a missing extracted_text rep like missing
+        // dash/mp4. skipServerUpdate should still skip the refresh; default reopen already
+        // calls loadFromServer() because skipServerUpdate is false.
+        const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps;
 
-        // Play from cache immediately. If extracted_text is missing, loadFromServer()
-        // still runs; handleFileInfoResponse then calls loadTranscription() on the
-        // live viewer. DashViewer.loadTranscription() no-ops without a url and can
-        // attach tracks after loadeddata, so blocking first paint is unnecessary.
+        // Play from cache immediately. Default reopen still refreshes file info in the
+        // background; handleFileInfoResponse then updates the live viewer if extracted_text
+        // arrived. A failed captions-only refresh must not uncache or destroy playback.
         this.loadViewer();
 
         if (needsServerRefresh) {
@@ -1254,7 +1251,14 @@ class Preview extends EventEmitter {
         this.api
             .get(fileInfoUrl, { headers: this.getRequestHeaders() })
             .then(this.handleFileInfoResponse)
-            .catch(this.handleFetchError);
+            .catch(err => {
+                // Captions are optional. If a cache-hit viewer is already playing dash/mp4,
+                // a failed background file-info refresh must not uncache or triggerError.
+                if (this.viewer && this.hasPlayableVideoReps(this.file)) {
+                    return;
+                }
+                this.handleFetchError(err);
+            });
     }
 
     /**
@@ -1369,15 +1373,14 @@ class Preview extends EventEmitter {
             } else if (needsTranscriptionReload) {
                 // Cache was valid but lacked extracted_text (e.g. prefetch without the hint).
                 // Server refresh now has the rep — update the already-playing viewer so
-                // loadTranscription can attach captions. If loadeddata has not fired yet,
-                // DashViewer's handler will call loadTranscription() with this file.
+                // loadTranscription can attach captions. Only call it after loadeddata;
+                // calling earlier duplicates the Auto-generated Shaka track and can throw
+                // if UI is not ready. If loadeddata has not fired, the handler uses this file.
                 if (this.viewer) {
                     this.viewer.options.file = this.file;
-                    if (typeof this.viewer.loadTranscription === 'function') {
+                    if (this.viewer.isLoaded() && typeof this.viewer.loadTranscription === 'function') {
                         this.viewer.loadTranscription();
                     }
-                } else {
-                    this.loadViewer();
                 }
             }
         } catch (err) {
@@ -1517,7 +1520,10 @@ class Preview extends EventEmitter {
      * @return {boolean}
      */
     hasTranscriptionRep(file) {
-        const extractedText = file && getRepresentation(file, 'extracted_text');
+        if (!file?.representations?.entries) {
+            return false;
+        }
+        const extractedText = getRepresentation(file, 'extracted_text');
         return !!extractedText?.content?.url_template;
     }
 

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -130,9 +130,6 @@ class Preview extends EventEmitter {
     /** @property {Object} - Current viewer instance */
     viewer;
 
-    /** @property {boolean} - Whether viewer load was deferred pending transcription metadata */
-    viewerLoadDeferredForTranscription = false;
-
     /** @property {string[]} - List of file IDs to preview */
     collection = [];
 
@@ -1219,18 +1216,11 @@ class Preview extends EventEmitter {
             !this.hasTranscriptionRep(this.file);
         const needsServerRefresh = !this.options.skipServerUpdate || needsVideoReps || needsTranscriptionRep;
 
-        // When playable video reps are already cached but extracted_text is not, defer loading the
-        // viewer until handleFileInfoResponse can supply transcription metadata. Loading dash first
-        // races loadeddata (no captions) against the server refresh.
-        const deferViewerForTranscription = needsTranscriptionRep && !needsVideoReps;
-
-        if (deferViewerForTranscription) {
-            this.viewerLoadDeferredForTranscription = true;
-        }
-
-        if (!deferViewerForTranscription) {
-            this.loadViewer();
-        }
+        // Play from cache immediately. If extracted_text is missing, loadFromServer()
+        // still runs; handleFileInfoResponse then calls loadTranscription() on the
+        // live viewer. DashViewer.loadTranscription() no-ops without a url and can
+        // attach tracks after loadeddata, so blocking first paint is unnecessary.
+        this.loadViewer();
 
         if (needsServerRefresh) {
             this.loadFromServer();
@@ -1378,7 +1368,9 @@ class Preview extends EventEmitter {
                 this.reload(true); // Reload viewer without fetching updated file info from server
             } else if (needsTranscriptionReload) {
                 // Cache was valid but lacked extracted_text (e.g. prefetch without the hint).
-                // Server refresh now has the rep — update the viewer so loadTranscription can run.
+                // Server refresh now has the rep — update the already-playing viewer so
+                // loadTranscription can attach captions. If loadeddata has not fired yet,
+                // DashViewer's handler will call loadTranscription() with this file.
                 if (this.viewer) {
                     this.viewer.options.file = this.file;
                     if (typeof this.viewer.loadTranscription === 'function') {
@@ -1387,9 +1379,6 @@ class Preview extends EventEmitter {
                 } else {
                     this.loadViewer();
                 }
-            } else if (!this.viewer && this.viewerLoadDeferredForTranscription) {
-                // Viewer load was deferred in loadFromCache() pending transcription metadata.
-                this.loadViewer();
             }
         } catch (err) {
             const error =
@@ -1413,8 +1402,6 @@ class Preview extends EventEmitter {
         if (!this.open) {
             return;
         }
-
-        this.viewerLoadDeferredForTranscription = false;
 
         // Tear down current viewer so its DOM (e.g. preload image for video) is cleared before creating the new one.
         if (this.viewer && typeof this.viewer.destroy === 'function') {
@@ -1799,18 +1786,6 @@ class Preview extends EventEmitter {
         // If preview is closed don't do anything
         if (!this.open) {
             return;
-        }
-
-        // Transcription is optional. If we deferred the viewer only to refresh
-        // extracted_text and still have dash/mp4 in memory, play now. Uncache +
-        // load(id) would replace this.file with { id } and stick on the spinner.
-        if (this.viewerLoadDeferredForTranscription && !this.viewer && this.hasPlayableVideoReps(this.file)) {
-            try {
-                this.loadViewer();
-                return;
-            } catch {
-                // Fall through to uncache / retry / error viewer
-            }
         }
 
         // Nuke the cache

--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -130,6 +130,9 @@ class Preview extends EventEmitter {
     /** @property {Object} - Current viewer instance */
     viewer;
 
+    /** @property {boolean} - Whether viewer load was deferred pending transcription metadata */
+    viewerLoadDeferredForTranscription = false;
+
     /** @property {string[]} - List of file IDs to preview */
     collection = [];
 
@@ -1210,6 +1213,7 @@ class Preview extends EventEmitter {
 
         const needsVideoReps = this.isVideoFileByExtension() && !this.hasPlayableVideoReps(this.file);
         const needsTranscriptionRep =
+            this.canUseDash() &&
             isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
             this.isVideoFileByExtension() &&
             !this.hasTranscriptionRep(this.file);
@@ -1218,7 +1222,11 @@ class Preview extends EventEmitter {
         // When playable video reps are already cached but extracted_text is not, defer loading the
         // viewer until handleFileInfoResponse can supply transcription metadata. Loading dash first
         // races loadeddata (no captions) against the server refresh.
-        const deferViewerForTranscription = needsTranscriptionRep && !needsVideoReps && needsServerRefresh;
+        const deferViewerForTranscription = needsTranscriptionRep && !needsVideoReps;
+
+        if (deferViewerForTranscription) {
+            this.viewerLoadDeferredForTranscription = true;
+        }
 
         if (!deferViewerForTranscription) {
             this.loadViewer();
@@ -1350,6 +1358,7 @@ class Preview extends EventEmitter {
             }
 
             const needsTranscriptionReload =
+                this.canUseDash() &&
                 isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES) &&
                 this.isVideoFileByExtension() &&
                 !this.hasTranscriptionRep(cachedFile) &&
@@ -1378,7 +1387,7 @@ class Preview extends EventEmitter {
                 } else {
                     this.loadViewer();
                 }
-            } else if (!this.viewer) {
+            } else if (!this.viewer && this.viewerLoadDeferredForTranscription) {
                 // Viewer load was deferred in loadFromCache() pending transcription metadata.
                 this.loadViewer();
             }
@@ -1404,6 +1413,8 @@ class Preview extends EventEmitter {
         if (!this.open) {
             return;
         }
+
+        this.viewerLoadDeferredForTranscription = false;
 
         // Tear down current viewer so its DOM (e.g. preload image for video) is cleared before creating the new one.
         if (this.viewer && typeof this.viewer.destroy === 'function') {
@@ -1519,8 +1530,18 @@ class Preview extends EventEmitter {
      * @return {boolean}
      */
     hasTranscriptionRep(file) {
-        const extractedText = getRepresentation(file, 'extracted_text');
+        const extractedText = file && getRepresentation(file, 'extracted_text');
         return !!extractedText?.content?.url_template;
+    }
+
+    /**
+     * Returns true when Dash playback is available and not disabled.
+     *
+     * @private
+     * @return {boolean}
+     */
+    canUseDash() {
+        return Browser.canPlayDash() && !this.disabledViewers.Dash;
     }
 
     /**
@@ -1785,6 +1806,12 @@ class Preview extends EventEmitter {
 
         // Check if we hit the retry limit for fetching file info
         if (this.retryCount > RETRY_COUNT) {
+            // Viewer load was deferred for transcription refresh; fall back to cached playback.
+            if (this.viewerLoadDeferredForTranscription && !this.viewer) {
+                this.loadViewer();
+                return;
+            }
+
             let errorCode = ERROR_CODE.EXCEEDED_RETRY_LIMIT;
             let errorMessage = __('error_refresh');
 
@@ -2025,7 +2052,7 @@ class Preview extends EventEmitter {
      * @return {Object} Headers
      */
     getRequestHeaders(token) {
-        const isDash = Browser.canPlayDash() && !this.disabledViewers.Dash;
+        const isDash = this.canUseDash();
         let videoHint = isDash ? X_REP_HINT_VIDEO_DASH : X_REP_HINT_VIDEO_MP4;
 
         if (isDash && isFeatureEnabled(this.options.features, AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES)) {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1780,6 +1780,7 @@ describe('lib/Preview', () => {
         });
 
         test('should refresh from server when skipServerUpdate but video lacks transcription rep', () => {
+            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
@@ -1997,6 +1998,54 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
+        test('should trigger account error when video file has only preload rep and no playable reps', () => {
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
+            stubs.getCachedFile.mockReturnValue(null);
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
+            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
+            expect(stubs.triggerError.mock.calls[0][0].message).toBe(__('error_account'));
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should trigger account error when Instant Preview viewer is showing jpg but server file has no playable reps', () => {
+            preview.viewer = {
+                options: {
+                    viewer: { NAME: 'Dash' },
+                    representation: { representation: PRELOAD_REP_NAME },
+                },
+            };
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: stubs.file.file_version.sha1 },
+            });
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
+            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should not trigger account error when video file has pending dash rep', () => {
+            stubs.loadViewer.mockImplementation(() => {});
+            stubs.file.extension = 'mp4';
+            stubs.file.representations.entries = [
+                { representation: PRELOAD_REP_NAME },
+                { representation: 'dash', status: { state: 'pending' } },
+            ];
+            stubs.getCachedFile.mockReturnValue(null);
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).not.toHaveBeenCalled();
+            expect(stubs.loadViewer).toHaveBeenCalled();
+        });
+
         test('should uncache the file if the file is watermarked', () => {
             stubs.isWatermarked.mockReturnValue(true);
             stubs.getCachedFile.mockReturnValue({
@@ -2040,6 +2089,7 @@ describe('lib/Preview', () => {
         });
 
         test('should update viewer and load transcription when cache lacked extracted_text', () => {
+            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             preview.file.extension = 'avi';
@@ -2068,6 +2118,8 @@ describe('lib/Preview', () => {
         });
 
         test('should load the deferred viewer when transcription is still unavailable on the server', () => {
+            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
+            preview.viewerLoadDeferredForTranscription = true;
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             preview.viewer = undefined;

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -2724,6 +2724,65 @@ describe('lib/Preview', () => {
             expect(stubs.uncacheFile).not.toHaveBeenCalled();
         });
 
+        test('should load cached video when transcription file-info refresh fails', () => {
+            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation();
+            preview.open = true;
+            preview.viewerLoadDeferredForTranscription = true;
+            preview.viewer = undefined;
+            preview.retryCount = 1;
+            preview.file = {
+                id: '123',
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            };
+
+            preview.handleFetchError(stubs.error);
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
+            expect(stubs.uncacheFile).not.toHaveBeenCalled();
+            expect(stubs.triggerError).not.toHaveBeenCalled();
+            jest.advanceTimersByTime(10000);
+            expect(stubs.load).not.toHaveBeenCalled();
+        });
+
+        test('should uncache and retry when transcription was deferred but file has no playable reps', () => {
+            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation();
+            preview.open = true;
+            preview.viewerLoadDeferredForTranscription = true;
+            preview.viewer = undefined;
+            preview.retryCount = 1;
+            preview.file = { id: '123' };
+
+            preview.handleFetchError(stubs.error);
+
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+            expect(stubs.uncacheFile).toHaveBeenCalled();
+            expect(stubs.triggerError).not.toHaveBeenCalled();
+            jest.advanceTimersByTime(4001);
+            expect(stubs.load).toHaveBeenCalledWith('123');
+        });
+
+        test('should fall through to error handling if deferred loadViewer throws', () => {
+            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation(() => {
+                throw new PreviewError(ERROR_CODE.PERMISSIONS_PREVIEW, __('error_permissions'));
+            });
+            preview.open = true;
+            preview.viewerLoadDeferredForTranscription = true;
+            preview.retryCount = 6;
+            preview.file = {
+                id: '123',
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            };
+
+            preview.handleFetchError(stubs.error);
+
+            expect(stubs.uncacheFile).toHaveBeenCalled();
+            expect(stubs.triggerError).toHaveBeenCalled();
+        });
+
         test('should clear the current file from the cache', () => {
             preview.file = {
                 id: '0',

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1779,8 +1779,7 @@ describe('lib/Preview', () => {
             expect(preview.loadFromServer).not.toHaveBeenCalled();
         });
 
-        test('should not refresh from server when skipServerUpdate even if transcription rep is missing', () => {
-            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
+        test('should refresh from server when skipServerUpdate but video lacks transcription rep', () => {
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
@@ -1797,7 +1796,7 @@ describe('lib/Preview', () => {
             preview.loadFromCache();
 
             expect(stubs.loadViewer).toHaveBeenCalled();
-            expect(stubs.loadFromServer).not.toHaveBeenCalled();
+            expect(stubs.loadFromServer).toHaveBeenCalled();
         });
 
         test('should load the viewer immediately when skipServerUpdate but video lacks playable reps', () => {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1779,7 +1779,7 @@ describe('lib/Preview', () => {
             expect(preview.loadFromServer).not.toHaveBeenCalled();
         });
 
-        test('should refresh from server when skipServerUpdate but video lacks transcription rep', () => {
+        test('should not refresh from server when skipServerUpdate even if transcription rep is missing', () => {
             jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
@@ -1797,10 +1797,10 @@ describe('lib/Preview', () => {
             preview.loadFromCache();
 
             expect(stubs.loadViewer).toHaveBeenCalled();
-            expect(stubs.loadFromServer).toHaveBeenCalled();
+            expect(stubs.loadFromServer).not.toHaveBeenCalled();
         });
 
-        test('should load the viewer immediately when video reps are also missing', () => {
+        test('should load the viewer immediately when skipServerUpdate but video lacks playable reps', () => {
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
@@ -1857,6 +1857,31 @@ describe('lib/Preview', () => {
             const expectedTag = Timer.createTag(1, LOAD_METRIC.fileInfoTime);
             preview.loadFromServer();
             expect(startStub).toHaveBeenCalledWith(expectedTag);
+        });
+
+        test('should not call handleFetchError when file-info fails but a playable viewer is showing', () => {
+            stubs.get.mockReturnValue(Promise.reject(new Error('network')));
+            preview.viewer = {};
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(true);
+
+            preview.loadFromServer();
+
+            return new Promise(resolve => setTimeout(resolve, 0)).then(() => {
+                expect(stubs.handleFetchError).not.toHaveBeenCalled();
+            });
+        });
+
+        test('should call handleFetchError when file-info fails and no playable viewer is showing', () => {
+            const error = new Error('network');
+            stubs.get.mockReturnValue(Promise.reject(error));
+            preview.viewer = undefined;
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(false);
+
+            preview.loadFromServer();
+
+            return new Promise(resolve => setTimeout(resolve, 0)).then(() => {
+                expect(stubs.handleFetchError).toHaveBeenCalledWith(error);
+            });
         });
     });
 
@@ -2088,7 +2113,7 @@ describe('lib/Preview', () => {
             expect(stubs.reload).toHaveBeenCalled();
         });
 
-        test('should update viewer and load transcription when cache lacked extracted_text', () => {
+        test('should update viewer and load transcription when cache lacked extracted_text and viewer is loaded', () => {
             jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
@@ -2107,6 +2132,7 @@ describe('lib/Preview', () => {
             preview.viewer = {
                 options: { file: {} },
                 player: {},
+                isLoaded: () => true,
                 loadTranscription,
             };
 
@@ -2117,11 +2143,11 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).not.toHaveBeenCalled();
         });
 
-        test('should load viewer when cache lacked extracted_text and viewer is not yet created', () => {
+        test('should update file but not load transcription when viewer exists but is not loaded', () => {
             jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
-            preview.viewer = undefined;
+            preview.file.extension = 'avi';
             stubs.getCachedFile.mockReturnValue({
                 file_version: { sha1: 2 },
                 representations: {
@@ -2132,10 +2158,42 @@ describe('lib/Preview', () => {
                 { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
                 { representation: 'extracted_text', content: { url_template: 'https://example.com/vtt' } },
             ];
+            const loadTranscription = jest.fn();
+            preview.viewer = {
+                options: { file: {} },
+                player: {},
+                isLoaded: () => false,
+                loadTranscription,
+            };
 
             preview.handleFileInfoResponse(stubs.file);
 
-            expect(stubs.loadViewer).toHaveBeenCalled();
+            expect(preview.viewer.options.file).toBe(stubs.file);
+            expect(loadTranscription).not.toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should not throw when the cached file lacks representations entries', () => {
+            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.viewer = {
+                options: { file: {} },
+                isLoaded: () => true,
+                loadTranscription: jest.fn(),
+            };
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+                { representation: 'extracted_text', content: { url_template: 'https://example.com/vtt' } },
+            ];
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.triggerError).not.toHaveBeenCalled();
+            expect(preview.viewer.loadTranscription).toHaveBeenCalled();
         });
 
         test('should not reload the viewer when transcription is still unavailable on the server', () => {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -10,7 +10,12 @@ import PreviewError from '../PreviewError';
 import PreviewPerf from '../PreviewPerf';
 import Timer from '../Timer';
 import loaders from '../loaders';
-import { API_HOST, CLASS_NAVIGATION_VISIBILITY, PRELOAD_REP_NAME } from '../constants';
+import {
+    API_HOST,
+    CLASS_NAVIGATION_VISIBILITY,
+    PRELOAD_REP_NAME,
+    AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES,
+} from '../constants';
 import {
     VIEWER_EVENT,
     ERROR_CODE,
@@ -1774,6 +1779,40 @@ describe('lib/Preview', () => {
             expect(preview.loadFromServer).not.toHaveBeenCalled();
         });
 
+        test('should refresh from server when skipServerUpdate but video lacks transcription rep', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(true);
+            preview.options.skipServerUpdate = true;
+            preview.file = {
+                id: '123',
+                extension: 'avi',
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            };
+
+            preview.loadFromCache();
+
+            expect(stubs.loadFromServer).toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should load the viewer immediately when video reps are also missing', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            jest.spyOn(preview, 'hasTranscriptionRep').mockReturnValue(false);
+            jest.spyOn(preview, 'hasPlayableVideoReps').mockReturnValue(false);
+            preview.options.skipServerUpdate = true;
+            preview.file = { id: '123', extension: 'avi' };
+
+            preview.loadFromCache();
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
+            expect(stubs.loadFromServer).toHaveBeenCalled();
+        });
+
         test('should refresh the file from the server to update the cache', () => {
             preview.loadFromCache();
             expect(preview.loadFromServer).toHaveBeenCalled();
@@ -1958,54 +1997,6 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
-        test('should trigger account error when video file has only preload rep and no playable reps', () => {
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
-            stubs.getCachedFile.mockReturnValue(null);
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
-            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
-            expect(stubs.triggerError.mock.calls[0][0].message).toBe(__('error_account'));
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
-        });
-
-        test('should trigger account error when Instant Preview viewer is showing jpg but server file has no playable reps', () => {
-            preview.viewer = {
-                options: {
-                    viewer: { NAME: 'Dash' },
-                    representation: { representation: PRELOAD_REP_NAME },
-                },
-            };
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [{ representation: PRELOAD_REP_NAME }];
-            stubs.getCachedFile.mockReturnValue({
-                file_version: { sha1: stubs.file.file_version.sha1 },
-            });
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).toHaveBeenCalledWith(expect.any(PreviewError));
-            expect(stubs.triggerError.mock.calls[0][0].code).toBe(ERROR_CODE.ACCOUNT);
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
-        });
-
-        test('should not trigger account error when video file has pending dash rep', () => {
-            stubs.loadViewer.mockImplementation(() => {});
-            stubs.file.extension = 'mp4';
-            stubs.file.representations.entries = [
-                { representation: PRELOAD_REP_NAME },
-                { representation: 'dash', status: { state: 'pending' } },
-            ];
-            stubs.getCachedFile.mockReturnValue(null);
-
-            preview.handleFileInfoResponse(stubs.file);
-
-            expect(stubs.triggerError).not.toHaveBeenCalled();
-            expect(stubs.loadViewer).toHaveBeenCalled();
-        });
-
         test('should uncache the file if the file is watermarked', () => {
             stubs.isWatermarked.mockReturnValue(true);
             stubs.getCachedFile.mockReturnValue({
@@ -2046,6 +2037,53 @@ describe('lib/Preview', () => {
             preview.handleFileInfoResponse(stubs.file);
             expect(preview.logger.setCacheStale).toHaveBeenCalled();
             expect(stubs.reload).toHaveBeenCalled();
+        });
+
+        test('should update viewer and load transcription when cache lacked extracted_text', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.file.extension = 'avi';
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+                { representation: 'extracted_text', content: { url_template: 'https://example.com/vtt' } },
+            ];
+            const loadTranscription = jest.fn();
+            preview.viewer = {
+                options: { file: {} },
+                player: {},
+                loadTranscription,
+            };
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(preview.viewer.options.file).toBe(stubs.file);
+            expect(loadTranscription).toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
+        });
+
+        test('should load the deferred viewer when transcription is still unavailable on the server', () => {
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.viewer = undefined;
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+            ];
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
         });
 
         test('should set the cache stale and re-load the viewer if the file is watermarked', () => {

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -1796,8 +1796,8 @@ describe('lib/Preview', () => {
 
             preview.loadFromCache();
 
+            expect(stubs.loadViewer).toHaveBeenCalled();
             expect(stubs.loadFromServer).toHaveBeenCalled();
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
         });
 
         test('should load the viewer immediately when video reps are also missing', () => {
@@ -2117,12 +2117,34 @@ describe('lib/Preview', () => {
             expect(stubs.loadViewer).not.toHaveBeenCalled();
         });
 
-        test('should load the deferred viewer when transcription is still unavailable on the server', () => {
+        test('should load viewer when cache lacked extracted_text and viewer is not yet created', () => {
             jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
-            preview.viewerLoadDeferredForTranscription = true;
             isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
             jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
             preview.viewer = undefined;
+            stubs.getCachedFile.mockReturnValue({
+                file_version: { sha1: 2 },
+                representations: {
+                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
+                },
+            });
+            stubs.file.representations.entries = [
+                { representation: 'dash', content: { url_template: 'https://example.com/dash' } },
+                { representation: 'extracted_text', content: { url_template: 'https://example.com/vtt' } },
+            ];
+
+            preview.handleFileInfoResponse(stubs.file);
+
+            expect(stubs.loadViewer).toHaveBeenCalled();
+        });
+
+        test('should not reload the viewer when transcription is still unavailable on the server', () => {
+            jest.spyOn(Browser, 'canPlayDash').mockReturnValue(true);
+            isFeatureEnabled.mockImplementation((_, name) => name === AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES);
+            jest.spyOn(preview, 'isVideoFileByExtension').mockReturnValue(true);
+            preview.viewer = {
+                options: { file: {} },
+            };
             stubs.getCachedFile.mockReturnValue({
                 file_version: { sha1: 2 },
                 representations: {
@@ -2135,7 +2157,7 @@ describe('lib/Preview', () => {
 
             preview.handleFileInfoResponse(stubs.file);
 
-            expect(stubs.loadViewer).toHaveBeenCalled();
+            expect(stubs.loadViewer).not.toHaveBeenCalled();
         });
 
         test('should set the cache stale and re-load the viewer if the file is watermarked', () => {
@@ -2722,65 +2744,6 @@ describe('lib/Preview', () => {
 
             preview.handleFetchError(stubs.error);
             expect(stubs.uncacheFile).not.toHaveBeenCalled();
-        });
-
-        test('should load cached video when transcription file-info refresh fails', () => {
-            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation();
-            preview.open = true;
-            preview.viewerLoadDeferredForTranscription = true;
-            preview.viewer = undefined;
-            preview.retryCount = 1;
-            preview.file = {
-                id: '123',
-                representations: {
-                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
-                },
-            };
-
-            preview.handleFetchError(stubs.error);
-
-            expect(stubs.loadViewer).toHaveBeenCalled();
-            expect(stubs.uncacheFile).not.toHaveBeenCalled();
-            expect(stubs.triggerError).not.toHaveBeenCalled();
-            jest.advanceTimersByTime(10000);
-            expect(stubs.load).not.toHaveBeenCalled();
-        });
-
-        test('should uncache and retry when transcription was deferred but file has no playable reps', () => {
-            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation();
-            preview.open = true;
-            preview.viewerLoadDeferredForTranscription = true;
-            preview.viewer = undefined;
-            preview.retryCount = 1;
-            preview.file = { id: '123' };
-
-            preview.handleFetchError(stubs.error);
-
-            expect(stubs.loadViewer).not.toHaveBeenCalled();
-            expect(stubs.uncacheFile).toHaveBeenCalled();
-            expect(stubs.triggerError).not.toHaveBeenCalled();
-            jest.advanceTimersByTime(4001);
-            expect(stubs.load).toHaveBeenCalledWith('123');
-        });
-
-        test('should fall through to error handling if deferred loadViewer throws', () => {
-            stubs.loadViewer = jest.spyOn(preview, 'loadViewer').mockImplementation(() => {
-                throw new PreviewError(ERROR_CODE.PERMISSIONS_PREVIEW, __('error_permissions'));
-            });
-            preview.open = true;
-            preview.viewerLoadDeferredForTranscription = true;
-            preview.retryCount = 6;
-            preview.file = {
-                id: '123',
-                representations: {
-                    entries: [{ representation: 'dash', content: { url_template: 'https://example.com/dash' } }],
-                },
-            };
-
-            preview.handleFetchError(stubs.error);
-
-            expect(stubs.uncacheFile).toHaveBeenCalled();
-            expect(stubs.triggerError).toHaveBeenCalled();
         });
 
         test('should clear the current file from the cache', () => {


### PR DESCRIPTION
## Summary
- When a cached video is missing an `extracted_text` transcription rep, refresh file metadata from the server (`needsTranscriptionRep`), including when `skipServerUpdate` is set.
- Load the Dash viewer immediately from cache. Captions are optional; do not defer playback for a missing transcription rep.

Fixes: on cache hits (e.g. reopen on dev), subtitles were skipped because cached file info lacked `extracted_text`.

## Test plan
- [x] Unit tests for `loadFromCache` server refresh when transcription rep is missing
- [x] Unit tests for `hasTranscriptionRep`
- [ ] Preview a video with AI transcription enabled, close preview, reopen same video — subtitles should still appear
- [ ] Preview a video, navigate away, return — subtitles should still appear