### PR TITLE
fix(video): keep V2 fullscreen button aligned when preview layout recenters

### DIFF
--- a/src/lib/viewers/controls/media/VideoFullscreenButton.tsx
+++ b/src/lib/viewers/controls/media/VideoFullscreenButton.tsx
@@ -33,8 +33,15 @@ export default function VideoFullscreenButton({ mediaEl, onFullscreenToggle }: P
 
         update();
 
+        // Watch both the video and the overlay parent. A sibling layout change
+        // (e.g. a host-page sidebar) can shrink the parent and re-center the
+        // video without changing the video element's box size, so observing
+        // mediaEl alone would leave the button at a stale `right` offset.
         const resizeObserver = new ResizeObserver(update);
         resizeObserver.observe(mediaEl);
+        if (ref.current?.offsetParent) {
+            resizeObserver.observe(ref.current.offsetParent);
+        }
         window.addEventListener('resize', update);
 
         return () => {

--- a/src/lib/viewers/controls/media/__tests__/VideoFullscreenButton-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/VideoFullscreenButton-test.tsx
@@ -99,12 +99,98 @@ describe('VideoFullscreenButton', () => {
     });
 
     describe('positioning', () => {
+        const rect = (overrides: Partial<DOMRect>): DOMRect =>
+            ({
+                x: 0,
+                y: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+                width: 0,
+                height: 0,
+                toJSON: () => ({}),
+                ...overrides,
+            } as DOMRect);
+
+        let observerCallback: () => void;
+
+        beforeEach(() => {
+            mockResizeObserver.mockImplementation((callback: () => void) => {
+                observerCallback = callback;
+                return {
+                    observe: jest.fn(),
+                    unobserve: jest.fn(),
+                    disconnect: jest.fn(),
+                };
+            });
+        });
+
+        const renderWithPositionedParent = () => {
+            const parent = document.createElement('div');
+            parent.style.position = 'relative';
+            document.body.appendChild(parent);
+
+            const view = render(<VideoFullscreenButton mediaEl={mediaEl} onFullscreenToggle={jest.fn()} />, {
+                container: parent,
+            });
+
+            return { parent, ...view };
+        };
+
         test('should observe the media element for resize', () => {
             renderComponent();
 
             expect(mockResizeObserver).toHaveBeenCalled();
             const observerInstance = mockResizeObserver.mock.results[0].value;
             expect(observerInstance.observe).toHaveBeenCalledWith(mediaEl);
+        });
+
+        test('should observe the overlay parent so layout changes recentering the video are tracked', () => {
+            const { parent } = renderWithPositionedParent();
+            const observerInstance = mockResizeObserver.mock.results[0].value;
+
+            expect(observerInstance.observe).toHaveBeenCalledWith(mediaEl);
+            expect(observerInstance.observe).toHaveBeenCalledWith(parent);
+
+            document.body.removeChild(parent);
+        });
+
+        test('should realign to the video when the parent resizes and the video is recentered', () => {
+            mediaEl.getBoundingClientRect = jest.fn(() =>
+                rect({ top: 100, right: 800, bottom: 500, left: 200, width: 600, height: 400 }),
+            );
+
+            const { parent } = renderWithPositionedParent();
+            parent.getBoundingClientRect = jest.fn(() =>
+                rect({ top: 0, right: 1000, bottom: 700, left: 0, width: 1000, height: 700 }),
+            );
+
+            act(() => {
+                observerCallback();
+            });
+
+            const button = screen.getByRole('button', { name: /fullscreen/i });
+            // top: 100 - 0 + 24, right: 1000 - 800 + 24
+            expect(button).toHaveStyle({ top: '124px', right: '224px' });
+
+            // Sidebar (300px) appears: parent shrinks from the right, centered video
+            // only shifts left by half that amount.
+            mediaEl.getBoundingClientRect = jest.fn(() =>
+                rect({ top: 100, right: 650, bottom: 500, left: 50, width: 600, height: 400 }),
+            );
+            parent.getBoundingClientRect = jest.fn(() =>
+                rect({ top: 0, right: 700, bottom: 700, left: 0, width: 700, height: 700 }),
+            );
+
+            act(() => {
+                observerCallback();
+            });
+
+            // top unchanged; right: 700 - 650 + 24 — still 24px from the video's right edge
+            expect(button).toHaveStyle({ top: '124px', right: '74px' });
+
+            document.body.removeChild(parent);
         });
 
         test('should disconnect observer on unmount', () => {


### PR DESCRIPTION
## Summary
- The V2 fullscreen button is absolutely positioned from a `getBoundingClientRect()` of the video vs its overlay parent. That measurement only reran when the `<video>` box or the window resized.
- A host-page sidebar (or any sibling that shrinks the preview) can re-center the video without changing the video element's size, so the button kept a stale `right` offset and drifted left by the full sidebar width.
- Observe the overlay `offsetParent` as well (same pattern as `VideoGuidesOverlay`) so parent layout changes recompute `top`/`right` and keep the button 24px inset from the video frame.

## Test plan
- [ ] Open a V2 video preview *before* the host-page sidebar finishes loading; confirm the fullscreen button starts on the video's top-right corner
- [ ] After the sidebar appears, confirm the button stays 24px inset from the video frame (does not drift left by the sidebar width)
- [ ] Repeat with a video that still fits the smaller viewport (size unchanged, only recentered) and with a large video that has to scale down
- [ ] Resize the preview pane without changing the browser window size and confirm the button stays aligned
- [ ] `yarn jest src/lib/viewers/controls/media/__tests__/VideoFullscreenButton-test.tsx --watchman=false`


Made with [Cursor](https://cursor.com)