### PR TITLE
fix(video): restore tap-to-pause on React video players

### DIFF
--- a/src/lib/viewers/media/VideoBaseViewer.js
+++ b/src/lib/viewers/media/VideoBaseViewer.js
@@ -463,12 +463,17 @@ class VideoBaseViewer extends MediaBaseViewer {
      */
     pointerHandler(event) {
         if (event.type === 'touchstart') {
-            // Prevents 'click' event from firing which would pause the video
+            // Prevents the subsequent 'click' from also firing (which would double-toggle play)
             event.preventDefault();
-            event.stopPropagation();
 
             if (this.mediaControls) {
+                // Legacy controls: tap shows/hides the control bar rather than toggling playback
+                event.stopPropagation();
                 this.mediaControls.toggle();
+            } else {
+                // React controls: tap toggles play/pause, matching click behavior.
+                // Do not stopPropagation so ControlsRoot can still show the control bar.
+                this.handlePlayRequest();
             }
         } else if (event.type === 'click') {
             this.handlePlayRequest();

--- a/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/VideoBaseViewer-test.js
@@ -404,6 +404,22 @@ describe('lib/viewers/media/VideoBaseViewer', () => {
             expect(videoBase.mediaControls.toggle).toBeCalled();
         });
 
+        test('should toggle play on touchstart when using React controls', () => {
+            const event = {
+                type: 'touchstart',
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn(),
+            };
+            videoBase.mediaControls = undefined;
+            jest.spyOn(videoBase, 'handlePlayRequest').mockImplementation();
+
+            videoBase.pointerHandler(event);
+
+            expect(event.preventDefault).toBeCalled();
+            expect(event.stopPropagation).not.toBeCalled();
+            expect(videoBase.handlePlayRequest).toBeCalled();
+        });
+
         test('should call handlePlayRequest on click', () => {
             jest.spyOn(videoBase, 'handlePlayRequest').mockImplementation();
 


### PR DESCRIPTION
## Summary
- On touch devices, tapping the video never paused playback for React v1 and v2 controls. `touchstart` prevented the click that toggles play, then only toggled the legacy control bar (`mediaControls`), which React players do not create.
- Legacy (non-React) controls are unchanged: a tap still shows/hides the bar, which always includes play/pause.
- React players now toggle play/pause on tap, matching desktop click behavior, and still let the control bar show.

## Test plan
- [ ] Play a video with React v1 controls (`useReactControls`, `videoPlayerV2.enabled` off) on a phone or DevTools mobile viewport and tap the video to pause/play
- [ ] Repeat with React v2 (`videoPlayerV2.enabled` on)
- [ ] Repeat on a narrow desktop window (< 580px)
- [ ] Confirm legacy (non-React) controls still show/hide the bar on tap rather than toggling playback
- [ ] Confirm a mouse click on the video still toggles play/pause on desktop


Made with [Cursor](https://cursor.com)