### PR TITLE
fix(doc): dispatch thumbnailrendered on render settle

### DIFF
--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -292,12 +292,15 @@ class Thumbnail {
     }
 
     /**
-     * Releases a page's decoded resources (images, operator list) after a thumbnail render.
-     * PDF.js otherwise retains them until document destroy, ballooning memory as gallery and
-     * sidebar renders touch every page the user scrolls past. Dispatching thumbnailrendered
-     * hands the release to PDF.js's own handler, which skips pages still buffered by the
-     * document viewer (so the visible page keeps its resources) and defers cleanup of pages
-     * that are rendering elsewhere via its pending-cleanup flag.
+     * Notifies PDF.js that a thumbnail render has settled, mirroring PDF.js's own
+     * PDFThumbnailView: the PDFViewer's thumbnailrendered handler calls pdfPage.cleanup()
+     * for pages its buffer no longer holds, releasing their decoded resources. Buffered
+     * pages keep their resources, and cleanup of pages rendering elsewhere is deferred via
+     * PDF.js's pending-cleanup flag. No-ops for viewers without an event bus.
+     *
+     * This matters for content whose decoded data lives in the JS heap (e.g. image masks)
+     * and for viewers without OffscreenCanvas support; bitmap-backed images in Chrome are
+     * already released by PDF.js for thumbnail-only pages (see PREVIEW-1548 investigation).
      *
      * @param {PDFPageProxy|null} pdfPage - The PDF.js page proxy, or null if the page was never loaded
      * @return {void}

--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -283,8 +283,8 @@ class Thumbnail {
             .finally(() => {
                 canvas.width = 0;
                 canvas.height = 0;
-                this.releasePageResources(pdfPage);
                 this.renderTasks?.delete(task);
+                this.releasePageResources(pdfPage);
             });
 
         this.renderTasks.add(task);
@@ -294,14 +294,12 @@ class Thumbnail {
     /**
      * Releases a page's decoded resources (images, operator list) after a thumbnail render.
      * PDF.js otherwise retains them until document destroy, ballooning memory as gallery and
-     * sidebar renders touch every page the user scrolls past. Mirrors PDF.js's own
-     * post-thumbnail cleanup: pages cached by the document viewer are skipped so the visible
-     * page never loses resources the main view still needs. Older bundled PDF.js viewers that
-     * do not expose isPageCached are skipped conservatively. cleanup() refuses by returning
-     * false (it does not throw) while the page is rendering elsewhere; PDF.js then finishes
-     * the release itself after that render completes, via its pending-cleanup flag.
+     * sidebar renders touch every page the user scrolls past. Dispatching thumbnailrendered
+     * hands the release to PDF.js's own handler, which skips pages still buffered by the
+     * document viewer (so the visible page keeps its resources) and defers cleanup of pages
+     * that are rendering elsewhere via its pending-cleanup flag.
      *
-     * @param {Object|null} pdfPage - The PDF.js page proxy, or null if the render never started
+     * @param {PDFPageProxy|null} pdfPage - The PDF.js page proxy, or null if the page was never loaded
      * @return {void}
      */
     releasePageResources(pdfPage) {
@@ -309,12 +307,11 @@ class Thumbnail {
             return;
         }
 
-        const isPageCached = this.pdfViewer?.isPageCached;
-        if (typeof isPageCached !== 'function' || isPageCached.call(this.pdfViewer, pdfPage.pageNumber)) {
-            return;
-        }
-
-        pdfPage.cleanup();
+        this.pdfViewer?.eventBus?.dispatch('thumbnailrendered', {
+            source: this,
+            pageNumber: pdfPage.pageNumber,
+            pdfPage,
+        });
     }
 
     /**

--- a/src/lib/Thumbnail.js
+++ b/src/lib/Thumbnail.js
@@ -213,6 +213,7 @@ class Thumbnail {
         const canvas = document.createElement('canvas');
         let isCancelled = false;
         let pdfRenderTask = null;
+        let pdfPage = null;
         const task = {
             cancel: () => {
                 if (isCancelled) {
@@ -230,6 +231,7 @@ class Thumbnail {
                 if (isCancelled || !this.thumbnailImageCache) {
                     return null;
                 }
+                pdfPage = page;
 
                 const rotation = ((this.pdfViewer.pagesRotation || 0) + page.rotate) % 360;
                 const viewport = page.getViewport({ scale: 1, rotation });
@@ -281,11 +283,38 @@ class Thumbnail {
             .finally(() => {
                 canvas.width = 0;
                 canvas.height = 0;
+                this.releasePageResources(pdfPage);
                 this.renderTasks?.delete(task);
             });
 
         this.renderTasks.add(task);
         return task;
+    }
+
+    /**
+     * Releases a page's decoded resources (images, operator list) after a thumbnail render.
+     * PDF.js otherwise retains them until document destroy, ballooning memory as gallery and
+     * sidebar renders touch every page the user scrolls past. Mirrors PDF.js's own
+     * post-thumbnail cleanup: pages cached by the document viewer are skipped so the visible
+     * page never loses resources the main view still needs. Older bundled PDF.js viewers that
+     * do not expose isPageCached are skipped conservatively. cleanup() refuses by returning
+     * false (it does not throw) while the page is rendering elsewhere; PDF.js then finishes
+     * the release itself after that render completes, via its pending-cleanup flag.
+     *
+     * @param {Object|null} pdfPage - The PDF.js page proxy, or null if the render never started
+     * @return {void}
+     */
+    releasePageResources(pdfPage) {
+        if (!pdfPage) {
+            return;
+        }
+
+        const isPageCached = this.pdfViewer?.isPageCached;
+        if (typeof isPageCached !== 'function' || isPageCached.call(this.pdfViewer, pdfPage.pageNumber)) {
+            return;
+        }
+
+        pdfPage.cleanup();
     }
 
     /**

--- a/src/lib/__tests__/Thumbnail-test.js
+++ b/src/lib/__tests__/Thumbnail-test.js
@@ -13,12 +13,15 @@ describe('Thumbnail', () => {
     beforeEach(() => {
         stubs.getViewport = jest.fn();
         stubs.cancelRender = jest.fn();
+        stubs.cleanup = jest.fn();
         stubs.render = jest.fn(() => ({
             cancel: stubs.cancelRender,
             promise: Promise.resolve(),
         }));
         page = {
+            cleanup: stubs.cleanup,
             getViewport: stubs.getViewport,
+            pageNumber: 1,
             render: stubs.render,
             rotate: 0,
         };
@@ -28,6 +31,7 @@ describe('Thumbnail', () => {
             pdfDocument: {
                 getPage: stubs.getPage,
             },
+            isPageCached: jest.fn().mockReturnValue(false),
         };
         thumbnail = new Thumbnail(pdfViewer);
     });
@@ -398,6 +402,83 @@ describe('Thumbnail', () => {
             const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
             await expect(task.promise).resolves.toMatchObject({ width: 20 });
             expect(stubs.getPage).toHaveBeenCalled();
+        });
+
+        test('should release PDF.js page resources after a successful render', async () => {
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await task.promise;
+            expect(stubs.cleanup).toHaveBeenCalled();
+        });
+
+        test('should release PDF.js page resources after cancelling a render that had started', async () => {
+            let rejectRender;
+            stubs.render.mockReturnValue({
+                cancel: stubs.cancelRender,
+                promise: new Promise((resolve, reject) => {
+                    rejectRender = reject;
+                }),
+            });
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await pagePromise;
+            await Promise.resolve();
+            task.cancel();
+            rejectRender(new Error('Rendering cancelled'));
+
+            await expect(task.promise).resolves.toBeNull();
+            expect(stubs.cleanup).toHaveBeenCalled();
+        });
+
+        test('should not clean up a page whose render was cancelled before it started', async () => {
+            let resolvePage;
+            stubs.getPage.mockReturnValue(
+                new Promise(resolve => {
+                    resolvePage = resolve;
+                }),
+            );
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            task.cancel();
+            resolvePage(page);
+
+            await expect(task.promise).resolves.toBeNull();
+            expect(stubs.cleanup).not.toHaveBeenCalled();
+        });
+
+        test('should resolve and clear the task when PDF.js defers cleanup because the page is rendering elsewhere', async () => {
+            stubs.cleanup.mockReturnValue(false);
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await expect(task.promise).resolves.toMatchObject({ width: 20 });
+            expect(stubs.cleanup).toHaveBeenCalled();
+            expect(thumbnail.renderTasks.size).toBe(0);
+        });
+
+        test('should skip cleanup while the main viewer caches the page', async () => {
+            pdfViewer.isPageCached.mockReturnValue(true);
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await expect(task.promise).resolves.toMatchObject({ width: 20 });
+
+            expect(pdfViewer.isPageCached).toHaveBeenCalledWith(1);
+            expect(stubs.cleanup).not.toHaveBeenCalled();
+        });
+
+        test('should clean up a page the main viewer has evicted from its cache', async () => {
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await task.promise;
+
+            expect(pdfViewer.isPageCached).toHaveBeenCalledWith(1);
+            expect(stubs.cleanup).toHaveBeenCalled();
+        });
+
+        test('should skip cleanup when the bundled PDF.js viewer cannot report its page cache', async () => {
+            delete pdfViewer.isPageCached;
+
+            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
+            await task.promise;
+
+            expect(stubs.cleanup).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/__tests__/Thumbnail-test.js
+++ b/src/lib/__tests__/Thumbnail-test.js
@@ -13,13 +13,12 @@ describe('Thumbnail', () => {
     beforeEach(() => {
         stubs.getViewport = jest.fn();
         stubs.cancelRender = jest.fn();
-        stubs.cleanup = jest.fn();
+        stubs.dispatch = jest.fn();
         stubs.render = jest.fn(() => ({
             cancel: stubs.cancelRender,
             promise: Promise.resolve(),
         }));
         page = {
-            cleanup: stubs.cleanup,
             getViewport: stubs.getViewport,
             pageNumber: 1,
             render: stubs.render,
@@ -28,10 +27,12 @@ describe('Thumbnail', () => {
         pagePromise = Promise.resolve(page);
         stubs.getPage = jest.fn(() => pagePromise);
         pdfViewer = {
+            eventBus: {
+                dispatch: stubs.dispatch,
+            },
             pdfDocument: {
                 getPage: stubs.getPage,
             },
-            isPageCached: jest.fn().mockReturnValue(false),
         };
         thumbnail = new Thumbnail(pdfViewer);
     });
@@ -404,13 +405,18 @@ describe('Thumbnail', () => {
             expect(stubs.getPage).toHaveBeenCalled();
         });
 
-        test('should release PDF.js page resources after a successful render', async () => {
+        test('should dispatch thumbnailrendered to release page resources after a successful render', async () => {
             const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
             await task.promise;
-            expect(stubs.cleanup).toHaveBeenCalled();
+
+            expect(stubs.dispatch).toHaveBeenCalledWith('thumbnailrendered', {
+                source: thumbnail,
+                pageNumber: 1,
+                pdfPage: page,
+            });
         });
 
-        test('should release PDF.js page resources after cancelling a render that had started', async () => {
+        test('should dispatch thumbnailrendered after cancelling a render that had started', async () => {
             let rejectRender;
             stubs.render.mockReturnValue({
                 cancel: stubs.cancelRender,
@@ -426,10 +432,13 @@ describe('Thumbnail', () => {
             rejectRender(new Error('Rendering cancelled'));
 
             await expect(task.promise).resolves.toBeNull();
-            expect(stubs.cleanup).toHaveBeenCalled();
+            expect(stubs.dispatch).toHaveBeenCalledWith(
+                'thumbnailrendered',
+                expect.objectContaining({ pdfPage: page }),
+            );
         });
 
-        test('should not clean up a page whose render was cancelled before it started', async () => {
+        test('should not dispatch thumbnailrendered when the render was cancelled before the page was loaded', async () => {
             let resolvePage;
             stubs.getPage.mockReturnValue(
                 new Promise(resolve => {
@@ -442,43 +451,26 @@ describe('Thumbnail', () => {
             resolvePage(page);
 
             await expect(task.promise).resolves.toBeNull();
-            expect(stubs.cleanup).not.toHaveBeenCalled();
+            expect(stubs.dispatch).not.toHaveBeenCalled();
         });
 
-        test('should resolve and clear the task when PDF.js defers cleanup because the page is rendering elsewhere', async () => {
-            stubs.cleanup.mockReturnValue(false);
+        test('should clear the render task before releasing page resources', async () => {
+            stubs.dispatch.mockImplementation(() => {
+                expect(thumbnail.renderTasks.size).toBe(0);
+            });
 
             const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
             await expect(task.promise).resolves.toMatchObject({ width: 20 });
-            expect(stubs.cleanup).toHaveBeenCalled();
+
+            expect(stubs.dispatch).toHaveBeenCalled();
             expect(thumbnail.renderTasks.size).toBe(0);
         });
 
-        test('should skip cleanup while the main viewer caches the page', async () => {
-            pdfViewer.isPageCached.mockReturnValue(true);
+        test('should skip the release when the viewer exposes no event bus', async () => {
+            delete pdfViewer.eventBus;
 
             const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
             await expect(task.promise).resolves.toMatchObject({ width: 20 });
-
-            expect(pdfViewer.isPageCached).toHaveBeenCalledWith(1);
-            expect(stubs.cleanup).not.toHaveBeenCalled();
-        });
-
-        test('should clean up a page the main viewer has evicted from its cache', async () => {
-            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
-            await task.promise;
-
-            expect(pdfViewer.isPageCached).toHaveBeenCalledWith(1);
-            expect(stubs.cleanup).toHaveBeenCalled();
-        });
-
-        test('should skip cleanup when the bundled PDF.js viewer cannot report its page cache', async () => {
-            delete pdfViewer.isPageCached;
-
-            const task = thumbnail.renderPageImage(1, { thumbMaxWidth: 20 });
-            await task.promise;
-
-            expect(stubs.cleanup).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Summary

- `Thumbnail.renderPageImage` now dispatches the `thumbnailrendered` event on the viewer's event bus when a render settles (success, cancel-after-start, or failure), mirroring what PDF.js's own `PDFThumbnailView` does. `PDFViewer`'s built-in handler for this event checks its page buffer and calls `pdfPage.cleanup()` for pages the main view no longer holds, deferring via the pending-cleanup flag when the page is rendering elsewhere — so resource release is owned by the code that owns the buffer, and the visible page never loses resources the main view still needs.
- Viewers without an event bus (or bundles without the handler) skip the release conservatively via optional chaining.
- Split out of #1733 so this unflagged change can ship independently of the `galleryViewV2`-gated ARIA grid work.

## Scope: convention alignment, not a measured memory fix

This PR originally claimed to fix a ~217 MB → ~950 MB heap growth when gallery-scrolling large documents. A/B verification on devpod could not reproduce any memory difference vs master, and the claim has been withdrawn:

- Tested with a synthetic 180-page stress document (unique image per page, each ~7.3 MB decoded — under PDF.js's ~10 MB self-cleanup threshold, so engineered to maximize retention). Renderer footprint settled at ~1.2 GB on **both** this branch and master; JS heap stayed flat on both.
- `queryObjects(ImageBitmap)` on **unfixed master** after a full gallery scroll showed only 4 live decoded bitmaps — the bundled PDF.js (`pdfjs-dist` 4.3.136) decodes images to `ImageBitmap` in Chrome and already releases them for thumbnail-only pages.
- The large footprint on both branches is legitimate working memory: the document viewer's page buffer plus the gallery's own tile cache (PNG data URLs, up to 500 entries).

Remaining potential benefit is limited to content whose decoded data lives in the JS heap (e.g. image/soft masks) and viewers without OffscreenCanvas support. This was not reproduced; the change ships as low-risk alignment with PDF.js's resource-management contract.

## Why the event dispatch (review finding)

An earlier revision guarded `pdfPage.cleanup()` with `pdfViewer.isPageCached(pageNumber)`, but that method does not exist in the bundled PDF.js (`2.107.0`, built from `pdfjs-dist` 4.3.136) — it only survives in the stale vendored `2.84.0`–`2.100.0` bundles — so the cleanup never ran. (The same dead guard currently exists in #1733, introduced by an automated review suggestion; flagged there.) `PDFViewer`'s built-in `thumbnailrendered` handler is the supported replacement and is present in the shipped bundle.

## Test Plan

- [x] Unit tests assert the event-bus contract: dispatches `thumbnailrendered` with `source`/1-based `pageNumber`/`pdfPage` on success and after cancel-after-start; no dispatch when cancelled before the page loaded; render task cleared from `renderTasks` before the release; no-event-bus skip — `yarn jest Thumbnail` passes
- [x] eslint clean on changed files
- [x] A/B memory verification on devpod (180-page image-heavy stress doc, gallery zoom-scroll): no regression vs master; no flicker or blanking of the visible page
