### PR TITLE
chore(i18n): Replace mojito-rb-gen with props2es wrapper

### DIFF
--- a/build/buildI18n.js
+++ b/build/buildI18n.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const srcDir = path.resolve(__dirname, '../src/i18n');
+const outDir = path.join(srcDir, 'json');
+const props2es = require.resolve('@box/frontend/i18n/props2es.js');
+const exportPrefix = 'export default ';
+
+// props2es treats cwd/i18n/json as react-intl extract arrays, not locale maps.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-i18n-'));
+const tmpI18n = path.join(tmpRoot, 'i18n');
+
+try {
+    fs.mkdirSync(tmpI18n);
+
+    const propertyFiles = fs.readdirSync(srcDir).filter(file => file.endsWith('.properties'));
+    if (!propertyFiles.includes('en-US.properties')) {
+        throw new Error(`buildI18n: missing baseline ${path.join(srcDir, 'en-US.properties')}`);
+    }
+
+    propertyFiles.forEach(file => {
+        fs.copyFileSync(path.join(srcDir, file), path.join(tmpI18n, file));
+    });
+
+    const result = spawnSync(process.execPath, [props2es], { cwd: tmpRoot, stdio: 'inherit' });
+    if (result.error) {
+        throw result.error;
+    }
+    if (result.signal) {
+        throw new Error(`buildI18n: props2es killed by ${result.signal}`);
+    }
+    if (result.status !== 0) {
+        throw new Error(`buildI18n: props2es exited ${result.status}`);
+    }
+
+    const loadLocale = file => {
+        const text = fs.readFileSync(path.join(tmpI18n, file), 'utf8');
+        if (!text.startsWith(exportPrefix)) {
+            throw new Error(`buildI18n: unexpected props2es output in ${file}`);
+        }
+        return JSON.parse(text.slice(exportPrefix.length));
+    };
+
+    propertyFiles.forEach(file => {
+        const js = file.replace(/\.properties$/, '.js');
+        if (!fs.existsSync(path.join(tmpI18n, js))) {
+            throw new Error(`buildI18n: props2es did not write ${js}`);
+        }
+    });
+
+    const baseline = loadLocale('en-US.js');
+    fs.rmSync(outDir, { recursive: true, force: true });
+    fs.mkdirSync(outDir, { recursive: true });
+
+    propertyFiles.forEach(file => {
+        const locale = file.replace(/\.properties$/, '');
+        const merged = { ...baseline, ...loadLocale(`${locale}.js`) };
+        fs.writeFileSync(path.join(outDir, `${locale}.json`), JSON.stringify(merged));
+    });
+} finally {
+    try {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch (cleanupError) {
+        process.stderr.write(`buildI18n: failed to remove temp dir ${tmpRoot}\n${cleanupError}\n`);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,13 +21,8 @@
         "./pdf.worker.min.mjs": "./dist/lib/pdf.worker.min.mjs",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },
@@ -114,7 +109,6 @@
         "lodash": "^4.18.1",
         "mini-css-extract-plugin": "^2.10.2",
         "mock-local-storage": "^1.1.15",
-        "mojito-rb-gen": "^0.0.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.5.18",
         "postcss-loader": "^8.1.1",
@@ -149,7 +143,7 @@
         "build": "yarn setup && yarn clean && yarn build:i18n && yarn build:dev",
         "build:ci": "yarn setup && yarn webpack --progress --config build/webpack.config.js",
         "build:dev": "BABEL_ENV=dev NODE_ENV=dev yarn webpack --progress --config build/webpack.config.js",
-        "build:i18n": "mojito-rb-gen -s src/i18n -o src/i18n/json -b en-US.properties",
+        "build:i18n": "node build/buildI18n.js",
         "build:lib": "yarn build:i18n && yarn build:lib:js && yarn build:lib:verify && yarn build:lib:types",
         "build:lib:verify": "node build/verifyLibBundle.js",
         "build:lib:js": "BABEL_ENV=production NODE_ENV=production yarn webpack --config build/webpack.config.lib.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5340,14 +5340,6 @@ cli-truncate@^5.0.0:
     slice-ansi "^8.0.0"
     string-width "^8.2.0"
 
-cli@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.npmjs.org/cli/-/cli-0.9.0.tgz"
-  integrity sha512-V587MVWZ+D7FnaStjY+BZQdkfhTiMsjjN9Hgir1Rp85H7buVFNgIp2ZiPEG5a5fZ7sbX3+URnQ1vw47xV8eUjg==
-  dependencies:
-    exit "0.1.2"
-    glob "^5.0.10"
-
 client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
@@ -7266,7 +7258,7 @@ executable@^4.1.1:
   dependencies:
     pify "^2.2.0"
 
-exit@0.1.2, exit@^0.1.2:
+exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
@@ -7872,17 +7864,6 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-
-glob@^5.0.10:
-  version "5.0.15"
-  resolved "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-  integrity sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
@@ -9847,11 +9828,6 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==
-
 lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4, lodash@^4.18.1, lodash@^4.2.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
@@ -10138,11 +10114,6 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-merge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
@@ -10248,7 +10219,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
-"minimatch@2 || 3", minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
@@ -10282,13 +10253,6 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1:
-  version "0.5.6"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
 mock-local-storage@^1.1.15:
   version "1.1.24"
   resolved "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.1.24.tgz"
@@ -10301,17 +10265,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-mojito-rb-gen@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/mojito-rb-gen/-/mojito-rb-gen-0.0.1.tgz"
-  integrity sha512-Qi9WhsjBo9XS7HzyFgRCWminCJTiszd59KyaXVyxQtJOneSN/a+Zi9Bja0A7FN9Io+NjLLHZOPmxe5H8YVF3EQ==
-  dependencies:
-    cli "^0.9.0"
-    lodash "^3.10.1"
-    merge "^1.2.0"
-    mkdirp "^0.5.1"
-    properties "^1.2.1"
 
 moo-color@^1.0.2:
   version "1.0.3"
@@ -11437,11 +11390,6 @@ properties-parser@^0.3.1:
   integrity sha512-AkSQxQAviJ89x4FIxOyHGfO3uund0gvYo7lfD0E+Gp7gFQKrTNgtoYQklu8EhrfHVZUzTwKGZx2r/KDSfnljcA==
   dependencies:
     string.prototype.codepointat "^0.2.0"
-
-properties@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/properties/-/properties-1.2.1.tgz"
-  integrity sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
## Summary

- `yarn build:i18n` runs `@box/frontend` `props2es` in a temp `i18n` directory, then writes `src/i18n/json/{locale}.json` with an English merge for missing keys.
- Removes unmaintained `mojito-rb-gen`. Properties stay in `src/i18n`. Webpack, Jest, and `dist/{version}/{locale}/preview.js` are unchanged.

Related: #1740 is a local properties-to-JSON script without `props2es`.

## Why

`mojito-rb-gen` is unmaintained (npm 0.0.1). `props2es` is the shared converter, but it only reads repo-root `i18n/` and does not merge English unless extract JSON exists. The wrapper keeps our `src/i18n` layout and the `-b en-US.properties` fallback (needed for incomplete locales such as `en-x-pseudo`).

## Test plan

- [ ] `yarn build:i18n` writes 26 files under `src/i18n/json`; `en-US` and `en-x-pseudo` both have 228 keys
- [ ] `yarn test` (Jest `global.__` still reads `src/i18n/json/en-US.json`)
- [ ] `yarn start` / `yarn build:prod` still emit per-locale `preview.js`
- [ ] Travis `clean build:i18n build:ci test:ci`
