### PR TITLE
feat(audio): add wavesurfer waveform view

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,14 @@
         "./pdf.worker.min.mjs": "./dist/lib/pdf.worker.min.mjs",
         "./package.json": "./package.json"
     },
-    "files": [
-        "dist/lib"
-    ],
-    "sideEffects": [
-        "*.css",
-        "*.scss"
-    ],
+    "files": ["dist/lib"],
+    "sideEffects": ["*.css", "*.scss"],
     "publishConfig": {
         "access": "public"
     },
     "dependencies": {
-        "pdfjs-dist": "4.3.136"
+        "pdfjs-dist": "4.3.136",
+        "wavesurfer.js": "7.12.11"
     },
     "peerDependencies": {
         "@box/blueprint-web": "^14.32.1",

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -1,0 +1,72 @@
+@import '../../../boxuiVariables';
+
+.bp-WaveformView {
+    box-sizing: border-box;
+    width: 100%;
+    height: 206px;
+    min-height: 206px;
+    padding: 0 40px;
+    overflow: visible;
+    background: none;
+}
+
+.bp-WaveformView-track {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+}
+
+.bp-WaveformView-canvas {
+    z-index: 0;
+    width: 100%;
+    height: 140px;
+}
+
+.bp-WaveformView-playhead {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: 1;
+    width: 2px;
+    height: 150px;
+    pointer-events: none;
+    background: linear-gradient(#2487ff, #006bed);
+
+    // Spread stroke instead of border: border-box on .bp-container * would collapse the 2px fill.
+    box-shadow: 0 0 0 1px #222, 0 0 10px 0 rgb(36 135 255 / 30%);
+    transform: translate(-50%, -50%);
+}
+
+.bp-WaveformView-hover {
+    position: absolute;
+    top: 100%;
+    z-index: 2;
+    margin-top: 4px;
+    pointer-events: none;
+    transform: translateX(-50%);
+}
+
+.bp-WaveformView-hoverTime {
+    padding: 4px 10px;
+    color: $white;
+    font-weight: normal;
+    font-size: 14px;
+    font-family: Lato, Arial, sans-serif;
+    line-height: 20px;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    background: rgb(34 34 34 / 92%);
+    border: 1px solid rgb(255 255 255 / 18%);
+    border-radius: 8px;
+}
+
+.bp-WaveformView--inert {
+    pointer-events: none;
+
+    .bp-WaveformView-track {
+        cursor: default;
+    }
+}

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -1,0 +1,320 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import WaveSurfer from 'wavesurfer.js';
+import {
+    getBufferedProgress,
+    getWaveformFills,
+    toCanvasFill,
+    WAVEFORM_COLOR_PLAYED,
+    WAVEFORM_COLOR_UNPLAYED,
+} from './colors';
+import { formatTime, morphPeaks, toChannels, WAVEFORM_PEAK_TRANSITION_MS } from './peaks';
+import './WaveformView.scss';
+
+export type WaveformViewProps = {
+    bufferedRange?: TimeRanges;
+    currentTime?: number;
+    durationSec: number;
+    height?: number;
+    interactive?: boolean;
+    mediaEl?: HTMLMediaElement | null;
+    onSeek?: (timeSec: number) => void;
+    peaks: ArrayLike<number>;
+};
+
+export const WAVEFORM_BAR_GAP = 2;
+export const WAVEFORM_BAR_WIDTH = 2;
+export const WAVEFORM_BAR_RADIUS = WAVEFORM_BAR_WIDTH / 2;
+/** Total bar height so the top and bottom radii meet as a circle on the mirror. */
+export const WAVEFORM_BAR_MIN_HEIGHT = WAVEFORM_BAR_WIDTH;
+export const WAVEFORM_HEIGHT = 140;
+
+function leftPercent(timeSec: number, durationSec: number): string {
+    const progress = durationSec > 0 ? Math.min(1, Math.max(0, timeSec / durationSec)) : 0;
+    return `${progress * 100}%`;
+}
+
+function fillWidth(container: HTMLElement | null): number {
+    const width = container ? container.clientWidth : 0;
+    const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    return width * pixelRatio;
+}
+
+type WaveSurferRenderer = {
+    render?: (data: unknown) => void;
+};
+
+function applyPeaks(wavesurfer: WaveSurfer, peaks: ArrayLike<number>, durationSec: number): void {
+    const channelData = toChannels(peaks);
+    if (wavesurfer.setOptions) {
+        wavesurfer.setOptions({
+            duration: durationSec,
+            peaks: channelData,
+        });
+    }
+
+    const decoded = wavesurfer.getDecodedData ? wavesurfer.getDecodedData() : null;
+    // Private wavesurfer renderer (7.12.11): force a redraw after setOptions(peaks).
+    const { renderer } = (wavesurfer as unknown) as { renderer?: WaveSurferRenderer };
+    if (decoded && renderer && renderer.render) {
+        renderer.render(decoded);
+        return;
+    }
+
+    if (wavesurfer.load) {
+        wavesurfer.load('', channelData, durationSec);
+    }
+}
+
+/**
+ * Renders V1 peaks with wavesurfer. Does not fetch audio or attach a media element.
+ */
+export default function WaveformView({
+    bufferedRange,
+    currentTime = 0,
+    durationSec,
+    height = WAVEFORM_HEIGHT,
+    interactive = true,
+    mediaEl,
+    onSeek,
+    peaks,
+}: WaveformViewProps): JSX.Element {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const playheadRef = useRef<HTMLDivElement>(null);
+    const playheadRafRef = useRef(0);
+    const wavesurferRef = useRef<WaveSurfer | null>(null);
+    const onSeekRef = useRef(onSeek);
+    const interactiveRef = useRef(interactive);
+    const currentTimeRef = useRef(currentTime);
+    const peaksRef = useRef(peaks);
+    const displayedPeaksRef = useRef<ArrayLike<number> | null>(null);
+    const peakTransitionRafRef = useRef(0);
+    const durationSecRef = useRef(durationSec);
+    onSeekRef.current = onSeek;
+    interactiveRef.current = interactive;
+    currentTimeRef.current = currentTime;
+    peaksRef.current = peaks;
+    durationSecRef.current = durationSec;
+
+    const [hoverProgress, setHoverProgress] = useState<number | null>(null);
+    const bufferProgress = getBufferedProgress(bufferedRange, durationSec);
+
+    const updatePlayheadPosition = useCallback((timeSec: number): void => {
+        const playhead = playheadRef.current;
+        if (!playhead) {
+            return;
+        }
+
+        playhead.style.left = leftPercent(timeSec, durationSecRef.current);
+
+        const wavesurfer = wavesurferRef.current;
+        if (wavesurfer && wavesurfer.setTime) {
+            wavesurfer.setTime(timeSec);
+        }
+    }, []);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) {
+            return undefined;
+        }
+
+        const wavesurfer = WaveSurfer.create({
+            autoScroll: false,
+            barGap: WAVEFORM_BAR_GAP,
+            barMinHeight: WAVEFORM_BAR_MIN_HEIGHT,
+            barRadius: WAVEFORM_BAR_RADIUS,
+            barWidth: WAVEFORM_BAR_WIDTH,
+            container,
+            cursorWidth: 0,
+            duration: durationSecRef.current,
+            fillParent: true,
+            height,
+            hideScrollbar: true,
+            interact: interactiveRef.current,
+            normalize: false,
+            peaks: toChannels(peaksRef.current),
+            progressColor: WAVEFORM_COLOR_PLAYED,
+            waveColor: WAVEFORM_COLOR_UNPLAYED,
+        });
+
+        const unsubscribeClick = wavesurfer.on('click', (relativeX: number) => {
+            if (!interactiveRef.current) {
+                return;
+            }
+            onSeekRef.current?.(relativeX * durationSecRef.current);
+        });
+
+        wavesurferRef.current = wavesurfer;
+        displayedPeaksRef.current = peaksRef.current;
+
+        return () => {
+            window.cancelAnimationFrame(peakTransitionRafRef.current);
+            unsubscribeClick();
+            wavesurfer.destroy();
+            wavesurferRef.current = null;
+            displayedPeaksRef.current = null;
+        };
+    }, [height]);
+
+    useEffect(() => {
+        const wavesurfer = wavesurferRef.current;
+        if (!wavesurfer || !wavesurfer.setOptions) {
+            return;
+        }
+        wavesurfer.setOptions({ interact: interactive });
+    }, [interactive]);
+
+    useLayoutEffect(() => {
+        if (mediaEl && !mediaEl.paused) {
+            updatePlayheadPosition(mediaEl.currentTime);
+            return;
+        }
+        updatePlayheadPosition(currentTime);
+    }, [currentTime, durationSec, mediaEl, updatePlayheadPosition]);
+
+    useEffect(() => {
+        const media = mediaEl;
+        if (!media) {
+            return undefined;
+        }
+
+        const tick = (): void => {
+            if (!media.paused) {
+                updatePlayheadPosition(media.currentTime);
+            }
+            playheadRafRef.current = window.requestAnimationFrame(tick);
+        };
+
+        const startLoop = (): void => {
+            window.cancelAnimationFrame(playheadRafRef.current);
+            playheadRafRef.current = window.requestAnimationFrame(tick);
+        };
+
+        const stopLoop = (): void => {
+            window.cancelAnimationFrame(playheadRafRef.current);
+            updatePlayheadPosition(media.currentTime);
+        };
+
+        const handleSeeked = (): void => {
+            updatePlayheadPosition(media.currentTime);
+        };
+
+        if (!media.paused) {
+            startLoop();
+        }
+
+        media.addEventListener('play', startLoop);
+        media.addEventListener('pause', stopLoop);
+        media.addEventListener('seeked', handleSeeked);
+
+        return () => {
+            window.cancelAnimationFrame(playheadRafRef.current);
+            media.removeEventListener('play', startLoop);
+            media.removeEventListener('pause', stopLoop);
+            media.removeEventListener('seeked', handleSeeked);
+        };
+    }, [mediaEl, updatePlayheadPosition]);
+
+    useEffect(() => {
+        const wavesurfer = wavesurferRef.current;
+        if (!wavesurfer || !wavesurfer.setOptions || !(durationSec > 0)) {
+            return undefined;
+        }
+
+        const fromPeaks = displayedPeaksRef.current;
+        const reduceMotion =
+            typeof window !== 'undefined' &&
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        window.cancelAnimationFrame(peakTransitionRafRef.current);
+
+        if (!fromPeaks || fromPeaks === peaks || reduceMotion) {
+            displayedPeaksRef.current = peaks;
+            applyPeaks(wavesurfer, peaks, durationSec);
+            return undefined;
+        }
+
+        const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const tick = (now: number): void => {
+            const elapsedMs = now - start;
+            const framePeaks = morphPeaks(fromPeaks, peaks, elapsedMs);
+            displayedPeaksRef.current = framePeaks;
+            applyPeaks(wavesurfer, framePeaks, durationSec);
+            if (elapsedMs < WAVEFORM_PEAK_TRANSITION_MS) {
+                peakTransitionRafRef.current = window.requestAnimationFrame(tick);
+            } else {
+                displayedPeaksRef.current = peaks;
+            }
+        };
+        peakTransitionRafRef.current = window.requestAnimationFrame(tick);
+
+        return () => window.cancelAnimationFrame(peakTransitionRafRef.current);
+    }, [durationSec, peaks]);
+
+    useEffect(() => {
+        const wavesurfer = wavesurferRef.current;
+        if (!wavesurfer || !wavesurfer.setOptions) {
+            return;
+        }
+
+        const fills = getWaveformFills({ bufferProgress, hoverProgress });
+        wavesurfer.setOptions({
+            progressColor: toCanvasFill(fills.progressColor, fillWidth(containerRef.current)),
+            waveColor: toCanvasFill(fills.waveColor, fillWidth(containerRef.current)),
+        });
+        wavesurfer.setTime(currentTimeRef.current);
+    }, [bufferProgress, hoverProgress]);
+
+    const onHoverMove = useCallback(
+        (event: React.MouseEvent<HTMLDivElement>) => {
+            if (!interactive) {
+                return;
+            }
+            const rect = event.currentTarget.getBoundingClientRect();
+            if (!(rect.width > 0) || !(durationSec > 0)) {
+                return;
+            }
+            const x = event.clientX - rect.left;
+            if (!Number.isFinite(x)) {
+                return;
+            }
+            setHoverProgress(Math.min(1, Math.max(0, x / rect.width)));
+        },
+        [durationSec, interactive],
+    );
+
+    const onHoverLeave = useCallback(() => {
+        setHoverProgress(null);
+    }, []);
+
+    const hoverLeft = hoverProgress == null ? null : `${hoverProgress * 100}%`;
+
+    return (
+        <div
+            className={`bp-WaveformView${interactive ? '' : ' bp-WaveformView--inert'}`}
+            data-testid="bp-waveform-view"
+        >
+            <div
+                className="bp-WaveformView-track"
+                onMouseLeave={interactive ? onHoverLeave : undefined}
+                onMouseMove={interactive ? onHoverMove : undefined}
+            >
+                <div ref={containerRef} className="bp-WaveformView-canvas" />
+                <div
+                    ref={playheadRef}
+                    aria-hidden="true"
+                    className="bp-WaveformView-playhead"
+                    data-testid="bp-waveform-playhead"
+                />
+                {hoverLeft != null && hoverProgress != null && (
+                    <div className="bp-WaveformView-hover" data-testid="bp-waveform-hover" style={{ left: hoverLeft }}>
+                        <div className="bp-WaveformView-hoverTime" data-testid="bp-waveform-hover-time">
+                            {formatTime(hoverProgress * durationSec)}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -33,36 +33,16 @@ function leftPercent(timeSec: number, durationSec: number): string {
     return `${progress * 100}%`;
 }
 
-function fillWidth(container: HTMLElement | null): number {
-    const width = container ? container.clientWidth : 0;
+function fillWidth(widthCssPx: number): number {
     const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
-    return width * pixelRatio;
+    return widthCssPx * pixelRatio;
 }
 
-type WaveSurferRenderer = {
-    render?: (data: unknown) => void;
-};
-
 function applyPeaks(wavesurfer: WaveSurfer, peaks: ArrayLike<number>, durationSec: number): void {
-    const channelData = toChannels(peaks);
-    if (wavesurfer.setOptions) {
-        wavesurfer.setOptions({
-            duration: durationSec,
-            peaks: channelData,
-        });
-    }
-
-    const decoded = wavesurfer.getDecodedData ? wavesurfer.getDecodedData() : null;
-    // Private wavesurfer renderer (7.12.11): force a redraw after setOptions(peaks).
-    const { renderer } = (wavesurfer as unknown) as { renderer?: WaveSurferRenderer };
-    if (decoded && renderer && renderer.render) {
-        renderer.render(decoded);
+    if (!wavesurfer.load) {
         return;
     }
-
-    if (wavesurfer.load) {
-        wavesurfer.load('', channelData, durationSec);
-    }
+    wavesurfer.load('', toChannels(peaks), durationSec);
 }
 
 /**
@@ -96,6 +76,7 @@ export default function WaveformView({
     durationSecRef.current = durationSec;
 
     const [hoverProgress, setHoverProgress] = useState<number | null>(null);
+    const [canvasWidthPx, setCanvasWidthPx] = useState(0);
     const bufferProgress = getBufferedProgress(bufferedRange, durationSec);
 
     const updatePlayheadPosition = useCallback((timeSec: number): void => {
@@ -155,6 +136,23 @@ export default function WaveformView({
             displayedPeaksRef.current = null;
         };
     }, [height]);
+
+    useLayoutEffect(() => {
+        const el = containerRef.current;
+        if (!el) {
+            return undefined;
+        }
+
+        setCanvasWidthPx(el.clientWidth);
+
+        const observer = new ResizeObserver(entries => {
+            entries.forEach(entry => {
+                setCanvasWidthPx(entry.contentRect.width);
+            });
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
 
     useEffect(() => {
         const wavesurfer = wavesurferRef.current;
@@ -260,11 +258,11 @@ export default function WaveformView({
 
         const fills = getWaveformFills({ bufferProgress, hoverProgress });
         wavesurfer.setOptions({
-            progressColor: toCanvasFill(fills.progressColor, fillWidth(containerRef.current)),
-            waveColor: toCanvasFill(fills.waveColor, fillWidth(containerRef.current)),
+            progressColor: toCanvasFill(fills.progressColor, fillWidth(canvasWidthPx)),
+            waveColor: toCanvasFill(fills.waveColor, fillWidth(canvasWidthPx)),
         });
         wavesurfer.setTime(currentTimeRef.current);
-    }, [bufferProgress, hoverProgress]);
+    }, [bufferProgress, canvasWidthPx, hoverProgress]);
 
     const onHoverMove = useCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import WaveSurfer from 'wavesurfer.js';
+import WaveformView, {
+    WAVEFORM_BAR_GAP,
+    WAVEFORM_BAR_RADIUS,
+    WAVEFORM_BAR_WIDTH,
+    WAVEFORM_HEIGHT,
+} from '../WaveformView';
+import { WAVEFORM_COLOR_PLAYED, WAVEFORM_COLOR_UNPLAYED } from '../colors';
+
+const mockDestroy = jest.fn();
+const mockSetOptions = jest.fn();
+const mockSetTime = jest.fn();
+const mockRender = jest.fn();
+const mockGetDecodedData = jest.fn(() => ({ duration: 8 }));
+const mockOn = jest.fn(() => jest.fn());
+
+jest.mock('wavesurfer.js', () => ({
+    __esModule: true,
+    default: {
+        create: jest.fn(() => ({
+            destroy: mockDestroy,
+            getDecodedData: mockGetDecodedData,
+            on: mockOn,
+            renderer: {
+                render: mockRender,
+            },
+            setOptions: mockSetOptions,
+            setTime: mockSetTime,
+        })),
+    },
+}));
+
+describe('WaveformView', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should mount a wavesurfer instance from peaks without a media url', () => {
+        render(<WaveformView durationSec={8} peaks={[0.2, 0.8, 0.1]} />);
+
+        expect(screen.getByTestId('bp-waveform-view')).toBeInTheDocument();
+        expect(WaveSurfer.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                barGap: WAVEFORM_BAR_GAP,
+                barRadius: WAVEFORM_BAR_RADIUS,
+                barWidth: WAVEFORM_BAR_WIDTH,
+                duration: 8,
+                height: WAVEFORM_HEIGHT,
+                peaks: [
+                    [0.2, 0.8, 0.1],
+                    [0.2, 0.8, 0.1],
+                ],
+                progressColor: WAVEFORM_COLOR_PLAYED,
+                waveColor: WAVEFORM_COLOR_UNPLAYED,
+            }),
+        );
+        const options = (WaveSurfer.create as jest.Mock).mock.calls[0][0];
+        expect(options.url).toBeUndefined();
+        expect(options.media).toBeUndefined();
+        expect(options.barAlign).toBeUndefined();
+        expect(options.cursorWidth).toBe(0);
+        expect(screen.getByTestId('bp-waveform-playhead')).toHaveStyle({ left: '0%' });
+    });
+
+    test('should position the playhead from current time', () => {
+        render(<WaveformView currentTime={2} durationSec={8} peaks={[0.2, 0.8]} />);
+
+        expect(screen.getByTestId('bp-waveform-playhead')).toHaveStyle({ left: '25%' });
+    });
+
+    test('should keep smoothing the playhead after a seek while playing', () => {
+        const mediaEl = document.createElement('audio');
+        Object.defineProperty(mediaEl, 'paused', { configurable: true, value: false });
+        Object.defineProperty(mediaEl, 'currentTime', { configurable: true, value: 1, writable: true });
+
+        const rafCallbacks: FrameRequestCallback[] = [];
+        const cancelRaf = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(jest.fn());
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+            rafCallbacks.push(cb);
+            return rafCallbacks.length;
+        });
+
+        render(<WaveformView currentTime={1} durationSec={8} mediaEl={mediaEl} peaks={[0.2, 0.8]} />);
+
+        cancelRaf.mockClear();
+        mockSetTime.mockClear();
+
+        mediaEl.currentTime = 4;
+        mediaEl.dispatchEvent(new Event('seeked'));
+
+        expect(cancelRaf).not.toHaveBeenCalled();
+        expect(mockSetTime).toHaveBeenCalledWith(4);
+    });
+
+    test('should apply hover fills and show a time chip while the pointer is over the track', () => {
+        render(<WaveformView durationSec={8} peaks={[0.2, 0.8]} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.mouseMove(track, { clientX: 50 });
+
+        expect(screen.getByTestId('bp-waveform-hover-time')).toHaveTextContent('0:02.00');
+        expect(screen.getByTestId('bp-waveform-hover')).toHaveStyle({ left: '25%' });
+    });
+
+    test('should hide the hover time when the pointer leaves', () => {
+        render(<WaveformView durationSec={8} peaks={[0.2, 0.8]} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.mouseMove(track, { clientX: 50 });
+        expect(screen.getByTestId('bp-waveform-hover-time')).toBeInTheDocument();
+
+        fireEvent.mouseLeave(track);
+        expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
+    });
+
+    test('should ignore hover and clicks while inert', () => {
+        render(<WaveformView durationSec={8} interactive={false} peaks={[0.2, 0.8]} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.mouseMove(track, { clientX: 50 });
+
+        expect(screen.getByTestId('bp-waveform-view')).toHaveClass('bp-WaveformView--inert');
+        expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
+        expect(WaveSurfer.create).toHaveBeenCalledWith(expect.objectContaining({ interact: false }));
+    });
+
+    test('should keep the wavesurfer instance when duration changes from the placeholder', () => {
+        const peaks = [0.2, 0.8];
+        const { rerender } = render(<WaveformView durationSec={1} peaks={peaks} />);
+
+        expect(WaveSurfer.create).toHaveBeenCalledTimes(1);
+
+        rerender(<WaveformView durationSec={8} peaks={peaks} />);
+
+        expect(WaveSurfer.create).toHaveBeenCalledTimes(1);
+        expect(mockDestroy).not.toHaveBeenCalled();
+        expect(mockSetOptions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                duration: 8,
+                peaks: [
+                    [0.2, 0.8],
+                    [0.2, 0.8],
+                ],
+            }),
+        );
+    });
+
+    test('should keep playhead left when playback smoothing starts', () => {
+        const mediaEl = document.createElement('audio');
+        Object.defineProperty(mediaEl, 'paused', { configurable: true, value: true, writable: true });
+        Object.defineProperty(mediaEl, 'currentTime', { configurable: true, value: 2, writable: true });
+
+        render(<WaveformView currentTime={2} durationSec={8} mediaEl={mediaEl} peaks={[0.2, 0.8]} />);
+        const playhead = screen.getByTestId('bp-waveform-playhead');
+        expect(playhead).toHaveStyle({ left: '25%' });
+
+        Object.defineProperty(mediaEl, 'paused', { configurable: true, value: false });
+        mediaEl.dispatchEvent(new Event('play'));
+
+        expect(playhead).toHaveStyle({ left: '25%' });
+    });
+
+    test('should morph peaks without remounting wavesurfer', () => {
+        const frames: FrameRequestCallback[] = [];
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+            frames.push(cb);
+            return frames.length;
+        });
+        jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(jest.fn());
+        jest.spyOn(performance, 'now').mockReturnValue(0);
+
+        const placeholder = [0.05, 0.05];
+        const decoded = [0.2, 0.8];
+        const { rerender } = render(<WaveformView durationSec={8} peaks={placeholder} />);
+
+        expect(WaveSurfer.create).toHaveBeenCalledTimes(1);
+
+        rerender(<WaveformView durationSec={8} peaks={decoded} />);
+
+        expect(WaveSurfer.create).toHaveBeenCalledTimes(1);
+        expect(frames.length).toBeGreaterThan(0);
+
+        frames[0](800);
+
+        const peakUpdate = mockSetOptions.mock.calls
+            .map(call => call[0])
+            .reverse()
+            .find(options => options && options.peaks);
+        expect(peakUpdate.duration).toBe(8);
+        expect(peakUpdate.peaks[0][0]).toBeCloseTo(0.2);
+        expect(peakUpdate.peaks[0][1]).toBeCloseTo(0.8);
+        expect(mockRender).toHaveBeenCalled();
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import WaveSurfer from 'wavesurfer.js';
 import WaveformView, {
     WAVEFORM_BAR_GAP,
@@ -10,22 +10,38 @@ import WaveformView, {
 import { WAVEFORM_COLOR_PLAYED, WAVEFORM_COLOR_UNPLAYED } from '../colors';
 
 const mockDestroy = jest.fn();
+const mockLoad = jest.fn();
 const mockSetOptions = jest.fn();
 const mockSetTime = jest.fn();
-const mockRender = jest.fn();
-const mockGetDecodedData = jest.fn(() => ({ duration: 8 }));
-const mockOn = jest.fn(() => jest.fn());
+const mockObserve = jest.fn();
+const mockDisconnect = jest.fn();
+let clickHandler: ((relativeX: number) => void) | undefined;
+let resizeCallback: ResizeObserverCallback | undefined;
+
+const mockOn = jest.fn((event: string, handler: (relativeX: number) => void) => {
+    if (event === 'click') {
+        clickHandler = handler;
+    }
+    return jest.fn();
+});
+
+const mockResizeObserver = jest.fn().mockImplementation((callback: ResizeObserverCallback) => {
+    resizeCallback = callback;
+    return {
+        disconnect: mockDisconnect,
+        observe: mockObserve,
+        unobserve: jest.fn(),
+    };
+});
+((global as unknown) as { ResizeObserver: jest.Mock }).ResizeObserver = mockResizeObserver;
 
 jest.mock('wavesurfer.js', () => ({
     __esModule: true,
     default: {
         create: jest.fn(() => ({
             destroy: mockDestroy,
-            getDecodedData: mockGetDecodedData,
+            load: mockLoad,
             on: mockOn,
-            renderer: {
-                render: mockRender,
-            },
             setOptions: mockSetOptions,
             setTime: mockSetTime,
         })),
@@ -33,7 +49,17 @@ jest.mock('wavesurfer.js', () => ({
 }));
 
 describe('WaveformView', () => {
+    beforeAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 200 });
+    });
+
+    afterAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 });
+    });
+
     beforeEach(() => {
+        clickHandler = undefined;
+        resizeCallback = undefined;
         jest.clearAllMocks();
     });
 
@@ -137,8 +163,19 @@ describe('WaveformView', () => {
         expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
     });
 
+    test('should seek from a wavesurfer click', () => {
+        const onSeek = jest.fn();
+        render(<WaveformView durationSec={8} onSeek={onSeek} peaks={[0.2, 0.8]} />);
+
+        expect(clickHandler).toBeDefined();
+        clickHandler?.(0.25);
+
+        expect(onSeek).toHaveBeenCalledWith(2);
+    });
+
     test('should ignore hover and clicks while inert', () => {
-        render(<WaveformView durationSec={8} interactive={false} peaks={[0.2, 0.8]} />);
+        const onSeek = jest.fn();
+        render(<WaveformView durationSec={8} interactive={false} onSeek={onSeek} peaks={[0.2, 0.8]} />);
         const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
         jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
             bottom: 140,
@@ -153,10 +190,12 @@ describe('WaveformView', () => {
         });
 
         fireEvent.mouseMove(track, { clientX: 50 });
+        clickHandler?.(0.25);
 
         expect(screen.getByTestId('bp-waveform-view')).toHaveClass('bp-WaveformView--inert');
         expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
         expect(WaveSurfer.create).toHaveBeenCalledWith(expect.objectContaining({ interact: false }));
+        expect(onSeek).not.toHaveBeenCalled();
     });
 
     test('should keep the wavesurfer instance when duration changes from the placeholder', () => {
@@ -169,14 +208,13 @@ describe('WaveformView', () => {
 
         expect(WaveSurfer.create).toHaveBeenCalledTimes(1);
         expect(mockDestroy).not.toHaveBeenCalled();
-        expect(mockSetOptions).toHaveBeenCalledWith(
-            expect.objectContaining({
-                duration: 8,
-                peaks: [
-                    [0.2, 0.8],
-                    [0.2, 0.8],
-                ],
-            }),
+        expect(mockLoad).toHaveBeenCalledWith(
+            '',
+            [
+                [0.2, 0.8],
+                [0.2, 0.8],
+            ],
+            8,
         );
     });
 
@@ -217,13 +255,38 @@ describe('WaveformView', () => {
 
         frames[0](800);
 
-        const peakUpdate = mockSetOptions.mock.calls
-            .map(call => call[0])
-            .reverse()
-            .find(options => options && options.peaks);
-        expect(peakUpdate.duration).toBe(8);
-        expect(peakUpdate.peaks[0][0]).toBeCloseTo(0.2);
-        expect(peakUpdate.peaks[0][1]).toBeCloseTo(0.8);
-        expect(mockRender).toHaveBeenCalled();
+        const peakLoad = [...mockLoad.mock.calls].reverse().find(call => call[1]);
+        expect(peakLoad[0]).toBe('');
+        expect(peakLoad[2]).toBe(8);
+        expect(peakLoad[1][0][0]).toBeCloseTo(0.2);
+        expect(peakLoad[1][0][1]).toBeCloseTo(0.8);
+    });
+
+    test('should recompute fills when the canvas width changes', () => {
+        const bufferedRange = ({
+            end: () => 4,
+            length: 1,
+            start: () => 0,
+        } as unknown) as TimeRanges;
+
+        render(<WaveformView bufferedRange={bufferedRange} durationSec={8} peaks={[0.2, 0.8]} />);
+
+        expect(mockResizeObserver).toHaveBeenCalled();
+        expect(mockObserve).toHaveBeenCalled();
+        expect(resizeCallback).toBeDefined();
+
+        mockSetOptions.mockClear();
+        act(() => {
+            resizeCallback?.(
+                [
+                    ({
+                        contentRect: { width: 400 },
+                    } as unknown) as ResizeObserverEntry,
+                ],
+                ({} as unknown) as ResizeObserver,
+            );
+        });
+
+        expect(mockSetOptions).toHaveBeenCalled();
     });
 });

--- a/src/lib/viewers/media/waveform/__tests__/colors-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/colors-test.ts
@@ -1,0 +1,81 @@
+import {
+    getBufferedProgress,
+    getWaveformFills,
+    WAVEFORM_COLOR_BUFFER,
+    WAVEFORM_COLOR_HOVER_AREA,
+    WAVEFORM_COLOR_HOVER_BUFFER,
+    WAVEFORM_COLOR_HOVER_PLAYED,
+    WAVEFORM_COLOR_HOVER_UNPLAYED,
+    WAVEFORM_COLOR_PLAYED,
+    WAVEFORM_COLOR_UNPLAYED,
+} from '../colors';
+
+function rgbChannel(color: string): number {
+    const match = color.match(/\d+/);
+    return match ? Number(match[0]) : 0;
+}
+
+function mockBufferedRange(endSec: number): TimeRanges {
+    return {
+        length: 1,
+        start: () => 0,
+        end: () => endSec,
+    } as TimeRanges;
+}
+
+describe('colors', () => {
+    test('should keep the played fill lighter than unplayed', () => {
+        expect(rgbChannel(WAVEFORM_COLOR_PLAYED)).toBeGreaterThan(rgbChannel(WAVEFORM_COLOR_UNPLAYED));
+    });
+
+    test('should use played / unplayed / buffer tokens at rest', () => {
+        const fills = getWaveformFills({ bufferProgress: 0.5, hoverProgress: null });
+
+        expect(fills.progressColor).toBe(WAVEFORM_COLOR_PLAYED);
+        expect(fills.waveColor).toEqual([
+            { color: WAVEFORM_COLOR_UNPLAYED, offset: 0 },
+            { color: WAVEFORM_COLOR_UNPLAYED, offset: 0.5 },
+            { color: WAVEFORM_COLOR_BUFFER, offset: 0.5 },
+            { color: WAVEFORM_COLOR_BUFFER, offset: 1 },
+        ]);
+    });
+
+    test('should use a solid unplayed fill when the file is fully buffered', () => {
+        const fills = getWaveformFills({ bufferProgress: 1, hoverProgress: null });
+
+        expect(fills.waveColor).toBe(WAVEFORM_COLOR_UNPLAYED);
+    });
+
+    test('should brighten played and fill the hover area when scrubbing ahead', () => {
+        const fills = getWaveformFills({ bufferProgress: 1, hoverProgress: 0.4 });
+
+        expect(fills.progressColor).toEqual([
+            { color: WAVEFORM_COLOR_HOVER_PLAYED, offset: 0 },
+            { color: WAVEFORM_COLOR_HOVER_PLAYED, offset: 0.4 },
+            { color: WAVEFORM_COLOR_HOVER_AREA, offset: 0.4 },
+            { color: WAVEFORM_COLOR_HOVER_AREA, offset: 1 },
+        ]);
+        expect(fills.waveColor).toEqual([
+            { color: WAVEFORM_COLOR_HOVER_AREA, offset: 0 },
+            { color: WAVEFORM_COLOR_HOVER_AREA, offset: 0.4 },
+            { color: WAVEFORM_COLOR_HOVER_UNPLAYED, offset: 0.4 },
+            { color: WAVEFORM_COLOR_HOVER_UNPLAYED, offset: 1 },
+        ]);
+    });
+
+    test('should keep hover-buffer past the loaded edge', () => {
+        const fills = getWaveformFills({ bufferProgress: 0.5, hoverProgress: 0.8 });
+
+        expect(fills.waveColor).toEqual(
+            expect.arrayContaining([
+                { color: WAVEFORM_COLOR_HOVER_BUFFER, offset: 0.8 },
+                { color: WAVEFORM_COLOR_HOVER_BUFFER, offset: 1 },
+            ]),
+        );
+    });
+
+    test('should treat missing buffered ranges as fully loaded', () => {
+        expect(getBufferedProgress(undefined, 8)).toBe(1);
+        expect(getBufferedProgress(mockBufferedRange(4), 8)).toBe(0.5);
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/peaks-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/peaks-test.ts
@@ -1,0 +1,82 @@
+import {
+    formatTime,
+    resizePeaks,
+    morphPeaks,
+    PLACEHOLDER_PEAK_AMPLITUDE,
+    placeholderPeaks,
+    toChannels,
+    WAVEFORM_PEAK_MORPH_MS,
+    WAVEFORM_PEAK_STAGGER_MS,
+    WAVEFORM_PEAK_TRANSITION_MS,
+} from '../peaks';
+
+describe('peaks', () => {
+    test('should fill every sample with the default amplitude', () => {
+        expect(placeholderPeaks()).toHaveLength(2000);
+        expect(placeholderPeaks(8)).toEqual(new Array(8).fill(PLACEHOLDER_PEAK_AMPLITUDE));
+    });
+
+    test('should be deterministic', () => {
+        expect(placeholderPeaks(16)).toEqual(placeholderPeaks(16));
+    });
+
+    test('should duplicate unit peaks as mirrored channels', () => {
+        expect(toChannels([0.1, 0.5, 1])).toEqual([
+            [0.1, 0.5, 1],
+            [0.1, 0.5, 1],
+        ]);
+    });
+
+    test.each`
+        time      | expected
+        ${0}      | ${'0:00.00'}
+        ${33.23}  | ${'0:33.23'}
+        ${65.5}   | ${'1:05.50'}
+        ${3661.2} | ${'1:01:01.20'}
+        ${NaN}    | ${'0:00.00'}
+    `('should format $time as $expected', ({ expected, time }) => {
+        expect(formatTime(time)).toBe(expected);
+    });
+
+    test('should return the destination peaks after morph plus stagger', () => {
+        const to = [0.2, 0.8, 0.4];
+        const morphed = morphPeaks(
+            [PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE],
+            to,
+            WAVEFORM_PEAK_TRANSITION_MS,
+        );
+        expect(morphed[0]).toBeCloseTo(0.2);
+        expect(morphed[1]).toBeCloseTo(0.8);
+        expect(morphed[2]).toBeCloseTo(0.4);
+    });
+
+    test('should stay at the placeholder at 0ms', () => {
+        const from = [PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE];
+        const morphed = morphPeaks(from, [1, 0], 0);
+        expect(morphed[0]).toBeCloseTo(PLACEHOLDER_PEAK_AMPLITUDE);
+        expect(morphed[1]).toBeCloseTo(PLACEHOLDER_PEAK_AMPLITUDE);
+    });
+
+    test('should leave the last peak at rest when stagger elapses and the first peak is mid-morph', () => {
+        const from = [PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE];
+        const to = [1, 1, 1];
+        const morphed = morphPeaks(from, to, WAVEFORM_PEAK_STAGGER_MS);
+        const firstPeakT = WAVEFORM_PEAK_STAGGER_MS / WAVEFORM_PEAK_MORPH_MS;
+        const firstPeakEased = 1 - (1 - firstPeakT) ** 3;
+
+        expect(morphed[0]).toBeCloseTo(firstPeakEased);
+        expect(morphed[2]).toBeCloseTo(PLACEHOLDER_PEAK_AMPLITUDE);
+    });
+
+    test('should resize placeholder peaks onto the destination length', () => {
+        const resized = resizePeaks([PLACEHOLDER_PEAK_AMPLITUDE, PLACEHOLDER_PEAK_AMPLITUDE], 4);
+        expect(resized).toHaveLength(4);
+        Array.from(resized).forEach(peak => {
+            expect(peak).toBeCloseTo(PLACEHOLDER_PEAK_AMPLITUDE);
+        });
+    });
+
+    test('should expose a positive transition duration', () => {
+        expect(WAVEFORM_PEAK_TRANSITION_MS).toBeGreaterThan(0);
+    });
+});

--- a/src/lib/viewers/media/waveform/colors.ts
+++ b/src/lib/viewers/media/waveform/colors.ts
@@ -1,0 +1,161 @@
+/**
+ * Figma Audio Player waveform tokens as opaque fills.
+ * Wavesurfer paints progress with canvas `source-in`, which multiplies alpha against
+ * the unplayed bars — rgba whites would make the played region darker, not brighter.
+ */
+
+function whiteOnBlack(alpha: number): string {
+    const channel = Math.round(255 * alpha);
+    return `rgb(${channel}, ${channel}, ${channel})`;
+}
+
+export const WAVEFORM_COLOR_PLAYED = whiteOnBlack(0.6);
+export const WAVEFORM_COLOR_UNPLAYED = whiteOnBlack(0.3);
+export const WAVEFORM_COLOR_BUFFER = whiteOnBlack(0.16);
+export const WAVEFORM_COLOR_HOVER_PLAYED = whiteOnBlack(0.9);
+export const WAVEFORM_COLOR_HOVER_AREA = whiteOnBlack(0.6);
+export const WAVEFORM_COLOR_HOVER_UNPLAYED = whiteOnBlack(0.3);
+export const WAVEFORM_COLOR_HOVER_BUFFER = whiteOnBlack(0.16);
+
+/** One canvas linear-gradient stop. `offset` is 0–1 along the bar. */
+export type GradientStop = {
+    color: string;
+    offset: number;
+};
+
+/**
+ * Wavesurfer's two paints: left of the playhead (`progressColor`) and right of it (`waveColor`).
+ * A string is a solid fill; a stop list is a left-to-right step gradient.
+ */
+export type WaveformFills = {
+    progressColor: string | GradientStop[];
+    waveColor: string | GradientStop[];
+};
+
+type ColorRange = {
+    color: string;
+    end: number;
+    start: number;
+};
+
+/** Pin a value to the closed interval [0, 1]. */
+function clampTo0And1(value: number): number {
+    if (!Number.isFinite(value) || value < 0) {
+        return 0;
+    }
+    if (value > 1) {
+        return 1;
+    }
+    return value;
+}
+
+function solidColorIfUniform(stops: GradientStop[]): string | null {
+    if (!stops.length) {
+        return null;
+    }
+    const { color } = stops[0];
+    return stops.every(stop => stop.color === color) ? color : null;
+}
+
+/**
+ * Turn colored 0–1 ranges into canvas gradient stops.
+ * Each range becomes a pair of stops at start and end so the color is flat (no blend).
+ * If every stop is the same color, return that solid string instead.
+ */
+function gradientStopsFromColorRanges(ranges: ColorRange[]): string | GradientStop[] {
+    const stops: GradientStop[] = [];
+
+    ranges.forEach(range => {
+        const start = clampTo0And1(range.start);
+        const end = clampTo0And1(range.end);
+        if (end <= start) {
+            return;
+        }
+        stops.push({ color: range.color, offset: start });
+        stops.push({ color: range.color, offset: end });
+    });
+
+    const color = solidColorIfUniform(stops);
+    if (color) {
+        return color;
+    }
+    if (!stops.length) {
+        return WAVEFORM_COLOR_UNPLAYED;
+    }
+    return stops;
+}
+
+/** Last buffered edge as a 0–1 fraction of duration. Missing range is treated as fully loaded. */
+export function getBufferedProgress(bufferedRange: TimeRanges | undefined, durationSec: number): number {
+    if (!bufferedRange || !bufferedRange.length || !(durationSec > 0)) {
+        return 1;
+    }
+
+    return clampTo0And1(bufferedRange.end(bufferedRange.length - 1) / durationSec);
+}
+
+/**
+ * progressColor paints left of the playhead (clipped by wavesurfer).
+ * waveColor paints right of the playhead, including buffered vs not-yet-buffered.
+ */
+export function getWaveformFills({
+    bufferProgress,
+    hoverProgress,
+}: {
+    bufferProgress: number;
+    hoverProgress: number | null;
+}): WaveformFills {
+    const buffer = clampTo0And1(bufferProgress);
+
+    if (hoverProgress == null) {
+        return {
+            progressColor: WAVEFORM_COLOR_PLAYED,
+            waveColor: gradientStopsFromColorRanges([
+                { color: WAVEFORM_COLOR_UNPLAYED, end: buffer, start: 0 },
+                { color: WAVEFORM_COLOR_BUFFER, end: 1, start: buffer },
+            ]),
+        };
+    }
+
+    const hover = clampTo0And1(hoverProgress);
+
+    return {
+        progressColor: gradientStopsFromColorRanges([
+            { color: WAVEFORM_COLOR_HOVER_PLAYED, end: hover, start: 0 },
+            { color: WAVEFORM_COLOR_HOVER_AREA, end: 1, start: hover },
+        ]),
+        waveColor: gradientStopsFromColorRanges([
+            { color: WAVEFORM_COLOR_HOVER_AREA, end: hover, start: 0 },
+            { color: WAVEFORM_COLOR_HOVER_UNPLAYED, end: buffer, start: hover },
+            { color: WAVEFORM_COLOR_HOVER_BUFFER, end: 1, start: Math.max(hover, buffer) },
+        ]),
+    };
+}
+
+/** Solid string, or a canvas linear gradient from stops, sized to the waveform width. */
+export function toCanvasFill(color: string | GradientStop[], widthPx: number): string | CanvasGradient {
+    if (typeof color === 'string') {
+        return color;
+    }
+    if (!(widthPx > 0) || typeof document === 'undefined') {
+        return color[0] ? color[0].color : WAVEFORM_COLOR_UNPLAYED;
+    }
+
+    const context = document.createElement('canvas').getContext('2d');
+    if (!context || !context.createLinearGradient) {
+        return color[0] ? color[0].color : WAVEFORM_COLOR_UNPLAYED;
+    }
+
+    const gradient = context.createLinearGradient(0, 0, widthPx, 0);
+    let lastOffset = -1;
+    color.forEach(stop => {
+        let offset = clampTo0And1(stop.offset);
+        if (offset <= lastOffset) {
+            offset = Math.min(1, lastOffset + 1e-6);
+        }
+        lastOffset = offset;
+        gradient.addColorStop(offset, stop.color);
+    });
+
+    return gradient;
+}

--- a/src/lib/viewers/media/waveform/peaks.ts
+++ b/src/lib/viewers/media/waveform/peaks.ts
@@ -1,0 +1,100 @@
+export const PLACEHOLDER_PEAK_AMPLITUDE = 0;
+export const PLACEHOLDER_PEAK_COUNT = 2000;
+/** Stand-in timeline length (seconds) until media metadata supplies real duration. */
+export const PLACEHOLDER_DURATION_SEC = 1;
+/** How long one peak takes to morph from placeholder to decoded. */
+export const WAVEFORM_PEAK_MORPH_MS = 400;
+/** How long it takes for the morph start to sweep from the first peak to the last. */
+export const WAVEFORM_PEAK_STAGGER_MS = 200;
+/** First peak starts at 0; last peak starts after the stagger and then morphs. */
+export const WAVEFORM_PEAK_TRANSITION_MS = WAVEFORM_PEAK_MORPH_MS + WAVEFORM_PEAK_STAGGER_MS;
+
+/**
+ * Flat unit peaks used until client decode or Conversion supplies a payload.
+ * Visual stand-in only; real duration comes from the media element once known.
+ */
+export function placeholderPeaks(peakCount: number = PLACEHOLDER_PEAK_COUNT): number[] {
+    const count = Math.max(1, peakCount);
+    return new Array(count).fill(PLACEHOLDER_PEAK_AMPLITUDE);
+}
+
+/** Convert in-viewer unit peaks to wavesurfer channels. Duplicate for a mirrored envelope. */
+export function toChannels(peaks: ArrayLike<number>): number[][] {
+    const channel = Array.from(peaks);
+    return [channel, channel.slice()];
+}
+
+/**
+ * Hover scrub time: m:ss.cc (or h:mm:ss.cc when over an hour).
+ */
+export function formatTime(time: number): string {
+    const totalCs = Number.isFinite(time) ? Math.max(0, Math.round(time * 100)) : 0;
+    const hours = Math.floor(totalCs / 360000);
+    const minutes = Math.floor((totalCs % 360000) / 6000);
+    const seconds = Math.floor((totalCs % 6000) / 100);
+    const centiseconds = totalCs % 100;
+    const paddedSeconds = `${seconds < 10 ? '0' : ''}${seconds}.${centiseconds < 10 ? '0' : ''}${centiseconds}`;
+
+    if (hours > 0) {
+        const paddedMinutes = minutes < 10 ? `0${minutes}` : String(minutes);
+        return `${hours}:${paddedMinutes}:${paddedSeconds}`;
+    }
+
+    return `${minutes}:${paddedSeconds}`;
+}
+
+function easeOutCubic(t: number): number {
+    return 1 - (1 - t) ** 3;
+}
+
+/** Resize a peak array to `length` by interpolating between neighboring samples. */
+export function resizePeaks(peaks: ArrayLike<number>, length: number): Float32Array {
+    const out = new Float32Array(length);
+    const sourceLength = peaks.length;
+    if (!(length > 0) || !(sourceLength > 0)) {
+        return out;
+    }
+    if (sourceLength === length) {
+        for (let index = 0; index < length; index += 1) {
+            out[index] = Number(peaks[index]) || 0;
+        }
+        return out;
+    }
+    if (length === 1) {
+        out[0] = Number(peaks[0]) || 0;
+        return out;
+    }
+
+    for (let index = 0; index < length; index += 1) {
+        const position = (index / (length - 1)) * (sourceLength - 1);
+        const left = Math.floor(position);
+        const right = Math.min(sourceLength - 1, left + 1);
+        const fraction = position - left;
+        const from = Number(peaks[left]) || 0;
+        const to = Number(peaks[right]) || 0;
+        out[index] = from + (to - from) * fraction;
+    }
+
+    return out;
+}
+
+/**
+ * Staggered morph from `from` toward `to` after `elapsedMs`.
+ * Each bar eases over WAVEFORM_PEAK_MORPH_MS; start times sweep left-to-right over WAVEFORM_PEAK_STAGGER_MS.
+ */
+export function morphPeaks(from: ArrayLike<number>, to: ArrayLike<number>, elapsedMs: number): Float32Array {
+    const { length } = to;
+    const source = resizePeaks(from, length);
+    const out = new Float32Array(length);
+    const stagger = length > 1 ? WAVEFORM_PEAK_STAGGER_MS : 0;
+    const elapsed = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+
+    for (let index = 0; index < length; index += 1) {
+        const delay = stagger === 0 ? 0 : (index / (length - 1)) * stagger;
+        const localT = Math.min(1, Math.max(0, (elapsed - delay) / WAVEFORM_PEAK_MORPH_MS));
+        const dest = Number(to[index]) || 0;
+        out[index] = source[index] + (dest - source[index]) * easeOutCubic(localT);
+    }
+
+    return out;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12020,6 +12020,11 @@ watchpack@^2.5.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+wavesurfer.js@7.12.11:
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/wavesurfer.js/-/wavesurfer.js-7.12.11.tgz#e82811da84d3796c3dbe41f440fdc6177304febe"
+  integrity sha512-Sx0yZIz7jRJ9J9p7UL+pl9y0UQBB6UN/XNo+R7Gy4tCR5xZI9jMyA0dnt1R8TMVSQ4LZ10SeB2HJYQ+dV2dPSA==
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz"


### PR DESCRIPTION
## Summary

- Adds a peaks-only `WaveformView` that draws unit peaks with wavesurfer (`7.12.11`). It does not fetch audio or attach a media element.
- Playhead, hover time, buffer/hover fills, and a placeholder→decoded peak morph (with reduced-motion skip) live in this module. Duration can change without remounting the wavesurfer instance.
- No MP3 player chrome, client decode, or zoom in this PR. Those follow in stacked PRs.