### PR TITLE
chore(preview): Roll out Authorization headers for representations

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -641,11 +641,29 @@ class Preview extends EventEmitter {
             // This allows the browser to download representation content
             const params = { response_content_disposition_type: 'attachment', ...queryParams };
             const downloadUrl = appendQueryParams(
-                this.viewer.createContentUrlWithAuthParams(contentUrlTemplate, this.viewer.getAssetPath()),
+                this.viewer.createContentUrlV2(contentUrlTemplate, this.viewer.getAssetPath()),
                 params,
             );
 
-            this.api.reachability.downloadWithReachabilityCheck(downloadUrl);
+            this.api
+                .get(downloadUrl, { type: 'blob', headers: this.getRequestHeaders() })
+                .then(data => {
+                    const blob = data instanceof Blob ? data : new Blob([data]);
+                    const blobUrl = URL.createObjectURL(blob);
+                    const anchor = document.createElement('a');
+                    anchor.href = blobUrl;
+                    anchor.download = (this.file && this.file.name) || 'download';
+                    document.body.appendChild(anchor);
+                    anchor.click();
+                    document.body.removeChild(anchor);
+                    URL.revokeObjectURL(blobUrl);
+                })
+                .catch(error => {
+                    const code = getProp(error, 'response.data.code');
+                    const msg =
+                        code === ERROR_CODE_403_FORBIDDEN_BY_POLICY ? downloadErrorDueToPolicyMsg : downloadErrorMsg;
+                    this.ui.showNotification(msg);
+                });
 
             // Otherwise, get the content download URL of the original file and download
         } else {
@@ -721,7 +739,6 @@ class Preview extends EventEmitter {
         preload = false,
         isDocFirstPrefetchEnabled = false,
         docFirstPagesConfig = null,
-        isAccessTokenHeaderEnabled = false,
     }) {
         let file;
         let loader;
@@ -762,10 +779,6 @@ class Preview extends EventEmitter {
             options.sharedLinkPassword = sharedLinkPassword;
             options.isDocFirstPrefetchEnabled = isDocFirstPrefetchEnabled;
             options.docFirstPagesConfig = docFirstPagesConfig;
-            options.features = {
-                ...this.options.features,
-                migrateAccessTokenToHeader: isAccessTokenHeaderEnabled,
-            };
         }
 
         const viewerInstance = new viewer.CONSTRUCTOR(this.createViewerOptions(options));

--- a/src/lib/RepStatus.js
+++ b/src/lib/RepStatus.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import { appendAuthParams, appendAuthParamsV2, getHeaders } from './util';
+import { appendAuthParamsV2, getHeaders } from './util';
 import { STATUS_SUCCESS, STATUS_VIEWABLE, STATUS_PENDING, STATUS_NONE } from './constants';
 import PreviewError from './PreviewError';
 import Timer from './Timer';
@@ -50,16 +50,7 @@ class RepStatus extends EventEmitter {
      * @param {Object} [options.logger] - Optional logger instance
      * @return {RepStatus} RepStatus instance
      */
-    constructor({
-        api,
-        representation,
-        token,
-        sharedLink,
-        sharedLinkPassword,
-        logger,
-        fileId,
-        migrateAccessTokenToHeader = false,
-    }) {
+    constructor({ api, representation, token, sharedLink, sharedLinkPassword, logger, fileId }) {
         super();
 
         this.api = api;
@@ -69,12 +60,8 @@ class RepStatus extends EventEmitter {
 
         // Some representations (e.g. ORIGINAL) may not have an info url
         const repInfo = this.representation.info;
-        if (migrateAccessTokenToHeader) {
-            this.infoUrl = repInfo ? appendAuthParamsV2(repInfo.url, sharedLink, sharedLinkPassword) : '';
-            this.headers = getHeaders({}, token);
-        } else {
-            this.infoUrl = repInfo ? appendAuthParams(repInfo.url, token, sharedLink, sharedLinkPassword) : '';
-        }
+        this.infoUrl = repInfo ? appendAuthParamsV2(repInfo.url, sharedLink, sharedLinkPassword) : '';
+        this.headers = getHeaders({}, token);
 
         this.promise = new Promise((resolve, reject) => {
             this.resolve = resolve;

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -744,7 +744,6 @@ describe('lib/Preview', () => {
                 sharedLinkPassword,
                 isDocFirstPrefetchEnabled: false,
                 docFirstPagesConfig: null,
-                features: { migrateAccessTokenToHeader: false },
             });
         });
 
@@ -805,43 +804,6 @@ describe('lib/Preview', () => {
             jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
 
             preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword, preload: true });
-        });
-
-        test('should pass migrateAccessTokenToHeader feature to viewer options when isAccessTokenHeaderEnabled is true', () => {
-            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
-            jest.spyOn(preview, 'createViewerOptions');
-            preview.options.features = { existingFeature: true };
-
-            preview.prefetch({
-                fileId,
-                token,
-                sharedLink,
-                sharedLinkPassword,
-                preload: true,
-                isAccessTokenHeaderEnabled: true,
-            });
-
-            expect(preview.createViewerOptions).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    features: { existingFeature: true, migrateAccessTokenToHeader: true },
-                }),
-            );
-            expect(preview.options.features).toEqual({ existingFeature: true });
-        });
-
-        test('should pass migrateAccessTokenToHeader=false to viewer options when isAccessTokenHeaderEnabled is false', () => {
-            jest.spyOn(loader, 'determineViewer').mockReturnValue(viewer);
-            jest.spyOn(preview, 'createViewerOptions');
-            preview.options.features = { existingFeature: true };
-
-            preview.prefetch({ fileId, token, sharedLink, sharedLinkPassword, preload: true });
-
-            expect(preview.createViewerOptions).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    features: { existingFeature: true, migrateAccessTokenToHeader: false },
-                }),
-            );
-            expect(preview.options.features).toEqual({ existingFeature: true });
         });
     });
 
@@ -1097,7 +1059,7 @@ describe('lib/Preview', () => {
                 getRepresentation: jest.fn(),
                 getAssetPath: jest.fn(),
                 getLoadStatus: jest.fn(),
-                createContentUrlWithAuthParams: jest.fn(),
+                createContentUrlV2: jest.fn(),
                 options: {
                     viewer: {
                         ASSET: '',
@@ -1145,19 +1107,73 @@ describe('lib/Preview', () => {
                 },
             };
             const url = 'someurl';
+            const blobUrl = 'blob:http://localhost/watermarked';
+            const blob = new Blob(['wm']);
+            const click = jest.fn();
+            const realCreateElement = document.createElement.bind(document);
+            let anchor;
 
+            preview.file = { name: 'watermarked.jpg' };
             preview.viewer.getRepresentation.mockReturnValue(representation);
             preview.viewer.getAssetPath.mockReturnValue('1.jpg');
-            preview.viewer.createContentUrlWithAuthParams.mockReturnValue(url);
-
+            preview.viewer.createContentUrlV2.mockReturnValue(url);
+            preview.getRequestHeaders.mockReturnValue({ Authorization: 'Bearer token' });
             util.appendQueryParams.mockReturnValue(url);
+            Api.prototype.get.mockResolvedValue(blob);
+            jest.spyOn(URL, 'createObjectURL').mockReturnValue(blobUrl);
+            jest.spyOn(URL, 'revokeObjectURL');
+            jest.spyOn(document, 'createElement').mockImplementation(tagName => {
+                const el = realCreateElement(tagName);
+                if (tagName === 'a') {
+                    anchor = el;
+                    el.click = click;
+                }
+                return el;
+            });
 
             preview.download();
 
             expect(util.appendQueryParams).toHaveBeenCalledWith(url, {
                 response_content_disposition_type: 'attachment',
             });
-            expect(stubs.downloadReachability.downloadWithReachabilityCheck).toHaveBeenCalledWith(url);
+
+            return Promise.resolve().then(() => {
+                expect(Api.prototype.get).toHaveBeenCalledWith(url, {
+                    type: 'blob',
+                    headers: { Authorization: 'Bearer token' },
+                });
+                expect(click).toHaveBeenCalled();
+                expect(anchor.download).toBe('watermarked.jpg');
+                expect(anchor.href).toBe(blobUrl);
+                expect(URL.revokeObjectURL).toHaveBeenCalledWith(blobUrl);
+                expect(stubs.downloadReachability.downloadWithReachabilityCheck).not.toHaveBeenCalled();
+            });
+        });
+
+        test('should show a policy error when watermarked download is forbidden', () => {
+            file.canDownload.mockReturnValue(true);
+            file.shouldDownloadWM.mockReturnValue(true);
+            preview.viewer.getRepresentation.mockReturnValue({
+                content: { url_template: 'someTemplate' },
+            });
+            preview.viewer.getAssetPath.mockReturnValue('1.jpg');
+            preview.viewer.createContentUrlV2.mockReturnValue('someurl');
+            util.appendQueryParams.mockReturnValue('someurl');
+            preview.getRequestHeaders.mockReturnValue({ Authorization: 'Bearer token' });
+            Api.prototype.get.mockRejectedValue({
+                response: { data: { code: 'forbidden_by_policy' } },
+            });
+
+            preview.download();
+
+            return Promise.resolve()
+                .then(() => Promise.resolve())
+                .then(() => {
+                    expect(preview.ui.showNotification).toHaveBeenCalledWith(
+                        __('notification_cannot_download_due_to_policy'),
+                    );
+                    expect(stubs.downloadReachability.downloadWithReachabilityCheck).not.toHaveBeenCalled();
+                });
         });
 
         test('should download original file if file should not be downloaded as watermarked', () => {

--- a/src/lib/__tests__/RepStatus-test.js
+++ b/src/lib/__tests__/RepStatus-test.js
@@ -77,7 +77,8 @@ describe('lib/RepStatus', () => {
         const infoUrl = 'someUrl';
 
         beforeEach(() => {
-            jest.spyOn(util, 'appendAuthParams').mockReturnValue(infoUrl);
+            jest.spyOn(util, 'appendAuthParamsV2').mockReturnValue(infoUrl);
+            jest.spyOn(util, 'getHeaders').mockReturnValue({});
         });
 
         test('should set the correct object properties', () => {
@@ -93,10 +94,10 @@ describe('lib/RepStatus', () => {
             expect(repStatus.promise).toBeInstanceOf(Promise);
         });
 
-        test('should use appendAuthParamsV2 and set headers when migrateAccessTokenToHeader is true', () => {
+        test('should use appendAuthParamsV2 and set Authorization headers', () => {
             const v2Url = 'v2Url';
-            jest.spyOn(util, 'appendAuthParamsV2').mockReturnValue(v2Url);
-            jest.spyOn(util, 'getHeaders').mockReturnValue({ Authorization: 'Bearer token' });
+            util.appendAuthParamsV2.mockReturnValue(v2Url);
+            util.getHeaders.mockReturnValue({ Authorization: 'Bearer token' });
 
             repStatus = new RepStatus({
                 api: {},
@@ -105,7 +106,6 @@ describe('lib/RepStatus', () => {
                 sharedLink: 'sharedLink',
                 sharedLinkPassword: 'password',
                 logger: {},
-                migrateAccessTokenToHeader: true,
             });
 
             expect(util.appendAuthParamsV2).toBeCalledWith(rep.info.url, 'sharedLink', 'password');

--- a/src/lib/viewers/BaseViewer.js
+++ b/src/lib/viewers/BaseViewer.js
@@ -474,13 +474,9 @@ class BaseViewer extends EventEmitter {
             template = this.api.reachability.constructor.replaceDownloadHostWithDefault(template);
         }
 
-        // Cache-buster only needed when auth is header-based; the in-URL token otherwise
-        // varies the cache key on its own.
-        const resolveCacheBuster = this.featureEnabled('migrateAccessTokenToHeader');
-
-        // Append optional query params
+        // Auth is header-based, so re-resolve the cache-buster per request.
         const { queryParams } = this.options;
-        return appendQueryParams(createContentUrl(template, asset, resolveCacheBuster), queryParams);
+        return appendQueryParams(createContentUrl(template, asset, true), queryParams);
     }
 
     /**
@@ -494,11 +490,7 @@ class BaseViewer extends EventEmitter {
      * @return {string} content url
      */
     createContentUrlWithAuthParams(template, asset) {
-        const urlWithAuthParams = this.appendAuthParams(this.createContentUrl(template, asset));
-
-        // Append optional query params
-        const { queryParams } = this.options;
-        return appendQueryParams(urlWithAuthParams, queryParams);
+        return this.createContentUrlV2(template, asset);
     }
 
     /**
@@ -938,7 +930,6 @@ class BaseViewer extends EventEmitter {
             sharedLinkPassword,
             fileId: file.id,
             logger: representation ? null : logger, // Do not log to main preview status if rep is passed in
-            migrateAccessTokenToHeader: this.featureEnabled('migrateAccessTokenToHeader'),
         });
 
         // Don't time out while conversion is pending

--- a/src/lib/viewers/__tests__/BaseViewer-test.js
+++ b/src/lib/viewers/__tests__/BaseViewer-test.js
@@ -358,18 +358,13 @@ describe('lib/viewers/BaseViewer', () => {
 
             const result = base.createContentUrl(url, '');
             expect(result).toBe('url');
-            expect(util.createContentUrl).toBeCalledWith(url, '', false);
+            expect(util.createContentUrl).toBeCalledWith(url, '', true);
         });
 
-        test('should resolve the cache-buster only when migrateAccessTokenToHeader is enabled', () => {
+        test('should resolve the cache-buster on every request', () => {
             const url = 'url{+asset_path}';
             jest.spyOn(util, 'createContentUrl');
 
-            base.options.features = {};
-            base.createContentUrl(url, '');
-            expect(util.createContentUrl).toBeCalledWith(url, '', false);
-
-            base.options.features = { migrateAccessTokenToHeader: true };
             base.createContentUrl(url, '');
             expect(util.createContentUrl).toBeCalledWith(url, '', true);
         });
@@ -388,7 +383,7 @@ describe('lib/viewers/BaseViewer', () => {
             jest.spyOn(util, 'createContentUrl');
             const result = base.createContentUrl(url, 'bar');
             expect(result).toBe('urlbar');
-            expect(util.createContentUrl).toBeCalledWith(url, 'bar', false);
+            expect(util.createContentUrl).toBeCalledWith(url, 'bar', true);
         });
 
         test('should fallback to the default host if we have retried', () => {
@@ -402,13 +397,11 @@ describe('lib/viewers/BaseViewer', () => {
     });
 
     describe('createContentUrlWithAuthParams()', () => {
-        test('should return content url with no asset path', () => {
-            jest.spyOn(util, 'createContentUrl').mockReturnValue('foo');
-            jest.spyOn(base, 'appendAuthParams').mockReturnValue('bar');
+        test('should return the header-auth content url', () => {
+            jest.spyOn(base, 'createContentUrlV2').mockReturnValue('bar');
             const result = base.createContentUrlWithAuthParams('boo', 'hoo');
             expect(result).toBe('bar');
-            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo', false);
-            expect(base.appendAuthParams).toBeCalledWith('foo');
+            expect(base.createContentUrlV2).toBeCalledWith('boo', 'hoo');
         });
     });
 
@@ -420,7 +413,7 @@ describe('lib/viewers/BaseViewer', () => {
             base.options.sharedLinkPassword = 'pass';
             const result = base.createContentUrlV2('boo', 'hoo');
             expect(result).toBe('bar');
-            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo', false);
+            expect(util.createContentUrl).toBeCalledWith('boo', 'hoo', true);
             expect(util.appendAuthParamsV2).toBeCalledWith('foo', 'https://app.box.com/s/HASH', 'pass');
         });
     });

--- a/src/lib/viewers/archive/ArchiveViewer.js
+++ b/src/lib/viewers/archive/ArchiveViewer.js
@@ -50,13 +50,8 @@ class ArchiveViewer extends BaseViewer {
                 const template = get(representation, 'content.url_template');
                 this.startLoadTimer();
 
-                if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                    const contentUrl = this.createContentUrlV2(template);
-                    return this.api.get(contentUrl, { headers: this.appendAuthHeader() });
-                }
-
-                const contentUrl = this.createContentUrlWithAuthParams(template);
-                return this.api.get(contentUrl);
+                const contentUrl = this.createContentUrlV2(template);
+                return this.api.get(contentUrl, { headers: this.appendAuthHeader() });
             })
             .then(this.finishLoading)
             .catch(this.handleAssetError);

--- a/src/lib/viewers/archive/__tests__/ArchiveViewer-test.js
+++ b/src/lib/viewers/archive/__tests__/ArchiveViewer-test.js
@@ -80,22 +80,10 @@ describe('lib/viewers/archive/ArchiveViewer', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: loadFunc });
         });
 
-        test('should call createContentUrlWithAuthParams with right template when flag is off', () => {
-            Object.defineProperty(BaseViewer.prototype, 'load', { value: jest.fn() });
-
-            jest.spyOn(archive, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(archive, 'createContentUrlWithAuthParams');
-
-            return archive.load().then(() => {
-                expect(archive.createContentUrlWithAuthParams).toBeCalledWith('archiveUrl{+asset_path}');
-            });
-        });
-
-        test('should use auth headers when migrateAccessTokenToHeader flag is on', () => {
+        test('should fetch archive content with Authorization headers', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: jest.fn() });
 
             const mockHeaders = { Authorization: 'Bearer token' };
-            jest.spyOn(archive, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(archive, 'createContentUrlV2').mockReturnValue('contentUrl');
             jest.spyOn(archive, 'appendAuthHeader').mockReturnValue(mockHeaders);
 

--- a/src/lib/viewers/doc/DocBaseViewer.js
+++ b/src/lib/viewers/doc/DocBaseViewer.js
@@ -427,14 +427,11 @@ class DocBaseViewer extends BaseViewer {
             jpegPreloadRep && this.isRepresentationReady(jpegPreloadRep) && jpegPreloadRep.content?.url_template;
         const onlyJpegRepAvailable = jpegRepReady && !pagedWebpRepReady;
 
-        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
-        const headersOption = useHeaders ? { headers: this.appendAuthHeader() } : {};
+        const headersOption = { headers: this.appendAuthHeader() };
 
         if (onlyJpegRepAvailable) {
             const { url_template: jpegUrlTemplate = '' } = jpegPreloadRep.content;
-            const jpegUrlAuthTemplate = useHeaders
-                ? this.createContentUrlV2(jpegUrlTemplate)
-                : this.createContentUrlWithAuthParams(jpegUrlTemplate);
+            const jpegUrlAuthTemplate = this.createContentUrlV2(jpegUrlTemplate);
             const promises = getPreloadImageRequestPromises(this.api, jpegUrlAuthTemplate, 1, '', headersOption);
             Promise.all(promises).then(() => {
                 this.preloaderImagesPrefetched = true;
@@ -443,9 +440,7 @@ class DocBaseViewer extends BaseViewer {
             const { url_template: pagedUrlTemplate = '' } = pagedWebpRep.content;
             const pageCount = pagedWebpRep.metadata?.pages || 8;
             const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
-            const pagedUrlAuthTemplate = useHeaders
-                ? this.createContentUrlV2(newPagedUrlTemplate)
-                : this.createContentUrlWithAuthParams(newPagedUrlTemplate);
+            const pagedUrlAuthTemplate = this.createContentUrlV2(newPagedUrlTemplate);
 
             if (docFirstPagesConfig && docFirstPagesConfig.priorityPages) {
                 const {
@@ -525,13 +520,8 @@ class DocBaseViewer extends BaseViewer {
                 if (preloadRep && this.isRepresentationReady(preloadRep)) {
                     const { url_template: template } = preloadRep.content;
 
-                    // Prefetch as blob since preload needs to load image as a blob
-                    if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                        const contentUrl = this.createContentUrlV2(template);
-                        this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() });
-                    } else {
-                        this.api.get(this.createContentUrlWithAuthParams(template), { type: 'blob' });
-                    }
+                    const contentUrl = this.createContentUrlV2(template);
+                    this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() });
                 }
             } else {
                 this.prefetchPreloaderImages(file);
@@ -540,12 +530,8 @@ class DocBaseViewer extends BaseViewer {
 
         if (content && !isWatermarked && this.isRepresentationReady(representation)) {
             const { url_template: template } = representation.content;
-            if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                const contentUrl = this.createContentUrlV2(template);
-                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
-            } else {
-                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
-            }
+            const contentUrl = this.createContentUrlV2(template);
+            this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
         }
     }
 
@@ -605,11 +591,8 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const { url_template: template = '' } = preloadRep?.content || {};
-        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
-        const preloadUrl = useHeaders
-            ? this.createContentUrlV2(template)
-            : this.createContentUrlWithAuthParams(template);
-        const headersOption = useHeaders ? { headers: this.appendAuthHeader() } : {};
+        const preloadUrl = this.createContentUrlV2(template);
+        const headersOption = { headers: this.appendAuthHeader() };
 
         if (!this.docFirstPagesEnabled) {
             this.startPreloadTimer();
@@ -630,9 +613,7 @@ class DocBaseViewer extends BaseViewer {
                 const { pages: pageCount = 1 } = preloadRepPaged?.metadata || {};
                 const { url_template: pagedUrlTemplate = '' } = preloadRepPaged?.content || {};
                 const newPagedUrlTemplate = pagedUrlTemplate.replace(/\{.*\}/, PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER);
-                const pagedPreLoadUrl = useHeaders
-                    ? this.createContentUrlV2(newPagedUrlTemplate)
-                    : this.createContentUrlWithAuthParams(newPagedUrlTemplate);
+                const pagedPreLoadUrl = this.createContentUrlV2(newPagedUrlTemplate);
                 this.preloader.showPreload(null, this.containerEl, pagedPreLoadUrl, pageCount, this, headersOption);
             }
         }
@@ -674,11 +655,7 @@ class DocBaseViewer extends BaseViewer {
         }
 
         const template = this.options.representation.content.url_template;
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            this.pdfUrl = this.createContentUrlV2(template);
-        } else {
-            this.pdfUrl = this.createContentUrlWithAuthParams(template);
-        }
+        this.pdfUrl = this.createContentUrlV2(template);
         let jsAssets;
         let cssAssets;
         const useNpmPdfjs = this.featureEnabled('useNpmPdfjs');
@@ -1093,9 +1070,7 @@ class DocBaseViewer extends BaseViewer {
             url: pdfUrl,
         };
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            pdfDocConfig.httpHeaders = this.appendAuthHeader();
-        }
+        pdfDocConfig.httpHeaders = this.appendAuthHeader();
 
         this.pdfLoadingTask = this.pdfjsLib.getDocument(pdfDocConfig);
 
@@ -1423,11 +1398,7 @@ class DocBaseViewer extends BaseViewer {
      * @return {Promise} Promise setting print blob
      */
     fetchPrintBlob(pdfUrl) {
-        const options = { type: 'blob' };
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            options.headers = this.appendAuthHeader();
-        }
-        return this.api.get(pdfUrl, options).then(blob => {
+        return this.api.get(pdfUrl, { type: 'blob', headers: this.appendAuthHeader() }).then(blob => {
             this.printBlob = blob;
         });
     }

--- a/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocBaseViewer-test.js
@@ -67,18 +67,6 @@ let containerEl;
 let rootEl;
 let stubs = {};
 
-const STANDARD_HEADERS = [
-    'Accept',
-    'Accept-Language',
-    'Content-Language',
-    'Content-Type',
-    'DPR',
-    'Downlink',
-    'Save-Data',
-    'Viewport-Width',
-    'Width',
-];
-
 describe('src/lib/viewers/doc/DocBaseViewer', () => {
     const setupFunc = BaseViewer.prototype.setup;
     const pdfjsLib = { GlobalWorkerOptions: {} };
@@ -523,11 +511,11 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 };
                 jest.spyOn(stubs.api, 'get').mockImplementation();
                 jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation();
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation();
 
                 docBase.prefetch({ assets: false, preload: true, content: false });
 
-                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith(template);
+                expect(docBase.createContentUrlV2).toHaveBeenCalledWith(template);
             });
 
             test('should not prefetch preload if preload is true and representation is not ready', () => {
@@ -542,22 +530,22 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 };
                 jest.spyOn(stubs.api, 'get');
                 jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams');
+                jest.spyOn(docBase, 'createContentUrlV2');
 
                 docBase.prefetch({ assets: false, preload: true, content: false });
 
-                expect(docBase.createContentUrlWithAuthParams).not.toBeCalledWith(template);
+                expect(docBase.createContentUrlV2).not.toBeCalledWith(template);
             });
 
             test('should not prefetch preload if file is watermarked', () => {
                 docBase.options.file.watermark_info = {
                     is_watermarked: true,
                 };
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation();
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation();
 
                 docBase.prefetch({ assets: false, preload: true, content: false });
 
-                expect(docBase.createContentUrlWithAuthParams).not.toHaveBeenCalled();
+                expect(docBase.createContentUrlV2).not.toHaveBeenCalled();
             });
 
             test('should prefetch content if content is true and representation is ready', () => {
@@ -588,7 +576,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 ];
                 docBase.options.isDocFirstPrefetchEnabled = true;
                 const contentUrl = 'someContentUrl';
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue(contentUrl);
                 jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
                 docBase.prefetch({ assets: false, preload: true, content: true });
                 expect(stubs.getPreloadImageRequestPromises).toBeCalled();
@@ -614,7 +602,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 docBase.prefetch({ assets: false, preload: false, content: true });
             });
 
-            test('should use createContentUrlV2 and pass headers when prefetching preload with migrateAccessTokenToHeader flag on', () => {
+            test('should use createContentUrlV2 and pass headers when prefetching preload', () => {
                 const preloadRep = {
                     content: {
                         url_template: 'preload-template',
@@ -626,7 +614,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
                 jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
                 jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
                 jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
                 jest.spyOn(stubs.api, 'get');
@@ -637,31 +624,9 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 expect(stubs.api.get).toHaveBeenCalledWith('url-without-token', { type: 'blob', headers: mockHeaders });
             });
 
-            test('should use createContentUrlWithAuthParams when prefetching preload with migrateAccessTokenToHeader flag off', () => {
-                const preloadRep = {
-                    content: {
-                        url_template: 'preload-template',
-                    },
-                    status: {
-                        state: 'success',
-                    },
-                };
-                jest.spyOn(file, 'getRepresentation').mockReturnValue(preloadRep);
-                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
-                jest.spyOn(stubs.api, 'get');
-
-                docBase.prefetch({ assets: false, preload: true, content: false });
-
-                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('preload-template');
-                expect(stubs.api.get).toHaveBeenCalledWith('url-with-token', { type: 'blob' });
-            });
-
-            test('should use createContentUrlV2 and pass headers when prefetching content with migrateAccessTokenToHeader flag on', () => {
+            test('should use createContentUrlV2 and pass headers when prefetching content', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
                 jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
                 jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
                 jest.spyOn(stubs.api, 'get');
@@ -673,18 +638,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     type: 'document',
                     headers: mockHeaders,
                 });
-            });
-
-            test('should use createContentUrlWithAuthParams when prefetching content with migrateAccessTokenToHeader flag off', () => {
-                jest.spyOn(docBase, 'isRepresentationReady').mockReturnValue(true);
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
-                jest.spyOn(stubs.api, 'get');
-
-                docBase.prefetch({ assets: false, preload: false, content: true });
-
-                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
-                expect(stubs.api.get).toHaveBeenCalledWith('url-with-token', { type: 'document' });
             });
         });
 
@@ -902,7 +855,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     .stub(docBase, 'getViewerOption')
                     .withArgs('preload')
                     .returns(true);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue(preloadUrl);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue(preloadUrl);
                 sandbox
                     .mock(docBase.preloader)
                     .expects('showPreload')
@@ -927,7 +880,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     .stub(docBase, 'getViewerOption')
                     .withArgs('preload')
                     .returns(true);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue(preloadUrl);
+                jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue(preloadUrl);
 
                 sandbox.mock(docBase.preloader).expects('showPreload');
 
@@ -937,7 +890,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             });
 
             test('should load doc first preloader properly for doc first pages when webp rep available', () => {
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     // pagedUrlTemplate gets turned into this url in the code as {+asset_path} is replaced with PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER
                     if (url === `https://url/${PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER}`) {
                         return 'paged-url';
@@ -959,13 +912,13 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     'paged-url',
                     4,
                     docBase,
-                    {},
+                    expect.objectContaining({ headers: expect.any(Object) }),
                 );
             });
 
             test('should not throw an error in doc first preloader and use jpeg rep if no webp rep available', () => {
                 webpRep = null;
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     if (url === jpegUrlTemplate) {
                         return 'jpeg-preload-url';
                     }
@@ -983,7 +936,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
-                    {},
+                    expect.objectContaining({ headers: expect.any(Object) }),
                 );
             });
 
@@ -997,7 +950,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     },
                 };
 
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     // the webpRep template gets turned into this url in the code as {+asset_path} is replaced with PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER
                     if (url === `https://url/${PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER}`) {
                         return 'paged-url';
@@ -1019,13 +972,13 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
-                    {},
+                    expect.objectContaining({ headers: expect.any(Object) }),
                 );
             });
 
             test('should skip preload when preloaderImagesPrefetched is true and only jpeg rep available (single-page path)', () => {
                 webpRep = null;
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     if (url === jpegUrlTemplate) {
                         return 'jpeg-preload-url';
                     }
@@ -1044,7 +997,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test('should show preload when preloaderImagesPrefetched is false even for single-page path', () => {
                 webpRep = null;
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation(url => {
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     if (url === jpegUrlTemplate) {
                         return 'jpeg-preload-url';
                     }
@@ -1064,13 +1017,12 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     null,
                     1,
                     docBase,
-                    {},
+                    expect.objectContaining({ headers: expect.any(Object) }),
                 );
             });
 
-            test('should use createContentUrlV2 and pass headers when migrateAccessTokenToHeader flag is on', () => {
+            test('should use createContentUrlV2 and pass headers for jpeg preload', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
                 jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
                 jest.spyOn(docBase.preloader, 'showPreload').mockImplementation();
@@ -1084,22 +1036,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
-                jest.spyOn(docBase, 'appendAuthHeader');
-                jest.spyOn(docBase.preloader, 'showPreload').mockImplementation();
-
-                docBase.showPreload();
-
-                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalled();
-                expect(docBase.appendAuthHeader).not.toHaveBeenCalled();
-                expect(docBase.preloader.showPreload).toHaveBeenCalledWith('url-with-token', containerEl, {});
-            });
-
-            test('should use createContentUrlV2 for paged preload when migrateAccessTokenToHeader flag is on', () => {
+            test('should use createContentUrlV2 for paged preload', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     if (url.includes(PAGED_URL_TEMPLATE_PAGE_NUMBER_HOLDER)) {
                         return 'paged-url-without-token';
@@ -1158,7 +1096,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 jest.spyOn(stubs.api, 'get').mockImplementation();
                 jest.spyOn(docBase, 'setup').mockImplementation();
                 Object.defineProperty(BaseViewer.prototype, 'load', { value: sandbox.mock() });
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockImplementation();
+                jest.spyOn(docBase, 'createContentUrlV2').mockImplementation();
                 jest.spyOn(docBase, 'handleAssetAndRepLoad').mockImplementation();
                 jest.spyOn(docBase, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
                 jest.spyOn(docBase, 'loadAssets').mockResolvedValue();
@@ -1174,7 +1112,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.load().then(() => {
                     expect(docBase.loadAssets).toHaveBeenCalledWith(JS, CSS);
                     expect(docBase.setup).not.toHaveBeenCalled();
-                    expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
+                    expect(docBase.createContentUrlV2).toHaveBeenCalledWith('foo');
                     expect(docBase.handleAssetAndRepLoad).toHaveBeenCalled();
                     expect(docBase.loadAssets).not.toHaveBeenCalledWith(EXIF_READER);
                 });
@@ -1186,26 +1124,17 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect(docBase.loadAssets).toHaveBeenNthCalledWith(2, JS_NO_EXIF, CSS);
                     expect(docBase.loadAssets).toHaveBeenNthCalledWith(1, EXIF_READER);
                     expect(docBase.setup).not.toHaveBeenCalled();
-                    expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
+                    expect(docBase.createContentUrlV2).toHaveBeenCalledWith('foo');
                     expect(docBase.handleAssetAndRepLoad).toHaveBeenCalled();
                 });
             });
 
-            test('should use createContentUrlV2 when migrateAccessTokenToHeader flag is on', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
+            test('should set pdfUrl from createContentUrlV2', () => {
                 jest.spyOn(docBase, 'createContentUrlV2').mockReturnValue('url-without-token');
 
                 return docBase.load().then(() => {
                     expect(docBase.createContentUrlV2).toHaveBeenCalledWith('foo');
                     expect(docBase.pdfUrl).toBe('url-without-token');
-                });
-            });
-
-            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-
-                return docBase.load().then(() => {
-                    expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo');
                 });
             });
 
@@ -2143,23 +2072,15 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should avoid preflight requests by not adding non-standard headers', () => {
-                docBase.options.location = {
-                    locale: 'en-US',
-                };
-                let httpHeaders;
-
-                docBase.pdfjsLib.getDocument = jest.fn(docInitParams => {
-                    httpHeaders = docInitParams.httpHeaders || {};
-                    return { promise: new Promise(() => {}) };
-                });
+            test('should pass Authorization headers to pdf.js', () => {
+                const mockHeaders = { Authorization: 'Bearer token' };
+                jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
 
                 docBase.initViewer('');
 
-                expect(docBase.pdfjsLib.getDocument).toHaveBeenCalled();
-                const headerKeys = Object.keys(httpHeaders);
-                const containsNonStandardHeader = headerKeys.some(header => !STANDARD_HEADERS.includes(header));
-                expect(containsNonStandardHeader).toBe(false);
+                expect(docBase.pdfjsLib.getDocument).toHaveBeenCalledWith(
+                    expect.objectContaining({ httpHeaders: mockHeaders }),
+                );
             });
 
             test('should resolve the loading task and set the document/viewer', () => {
@@ -2448,9 +2369,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 );
             });
 
-            test('should pass httpHeaders when migrateAccessTokenToHeader flag is on', () => {
+            test('should pass httpHeaders to pdf.js', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
                 const doc = {
                     numPages: 1,
@@ -2460,20 +2380,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 return docBase.initViewer('url').then(() => {
                     expect(stubs.getDocument).toHaveBeenCalledWith(
                         expect.objectContaining({ httpHeaders: mockHeaders }),
-                    );
-                });
-            });
-
-            test('should not pass httpHeaders when migrateAccessTokenToHeader flag is off', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-                const doc = {
-                    numPages: 1,
-                };
-                stubs.getDocument.mockReturnValue({ promise: Promise.resolve(doc) });
-
-                return docBase.initViewer('url').then(() => {
-                    expect(stubs.getDocument).toHaveBeenCalledWith(
-                        expect.not.objectContaining({ httpHeaders: expect.anything() }),
                     );
                 });
             });
@@ -2798,22 +2704,12 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 });
             });
 
-            test('should pass auth headers when migrateAccessTokenToHeader flag is on', () => {
+            test('should pass auth headers when fetching the print blob', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'appendAuthHeader').mockReturnValue(mockHeaders);
 
                 return docBase.fetchPrintBlob('url').then(() => {
                     expect(stubs.get).toHaveBeenCalledWith('url', { type: 'blob', headers: mockHeaders });
-                    expect(docBase.printBlob).toBe('blob');
-                });
-            });
-
-            test('should not pass auth headers when migrateAccessTokenToHeader flag is off', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-
-                return docBase.fetchPrintBlob('url').then(() => {
-                    expect(stubs.get).toHaveBeenCalledWith('url', { type: 'blob' });
                     expect(docBase.printBlob).toBe('blob');
                 });
             });
@@ -5035,10 +4931,9 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
             let mockFile;
             let jpegRep;
             let webpRep;
-            const webpUrl =
-                'https://example.com/webp/page_number?access_token=auth_token&box_client_name=name&box_client_version=version';
-            const jpegUrl =
-                'https://example.com/jpeg/{+asset}?access_token=auth_token&box_client_name=name&box_client_version=version';
+            const webpUrl = 'https://example.com/webp/page_number?box_client_name=name&box_client_version=version';
+            const jpegUrl = 'https://example.com/jpeg/{+asset}?box_client_name=name&box_client_version=version';
+            const preloadHeaders = { headers: expect.objectContaining({ Authorization: 'Bearer auth_token' }) };
             beforeEach(() => {
                 // Mock representations
                 jpegRep = {
@@ -5085,7 +4980,13 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
 
             test('should clear sharedLink and sharedLinkPassword options and reset them after prefetching', () => {
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl, {});
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                    docBase.api,
+                    '',
+                    5,
+                    webpUrl,
+                    preloadHeaders,
+                );
                 expect(docBase.options.sharedLink).toBe('original-shared-link');
                 expect(docBase.options.sharedLinkPassword).toBe('original-password');
             });
@@ -5115,13 +5016,19 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     jpegUrl,
                     1, // default fallback page count when webp metadata is not available
                     '',
-                    {},
+                    preloadHeaders,
                 );
             });
 
             test('should only prefetch webp representations when webp is ready', () => {
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, '', 5, webpUrl, {});
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                    docBase.api,
+                    '',
+                    5,
+                    webpUrl,
+                    preloadHeaders,
+                );
             });
 
             test('should handle webp representation without metadata pages', () => {
@@ -5133,7 +5040,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '',
                     8,
                     expect.any(String),
-                    {},
+                    preloadHeaders,
                 );
             });
 
@@ -5147,7 +5054,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '', // jpegUrlAuthTemplate should be false when webp is available
                     8, // default page count when pages is not specified
                     expect.any(String),
-                    {},
+                    preloadHeaders,
                 );
             });
 
@@ -5159,14 +5066,20 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     '', // jpegUrlAuthTemplate should be false when webp is available
                     5,
                     webpUrl,
-                    {},
+                    preloadHeaders,
                 );
             });
 
             test('should handle webp representation without content', () => {
                 webpRep.content = null;
                 docBase.prefetchPreloaderImages(mockFile);
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(docBase.api, jpegUrl, 1, '', {});
+                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
+                    docBase.api,
+                    jpegUrl,
+                    1,
+                    '',
+                    preloadHeaders,
+                );
             });
 
             test('should call Promise.all with the returned promises', () => {
@@ -5210,7 +5123,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
-                    {},
+                    preloadHeaders,
                 );
 
                 // Wait for promises to resolve
@@ -5296,7 +5209,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
-                    {},
+                    preloadHeaders,
                 );
                 expect(getPreloadImageRequestPromisesByBatchSpy).toHaveBeenCalledTimes(1);
 
@@ -5337,7 +5250,7 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     expect.any(String),
                     1,
                     2,
-                    {},
+                    preloadHeaders,
                 );
 
                 // Wait for promises to resolve
@@ -5438,9 +5351,8 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                 getPreloadImageRequestPromisesByBatchSpy.mockRestore();
             });
 
-            test('should use createContentUrlV2 and pass headers when migrateAccessTokenToHeader flag is on', () => {
+            test('should use createContentUrlV2 and pass headers when prefetching preloader images', () => {
                 const mockHeaders = { Authorization: 'Bearer token123' };
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(docBase, 'createContentUrlV2').mockImplementation(url => {
                     if (url.includes('page_number')) {
                         return 'webp-url-without-token';
@@ -5458,22 +5370,6 @@ describe('src/lib/viewers/doc/DocBaseViewer', () => {
                     5,
                     'webp-url-without-token',
                     { headers: mockHeaders },
-                );
-            });
-
-            test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
-                jest.spyOn(docBase, 'featureEnabled').mockReturnValue(false);
-                jest.spyOn(docBase, 'createContentUrlWithAuthParams').mockReturnValue('url-with-token');
-
-                docBase.prefetchPreloaderImages(mockFile);
-
-                expect(docBase.createContentUrlWithAuthParams).toHaveBeenCalled();
-                expect(stubs.getPreloadImageRequestPromises).toHaveBeenCalledWith(
-                    docBase.api,
-                    '',
-                    5,
-                    'url-with-token',
-                    {},
                 );
             });
         });

--- a/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
+++ b/src/lib/viewers/doc/__tests__/DocumentViewer-test.js
@@ -110,7 +110,7 @@ describe('lib/viewers/doc/DocumentViewer', () => {
             Object.defineProperty(DocBaseViewer.prototype, 'load', {
                 value: jest.fn().mockImplementation(() => Promise.resolve()),
             });
-            jest.spyOn(doc, 'createContentUrlWithAuthParams').mockImplementation();
+            jest.spyOn(doc, 'createContentUrlV2').mockImplementation();
             jest.spyOn(doc, 'handleAssetAndRepLoad').mockImplementation();
             jest.spyOn(doc, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
             jest.spyOn(doc, 'loadAssets').mockImplementation();

--- a/src/lib/viewers/image/ImageViewer.js
+++ b/src/lib/viewers/image/ImageViewer.js
@@ -7,7 +7,6 @@ import {
     ANNOTATOR_EVENT,
     CLASS_ANNOTATIONS_IMAGE_FTUX_CURSOR_SEEN,
     CLASS_INVISIBLE,
-    CLASS_PREFETCHED_IMAGE,
     DISCOVERABILITY_ATTRIBUTE,
     IMAGE_FTUX_CURSOR_SEEN_KEY,
 } from '../../constants';
@@ -62,8 +61,7 @@ class ImageViewer extends ImageBaseViewer {
             this.removeListener('zoom', this.handleZoomEvent);
         }
 
-        // Auth header migration uses blob URLs for images (XHR fetch + createObjectURL).
-        // Revoke to free the memory since blobs persist until explicitly released.
+        // Blob URLs stay allocated until revoked.
         if (this.imageEl && this.imageEl.src && this.imageEl.src.startsWith('blob:')) {
             URL.revokeObjectURL(this.imageEl.src);
         }
@@ -116,30 +114,24 @@ class ImageViewer extends ImageBaseViewer {
 
         this.bindDOMListeners();
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
-            return this.getRepStatus()
-                .getPromise()
-                .then(() => {
-                    this.startLoadTimer();
-                    // Reuse prefetched blob URL if available, otherwise fetch now
-                    return this.prefetchedBlobUrlPromise || this.fetchContentAsBlobUrl(contentUrl);
-                })
-                .then(blobUrl => {
-                    this.prefetchedBlobUrlPromise = null;
-                    this.imageEl.src = blobUrl;
-                    if (this.imageEl.complete) {
-                        this.finishLoading();
-                    }
-                    super.handleAssetAndRepLoad();
-                })
-                .catch(this.handleAssetError);
-        }
-
-        const downloadUrl = this.createContentUrlWithAuthParams(template, viewer.ASSET);
+        const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
         return this.getRepStatus()
             .getPromise()
-            .then(() => this.handleAssetAndRepLoad(downloadUrl))
+            .then(() => {
+                this.startLoadTimer();
+                return this.fetchContentAsBlobUrl(contentUrl);
+            })
+            .then(blobUrl => {
+                if (this.isDestroyed()) {
+                    URL.revokeObjectURL(blobUrl);
+                    return;
+                }
+                this.imageEl.src = blobUrl;
+                if (this.imageEl.complete) {
+                    this.finishLoading();
+                }
+                super.handleAssetAndRepLoad();
+            })
             .catch(this.handleAssetError);
     }
 
@@ -189,10 +181,6 @@ class ImageViewer extends ImageBaseViewer {
         }
     }
 
-    prefetchFinishedLoading(event) {
-        document.body.removeChild(event?.currentTarget);
-    }
-
     /**
      * Prefetches assets for an image.
      *
@@ -206,17 +194,10 @@ class ImageViewer extends ImageBaseViewer {
         if ((content || preload) && !isWatermarked && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
 
-            if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
-                this.prefetchedBlobUrlPromise = this.fetchContentAsBlobUrl(contentUrl);
-            } else {
-                const preFetchedImg = document.createElement('img');
-                preFetchedImg.addEventListener('load', this.prefetchFinishedLoading);
-                preFetchedImg.classList.add(CLASS_PREFETCHED_IMAGE);
-                document.body.appendChild(preFetchedImg);
-
-                preFetchedImg.src = this.createContentUrlWithAuthParams(template, viewer.ASSET);
-            }
+            const contentUrl = this.createContentUrlV2(template, viewer.ASSET);
+            this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() }).catch(err => {
+                console.warn('Image prefetch failed', err); // eslint-disable-line no-console
+            });
         }
     }
 

--- a/src/lib/viewers/image/MultiImageViewer.js
+++ b/src/lib/viewers/image/MultiImageViewer.js
@@ -61,8 +61,7 @@ class MultiImageViewer extends ImageBaseViewer {
      */
     destroy() {
         if (this.singleImageEls && this.singleImageEls.length > 0) {
-            // Auth header migration uses blob URLs for images (XHR fetch + createObjectURL).
-            // Revoke to free the memory since blobs persist until explicitly released.
+            // Blob URLs stay allocated until revoked.
             this.singleImageEls.forEach((el, index) => {
                 if (el.src && el.src.startsWith('blob:')) {
                     URL.revokeObjectURL(el.src);
@@ -137,10 +136,7 @@ class MultiImageViewer extends ImageBaseViewer {
         const asset = viewer.ASSET;
         this.pagesCount = metadata.pages;
 
-        const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
-        const urlBase = useHeaders
-            ? this.createContentUrlV2(template, asset)
-            : this.createContentUrlWithAuthParams(template, asset);
+        const urlBase = this.createContentUrlV2(template, asset);
         const urls = [];
         for (let pageNum = 1; pageNum <= this.pagesCount; pageNum += 1) {
             urls.push(urlBase.replace('{page}', pageNum));
@@ -167,13 +163,15 @@ class MultiImageViewer extends ImageBaseViewer {
         this.singleImageEls[index].setAttribute('data-page-number', index + 1);
         this.singleImageEls[index].classList.add(CLASS_MULTI_IMAGE_PAGE);
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            this.fetchContentAsBlobUrl(imageUrl).then(blobUrl => {
+        this.fetchContentAsBlobUrl(imageUrl)
+            .then(blobUrl => {
+                if (this.isDestroyed()) {
+                    URL.revokeObjectURL(blobUrl);
+                    return;
+                }
                 this.singleImageEls[index].src = blobUrl;
-            });
-        } else {
-            this.singleImageEls[index].src = imageUrl;
-        }
+            })
+            .catch(this.handleMultiImageDownloadError);
     }
 
     /**

--- a/src/lib/viewers/image/__tests__/ImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/ImageViewer-test.js
@@ -130,108 +130,53 @@ describe('lib/viewers/image/ImageViewer', () => {
     });
 
     describe('load()', () => {
-        test('should fetch the image URL and load an image', () => {
-            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue(imageUrl);
+        test('should fetch the image as a blob URL and load it', () => {
+            const blobUrl = 'blob:http://example.com/blob-id';
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
             jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
-            stubs.event = jest.spyOn(image.imageEl, 'addEventListener');
-            stubs.load = jest.spyOn(image, 'finishLoading');
             stubs.bind = jest.spyOn(image, 'bindDOMListeners');
 
-            // load the image
-            return image
-                .load(imageUrl)
-                .then(() => {
-                    expect(image.bindDOMListeners).toBeCalled();
-                    expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
-                })
-                .catch(() => {});
+            return image.load().then(() => {
+                expect(image.bindDOMListeners).toBeCalled();
+                expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
+                expect(image.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
+                expect(image.imageEl.src).toBe(blobUrl);
+            });
         });
 
         test('should invoke startLoadTimer()', () => {
             jest.spyOn(image, 'startLoadTimer');
-            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue(imageUrl);
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue(imageUrl);
+            jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(imageUrl));
             jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
 
-            // load the image
-            return image
-                .load(imageUrl)
-                .then(() => {
-                    expect(image.startLoadTimer).toBeCalled();
-                })
-                .catch(() => {});
+            return image.load().then(() => {
+                expect(image.startLoadTimer).toBeCalled();
+            });
         });
 
-        test('should use createContentUrlV2 and fetchContentAsBlobUrl when migrateAccessTokenToHeader flag is on', () => {
+        test('should revoke the blob URL if destroyed before the fetch resolves', () => {
             const blobUrl = 'blob:http://example.com/blob-id';
-            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
             jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
             jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
             jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
-            jest.spyOn(image, 'startLoadTimer');
-            jest.spyOn(image, 'finishLoading');
+            jest.spyOn(image, 'isDestroyed').mockReturnValue(true);
+            jest.spyOn(URL, 'revokeObjectURL');
 
-            return image
-                .load()
-                .then(() => {
-                    expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
-                    expect(image.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
-                    expect(image.imageEl.src).toBe(blobUrl);
-                    expect(image.startLoadTimer).toBeCalled();
-                })
-                .catch(() => {});
-        });
-
-        test('should reuse prefetchedBlobUrlPromise when migrateAccessTokenToHeader flag is on', () => {
-            const blobUrl = 'blob:http://example.com/prefetched-blob';
-            const prefetchedPromise = Promise.resolve(blobUrl);
-            image.prefetchedBlobUrlPromise = prefetchedPromise;
-
-            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
-            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
-            jest.spyOn(image, 'fetchContentAsBlobUrl');
-            jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
-            jest.spyOn(image, 'startLoadTimer');
-
-            return image
-                .load()
-                .then(() => {
-                    expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
-                    expect(image.imageEl.src).toBe(blobUrl);
-                    expect(image.prefetchedBlobUrlPromise).toBeNull();
-                })
-                .catch(() => {});
-        });
-
-        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
-            jest.spyOn(image, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue(imageUrl);
-            jest.spyOn(image, 'createContentUrl');
-            jest.spyOn(image, 'fetchContentAsBlobUrl');
-            jest.spyOn(image, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
-
-            return image
-                .load()
-                .then(() => {
-                    expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
-                    expect(image.createContentUrl).not.toHaveBeenCalled();
-                    expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
-                })
-                .catch(() => {});
+            return image.load().then(() => {
+                expect(URL.revokeObjectURL).toHaveBeenCalledWith(blobUrl);
+                expect(image.imageEl.src).not.toBe(blobUrl);
+            });
         });
     });
 
     describe('prefetch()', () => {
         beforeEach(() => {
-            // Reset DOM
-            document.body.innerHTML = '';
             jest.spyOn(image, 'isRepresentationReady').mockReturnValue(true);
-            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue('https://example.com/image.jpg');
-        });
-
-        afterEach(() => {
-            // Clean up any remaining prefetched images
-            const prefetchedImages = document.querySelectorAll('.bp-prefetched-image');
-            prefetchedImages.forEach(img => img.remove());
+            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
+            jest.spyOn(image, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
+            image.api = { get: jest.fn().mockReturnValue(Promise.resolve()) };
         });
 
         test.each`
@@ -244,18 +189,14 @@ describe('lib/viewers/image/ImageViewer', () => {
             image.prefetch(options);
 
             if (shouldPrefetch) {
-                expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
-
-                const prefetchedImg = document.querySelector('.bp-prefetched-image');
-                expect(prefetchedImg).toBeTruthy();
-                expect(prefetchedImg.tagName).toBe('IMG');
-                expect(prefetchedImg.src).toBe('https://example.com/image.jpg');
-                expect(document.body.contains(prefetchedImg)).toBe(true);
+                expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
+                expect(image.api.get).toHaveBeenCalledWith('https://example.com/image.jpg', {
+                    type: 'blob',
+                    headers: { Authorization: 'Bearer token' },
+                });
             } else {
-                expect(image.createContentUrlWithAuthParams).not.toHaveBeenCalled();
-
-                const prefetchedImg = document.querySelector('.bp-prefetched-image');
-                expect(prefetchedImg).toBeFalsy();
+                expect(image.createContentUrlV2).not.toHaveBeenCalled();
+                expect(image.api.get).not.toHaveBeenCalled();
             }
         });
 
@@ -264,10 +205,8 @@ describe('lib/viewers/image/ImageViewer', () => {
 
             image.prefetch({ content: true });
 
-            expect(image.createContentUrlWithAuthParams).not.toHaveBeenCalled();
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeFalsy();
+            expect(image.createContentUrlV2).not.toHaveBeenCalled();
+            expect(image.api.get).not.toHaveBeenCalled();
         });
 
         test('should not prefetch content if file is watermarked', () => {
@@ -277,89 +216,18 @@ describe('lib/viewers/image/ImageViewer', () => {
 
             image.prefetch({ content: true });
 
-            expect(image.createContentUrlWithAuthParams).not.toHaveBeenCalled();
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeFalsy();
-        });
-
-        test('should add load event listener to prefetched image', () => {
-            const addEventListenerSpy = jest.spyOn(HTMLImageElement.prototype, 'addEventListener');
-
-            image.prefetch({ content: true });
-
-            expect(addEventListenerSpy).toHaveBeenCalledWith('load', image.prefetchFinishedLoading);
-
-            addEventListenerSpy.mockRestore();
-        });
-
-        test('should apply bp-prefetched-image class to prefetched image', () => {
-            image.prefetch({ content: true });
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeTruthy();
-            expect(prefetchedImg.classList.contains('bp-prefetched-image')).toBe(true);
-        });
-
-        test('should call prefetchFinishedLoading when prefetched image loads', () => {
-            jest.spyOn(image, 'prefetchFinishedLoading');
-
-            image.prefetch({ content: true });
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-
-            // Simulate image load event
-            const loadEvent = new Event('load');
-            Object.defineProperty(loadEvent, 'currentTarget', { value: prefetchedImg });
-            prefetchedImg.dispatchEvent(loadEvent);
-
-            expect(image.prefetchFinishedLoading).toHaveBeenCalledWith(loadEvent);
+            expect(image.createContentUrlV2).not.toHaveBeenCalled();
+            expect(image.api.get).not.toHaveBeenCalled();
         });
 
         test('should use default parameters when no options provided', () => {
             image.prefetch();
 
-            // Default is content: true, preload: false, so should prefetch
-            expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeTruthy();
-        });
-
-        test('should use fetchContentAsBlobUrl and store promise when migrateAccessTokenToHeader flag is on', () => {
-            const blobUrl = 'blob:http://example.com/prefetch-blob';
-            jest.spyOn(image, 'featureEnabled').mockImplementation(feature => feature === 'migrateAccessTokenToHeader');
-            jest.spyOn(image, 'createContentUrlV2').mockReturnValue('https://example.com/image.jpg');
-            jest.spyOn(image, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
-
-            image.prefetch({ content: true });
-
             expect(image.createContentUrlV2).toHaveBeenCalledWith('foo', '1.png');
-            expect(image.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
-            expect(image.prefetchedBlobUrlPromise).toBeDefined();
-            expect(image.prefetchedBlobUrlPromise).toBeInstanceOf(Promise);
-
-            // Should not create an img element in the DOM
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeFalsy();
-        });
-
-        test('should create img prefetch element when migrateAccessTokenToHeader flag is off', () => {
-            jest.spyOn(image, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(image, 'createContentUrlWithAuthParams').mockReturnValue('https://example.com/image.jpg');
-            jest.spyOn(image, 'createContentUrl');
-            jest.spyOn(image, 'fetchContentAsBlobUrl');
-
-            image.prefetch({ content: true });
-
-            expect(image.createContentUrlWithAuthParams).toHaveBeenCalledWith('foo', '1.png');
-            expect(image.createContentUrl).not.toHaveBeenCalled();
-            expect(image.fetchContentAsBlobUrl).not.toHaveBeenCalled();
-            expect(image.prefetchedBlobUrlPromise).toBeUndefined();
-
-            const prefetchedImg = document.querySelector('.bp-prefetched-image');
-            expect(prefetchedImg).toBeTruthy();
-            expect(prefetchedImg.src).toBe('https://example.com/image.jpg');
+            expect(image.api.get).toHaveBeenCalledWith('https://example.com/image.jpg', {
+                type: 'blob',
+                headers: { Authorization: 'Bearer token' },
+            });
         });
     });
 
@@ -983,25 +851,6 @@ describe('lib/viewers/image/ImageViewer', () => {
             image.emitFirstRenderMetric();
 
             expect(image.emitMetric).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('prefetchFinishedLoading', () => {
-        test('should remove image element from document body', () => {
-            const mockImg = document.createElement('img');
-            document.body.appendChild(mockImg);
-
-            const mockEvent = {
-                currentTarget: mockImg,
-            };
-
-            // Verify the image is in the DOM before calling the method
-            expect(document.body.contains(mockImg)).toBe(true);
-
-            image.prefetchFinishedLoading(mockEvent);
-
-            // Verify the image was removed from the DOM
-            expect(document.body.contains(mockImg)).toBe(false);
         });
     });
 

--- a/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
+++ b/src/lib/viewers/image/__tests__/MultiImageViewer-test.js
@@ -184,6 +184,9 @@ describe('lib/viewers/image/MultiImageViewer', () => {
 
     describe('constructImageUrls()', () => {
         test('should remove both the new and old form of asset path', () => {
+            jest.spyOn(multiImage, 'createContentUrlV2').mockImplementation((template, asset) =>
+                template.includes('{+asset_path}') ? template.replace('{+asset_path}', asset) : template,
+            );
             const firstURL = 'file/100/content/1.png';
             const result = multiImage.constructImageUrls('file/100/content/{page}.png');
 
@@ -209,41 +212,16 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             expect(result.length).toBe(3);
         });
 
-        test('should use createContentUrlV2 when migrateAccessTokenToHeader flag is on', () => {
-            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
-                feature => feature === 'migrateAccessTokenToHeader',
-            );
+        test('should use createContentUrlV2', () => {
             jest.spyOn(multiImage, 'createContentUrlV2').mockReturnValue('https://example.com/image-{page}.jpg');
-            jest.spyOn(multiImage, 'createContentUrlWithAuthParams');
 
             const result = multiImage.constructImageUrls('file/100/content/{page}.png');
 
             expect(multiImage.createContentUrlV2).toHaveBeenCalledWith('file/100/content/{page}.png', '{page}.png');
-            expect(multiImage.createContentUrlWithAuthParams).not.toHaveBeenCalled();
             expect(result.length).toBe(3);
             expect(result[0]).toBe('https://example.com/image-1.jpg');
             expect(result[1]).toBe('https://example.com/image-2.jpg');
             expect(result[2]).toBe('https://example.com/image-3.jpg');
-        });
-
-        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is off', () => {
-            jest.spyOn(multiImage, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(multiImage, 'createContentUrlWithAuthParams').mockReturnValue(
-                'https://example.com/auth-image-{page}.jpg',
-            );
-            jest.spyOn(multiImage, 'createContentUrl');
-
-            const result = multiImage.constructImageUrls('file/100/content/{page}.png');
-
-            expect(multiImage.createContentUrlWithAuthParams).toHaveBeenCalledWith(
-                'file/100/content/{page}.png',
-                '{page}.png',
-            );
-            expect(multiImage.createContentUrl).not.toHaveBeenCalled();
-            expect(result.length).toBe(3);
-            expect(result[0]).toBe('https://example.com/auth-image-1.jpg');
-            expect(result[1]).toBe('https://example.com/auth-image-2.jpg');
-            expect(result[2]).toBe('https://example.com/auth-image-3.jpg');
         });
     });
 
@@ -251,21 +229,26 @@ describe('lib/viewers/image/MultiImageViewer', () => {
         beforeEach(() => {
             multiImage.setup();
             stubs.bindImageListeners = jest.spyOn(multiImage, 'bindImageListeners');
+            jest.spyOn(multiImage, 'fetchContentAsBlobUrl').mockImplementation(url => Promise.resolve(url));
         });
 
         test('should set the single image el and error handler if it is not the first image', () => {
             multiImage.singleImageEls = [null, stubs.singleImageEl];
 
             multiImage.setupImageEls('file/100/content/{page}.png', 1);
-            expect(multiImage.singleImageEls[1].src).toBeDefined();
             expect(stubs.bindImageListeners).toBeCalled();
+            expect(multiImage.fetchContentAsBlobUrl).toHaveBeenCalledWith('file/100/content/{page}.png');
         });
 
-        test('should set the image source', () => {
+        test('should set the image source from a blob URL', () => {
             multiImage.singleImageEls = [stubs.singleImageEl];
 
             multiImage.setupImageEls('file/100/content/{page}.png', 0);
-            expect(multiImage.singleImageEls[0].src).toBe('file/100/content/{page}.png');
+            expect(multiImage.fetchContentAsBlobUrl).toHaveBeenCalledWith('file/100/content/{page}.png');
+
+            return multiImage.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(multiImage.singleImageEls[0].src).toBe('file/100/content/{page}.png');
+            });
         });
 
         test('should set the page number for each image el', () => {
@@ -282,41 +265,9 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             expect(stubs.singleImageEl.classList.add).toBeCalledWith(CLASS_MULTI_IMAGE_PAGE);
         });
 
-        test('should use fetchContentAsBlobUrl when migrateAccessTokenToHeader flag is on', () => {
-            const blobUrl = 'blob:http://example.com/image-blob';
-            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
-                feature => feature === 'migrateAccessTokenToHeader',
-            );
-            jest.spyOn(multiImage, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
-            multiImage.singleImageEls = [stubs.singleImageEl];
-
-            multiImage.setupImageEls('https://example.com/image.jpg', 0);
-
-            expect(multiImage.fetchContentAsBlobUrl).toHaveBeenCalledWith('https://example.com/image.jpg');
-
-            // Wait for promise to resolve
-            return multiImage.fetchContentAsBlobUrl().then(() => {
-                expect(stubs.singleImageEl.src).toBe(blobUrl);
-            });
-        });
-
-        test('should set src directly when migrateAccessTokenToHeader flag is off', () => {
-            jest.spyOn(multiImage, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(multiImage, 'fetchContentAsBlobUrl');
-            multiImage.singleImageEls = [stubs.singleImageEl];
-
-            multiImage.setupImageEls('https://example.com/image-auth.jpg', 0);
-
-            expect(multiImage.fetchContentAsBlobUrl).not.toHaveBeenCalled();
-            expect(stubs.singleImageEl.src).toBe('https://example.com/image-auth.jpg');
-        });
-
-        test('should use fetchContentAsBlobUrl for each page when migrateAccessTokenToHeader flag is on', () => {
+        test('should use fetchContentAsBlobUrl for each page', () => {
             const blobUrl1 = 'blob:http://example.com/image1-blob';
             const blobUrl2 = 'blob:http://example.com/image2-blob';
-            jest.spyOn(multiImage, 'featureEnabled').mockImplementation(
-                feature => feature === 'migrateAccessTokenToHeader',
-            );
             const fetchSpy = jest
                 .spyOn(multiImage, 'fetchContentAsBlobUrl')
                 .mockReturnValueOnce(Promise.resolve(blobUrl1))
@@ -332,6 +283,36 @@ describe('lib/viewers/image/MultiImageViewer', () => {
             expect(fetchSpy).toHaveBeenCalledTimes(2);
             expect(fetchSpy).toHaveBeenNthCalledWith(1, 'https://example.com/page1.jpg');
             expect(fetchSpy).toHaveBeenNthCalledWith(2, 'https://example.com/page2.jpg');
+        });
+
+        test('should handle a page fetch error as a download error', () => {
+            const err = new Error('401');
+            jest.spyOn(multiImage, 'fetchContentAsBlobUrl').mockReturnValue(Promise.reject(err));
+            jest.spyOn(multiImage, 'handleMultiImageDownloadError').mockImplementation();
+            multiImage.singleImageEls = [stubs.singleImageEl];
+
+            multiImage.setupImageEls('https://example.com/page1.jpg', 0);
+
+            return Promise.resolve()
+                .then(() => Promise.resolve())
+                .then(() => {
+                    expect(multiImage.handleMultiImageDownloadError).toHaveBeenCalledWith(err);
+                });
+        });
+
+        test('should revoke the blob URL if destroyed before the fetch resolves', () => {
+            const blobUrl = 'blob:http://example.com/page';
+            jest.spyOn(multiImage, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
+            jest.spyOn(multiImage, 'isDestroyed').mockReturnValue(true);
+            jest.spyOn(URL, 'revokeObjectURL');
+            multiImage.singleImageEls = [stubs.singleImageEl];
+
+            multiImage.setupImageEls('https://example.com/page1.jpg', 0);
+
+            return multiImage.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(URL.revokeObjectURL).toHaveBeenCalledWith(blobUrl);
+                expect(stubs.singleImageEl.src).not.toBe(blobUrl);
+            });
         });
     });
 

--- a/src/lib/viewers/media/DashViewer.js
+++ b/src/lib/viewers/media/DashViewer.js
@@ -131,7 +131,7 @@ class DashViewer extends VideoBaseViewer {
             this.filmstripStatus.destroy();
         }
 
-        // Release blob: URL allocated for the filmstrip when migrateAccessTokenToHeader is on
+        // Release blob: URL allocated for the filmstrip
         if (this.filmstripUrl && this.filmstripUrl.startsWith('blob:')) {
             URL.revokeObjectURL(this.filmstripUrl);
         }
@@ -207,12 +207,8 @@ class DashViewer extends VideoBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                const contentUrl = this.createContentUrlV2(template, MANIFEST);
-                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
-            } else {
-                this.api.get(this.createContentUrlWithAuthParams(template, MANIFEST), { type: 'document' });
-            }
+            const contentUrl = this.createContentUrlV2(template, MANIFEST);
+            this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
         }
     }
 
@@ -340,7 +336,7 @@ class DashViewer extends VideoBaseViewer {
     }
 
     /**
-     * A networking filter to append representation URLs with tokens
+     * Rewrites representation URIs without an access token and attaches Authorization headers.
      * Manifest type will use an asset name. Segments will not.
      *
      * @private
@@ -351,24 +347,14 @@ class DashViewer extends VideoBaseViewer {
     requestFilter(type, request) {
         const asset = type === shaka.net.NetworkingEngine.RequestType.MANIFEST ? MANIFEST : undefined;
         /* eslint-disable no-param-reassign */
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            request.uris = request.uris.map(uri => {
-                let newUri = this.createContentUrlV2(uri, asset);
-                if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
-                    newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
-                }
-                return newUri;
-            });
-            Object.assign(request.headers, this.appendAuthHeader());
-        } else {
-            request.uris = request.uris.map(uri => {
-                let newUri = this.createContentUrlWithAuthParams(uri, asset);
-                if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
-                    newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
-                }
-                return newUri;
-            });
-        }
+        request.uris = request.uris.map(uri => {
+            let newUri = this.createContentUrlV2(uri, asset);
+            if (asset !== MANIFEST && this.options.file.watermark_info.is_watermarked) {
+                newUri = appendQueryParams(newUri, { watermark_content: this.watermarkCacheBust });
+            }
+            return newUri;
+        });
+        request.headers = Object.assign(request.headers || {}, this.appendAuthHeader());
         /* eslint-enable no-param-reassign */
     }
 
@@ -969,36 +955,19 @@ class DashViewer extends VideoBaseViewer {
         const filmstripInterval = filmstrip && filmstrip.metadata && filmstrip.metadata.interval;
 
         if (filmstripInterval > 0) {
-            const useHeaders = this.featureEnabled('migrateAccessTokenToHeader');
             const useReactControls = this.useReactControls();
-            const url = useHeaders
-                ? this.createContentUrlV2(filmstrip.content.url_template)
-                : this.createContentUrlWithAuthParams(filmstrip.content.url_template);
+            const url = this.createContentUrlV2(filmstrip.content.url_template);
 
             this.filmstripInterval = filmstripInterval;
             this.filmstripStatus = this.getRepStatus(filmstrip);
-            // When useHeaders is on, the URL has no token and would 401 if rendered as <img src>.
-            // Defer setting filmstripUrl until the blob: URL is ready below.
-            this.filmstripUrl = useHeaders ? null : url;
-
-            // Legacy controls have a synchronous init path when the URL already carries a token.
-            if (!useHeaders && !useReactControls) {
-                this.mediaControls.initFilmstrip(url, this.filmstripStatus, this.aspect, filmstripInterval);
-                return;
-            }
+            this.filmstripUrl = null;
 
             this.filmstripStatus
                 .getPromise()
-                .then(() => (useHeaders ? this.fetchContentAsBlobUrl(url) : url))
+                .then(() => this.fetchContentAsBlobUrl(url))
                 .then(filmstripUrl => {
-                    // <img src> can't carry an Authorization header, so when the access-token has
-                    // been migrated out of the URL we expose the rep as a blob: URL instead.
-                    // If the viewer was destroyed while we were fetching, release the blob now —
-                    // destroy() can't see it because filmstripUrl was still null when it ran.
                     if (this.destroyed) {
-                        if (useHeaders) {
-                            URL.revokeObjectURL(filmstripUrl);
-                        }
+                        URL.revokeObjectURL(filmstripUrl);
                         return;
                     }
                     this.filmstripUrl = filmstripUrl;
@@ -1013,9 +982,8 @@ class DashViewer extends VideoBaseViewer {
                         );
                     }
                 })
-                // Filmstrip is a non-critical scrubbing-preview enhancement, so any failure
-                // (rep status reject, blob fetch reject) is swallowed rather than failing
-                // the whole viewer. Warn so prod 401s leave a breadcrumb in DevTools.
+                // Filmstrip is a non-critical scrubbing-preview enhancement.
+                // Warn so prod 401s leave a breadcrumb in DevTools.
                 .catch(err => {
                     console.warn('Filmstrip load failed', err); // eslint-disable-line no-console
                 });
@@ -1038,9 +1006,7 @@ class DashViewer extends VideoBaseViewer {
             return;
         }
 
-        const transcriptionUrl = this.featureEnabled('migrateAccessTokenToHeader')
-            ? this.createContentUrlV2(extractedText.content.url_template)
-            : this.createContentUrlWithAuthParams(extractedText.content.url_template);
+        const transcriptionUrl = this.createContentUrlV2(extractedText.content.url_template);
         this.transcriptionStatus = this.getRepStatus(extractedText);
 
         try {

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -214,28 +214,17 @@ class MediaBaseViewer extends BaseViewer {
             this.mediaEl.autoplay = true;
         }
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            const contentUrl = this.createContentUrlV2(template);
-            return this.getRepStatus()
-                .getPromise()
-                .then(() => {
-                    this.startLoadTimer();
-                    return this.fetchContentAsBlobUrl(contentUrl);
-                })
-                .then(blobUrl => {
-                    this.mediaBlobUrl = blobUrl;
-                    this.mediaUrl = blobUrl;
-                    this.mediaEl.src = blobUrl;
-                })
-                .catch(this.handleAssetError);
-        }
-
-        this.mediaUrl = this.createContentUrlWithAuthParams(template);
+        const contentUrl = this.createContentUrlV2(template);
         return this.getRepStatus()
             .getPromise()
             .then(() => {
                 this.startLoadTimer();
-                this.mediaEl.src = this.mediaUrl;
+                return this.fetchContentAsBlobUrl(contentUrl);
+            })
+            .then(blobUrl => {
+                this.mediaBlobUrl = blobUrl;
+                this.mediaUrl = blobUrl;
+                this.mediaEl.src = blobUrl;
             })
             .catch(this.handleAssetError);
     }
@@ -342,23 +331,17 @@ class MediaBaseViewer extends BaseViewer {
         this.currentTime = currentTime;
         this.options.token = newToken;
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            if (this.mediaBlobUrl) {
-                URL.revokeObjectURL(this.mediaBlobUrl);
-            }
-            const contentUrl = this.createContentUrlV2(this.options.representation.content.url_template);
-            this.fetchContentAsBlobUrl(contentUrl)
-                .then(blobUrl => {
-                    this.mediaBlobUrl = blobUrl;
-                    this.mediaUrl = blobUrl;
-                    this.mediaEl.src = blobUrl;
-                })
-                .catch(this.handleAssetError);
-            return;
+        if (this.mediaBlobUrl) {
+            URL.revokeObjectURL(this.mediaBlobUrl);
         }
-
-        this.mediaUrl = this.createContentUrlWithAuthParams(this.options.representation.content.url_template);
-        this.mediaEl.src = this.mediaUrl;
+        const contentUrl = this.createContentUrlV2(this.options.representation.content.url_template);
+        this.fetchContentAsBlobUrl(contentUrl)
+            .then(blobUrl => {
+                this.mediaBlobUrl = blobUrl;
+                this.mediaUrl = blobUrl;
+                this.mediaEl.src = blobUrl;
+            })
+            .catch(this.handleAssetError);
     }
 
     /**

--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -229,21 +229,24 @@ class VideoBaseViewer extends MediaBaseViewer {
             };
         }
 
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            const contentUrl = this.createContentUrlV2(template);
-            if (this.preloadBlobUrl) {
-                URL.revokeObjectURL(this.preloadBlobUrl);
-            }
-            this.fetchContentAsBlobUrl(contentUrl)
-                .then(blobUrl => {
-                    this.preloadBlobUrl = blobUrl;
-                    this.preloader.showPreload(blobUrl, this.mediaContainerEl, options);
-                })
-                .catch(this.handleAssetError);
-        } else {
-            const preloadUrlWithAuth = this.createContentUrlWithAuthParams(template);
-            this.preloader.showPreload(preloadUrlWithAuth, this.mediaContainerEl, options);
+        const contentUrl = this.createContentUrlV2(template);
+        if (this.preloadBlobUrl) {
+            URL.revokeObjectURL(this.preloadBlobUrl);
         }
+        this.fetchContentAsBlobUrl(contentUrl)
+            .then(blobUrl => {
+                if (this.isDestroyed()) {
+                    URL.revokeObjectURL(blobUrl);
+                    return;
+                }
+                this.preloadBlobUrl = blobUrl;
+                this.preloader.showPreload(blobUrl, this.mediaContainerEl, options);
+            })
+            .catch(err => {
+                // Poster is a non-critical first-frame enhancement.
+                // Warn so prod 401s leave a breadcrumb in DevTools.
+                console.warn('Video preload failed', err); // eslint-disable-line no-console
+            });
         this.mediaEl.classList.add(CLASS_INVISIBLE);
     }
 
@@ -278,13 +281,10 @@ class VideoBaseViewer extends MediaBaseViewer {
         if (!preloadRep || !this.isRepresentationReady(preloadRep) || !preloadRep.content?.url_template) {
             return;
         }
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            const contentUrl = this.createContentUrlV2(preloadRep.content.url_template);
-            this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() }).catch(() => {});
-        } else {
-            const preloadUrlWithAuth = this.createContentUrlWithAuthParams(preloadRep.content.url_template);
-            this.api.get(preloadUrlWithAuth, { type: 'blob' }).catch(() => {});
-        }
+        const contentUrl = this.createContentUrlV2(preloadRep.content.url_template);
+        this.api.get(contentUrl, { type: 'blob', headers: this.appendAuthHeader() }).catch(err => {
+            console.warn('Video preload prefetch failed', err); // eslint-disable-line no-console
+        });
     }
 
     buildPlayButtonWithSeekButtons() {

--- a/src/lib/viewers/media/__tests__/DashViewer-test.js
+++ b/src/lib/viewers/media/__tests__/DashViewer-test.js
@@ -211,7 +211,8 @@ describe('lib/viewers/media/DashViewer', () => {
     describe('prefetch()', () => {
         beforeEach(() => {
             stubs.prefetchAssets = jest.spyOn(dash, 'prefetchAssets').mockImplementation();
-            stubs.createUrl = jest.spyOn(dash, 'createContentUrlWithAuthParams').mockImplementation();
+            stubs.createUrl = jest.spyOn(dash, 'createContentUrlV2').mockImplementation();
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
             stubs.repReady = jest.spyOn(dash, 'isRepresentationReady').mockReturnValue(true);
         });
 
@@ -246,7 +247,7 @@ describe('lib/viewers/media/DashViewer', () => {
             sandbox
                 .mock(stubs.api)
                 .expects('get')
-                .withArgs(contentUrl, { type: 'document' });
+                .withArgs(contentUrl, { type: 'document', headers: { Authorization: 'Bearer token' } });
 
             dash.prefetch({ assets: false, content: true });
             expect(stubs.prefetchAssets).not.toBeCalled();
@@ -268,7 +269,10 @@ describe('lib/viewers/media/DashViewer', () => {
 
             dash.prefetch({ assets: false, content: false, preload: true });
 
-            expect(stubs.api.get).toHaveBeenCalledWith(jpgUrlWithAuth, { type: 'blob' });
+            expect(stubs.api.get).toHaveBeenCalledWith(jpgUrlWithAuth, {
+                type: 'blob',
+                headers: { Authorization: 'Bearer token' },
+            });
         });
     });
 
@@ -323,9 +327,10 @@ describe('lib/viewers/media/DashViewer', () => {
     });
 
     describe('requestFilter()', () => {
-        test('should append representation URLs with tokens', () => {
-            stubs.createUrl = jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('auth_url');
-            stubs.req = { uris: ['uri'] };
+        test('should rewrite representation URIs and attach auth headers', () => {
+            stubs.createUrl = jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('auth_url');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
+            stubs.req = { uris: ['uri'], headers: {} };
             dash.options = {
                 file: {
                     watermark_info: {
@@ -344,10 +349,9 @@ describe('lib/viewers/media/DashViewer', () => {
         });
 
         test('should append watermark cache-busting query params if file is watermarked', () => {
-            stubs.createUrl = jest
-                .spyOn(dash, 'createContentUrlWithAuthParams')
-                .mockReturnValue('www.authed.com/?foo=bar');
-            stubs.req = { uris: ['uri'] };
+            stubs.createUrl = jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('www.authed.com/?foo=bar');
+            jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
+            stubs.req = { uris: ['uri'], headers: {} };
             dash.watermarkCacheBust = '123';
             dash.options = {
                 file: {
@@ -893,7 +897,7 @@ describe('lib/viewers/media/DashViewer', () => {
                     },
                 },
             };
-            stubs.createUrl = jest.spyOn(dash, 'createContentUrlWithAuthParams');
+            stubs.createUrl = jest.spyOn(dash, 'createContentUrlV2');
             stubs.renderUI = jest.spyOn(dash, 'renderUI');
             jest.spyOn(dash, 'getRepStatus');
         });
@@ -933,6 +937,11 @@ describe('lib/viewers/media/DashViewer', () => {
         });
 
         test('should load the film strip', () => {
+            jest.spyOn(dash, 'getRepStatus').mockReturnValue({
+                getPromise: () => Promise.resolve(),
+                destroy: jest.fn(),
+            });
+            jest.spyOn(dash, 'fetchContentAsBlobUrl').mockResolvedValue('blob:filmstrip');
             dash.loadFilmStrip();
             expect(stubs.createUrl).toBeCalled();
         });
@@ -950,6 +959,7 @@ describe('lib/viewers/media/DashViewer', () => {
                 metadata: { interval: 1 },
                 status: { state: 'ready' },
             };
+            jest.spyOn(dash, 'fetchContentAsBlobUrl').mockResolvedValue('blob:filmstrip');
             dash.loadFilmStrip();
             await flushPromises();
 
@@ -976,7 +986,7 @@ describe('lib/viewers/media/DashViewer', () => {
                     },
                 },
             };
-            stubs.createUrl = jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('authed-url');
+            stubs.createUrl = jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('authed-url');
             stubs.loadSubtitles = jest.spyOn(dash, 'loadSubtitles').mockImplementation();
             jest.spyOn(dash, 'isDestroyed').mockReturnValue(false);
         });
@@ -1186,10 +1196,7 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(stubs.loadSubtitles).not.toBeCalled();
         });
 
-        test('should use createContentUrlV2 when migrateAccessTokenToHeader is enabled', () => {
-            jest.spyOn(dash, 'featureEnabled').mockImplementation(
-                feature => feature === 'aiTranscriptionForVideoSubtitles' || feature === 'migrateAccessTokenToHeader',
-            );
+        test('should use createContentUrlV2 for the transcription URL', () => {
             const createUrlV2 = jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('v2-url');
             jest.spyOn(dash, 'getRepStatus').mockReturnValueOnce({
                 destroy: jest.fn(),
@@ -1199,21 +1206,6 @@ describe('lib/viewers/media/DashViewer', () => {
             dash.loadTranscription();
 
             expect(createUrlV2).toHaveBeenCalledWith('https://api.box.com/transcription.vtt');
-            expect(stubs.createUrl).not.toBeCalled();
-        });
-
-        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader is disabled', () => {
-            jest.spyOn(dash, 'featureEnabled').mockImplementation(
-                feature => feature === 'aiTranscriptionForVideoSubtitles',
-            );
-            jest.spyOn(dash, 'getRepStatus').mockReturnValueOnce({
-                destroy: jest.fn(),
-                getPromise: () => Promise.resolve(),
-            });
-
-            dash.loadTranscription();
-
-            expect(stubs.createUrl).toHaveBeenCalledWith('https://api.box.com/transcription.vtt');
         });
     });
 
@@ -2278,19 +2270,18 @@ describe('lib/viewers/media/DashViewer', () => {
         });
     });
 
-    describe('requestFilter() with migrateAccessTokenToHeader', () => {
+    describe('requestFilter() with header auth', () => {
         beforeEach(() => {
             dash.options.file.watermark_info = { is_watermarked: false };
             dash.watermarkCacheBust = 12345;
         });
 
-        test('should use createContentUrlV2 and append auth headers when flag is enabled for manifest', () => {
+        test('should rewrite the manifest URI and attach auth headers', () => {
             const request = {
                 uris: ['http://localhost/original/manifest.mpd'],
                 headers: {},
             };
 
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/manifest.mpd');
             jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
 
@@ -2305,13 +2296,12 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(request.headers).toEqual({ Authorization: 'Bearer token123' });
         });
 
-        test('should use createContentUrlV2 and append auth headers when flag is enabled for segments', () => {
+        test('should rewrite segment URIs and attach auth headers', () => {
             const request = {
                 uris: ['http://localhost/original/segment1.m4s'],
                 headers: {},
             };
 
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/segment1.m4s');
             jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
 
@@ -2323,14 +2313,13 @@ describe('lib/viewers/media/DashViewer', () => {
             expect(request.headers).toEqual({ Authorization: 'Bearer token123' });
         });
 
-        test('should append watermark query param for segments when watermarked and flag is enabled', () => {
+        test('should append watermark query param for segments when watermarked', () => {
             dash.options.file.watermark_info = { is_watermarked: true };
             const request = {
                 uris: ['http://localhost/original/segment1.m4s'],
                 headers: {},
             };
 
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/segment1.m4s');
             jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
 
@@ -2338,27 +2327,9 @@ describe('lib/viewers/media/DashViewer', () => {
 
             expect(request.uris[0]).toContain('watermark_content=12345');
         });
-
-        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
-            const request = {
-                uris: ['http://localhost/original/manifest.mpd'],
-                headers: {},
-            };
-
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
-
-            dash.requestFilter(shaka.net.NetworkingEngine.RequestType.MANIFEST, request);
-
-            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith(
-                'http://localhost/original/manifest.mpd',
-                'manifest.mpd',
-            );
-            expect(request.uris).toEqual(['http://localhost/content?token=abc']);
-        });
     });
 
-    describe('prefetch() with migrateAccessTokenToHeader', () => {
+    describe('prefetch() with header auth', () => {
         beforeEach(() => {
             dash.options.representation = {
                 content: {
@@ -2368,8 +2339,7 @@ describe('lib/viewers/media/DashViewer', () => {
             jest.spyOn(dash, 'isRepresentationReady').mockReturnValue(true);
         });
 
-        test('should use createContentUrlV2 with auth headers when flag is enabled', () => {
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+        test('should use createContentUrlV2 with auth headers', () => {
             jest.spyOn(dash, 'createContentUrlV2').mockReturnValue('http://localhost/content/manifest.mpd');
             jest.spyOn(dash, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
             jest.spyOn(stubs.api, 'get').mockReturnValue(Promise.resolve());
@@ -2383,24 +2353,12 @@ describe('lib/viewers/media/DashViewer', () => {
                 headers: { Authorization: 'Bearer token123' },
             });
         });
-
-        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
-            jest.spyOn(stubs.api, 'get').mockReturnValue(Promise.resolve());
-
-            dash.prefetch({ content: true });
-
-            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/dash', 'manifest.mpd');
-            expect(stubs.api.get).toHaveBeenCalledWith('http://localhost/content?token=abc', { type: 'document' });
-        });
     });
 
-    describe('loadFilmStrip() with migrateAccessTokenToHeader', () => {
+    describe('loadFilmStrip() with header auth', () => {
         const FILMSTRIP_TEMPLATE = 'www.box.com/filmstrip.jpg';
         const FILMSTRIP_URL = 'http://localhost/filmstrip.jpg';
         const FILMSTRIP_BLOB = 'blob:http://localhost/abc';
-        const FILMSTRIP_TOKEN_URL = 'http://localhost/filmstrip.jpg?token=abc';
         const ASPECT = 1.78;
         const INTERVAL = 2;
 
@@ -2425,11 +2383,10 @@ describe('lib/viewers/media/DashViewer', () => {
             jest.spyOn(dash.mediaControls, 'initFilmstrip').mockImplementation();
         });
 
-        describe('with flag enabled, legacy controls', () => {
+        describe('legacy controls', () => {
             let revokeSpy;
 
             beforeEach(() => {
-                jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
                 jest.spyOn(dash, 'createContentUrlV2').mockReturnValue(FILMSTRIP_URL);
                 jest.spyOn(dash, 'useReactControls').mockReturnValue(false);
                 revokeSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation();
@@ -2501,28 +2458,7 @@ describe('lib/viewers/media/DashViewer', () => {
             });
         });
 
-        test('should use createContentUrlWithAuthParams when flag is disabled', () => {
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(dash, 'createContentUrlWithAuthParams').mockReturnValue(FILMSTRIP_TOKEN_URL);
-            jest.spyOn(dash, 'fetchContentAsBlobUrl');
-            jest.spyOn(dash, 'useReactControls').mockReturnValue(false);
-
-            // Flag-off path is fully synchronous: no awaits needed.
-            dash.loadFilmStrip();
-
-            expect(dash.createContentUrlWithAuthParams).toHaveBeenCalledWith(FILMSTRIP_TEMPLATE);
-            expect(dash.fetchContentAsBlobUrl).not.toHaveBeenCalled();
-            expect(dash.filmstripUrl).toBe(FILMSTRIP_TOKEN_URL);
-            expect(dash.mediaControls.initFilmstrip).toHaveBeenCalledWith(
-                FILMSTRIP_TOKEN_URL,
-                expect.any(Object),
-                ASPECT,
-                INTERVAL,
-            );
-        });
-
-        test('should fetch as blob and re-render with React controls when flag is enabled', async () => {
-            jest.spyOn(dash, 'featureEnabled').mockReturnValue(true);
+        test('should fetch as blob and re-render with React controls', async () => {
             jest.spyOn(dash, 'createContentUrlV2').mockReturnValue(FILMSTRIP_URL);
             jest.spyOn(dash, 'fetchContentAsBlobUrl').mockResolvedValue(FILMSTRIP_BLOB);
             jest.spyOn(dash, 'useReactControls').mockReturnValue(true);

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -127,18 +127,23 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         });
 
         test('should load mediaUrl in the media element', () => {
+            const blobUrl = 'blob:http://localhost/media';
             jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockResolvedValue(blobUrl);
 
             return media.load().then(() => {
                 expect(media.mediaEl.addEventListener).toBeCalledWith('loadedmetadata', media.loadeddataHandler);
                 expect(media.mediaEl.addEventListener).toBeCalledWith('error', media.errorHandler);
-                expect(media.mediaEl.src).toBe('http://localhost/www.box.com');
+                expect(media.mediaEl.src).toBe(blobUrl);
             });
         });
 
         test('should enable autoplay if on iOS', () => {
             jest.spyOn(Browser, 'isIOS').mockReturnValue(true);
             jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockResolvedValue('blob:media');
             media.mediaEl = document.createElement('video');
 
             return media.load().then(() => {
@@ -149,6 +154,8 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         test('should invoke startLoadTimer()', () => {
             jest.spyOn(media, 'startLoadTimer');
             jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockResolvedValue('blob:media');
 
             return media.load().then(() => {
                 expect(media.startLoadTimer).toBeCalled();
@@ -1607,21 +1614,19 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
         });
     });
 
-    describe('load() with migrateAccessTokenToHeader', () => {
+    describe('load() with header auth', () => {
         beforeEach(() => {
             media.mediaEl = document.createElement('video');
             media.mediaEl.addEventListener = jest.fn();
         });
 
-        test('should use fetchContentAsBlobUrl when flag is enabled', () => {
+        test('should use fetchContentAsBlobUrl', () => {
             const blobUrl = 'blob:http://localhost/abc-123';
-            jest.spyOn(media, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
             jest.spyOn(media, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
             jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
 
             return media.load().then(() => {
-                expect(media.featureEnabled).toHaveBeenCalledWith('migrateAccessTokenToHeader');
                 expect(media.createContentUrlV2).toHaveBeenCalledWith('www.box.com');
                 expect(media.fetchContentAsBlobUrl).toHaveBeenCalledWith('http://localhost/content');
                 expect(media.mediaEl.src).toBe(blobUrl);
@@ -1629,20 +1634,9 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
                 expect(media.mediaUrl).toBe(blobUrl);
             });
         });
-
-        test('should use createContentUrlWithAuthParams when flag is disabled', () => {
-            jest.spyOn(media, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(media, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=abc');
-            jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
-
-            return media.load().then(() => {
-                expect(media.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com');
-                expect(media.mediaEl.src).toBe('http://localhost/content?token=abc');
-            });
-        });
     });
 
-    describe('restartPlayback() with migrateAccessTokenToHeader', () => {
+    describe('restartPlayback() with header auth', () => {
         beforeEach(() => {
             media.mediaEl = document.createElement('video');
             media.mediaEl.currentTime = 10;
@@ -1656,13 +1650,12 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             };
         });
 
-        test('should revoke old blob URL and fetch new one when flag is enabled', () => {
+        test('should revoke old blob URL and fetch new one', () => {
             const oldBlobUrl = 'blob:http://localhost/old-123';
             const newBlobUrl = 'blob:http://localhost/new-456';
             media.mediaBlobUrl = oldBlobUrl;
 
             jest.spyOn(URL, 'revokeObjectURL');
-            jest.spyOn(media, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
             jest.spyOn(media, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(newBlobUrl));
 
@@ -1680,20 +1673,9 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
                 expect(media.mediaEl.src).toBe(newBlobUrl);
             });
         });
-
-        test('should use createContentUrlWithAuthParams when flag is disabled', () => {
-            jest.spyOn(media, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(media, 'createContentUrlWithAuthParams').mockReturnValue('http://localhost/content?token=new');
-
-            media.restartPlayback('new-token');
-
-            expect(media.options.token).toBe('new-token');
-            expect(media.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com');
-            expect(media.mediaEl.src).toBe('http://localhost/content?token=new');
-        });
     });
 
-    describe('destroy() with migrateAccessTokenToHeader', () => {
+    describe('destroy() with blob media URL', () => {
         test('should revoke mediaBlobUrl if it exists', () => {
             const blobUrl = 'blob:http://localhost/abc-123';
             media.mediaBlobUrl = blobUrl;

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -1539,7 +1539,8 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             };
             jest.spyOn(videoBase, 'getViewerOption').mockReturnValue(true);
             jest.spyOn(videoBase, 'isRepresentationReady').mockReturnValue(true);
-            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(
+            jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('https://example.com/preview.jpg');
+            jest.spyOn(videoBase, 'fetchContentAsBlobUrl').mockResolvedValue(
                 'https://example.com/preview.jpg?auth=token',
             );
         });
@@ -1586,11 +1587,13 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.showPreload();
 
             expect(videoBase.preloader).toBeInstanceOf(VideoPreloader);
-            expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
-                'https://example.com/preview.jpg?auth=token',
-                videoBase.mediaContainerEl,
-                expect.objectContaining({ onImageClick: expect.any(Function) }),
-            );
+            return videoBase.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
+                    'https://example.com/preview.jpg?auth=token',
+                    videoBase.mediaContainerEl,
+                    expect.objectContaining({ onImageClick: expect.any(Function) }),
+                );
+            });
         });
 
         test('should size the shared media frame when early paint is enabled', () => {
@@ -1606,18 +1609,20 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
             videoBase.showPreload();
 
-            expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
-                'https://example.com/preview.jpg?auth=token',
-                videoBase.mediaContainerEl,
-                expect.objectContaining({
-                    onImageClick: expect.any(Function),
-                    earlyPaint: true,
-                    getViewport: expect.any(Function),
-                }),
-            );
+            return videoBase.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
+                    'https://example.com/preview.jpg?auth=token',
+                    videoBase.mediaContainerEl,
+                    expect.objectContaining({
+                        onImageClick: expect.any(Function),
+                        earlyPaint: true,
+                        getViewport: expect.any(Function),
+                    }),
+                );
 
-            const { getViewport } = VideoPreloader.prototype.showPreload.mock.calls[0][2];
-            expect(getViewport()).toEqual({ height: 450, width: 800 });
+                const { getViewport } = VideoPreloader.prototype.showPreload.mock.calls[0][2];
+                expect(getViewport()).toEqual({ height: 450, width: 800 });
+            });
         });
 
         test('should preserve container sizing when V2 is disabled', () => {
@@ -1626,11 +1631,13 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
             videoBase.showPreload();
 
-            expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
-                'https://example.com/preview.jpg?auth=token',
-                videoBase.mediaContainerEl,
-                expect.not.objectContaining({ sizeWrapperToViewport: expect.anything() }),
-            );
+            return videoBase.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(VideoPreloader.prototype.showPreload).toBeCalledWith(
+                    'https://example.com/preview.jpg?auth=token',
+                    videoBase.mediaContainerEl,
+                    expect.not.objectContaining({ sizeWrapperToViewport: expect.anything() }),
+                );
+            });
         });
 
         test('should reuse existing VideoPreloader instance', () => {
@@ -1640,8 +1647,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
 
             videoBase.showPreload();
 
-            expect(videoBase.preloader).toBe(existingPreloader);
-            expect(VideoPreloader.prototype.showPreload).toBeCalled();
+            return videoBase.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                expect(videoBase.preloader).toBe(existingPreloader);
+                expect(VideoPreloader.prototype.showPreload).toBeCalled();
+            });
         });
 
         test('should call emitFirstRenderMetric when preloader emits preload', () => {
@@ -1649,9 +1658,10 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             jest.spyOn(videoBase, 'emitFirstRenderMetric').mockImplementation();
 
             videoBase.showPreload();
-            videoBase.preloader.emit('preload');
-
-            expect(videoBase.emitFirstRenderMetric).toBeCalled();
+            return videoBase.fetchContentAsBlobUrl.mock.results[0].value.then(() => {
+                videoBase.preloader.emit('preload');
+                expect(videoBase.emitFirstRenderMetric).toBeCalled();
+            });
         });
     });
 
@@ -1672,14 +1682,18 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                     ],
                 },
             };
-            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(jpgUrlWithAuth);
+            jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue(jpgUrlWithAuth);
+            jest.spyOn(videoBase, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
             jest.spyOn(videoBase, 'isRepresentationReady').mockReturnValue(true);
         });
 
         test('should fetch JPG preload image when preload is true and file has ready jpg rep', () => {
             videoBase.prefetch({ preload: true });
 
-            expect(videoBase.api.get).toHaveBeenCalledWith(jpgUrlWithAuth, { type: 'blob' });
+            expect(videoBase.api.get).toHaveBeenCalledWith(jpgUrlWithAuth, {
+                type: 'blob',
+                headers: { Authorization: 'Bearer token' },
+            });
         });
 
         test('should not fetch JPG when preload is false', () => {
@@ -1839,7 +1853,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
         });
     });
 
-    describe('showPreload() with migrateAccessTokenToHeader', () => {
+    describe('showPreload() with header auth', () => {
         beforeEach(() => {
             videoBase.options.file = {
                 id: 123,
@@ -1864,9 +1878,8 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             videoBase.wrapperEl.style.height = '600px';
         });
 
-        test('should fetch blob URL for poster image when flag is enabled', () => {
+        test('should fetch blob URL for poster image', () => {
             const blobUrl = 'blob:http://localhost/preload-123';
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('http://localhost/preload.jpg');
             jest.spyOn(videoBase, 'fetchContentAsBlobUrl').mockReturnValue(Promise.resolve(blobUrl));
             jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
@@ -1886,25 +1899,25 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             });
         });
 
-        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(
-                'http://localhost/preload.jpg?token=abc',
-            );
-            jest.spyOn(VideoPreloader.prototype, 'showPreload').mockResolvedValue();
+        test('should not fail the viewer if the poster fetch fails', () => {
+            jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('http://localhost/preload.jpg');
+            jest.spyOn(videoBase, 'fetchContentAsBlobUrl').mockReturnValue(Promise.reject(new Error('401')));
+            jest.spyOn(videoBase, 'handleAssetError');
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
             videoBase.showPreload();
 
-            expect(videoBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/preload.jpg');
-            expect(VideoPreloader.prototype.showPreload).toHaveBeenCalledWith(
-                'http://localhost/preload.jpg?token=abc',
-                videoBase.mediaContainerEl,
-                expect.any(Object),
-            );
+            return Promise.resolve()
+                .then(() => Promise.resolve())
+                .then(() => {
+                    expect(videoBase.handleAssetError).not.toHaveBeenCalled();
+                    expect(warnSpy).toHaveBeenCalledWith('Video preload failed', expect.any(Error));
+                    warnSpy.mockRestore();
+                });
         });
     });
 
-    describe('prefetch() with migrateAccessTokenToHeader', () => {
+    describe('prefetch() with header auth', () => {
         let mockApi;
 
         beforeEach(() => {
@@ -1930,8 +1943,7 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             jest.spyOn(videoBase, 'isRepresentationReady').mockReturnValue(true);
         });
 
-        test('should use createContentUrlV2 with auth headers when flag is enabled', () => {
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(true);
+        test('should use createContentUrlV2 with auth headers', () => {
             jest.spyOn(videoBase, 'createContentUrlV2').mockReturnValue('http://localhost/preload.jpg');
             jest.spyOn(videoBase, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token123' });
 
@@ -1944,21 +1956,9 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
                 headers: { Authorization: 'Bearer token123' },
             });
         });
-
-        test('should use createContentUrlV2WithAuthParams when flag is disabled', () => {
-            jest.spyOn(videoBase, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(videoBase, 'createContentUrlWithAuthParams').mockReturnValue(
-                'http://localhost/preload.jpg?token=abc',
-            );
-
-            videoBase.prefetch({ preload: true });
-
-            expect(videoBase.createContentUrlWithAuthParams).toHaveBeenCalledWith('www.box.com/preload.jpg');
-            expect(mockApi.get).toHaveBeenCalledWith('http://localhost/preload.jpg?token=abc', { type: 'blob' });
-        });
     });
 
-    describe('destroy() with migrateAccessTokenToHeader', () => {
+    describe('destroy() with header auth', () => {
         test('should revoke preloadBlobUrl if it exists', () => {
             const blobUrl = 'blob:http://localhost/preload-123';
             videoBase.preloadBlobUrl = blobUrl;

--- a/src/lib/viewers/office/OfficeViewer.js
+++ b/src/lib/viewers/office/OfficeViewer.js
@@ -165,7 +165,7 @@ class OfficeViewer extends BaseViewer {
 
         // This occurs in the case of .xlsb files where no pdf rep exists
         if (template) {
-            this.pdfUrl = this.createContentUrlWithAuthParams(template);
+            this.pdfUrl = this.createContentUrlV2(template);
         }
     }
 
@@ -335,7 +335,7 @@ class OfficeViewer extends BaseViewer {
      * @return {Promise} Promise setting print blob
      */
     fetchPrintBlob(pdfUrl) {
-        return this.api.get(pdfUrl, { type: 'blob' }).then(blob => {
+        return this.api.get(pdfUrl, { type: 'blob', headers: this.appendAuthHeader() }).then(blob => {
             this.printBlob = blob;
         });
     }

--- a/src/lib/viewers/office/__tests__/OfficeViewer-test.js
+++ b/src/lib/viewers/office/__tests__/OfficeViewer-test.js
@@ -470,11 +470,13 @@ describe('lib/viewers/office/OfficeViewer', () => {
 
         test('should get and return the blob', () => {
             office.api = api;
+            const mockHeaders = { Authorization: 'Bearer token' };
+            stubs.appendAuthHeader.mockReturnValue(mockHeaders);
 
             office.fetchPrintBlob('url');
 
             return stubs.promise.then(blob => {
-                expect(stubs.get).toBeCalled();
+                expect(stubs.get).toBeCalledWith('url', { type: 'blob', headers: mockHeaders });
                 expect(blob.blob).toBe('blob');
             });
         });
@@ -482,7 +484,7 @@ describe('lib/viewers/office/OfficeViewer', () => {
 
     describe('setupPDFUrl', () => {
         beforeEach(() => {
-            stubs.createContentUrl = jest.spyOn(office, 'createContentUrlWithAuthParams');
+            stubs.createContentUrl = jest.spyOn(office, 'createContentUrlV2');
         });
 
         test('should not attempt to set pdfUrl if no pdf rep exist', () => {

--- a/src/lib/viewers/swf/SWFViewer.js
+++ b/src/lib/viewers/swf/SWFViewer.js
@@ -54,25 +54,19 @@ class SWFViewer extends BaseViewer {
 
         this.startLoadTimer();
 
-        /* istanbul ignore next */
-        swfobject.embedSWF(
-            this.createContentUrlWithAuthParams(template),
-            this.playerEl.id,
-            '100%',
-            '100%',
-            '9',
-            null,
-            null,
-            SWF_PARAMS,
-            null,
-            () => {
-                if (this.isDestroyed()) {
-                    return;
-                }
-                this.loaded = true;
-                this.emit(VIEWER_EVENT.load);
-            },
-        );
+        const contentUrl = this.createContentUrlV2(template);
+        return this.fetchContentAsBlobUrl(contentUrl)
+            .then(blobUrl => {
+                /* istanbul ignore next */
+                swfobject.embedSWF(blobUrl, this.playerEl.id, '100%', '100%', '9', null, null, SWF_PARAMS, null, () => {
+                    if (this.isDestroyed()) {
+                        return;
+                    }
+                    this.loaded = true;
+                    this.emit(VIEWER_EVENT.load);
+                });
+            })
+            .catch(this.handleAssetError);
     };
 
     /**

--- a/src/lib/viewers/swf/__tests__/SWFViewer-test.js
+++ b/src/lib/viewers/swf/__tests__/SWFViewer-test.js
@@ -58,7 +58,7 @@ describe('lib/viewers/SWFViewer', () => {
             Object.defineProperty(BaseViewer.prototype, 'load', { value: sandbox.mock() });
 
             jest.spyOn(swf, 'loadAssets').mockResolvedValue(undefined);
-            jest.spyOn(swf, 'postLoad');
+            jest.spyOn(swf, 'postLoad').mockImplementation();
             jest.spyOn(swf, 'setup');
 
             return swf.load().then(() => {
@@ -72,6 +72,7 @@ describe('lib/viewers/SWFViewer', () => {
 
             jest.spyOn(swf, 'loadAssets').mockResolvedValue(undefined);
             jest.spyOn(swf, 'setup');
+            jest.spyOn(swf, 'fetchContentAsBlobUrl').mockResolvedValue('blob:swf');
 
             jest.spyOn(swf, 'startLoadTimer');
 
@@ -83,12 +84,12 @@ describe('lib/viewers/SWFViewer', () => {
 
     describe('postLoad()', () => {
         test('should call embedSWF', () => {
-            const contentUrl = 'someurl';
+            const blobUrl = 'blob:swf';
             sandbox
                 .mock(window.swfobject)
                 .expects('embedSWF')
                 .withArgs(
-                    contentUrl,
+                    blobUrl,
                     'flash-player',
                     '100%',
                     '100%',
@@ -107,9 +108,10 @@ describe('lib/viewers/SWFViewer', () => {
                     null,
                     sinon.match.func,
                 );
-            jest.spyOn(swf, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            jest.spyOn(swf, 'createContentUrlV2').mockReturnValue('contentUrl');
+            jest.spyOn(swf, 'fetchContentAsBlobUrl').mockResolvedValue(blobUrl);
 
-            swf.postLoad();
+            return swf.postLoad();
         });
     });
 

--- a/src/lib/viewers/text/CSVViewer.js
+++ b/src/lib/viewers/text/CSVViewer.js
@@ -82,16 +82,11 @@ class CSVViewer extends TextBaseViewer {
                     });
                 };
 
-                if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                    const contentUrl = this.createContentUrlV2(template);
-                    return this.fetchContentAsBlobUrl(contentUrl).then(blobUrl => {
-                        this.blobUrl = blobUrl;
-                        parseCSV(blobUrl);
-                    });
-                }
-
-                parseCSV(this.createContentUrlWithAuthParams(template));
-                return undefined;
+                const contentUrl = this.createContentUrlV2(template);
+                return this.fetchContentAsBlobUrl(contentUrl).then(blobUrl => {
+                    this.blobUrl = blobUrl;
+                    parseCSV(blobUrl);
+                });
             })
             .catch(this.handleAssetError);
     }
@@ -141,12 +136,8 @@ class CSVViewer extends TextBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                const contentUrl = this.createContentUrlV2(template);
-                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
-            } else {
-                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
-            }
+            const contentUrl = this.createContentUrlV2(template);
+            this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
         }
     }
 

--- a/src/lib/viewers/text/PlainTextViewer.js
+++ b/src/lib/viewers/text/PlainTextViewer.js
@@ -69,12 +69,8 @@ class PlainTextViewer extends TextBaseViewer {
         const { representation } = this.options;
         if (content && this.isRepresentationReady(representation)) {
             const template = representation.content.url_template;
-            if (this.featureEnabled('migrateAccessTokenToHeader')) {
-                const contentUrl = this.createContentUrlV2(template);
-                this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
-            } else {
-                this.api.get(this.createContentUrlWithAuthParams(template), { type: 'document' });
-            }
+            const contentUrl = this.createContentUrlV2(template);
+            this.api.get(contentUrl, { type: 'document', headers: this.appendAuthHeader() });
         }
     }
 
@@ -200,13 +196,8 @@ class PlainTextViewer extends TextBaseViewer {
         this.truncated = size > SIZE_LIMIT_BYTES;
         const headers = this.truncated ? { Range: `bytes=0-${SIZE_LIMIT_BYTES}` } : {};
 
-        let contentUrl;
-        if (this.featureEnabled('migrateAccessTokenToHeader')) {
-            contentUrl = this.createContentUrlV2(template);
-            Object.assign(headers, this.appendAuthHeader());
-        } else {
-            contentUrl = this.createContentUrlWithAuthParams(template);
-        }
+        const contentUrl = this.createContentUrlV2(template);
+        Object.assign(headers, this.appendAuthHeader());
         this.startLoadTimer();
         return this.api
             .get(contentUrl, { headers, type: 'text' })

--- a/src/lib/viewers/text/__tests__/CSVViewer-test.js
+++ b/src/lib/viewers/text/__tests__/CSVViewer-test.js
@@ -124,11 +124,13 @@ describe('lib/viewers/text/CSVViewer', () => {
             csv.options.sharedLink = 'sharedLink';
             csv.options.sharedLinkPassword = 'sharedLinkPassword';
 
-            const csvUrlWithAuth = `csvUrl/?access_token=token&shared_link=sharedLink&shared_link_password=sharedLinkPassword&box_client_name=${__NAME__}&box_client_version=${__VERSION__}`;
+            const blobUrl = 'blob:csv';
+            jest.spyOn(csv, 'createContentUrlV2').mockReturnValue('csvUrl');
+            jest.spyOn(csv, 'fetchContentAsBlobUrl').mockResolvedValue(blobUrl);
 
             return csv.load().then(() => {
                 expect(window.Papa.parse).toBeCalledWith(
-                    csvUrlWithAuth,
+                    blobUrl,
                     expect.objectContaining({
                         download: true,
                         error: expect.any(Function),
@@ -145,6 +147,8 @@ describe('lib/viewers/text/CSVViewer', () => {
             csv.options.token = 'token';
             csv.options.sharedLink = 'sharedLink';
             csv.options.sharedLinkPassword = 'sharedLinkPassword';
+            jest.spyOn(csv, 'createContentUrlV2').mockReturnValue('csvUrl');
+            jest.spyOn(csv, 'fetchContentAsBlobUrl').mockResolvedValue('blob:csv');
             jest.spyOn(csv, 'startLoadTimer');
 
             return csv.load().then(() => {
@@ -152,44 +156,20 @@ describe('lib/viewers/text/CSVViewer', () => {
             });
         });
 
-        test('should use fetchContentAsBlobUrl and pass blob URL to PapaParse when migrateAccessTokenToHeader flag is enabled', () => {
+        test('should use fetchContentAsBlobUrl and pass blob URL to PapaParse', () => {
             Object.defineProperty(TextBaseViewer.prototype, 'load', { value: jest.fn() });
             const contentUrl = 'someContentUrl';
             const blobUrl = 'blob:http://localhost/abc123';
 
-            jest.spyOn(csv, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(csv, 'createContentUrlV2').mockReturnValue(contentUrl);
             jest.spyOn(csv, 'fetchContentAsBlobUrl').mockResolvedValue(blobUrl);
 
             return csv.load().then(() => {
-                expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
                 expect(csv.createContentUrlV2).toBeCalled();
                 expect(csv.fetchContentAsBlobUrl).toBeCalledWith(contentUrl);
                 expect(csv.blobUrl).toBe(blobUrl);
                 expect(window.Papa.parse).toBeCalledWith(
                     blobUrl,
-                    expect.objectContaining({
-                        download: true,
-                        error: expect.any(Function),
-                        complete: expect.any(Function),
-                        worker: true,
-                    }),
-                );
-            });
-        });
-
-        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is disabled', () => {
-            Object.defineProperty(TextBaseViewer.prototype, 'load', { value: jest.fn() });
-            const contentUrlWithAuth = 'contentUrlWithAuth';
-
-            jest.spyOn(csv, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(csv, 'createContentUrlWithAuthParams').mockReturnValue(contentUrlWithAuth);
-
-            return csv.load().then(() => {
-                expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
-                expect(csv.createContentUrlWithAuthParams).toBeCalled();
-                expect(window.Papa.parse).toBeCalledWith(
-                    contentUrlWithAuth,
                     expect.objectContaining({
                         download: true,
                         error: expect.any(Function),
@@ -210,13 +190,15 @@ describe('lib/viewers/text/CSVViewer', () => {
 
         test('should prefetch content if content is true and representation is ready', () => {
             const contentUrl = 'someContentUrl';
-            jest.spyOn(csv, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            const headers = { Authorization: 'Bearer token' };
+            jest.spyOn(csv, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(csv, 'appendAuthHeader').mockReturnValue(headers);
             jest.spyOn(csv, 'isRepresentationReady').mockReturnValue(true);
             jest.spyOn(csv.api, 'get').mockResolvedValue(undefined);
 
             csv.prefetch({ assets: false, content: true });
 
-            expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document' });
+            expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document', headers });
         });
 
         test('should not prefetch content if content is true but representation is not ready', () => {
@@ -228,10 +210,9 @@ describe('lib/viewers/text/CSVViewer', () => {
             expect(csv.api.get).not.toBeCalled();
         });
 
-        test('should prefetch content with auth header when migrateAccessTokenToHeader flag is enabled', () => {
+        test('should prefetch content with Authorization headers', () => {
             const contentUrl = 'someContentUrl';
             const headers = { Authorization: 'Bearer token' };
-            jest.spyOn(csv, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(csv, 'createContentUrlV2').mockReturnValue(contentUrl);
             jest.spyOn(csv, 'appendAuthHeader').mockReturnValue(headers);
             jest.spyOn(csv, 'isRepresentationReady').mockReturnValue(true);
@@ -239,24 +220,9 @@ describe('lib/viewers/text/CSVViewer', () => {
 
             csv.prefetch({ assets: false, content: true });
 
-            expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
             expect(csv.createContentUrlV2).toBeCalled();
             expect(csv.appendAuthHeader).toBeCalled();
             expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document', headers });
-        });
-
-        test('should prefetch content with auth params when migrateAccessTokenToHeader flag is disabled', () => {
-            const contentUrl = 'someContentUrl';
-            jest.spyOn(csv, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(csv, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
-            jest.spyOn(csv, 'isRepresentationReady').mockReturnValue(true);
-            jest.spyOn(csv.api, 'get').mockResolvedValue(undefined);
-
-            csv.prefetch({ assets: false, content: true });
-
-            expect(csv.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
-            expect(csv.createContentUrlWithAuthParams).toBeCalled();
-            expect(csv.api.get).toBeCalledWith(contentUrl, { type: 'document' });
         });
     });
 

--- a/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
+++ b/src/lib/viewers/text/__tests__/PlainTextViewer-test.js
@@ -143,12 +143,14 @@ describe('lib/viewers/text/PlainTextViewer', () => {
 
         test('should prefetch content if content is true and representation is ready', () => {
             const contentUrl = 'someContentUrl';
-            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
+            const headers = { Authorization: 'Bearer token' };
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(headers);
             jest.spyOn(text, 'isRepresentationReady').mockReturnValue(true);
             sandbox
                 .mock(stubs.api)
                 .expects('get')
-                .withArgs(contentUrl, { type: 'document' });
+                .withArgs(contentUrl, { type: 'document', headers });
 
             text.prefetch({ assets: false, content: true });
         });
@@ -162,10 +164,9 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             text.prefetch({ assets: false, content: true });
         });
 
-        test('should prefetch content with auth header when migrateAccessTokenToHeader flag is enabled', () => {
+        test('should prefetch content with Authorization headers', () => {
             const contentUrl = 'someContentUrl';
             const headers = { Authorization: 'Bearer token' };
-            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
             jest.spyOn(text, 'appendAuthHeader').mockReturnValue(headers);
             jest.spyOn(text, 'isRepresentationReady').mockReturnValue(true);
@@ -176,25 +177,8 @@ describe('lib/viewers/text/PlainTextViewer', () => {
 
             text.prefetch({ assets: false, content: true });
 
-            expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
             expect(text.createContentUrlV2).toBeCalled();
             expect(text.appendAuthHeader).toBeCalled();
-        });
-
-        test('should prefetch content with auth params when migrateAccessTokenToHeader flag is disabled', () => {
-            const contentUrl = 'someContentUrl';
-            jest.spyOn(text, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
-            jest.spyOn(text, 'isRepresentationReady').mockReturnValue(true);
-            sandbox
-                .mock(stubs.api)
-                .expects('get')
-                .withArgs(contentUrl, { type: 'document' });
-
-            text.prefetch({ assets: false, content: true });
-
-            expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
-            expect(text.createContentUrlWithAuthParams).toBeCalled();
         });
     });
 
@@ -227,29 +211,33 @@ describe('lib/viewers/text/PlainTextViewer', () => {
     });
 
     describe('postLoad()', () => {
-        test('should fetch text representation with access token in query param if file is small enough', () => {
-            const urlWithAccessToken = 'blah';
+        test('should fetch text representation with Authorization headers if file is small enough', () => {
+            const contentUrl = 'blah';
+            const authHeaders = { Authorization: 'Bearer token' };
             const getPromise = Promise.resolve('');
             text.options.file.size = 196608 - 1; // 192KB - 1
 
             jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
-            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(urlWithAccessToken);
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
             text.postLoad();
 
             return getPromise.then(() => {
                 expect(text.truncated).toBe(false);
-                expect(stubs.api.get).toBeCalledWith(urlWithAccessToken, { headers: {}, type: 'text' });
+                expect(stubs.api.get).toBeCalledWith(contentUrl, { headers: authHeaders, type: 'text' });
             });
         });
 
         test('should fetch text representation with a byte range if file size is too large', () => {
             const getPromise = Promise.resolve('');
             const url = 'url';
-            const headersWithRange = { Range: 'bytes=0-196608' };
+            const authHeaders = { Authorization: 'Bearer token' };
+            const headersWithRange = { Range: 'bytes=0-196608', ...authHeaders };
             text.options.file.size = 196608 + 1; // 192KB + 1
 
             jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
-            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(url);
+            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(url);
+            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
 
             text.postLoad();
 
@@ -314,34 +302,12 @@ describe('lib/viewers/text/PlainTextViewer', () => {
             });
         });
 
-        test('should use createContentUrl and merge auth headers when migrateAccessTokenToHeader flag is enabled', () => {
-            const contentUrl = 'someContentUrl';
-            const authHeaders = { Authorization: 'Bearer token' };
-            const getPromise = Promise.resolve('content');
-            text.options.file.size = 196608 - 1; // Small file
-
-            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
-            jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
-            jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
-            jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
-
-            text.postLoad();
-
-            return getPromise.then(() => {
-                expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
-                expect(text.createContentUrlV2).toBeCalled();
-                expect(text.appendAuthHeader).toBeCalled();
-                expect(stubs.api.get).toBeCalledWith(contentUrl, { headers: authHeaders, type: 'text' });
-            });
-        });
-
-        test('should merge auth headers with Range header when file is truncated and migrateAccessTokenToHeader flag is enabled', () => {
+        test('should merge Authorization headers with Range header when file is truncated', () => {
             const contentUrl = 'someContentUrl';
             const authHeaders = { Authorization: 'Bearer token' };
             const getPromise = Promise.resolve('content');
             text.options.file.size = 196608 + 1; // Large file requiring truncation
 
-            jest.spyOn(text, 'featureEnabled').mockReturnValue(true);
             jest.spyOn(text, 'createContentUrlV2').mockReturnValue(contentUrl);
             jest.spyOn(text, 'appendAuthHeader').mockReturnValue(authHeaders);
             jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
@@ -354,24 +320,6 @@ describe('lib/viewers/text/PlainTextViewer', () => {
                     headers: { Range: 'bytes=0-196608', ...authHeaders },
                     type: 'text',
                 });
-            });
-        });
-
-        test('should use createContentUrlWithAuthParams when migrateAccessTokenToHeader flag is disabled', () => {
-            const contentUrl = 'someContentUrl';
-            const getPromise = Promise.resolve('content');
-            text.options.file.size = 196608 - 1; // Small file
-
-            jest.spyOn(text, 'featureEnabled').mockReturnValue(false);
-            jest.spyOn(text, 'createContentUrlWithAuthParams').mockReturnValue(contentUrl);
-            jest.spyOn(stubs.api, 'get').mockReturnValue(getPromise);
-
-            text.postLoad();
-
-            return getPromise.then(() => {
-                expect(text.featureEnabled).toBeCalledWith('migrateAccessTokenToHeader');
-                expect(text.createContentUrlWithAuthParams).toBeCalled();
-                expect(stubs.api.get).toBeCalledWith(contentUrl, { headers: {}, type: 'text' });
             });
         });
     });


### PR DESCRIPTION
## Summary

Representation requests now always send auth in the Authorization header. Viewers that cannot attach headers (images, video, SWF) fetch the content as a blob and load a blob URL.

## Why

Completes the Authorization-header rollout for representation requests across preview viewers.

## Test plan

- Open image, multi-page image, PDF, video, and text previews
- Confirm watermarked download still saves a file
- Confirm video poster and DASH playback still load
- CI unit tests
