### PR TITLE
feat(audio): decode client waveform peaks under size and duration caps

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -133,6 +133,7 @@ export const MEDIA_METRIC = {
 export const MEDIA_METRIC_EVENTS = {
     bufferFill: 'media_metric_buffer_fill',
     endPlayback: 'media_metric_end_playback',
+    waveformDecode: 'media_metric_waveform_decode',
 };
 
 export const REPORT_ACI = 'advanced_insights_report';

--- a/src/lib/viewers/media/MP3ControlsV2.scss
+++ b/src/lib/viewers/media/MP3ControlsV2.scss
@@ -74,7 +74,7 @@
     align-items: center;
     justify-content: space-between;
     min-height: 32px;
-    padding: 30px 48px 20px;
+    padding: 30px 58px 25px;
     background: linear-gradient(to top, rgb(0 0 0 / 100%), rgb(0 0 0 / 0%));
     pointer-events: auto;
 }

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -211,13 +211,11 @@ class MP3Viewer extends MediaBaseViewer {
             return Promise.reject(new WaveformLoadError('LOAD_FAILED', 'Waveform fetch URL is missing'));
         }
 
-        const request = this.featureEnabled('migrateAccessTokenToHeader')
-            ? this.api.get(this.createContentUrlV2(template), {
-                  headers: this.appendAuthHeader(),
-                  signal,
-                  type: 'arraybuffer',
-              })
-            : this.api.get(this.createContentUrlWithAuthParams(template), { signal, type: 'arraybuffer' });
+        const request = this.api.get(this.createContentUrlV2(template), {
+            headers: this.appendAuthHeader(),
+            signal,
+            type: 'arraybuffer',
+        });
 
         return request.then(data => {
             if (data instanceof ArrayBuffer) {
@@ -297,7 +295,7 @@ class MP3Viewer extends MediaBaseViewer {
     /**
      * Apply peaks, record a retryable failure for overlay play, or emit a degrade metric.
      *
-     * @param {Object} result loadPeaks / probeDecode result
+     * @param {Object} result loadPeaks / runClientDecode result
      * @param {AbortController} controller in-flight controller for this attempt
      * @param {AbortSignal} signal
      * @return {void}

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -1,11 +1,19 @@
 import React from 'react';
-import { VIEWER_EVENT } from '../../events';
+import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../events';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
+import { WaveformLoadError } from './waveform/createWaveformLoader';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
+
+function isAbortError(error) {
+    return (
+        (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
+        (error instanceof Error && error.name === 'AbortError')
+    );
+}
 
 class MP3Viewer extends MediaBaseViewer {
     /**
@@ -94,6 +102,21 @@ class MP3Viewer extends MediaBaseViewer {
     }
 
     /**
+     * @return {Promise<{ loadPeaks: Function }>} client-decode helpers
+     */
+    importWaveformDecode() {
+        return import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    destroy() {
+        this.abortClientWaveformDecode();
+        super.destroy();
+    }
+
+    /**
      * @inheritdoc
      */
     load() {
@@ -138,9 +161,16 @@ class MP3Viewer extends MediaBaseViewer {
     loadeddataHandler() {
         super.loadeddataHandler();
 
-        if (this.isAudioPlayerV2 && this.userRequestedPlay) {
+        if (!this.isAudioPlayerV2) {
+            return;
+        }
+
+        // Play first so Safari has a user gesture before AudioContext is created.
+        if (this.userRequestedPlay) {
             this.play();
         }
+
+        this.startClientWaveformDecode();
     }
 
     /**
@@ -149,7 +179,166 @@ class MP3Viewer extends MediaBaseViewer {
     handlePlayRequest = () => {
         this.userRequestedPlay = true;
         this.togglePlay();
+
+        if (this.isWaveformDecodeRetryPending && !this.hasUsedWaveformDecodePlayRetry) {
+            this.hasUsedWaveformDecodePlayRetry = true;
+            this.isWaveformDecodeRetryPending = false;
+            this.startClientWaveformDecode();
+        }
     };
+
+    /**
+     * Fetch compressed audio bytes for client decode. Prefers an already-fetched blob URL.
+     *
+     * @param {AbortSignal} signal
+     * @return {Promise<ArrayBuffer>}
+     */
+    async fetchAudioArrayBuffer(signal) {
+        if (this.mediaBlobUrl) {
+            return fetch(this.mediaBlobUrl, { signal }).then(response => {
+                if (!response.ok) {
+                    throw new WaveformLoadError('LOAD_FAILED', `Waveform fetch failed (${response.status})`);
+                }
+                return response.arrayBuffer();
+            });
+        }
+
+        const template =
+            this.options.representation &&
+            this.options.representation.content &&
+            this.options.representation.content.url_template;
+        if (!template) {
+            return Promise.reject(new WaveformLoadError('LOAD_FAILED', 'Waveform fetch URL is missing'));
+        }
+
+        const request = this.featureEnabled('migrateAccessTokenToHeader')
+            ? this.api.get(this.createContentUrlV2(template), {
+                  headers: this.appendAuthHeader(),
+                  signal,
+                  type: 'arraybuffer',
+              })
+            : this.api.get(this.createContentUrlWithAuthParams(template), { signal, type: 'arraybuffer' });
+
+        return request.then(data => {
+            if (data instanceof ArrayBuffer) {
+                return data;
+            }
+            throw new WaveformLoadError('LOAD_FAILED', 'Waveform fetch did not return binary data');
+        });
+    }
+
+    abortClientWaveformDecode() {
+        if (!this.waveformDecodeController) {
+            return;
+        }
+        this.waveformDecodeController.abort();
+        this.waveformDecodeController = null;
+    }
+
+    /**
+     * Decode peaks in the background when the file is under size and duration caps.
+     * Does not block playback. Capped or failed decode keeps the placeholder waveform.
+     *
+     * @return {Promise<void>}
+     */
+    async startClientWaveformDecode() {
+        if (!this.isAudioPlayerV2 || this.destroyed) {
+            return Promise.resolve();
+        }
+
+        this.abortClientWaveformDecode();
+        const controller = new AbortController();
+        this.waveformDecodeController = controller;
+        const { signal } = controller;
+
+        return this.importWaveformDecode()
+            .then(mod => {
+                if (this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
+                    return null;
+                }
+
+                return mod.loadPeaks({
+                    compressedBytes: this.options.file && this.options.file.size,
+                    durationSec: this.mediaEl && this.mediaEl.duration,
+                    fetchArrayBuffer: innerSignal => this.fetchAudioArrayBuffer(innerSignal || signal),
+                    signal,
+                });
+            })
+            .then(result => {
+                this.handleClientWaveformDecodeResult(result, controller, signal);
+            })
+            .catch(error => {
+                if (isAbortError(error)) {
+                    this.handleClientWaveformDecodeResult({ status: 'cancelled' }, controller, signal);
+                    return;
+                }
+
+                let code = 'LOAD_FAILED';
+                if (error instanceof WaveformLoadError) {
+                    ({ code } = error);
+                } else if (error && error.name === 'DECODE_FAILED') {
+                    code = 'DECODE_FAILED';
+                }
+                this.handleClientWaveformDecodeResult(
+                    {
+                        status: 'failed',
+                        error: {
+                            code,
+                            message: error && error.message ? error.message : 'Client decode failed',
+                        },
+                        retryable: true,
+                    },
+                    controller,
+                    signal,
+                );
+            });
+    }
+
+    /**
+     * Apply peaks, record a retryable failure for overlay play, or emit a degrade metric.
+     *
+     * @param {Object} result loadPeaks / probeDecode result
+     * @param {AbortController} controller in-flight controller for this attempt
+     * @param {AbortSignal} signal
+     * @return {void}
+     */
+    handleClientWaveformDecodeResult(result, controller, signal) {
+        if (!result || this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
+            return;
+        }
+
+        if (result.status === 'ready') {
+            this.waveformPeaks = result.payload.peaks;
+            this.isWaveformDecodeRetryPending = false;
+            this.renderUI();
+            return;
+        }
+
+        if (result.status === 'cancelled') {
+            return;
+        }
+
+        if (result.status === 'failed' && result.retryable && !this.hasUsedWaveformDecodePlayRetry) {
+            this.isWaveformDecodeRetryPending = true;
+        }
+
+        this.emitWaveformDecodeMetric(result);
+    }
+
+    /**
+     * @param {Object} result capped or failed loadPeaks result
+     * @return {void}
+     */
+    emitWaveformDecodeMetric(result) {
+        const data = {
+            status: result.status,
+            code: result.error && result.error.code,
+        };
+        if (result.reason) {
+            data.reason = result.reason;
+        }
+        this.emitMetric(MEDIA_METRIC_EVENTS.waveformDecode, data);
+    }
 
     /**
      * @inheritdoc

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -3,17 +3,11 @@ import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../events';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
-import { WaveformLoadError } from './waveform/createWaveformLoader';
+import { errorFromUnknown, isAbortError, WaveformLoadError } from './waveform/createWaveformLoader';
+import { isRetryableWaveformError } from './waveform/validateWaveformPayload';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
-
-function isAbortError(error) {
-    return (
-        (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
-        (error instanceof Error && error.name === 'AbortError')
-    );
-}
 
 class MP3Viewer extends MediaBaseViewer {
     /**
@@ -36,6 +30,7 @@ class MP3Viewer extends MediaBaseViewer {
             this.wrapperEl.classList.add('bp-media--v2');
             this.mediaContainerEl.classList.add('bp-media-container--v2');
             this.ensureV2Controls();
+            this.importWaveformDecode();
         }
 
         // Audio element
@@ -105,7 +100,16 @@ class MP3Viewer extends MediaBaseViewer {
      * @return {Promise<{ loadPeaks: Function }>} client-decode helpers
      */
     importWaveformDecode() {
-        return import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode');
+        if (!this.waveformDecodeImport) {
+            this.waveformDecodeImport = import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode').catch(
+                error => {
+                    this.waveformDecodeImport = null;
+                    throw error;
+                },
+            );
+        }
+
+        return this.waveformDecodeImport;
     }
 
     /**
@@ -271,20 +275,12 @@ class MP3Viewer extends MediaBaseViewer {
                     return;
                 }
 
-                let code = 'LOAD_FAILED';
-                if (error instanceof WaveformLoadError) {
-                    ({ code } = error);
-                } else if (error && error.name === 'DECODE_FAILED') {
-                    code = 'DECODE_FAILED';
-                }
+                const waveformError = errorFromUnknown(error, 'LOAD_FAILED');
                 this.handleClientWaveformDecodeResult(
                     {
                         status: 'failed',
-                        error: {
-                            code,
-                            message: error && error.message ? error.message : 'Client decode failed',
-                        },
-                        retryable: true,
+                        error: waveformError,
+                        retryable: isRetryableWaveformError(waveformError.code),
                     },
                     controller,
                     signal,

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -72,6 +72,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.wrapperEl).toHaveClass('bp-media--v2');
             expect(mp3.mediaContainerEl).toHaveClass('bp-media-container--v2');
             expect(mp3.isAudioPlayerV2).toBe(true);
+            expect(mp3.importWaveformDecode).toBeCalled();
         });
 
         test('should not apply v2 classes when React controls are off', () => {
@@ -427,6 +428,24 @@ describe('lib/viewers/media/MP3Viewer', () => {
             });
         });
 
+        test('should include skip reason on the metric when metadata is missing', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'unavailable',
+                error: { code: 'UNAVAILABLE', message: 'missing' },
+                reason: 'missing_metadata',
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'unavailable',
+                code: 'UNAVAILABLE',
+                reason: 'missing_metadata',
+            });
+        });
+
         test('should keep empty peaks when decode fails', async () => {
             loadPeaks.mockResolvedValue({
                 status: 'failed',
@@ -459,9 +478,22 @@ describe('lib/viewers/media/MP3Viewer', () => {
             await mp3.startClientWaveformDecode();
 
             expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.isWaveformDecodeRetryPending).toBe(true);
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
                 status: 'failed',
                 code: 'LOAD_FAILED',
+            });
+        });
+
+        test('should not retry overlay play when the thrown error is not retryable', async () => {
+            mp3.importWaveformDecode.mockRejectedValue(new WaveformLoadError('INVALID_PAYLOAD', 'bad payload'));
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'INVALID_PAYLOAD',
             });
         });
 

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -5,7 +5,13 @@ import MP3ControlsV2 from '../MP3ControlsV2';
 import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
-import { VIEWER_EVENT } from '../../../events';
+import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../../events';
+import { loadPeaks } from '../waveform/decode';
+import { WaveformLoadError } from '../waveform/createWaveformLoader';
+
+jest.mock('../waveform/decode', () => ({
+    loadPeaks: jest.fn(() => Promise.resolve({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } })),
+}));
 
 let mp3;
 
@@ -30,6 +36,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
         };
         mp3.containerEl = containerEl;
         jest.spyOn(MP3Viewer.prototype, 'importV2Controls').mockResolvedValue({ default: MP3ControlsV2 });
+        jest.spyOn(MP3Viewer.prototype, 'importWaveformDecode').mockResolvedValue({ loadPeaks });
     });
 
     afterEach(() => {
@@ -211,11 +218,26 @@ describe('lib/viewers/media/MP3Viewer', () => {
     describe('handlePlayRequest()', () => {
         test('should remember the play request and toggle playback', () => {
             jest.spyOn(mp3, 'togglePlay').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
 
             mp3.handlePlayRequest();
 
             expect(mp3.userRequestedPlay).toBe(true);
             expect(mp3.togglePlay).toBeCalled();
+            expect(mp3.startClientWaveformDecode).not.toBeCalled();
+        });
+
+        test('should retry decode once after a retryable failure', () => {
+            jest.spyOn(mp3, 'togglePlay').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            mp3.isWaveformDecodeRetryPending = true;
+
+            mp3.handlePlayRequest();
+            mp3.handlePlayRequest();
+
+            expect(mp3.startClientWaveformDecode).toBeCalledTimes(1);
+            expect(mp3.hasUsedWaveformDecodePlayRetry).toBe(true);
+            expect(mp3.isWaveformDecodeRetryPending).toBe(false);
         });
     });
 
@@ -224,12 +246,14 @@ describe('lib/viewers/media/MP3Viewer', () => {
             Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
             mp3.isAudioPlayerV2 = true;
             mp3.userRequestedPlay = true;
-            jest.spyOn(mp3, 'play').mockImplementation();
+            const order = [];
+            jest.spyOn(mp3, 'play').mockImplementation(() => order.push('play'));
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation(() => order.push('decode'));
 
             mp3.loadeddataHandler();
 
             expect(MediaBaseViewer.prototype.loadeddataHandler).toBeCalled();
-            expect(mp3.play).toBeCalled();
+            expect(order).toEqual(['play', 'decode']);
         });
 
         test('should not auto-start playback when play was not requested', () => {
@@ -240,6 +264,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.loadeddataHandler();
 
             expect(mp3.play).not.toBeCalled();
+        });
+
+        test('should start client decode for v2 after metadata', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            jest.spyOn(mp3, 'play').mockImplementation();
+
+            mp3.loadeddataHandler();
+
+            expect(mp3.startClientWaveformDecode).toBeCalled();
         });
     });
 
@@ -353,6 +388,129 @@ describe('lib/viewers/media/MP3Viewer', () => {
             jest.spyOn(mp3, 'pause').mockImplementation();
             mp3.handleAutoplayFail();
             expect(mp3.pause).toBeCalled();
+        });
+    });
+
+    describe('startClientWaveformDecode()', () => {
+        beforeEach(() => {
+            loadPeaks.mockReset();
+            loadPeaks.mockResolvedValue({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } });
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaks = [];
+            mp3.mediaEl = { duration: 30 };
+            mp3.options.file = { id: 1, size: 1024 };
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+            jest.spyOn(mp3, 'emitMetric').mockImplementation();
+        });
+
+        test('should apply decoded peaks when loadPeaks is ready', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'ready',
+                payload: { peaks: [0.2, 0.8] },
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([0.2, 0.8]);
+            expect(mp3.renderUI).toBeCalled();
+            expect(mp3.emitMetric).not.toBeCalled();
+        });
+
+        test('should keep empty peaks when decode is skipped as capped', async () => {
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'capped',
+                code: 'CAP_EXCEEDED',
+            });
+        });
+
+        test('should keep empty peaks when decode fails', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'failed',
+                error: { code: 'LOAD_FAILED', message: 'network' },
+                retryable: true,
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.isWaveformDecodeRetryPending).toBe(true);
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'LOAD_FAILED',
+            });
+        });
+
+        test('should not decode when v2 is off', async () => {
+            mp3.isAudioPlayerV2 = false;
+
+            await mp3.startClientWaveformDecode();
+
+            expect(loadPeaks).not.toBeCalled();
+        });
+
+        test('should map a decode-chunk load failure to LOAD_FAILED', async () => {
+            mp3.importWaveformDecode.mockRejectedValue(new Error('chunk failed'));
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'LOAD_FAILED',
+            });
+        });
+
+        test('should abort an in-flight decode on destroy', () => {
+            loadPeaks.mockReturnValue(new Promise(() => undefined));
+            const superDestroy = jest.spyOn(MediaBaseViewer.prototype, 'destroy').mockImplementation();
+
+            mp3.startClientWaveformDecode();
+            const { signal } = mp3.waveformDecodeController;
+            mp3.destroy();
+
+            expect(signal.aborted).toBe(true);
+            expect(mp3.waveformDecodeController).toBeNull();
+            superDestroy.mockRestore();
+        });
+    });
+
+    describe('fetchAudioArrayBuffer()', () => {
+        const originalFetch = global.fetch;
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+        });
+
+        test('should prefer an existing blob URL over a second API GET', async () => {
+            mp3.mediaBlobUrl = 'blob:audio';
+            mp3.api = { get: jest.fn() };
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+            });
+
+            const buffer = await mp3.fetchAudioArrayBuffer(new AbortController().signal);
+
+            expect(buffer).toBeInstanceOf(ArrayBuffer);
+            expect(global.fetch).toHaveBeenCalledWith(
+                'blob:audio',
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+            expect(mp3.api.get).not.toHaveBeenCalled();
+        });
+
+        test('should reject when neither a blob URL nor a representation URL is available', async () => {
+            mp3.mediaBlobUrl = null;
+            mp3.options.representation = {};
+
+            await expect(mp3.fetchAudioArrayBuffer(new AbortController().signal)).rejects.toBeInstanceOf(
+                WaveformLoadError,
+            );
         });
     });
 });

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -5,7 +5,7 @@
     width: 100%;
     height: 206px;
     min-height: 206px;
-    padding: 0 40px;
+    padding: 0 60px;
     overflow: visible;
     background: none;
 }
@@ -34,6 +34,7 @@
     height: 150px;
     pointer-events: none;
     background: linear-gradient(#2487ff, #006bed);
+    border-radius: 999px;
 
     // Spread stroke instead of border: border-box on .bp-container * would collapse the 2px fill.
     box-shadow: 0 0 0 1px #222, 0 0 10px 0 rgb(36 135 255 / 30%);

--- a/src/lib/viewers/media/waveform/__tests__/decode-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/decode-test.ts
@@ -1,0 +1,389 @@
+import { CLIENT_DECODE_MAX_COMPRESSED_BYTES, CLIENT_DECODE_MAX_DURATION_SEC } from '../constants';
+import { WaveformLoadError } from '../createWaveformLoader';
+import { canDecode, decodePcm, extractPeaks, loadPeaks, probeDecode } from '../decode';
+
+function silentPcm(durationSec: number): Float32Array[] {
+    const samples = Math.max(8, Math.floor(durationSec * 100));
+    return [new Float32Array(samples)];
+}
+
+describe('canDecode', () => {
+    const underCap = {
+        compressedBytes: 1024 * 1024,
+        durationSec: 60,
+    };
+
+    test('should allow decode when size and duration are within limits', () => {
+        expect(canDecode(underCap)).toEqual({ isAllowed: true });
+    });
+
+    test('should allow decode at exact cap boundaries', () => {
+        expect(
+            canDecode({
+                compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+                durationSec: CLIENT_DECODE_MAX_DURATION_SEC,
+            }),
+        ).toEqual({ isAllowed: true });
+    });
+
+    test('should reject when compressed size is over the cap', () => {
+        expect(
+            canDecode({
+                ...underCap,
+                compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            }),
+        ).toEqual({ isAllowed: false, reason: 'compressed_size' });
+    });
+
+    test('should reject when duration is over the cap', () => {
+        expect(
+            canDecode({
+                ...underCap,
+                durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 0.1,
+            }),
+        ).toEqual({ isAllowed: false, reason: 'duration' });
+    });
+
+    test('should reject when metadata is missing', () => {
+        expect(canDecode({})).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+        expect(canDecode({ compressedBytes: 1000 })).toEqual({
+            isAllowed: false,
+            reason: 'missing_metadata',
+        });
+        expect(canDecode({ durationSec: 10 })).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+    });
+
+    test('should honor cap overrides', () => {
+        expect(canDecode(underCap, { maxCompressedBytes: 512 })).toEqual({
+            isAllowed: false,
+            reason: 'compressed_size',
+        });
+    });
+});
+
+describe('extractPeaks', () => {
+    test('should return empty peaks when there are no samples', () => {
+        expect(extractPeaks([new Float32Array(0)], 8)).toEqual([]);
+    });
+
+    test('should take max abs across stereo channels per bucket', () => {
+        const left = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+        const right = new Float32Array([0.5, 0.05, -0.9, 0.1]);
+        const peaks = extractPeaks([left, right], 2);
+
+        expect(peaks).toHaveLength(2);
+        expect(peaks[0]).toBeCloseTo(0.5);
+        expect(peaks[1]).toBeCloseTo(0.9);
+    });
+
+    test('should extract from an AudioBuffer without copying channels', () => {
+        const left = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+        const right = new Float32Array([0.5, 0.05, -0.9, 0.1]);
+        const audioBuffer = ({
+            numberOfChannels: 2,
+            getChannelData: (channelIndex: number) => (channelIndex === 0 ? left : right),
+        } as unknown) as AudioBuffer;
+
+        const peaks = extractPeaks(audioBuffer, 2);
+
+        expect(peaks).toHaveLength(2);
+        expect(peaks[0]).toBeCloseTo(0.5);
+        expect(peaks[1]).toBeCloseTo(0.9);
+    });
+
+    test('should clamp values above 1', () => {
+        const peaks = extractPeaks([new Float32Array([1.5, 1.5])], 1);
+        expect(peaks[0]).toBe(1);
+    });
+});
+
+describe('decodePcm', () => {
+    const audioWindow = window as Window & {
+        AudioContext?: unknown;
+        webkitAudioContext?: unknown;
+    };
+    const originalAudioContext = audioWindow.AudioContext;
+    const originalWebkitAudioContext = audioWindow.webkitAudioContext;
+    let close: jest.Mock;
+    let decodeAudioData: jest.Mock;
+
+    beforeEach(() => {
+        close = jest.fn().mockResolvedValue(undefined);
+        decodeAudioData = jest.fn(
+            (
+                buffer: ArrayBuffer,
+                success: (decoded: {
+                    duration: number;
+                    numberOfChannels: number;
+                    getChannelData: () => Float32Array;
+                }) => void,
+            ) => {
+                success({
+                    duration: 2,
+                    length: 3,
+                    numberOfChannels: 1,
+                    getChannelData: () => new Float32Array([0, 0.5, -1]),
+                });
+            },
+        );
+        audioWindow.AudioContext = jest.fn(() => ({
+            close,
+            decodeAudioData,
+        }));
+        audioWindow.webkitAudioContext = undefined;
+    });
+
+    afterEach(() => {
+        audioWindow.AudioContext = originalAudioContext;
+        audioWindow.webkitAudioContext = originalWebkitAudioContext;
+    });
+
+    test('should extract peaks from decodeAudioData before closing the context', async () => {
+        const result = await decodePcm(new ArrayBuffer(8), undefined, 3);
+
+        expect(result.durationSec).toBe(2);
+        expect(result.peaks).toEqual([0, 0.5, 1]);
+        expect('peakSource' in result).toBe(false);
+        expect(close).toHaveBeenCalled();
+    });
+
+    test('should throw DECODE_FAILED when AudioContext is missing', async () => {
+        audioWindow.AudioContext = undefined;
+        audioWindow.webkitAudioContext = undefined;
+
+        await expect(decodePcm(new ArrayBuffer(8))).rejects.toEqual(expect.objectContaining({ code: 'DECODE_FAILED' }));
+    });
+
+    test('should throw when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        await expect(decodePcm(new ArrayBuffer(8), controller.signal)).rejects.toMatchObject({
+            name: 'AbortError',
+        });
+        expect(audioWindow.AudioContext).not.toHaveBeenCalled();
+    });
+
+    test('should close AudioContext when aborted during decode', async () => {
+        decodeAudioData.mockImplementation(() => new Promise(() => undefined));
+        const controller = new AbortController();
+        const pending = decodePcm(new ArrayBuffer(8), controller.signal);
+
+        await Promise.resolve();
+        expect(audioWindow.AudioContext).toHaveBeenCalled();
+
+        controller.abort();
+
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+        expect(close).toHaveBeenCalled();
+    });
+
+    test('should map decode failure to DECODE_FAILED', async () => {
+        decodeAudioData.mockImplementation((buffer: ArrayBuffer, success: unknown, error: (err: Error) => void) => {
+            error(new Error('bad mp3'));
+        });
+
+        await expect(decodePcm(new ArrayBuffer(8))).rejects.toBeInstanceOf(WaveformLoadError);
+    });
+});
+
+describe('probeDecode', () => {
+    test('should skip decode when compressed size is over the cap', async () => {
+        const decodePcmFn = jest.fn();
+        const result = await probeDecode({
+            compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            durationSec: 30,
+            decodePcm: decodePcmFn,
+        });
+
+        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('compressed_size');
+        expect(result.timings.decodeMs).toBeNull();
+        if (result.status === 'capped') {
+            expect(result.error.code).toBe('CAP_EXCEEDED');
+        }
+    });
+
+    test('should skip decode when duration is over the cap', async () => {
+        const decodePcmFn = jest.fn();
+        const result = await probeDecode({
+            compressedBytes: 1024,
+            durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 1,
+            decodePcm: decodePcmFn,
+        });
+
+        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('duration');
+    });
+
+    test('should skip decode as unavailable when metadata is missing', async () => {
+        const decodePcmFn = jest.fn();
+        const result = await probeDecode({
+            decodePcm: decodePcmFn,
+        });
+
+        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('unavailable');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('missing_metadata');
+        expect(result.error && result.error.code).toBe('UNAVAILABLE');
+    });
+
+    test('should extract and validate peaks when under the cap', async () => {
+        const durationSec = 8;
+        const result = await probeDecode({
+            compressedBytes: 2048,
+            durationSec,
+            peakCount: 8,
+            decodePcm: async () => ({
+                durationSec,
+                peakSource: silentPcm(durationSec),
+            }),
+        });
+
+        expect(result.status).toBe('ready');
+        expect(result.isDecodeSkipped).toBe(false);
+        expect(result.timings.decodeMs).not.toBeNull();
+        expect(result.timings.extractMs).not.toBeNull();
+        if (result.status === 'ready') {
+            expect(result.payload.peaks).toBeInstanceOf(Float32Array);
+            expect(result.payload.peaks.length).toBe(8);
+            expect(result.payload.durationSec).toBe(durationSec);
+        }
+    });
+
+    test('should map named LOAD_FAILED throws without treating them as DECODE_FAILED', async () => {
+        const error = new Error('network');
+        error.name = 'LOAD_FAILED';
+        const result = await probeDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decodePcm: async () => {
+                throw error;
+            },
+        });
+
+        expect(result.status).toBe('failed');
+        if (result.status === 'failed') {
+            expect(result.error.code).toBe('LOAD_FAILED');
+            expect(result.retryable).toBe(true);
+        }
+    });
+
+    test('should map decode throws to failed DECODE_FAILED', async () => {
+        const result = await probeDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decodePcm: async () => {
+                throw new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed');
+            },
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.isDecodeSkipped).toBe(false);
+        if (result.status === 'failed') {
+            expect(result.error.code).toBe('DECODE_FAILED');
+            expect(result.retryable).toBe(true);
+        }
+    });
+
+    test('should cancel when the signal is already aborted', async () => {
+        const decodePcmFn = jest.fn();
+        const controller = new AbortController();
+        controller.abort();
+        const result = await probeDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decodePcm: decodePcmFn,
+            signal: controller.signal,
+        });
+
+        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('cancelled');
+        expect(result.isDecodeSkipped).toBe(true);
+    });
+});
+
+describe('loadPeaks', () => {
+    const audioWindow = window as Window & {
+        AudioContext?: unknown;
+        webkitAudioContext?: unknown;
+    };
+    const originalAudioContext = audioWindow.AudioContext;
+    const originalWebkitAudioContext = audioWindow.webkitAudioContext;
+
+    beforeEach(() => {
+        audioWindow.AudioContext = jest.fn(() => ({
+            close: jest.fn().mockResolvedValue(undefined),
+            decodeAudioData: (
+                buffer: ArrayBuffer,
+                success: (decoded: {
+                    duration: number;
+                    numberOfChannels: number;
+                    getChannelData: () => Float32Array;
+                }) => void,
+            ) => {
+                success({
+                    duration: 8,
+                    numberOfChannels: 1,
+                    getChannelData: () => new Float32Array(800),
+                });
+            },
+        }));
+        audioWindow.webkitAudioContext = undefined;
+    });
+
+    afterEach(() => {
+        audioWindow.AudioContext = originalAudioContext;
+        audioWindow.webkitAudioContext = originalWebkitAudioContext;
+    });
+
+    test('should not fetch or decode when over the compressed size cap', async () => {
+        const fetchArrayBuffer = jest.fn();
+        const result = await loadPeaks({
+            compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            durationSec: 30,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('compressed_size');
+    });
+
+    test('should not fetch or decode when size or duration is missing', async () => {
+        const fetchArrayBuffer = jest.fn();
+        const result = await loadPeaks({
+            durationSec: 30,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).not.toHaveBeenCalled();
+        expect(result.status).toBe('unavailable');
+        expect(result.reason).toBe('missing_metadata');
+        expect(result.error && result.error.code).toBe('UNAVAILABLE');
+    });
+
+    test('should fetch, decode, and return validated peaks when under the cap', async () => {
+        const durationSec = 8;
+        const fetchArrayBuffer = jest.fn().mockResolvedValue(new ArrayBuffer(16));
+
+        const result = await loadPeaks({
+            compressedBytes: 2048,
+            durationSec,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).toHaveBeenCalled();
+        expect(result.status).toBe('ready');
+        if (result.status === 'ready') {
+            expect(result.payload.peaks.length).toBeGreaterThan(0);
+            expect(result.payload.durationSec).toBe(durationSec);
+        }
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/decode-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/decode-test.ts
@@ -1,25 +1,25 @@
 import { CLIENT_DECODE_MAX_COMPRESSED_BYTES, CLIENT_DECODE_MAX_DURATION_SEC } from '../constants';
 import { WaveformLoadError } from '../createWaveformLoader';
-import { canDecode, decodePcm, extractPeaks, loadPeaks, probeDecode } from '../decode';
+import { getDecodeDecision, decodeToPeaks, extractPeaks, loadPeaks, runClientDecode } from '../decode';
 
-function silentPcm(durationSec: number): Float32Array[] {
+function silentSamples(durationSec: number): Float32Array[] {
     const samples = Math.max(8, Math.floor(durationSec * 100));
     return [new Float32Array(samples)];
 }
 
-describe('canDecode', () => {
+describe('getDecodeDecision', () => {
     const underCap = {
         compressedBytes: 1024 * 1024,
         durationSec: 60,
     };
 
     test('should allow decode when size and duration are within limits', () => {
-        expect(canDecode(underCap)).toEqual({ isAllowed: true });
+        expect(getDecodeDecision(underCap)).toEqual({ isAllowed: true });
     });
 
     test('should allow decode at exact cap boundaries', () => {
         expect(
-            canDecode({
+            getDecodeDecision({
                 compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES,
                 durationSec: CLIENT_DECODE_MAX_DURATION_SEC,
             }),
@@ -28,7 +28,7 @@ describe('canDecode', () => {
 
     test('should reject when compressed size is over the cap', () => {
         expect(
-            canDecode({
+            getDecodeDecision({
                 ...underCap,
                 compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
             }),
@@ -37,7 +37,7 @@ describe('canDecode', () => {
 
     test('should reject when duration is over the cap', () => {
         expect(
-            canDecode({
+            getDecodeDecision({
                 ...underCap,
                 durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 0.1,
             }),
@@ -45,16 +45,16 @@ describe('canDecode', () => {
     });
 
     test('should reject when metadata is missing', () => {
-        expect(canDecode({})).toEqual({ isAllowed: false, reason: 'missing_metadata' });
-        expect(canDecode({ compressedBytes: 1000 })).toEqual({
+        expect(getDecodeDecision({})).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+        expect(getDecodeDecision({ compressedBytes: 1000 })).toEqual({
             isAllowed: false,
             reason: 'missing_metadata',
         });
-        expect(canDecode({ durationSec: 10 })).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+        expect(getDecodeDecision({ durationSec: 10 })).toEqual({ isAllowed: false, reason: 'missing_metadata' });
     });
 
     test('should honor cap overrides', () => {
-        expect(canDecode(underCap, { maxCompressedBytes: 512 })).toEqual({
+        expect(getDecodeDecision(underCap, { maxCompressedBytes: 512 })).toEqual({
             isAllowed: false,
             reason: 'compressed_size',
         });
@@ -97,7 +97,7 @@ describe('extractPeaks', () => {
     });
 });
 
-describe('decodePcm', () => {
+describe('decodeToPeaks', () => {
     const audioWindow = window as Window & {
         AudioContext?: unknown;
         webkitAudioContext?: unknown;
@@ -138,7 +138,7 @@ describe('decodePcm', () => {
     });
 
     test('should extract peaks from decodeAudioData before closing the context', async () => {
-        const result = await decodePcm(new ArrayBuffer(8), undefined, 3);
+        const result = await decodeToPeaks(new ArrayBuffer(8), undefined, 3);
 
         expect(result.durationSec).toBe(2);
         expect(result.peaks).toEqual([0, 0.5, 1]);
@@ -150,14 +150,16 @@ describe('decodePcm', () => {
         audioWindow.AudioContext = undefined;
         audioWindow.webkitAudioContext = undefined;
 
-        await expect(decodePcm(new ArrayBuffer(8))).rejects.toEqual(expect.objectContaining({ code: 'DECODE_FAILED' }));
+        await expect(decodeToPeaks(new ArrayBuffer(8))).rejects.toEqual(
+            expect.objectContaining({ code: 'DECODE_FAILED' }),
+        );
     });
 
     test('should throw when the signal is already aborted', async () => {
         const controller = new AbortController();
         controller.abort();
 
-        await expect(decodePcm(new ArrayBuffer(8), controller.signal)).rejects.toMatchObject({
+        await expect(decodeToPeaks(new ArrayBuffer(8), controller.signal)).rejects.toMatchObject({
             name: 'AbortError',
         });
         expect(audioWindow.AudioContext).not.toHaveBeenCalled();
@@ -166,7 +168,7 @@ describe('decodePcm', () => {
     test('should close AudioContext when aborted during decode', async () => {
         decodeAudioData.mockImplementation(() => new Promise(() => undefined));
         const controller = new AbortController();
-        const pending = decodePcm(new ArrayBuffer(8), controller.signal);
+        const pending = decodeToPeaks(new ArrayBuffer(8), controller.signal);
 
         await Promise.resolve();
         expect(audioWindow.AudioContext).toHaveBeenCalled();
@@ -182,20 +184,20 @@ describe('decodePcm', () => {
             error(new Error('bad mp3'));
         });
 
-        await expect(decodePcm(new ArrayBuffer(8))).rejects.toBeInstanceOf(WaveformLoadError);
+        await expect(decodeToPeaks(new ArrayBuffer(8))).rejects.toBeInstanceOf(WaveformLoadError);
     });
 });
 
-describe('probeDecode', () => {
+describe('runClientDecode', () => {
     test('should skip decode when compressed size is over the cap', async () => {
-        const decodePcmFn = jest.fn();
-        const result = await probeDecode({
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
             compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
             durationSec: 30,
-            decodePcm: decodePcmFn,
+            decode: decodeToPeaksFn,
         });
 
-        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
         expect(result.status).toBe('capped');
         expect(result.isDecodeSkipped).toBe(true);
         expect(result.reason).toBe('compressed_size');
@@ -206,26 +208,26 @@ describe('probeDecode', () => {
     });
 
     test('should skip decode when duration is over the cap', async () => {
-        const decodePcmFn = jest.fn();
-        const result = await probeDecode({
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
             compressedBytes: 1024,
             durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 1,
-            decodePcm: decodePcmFn,
+            decode: decodeToPeaksFn,
         });
 
-        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
         expect(result.status).toBe('capped');
         expect(result.isDecodeSkipped).toBe(true);
         expect(result.reason).toBe('duration');
     });
 
     test('should skip decode as unavailable when metadata is missing', async () => {
-        const decodePcmFn = jest.fn();
-        const result = await probeDecode({
-            decodePcm: decodePcmFn,
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
+            decode: decodeToPeaksFn,
         });
 
-        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
         expect(result.status).toBe('unavailable');
         expect(result.isDecodeSkipped).toBe(true);
         expect(result.reason).toBe('missing_metadata');
@@ -234,14 +236,13 @@ describe('probeDecode', () => {
 
     test('should extract and validate peaks when under the cap', async () => {
         const durationSec = 8;
-        const result = await probeDecode({
+        const result = await runClientDecode({
             compressedBytes: 2048,
             durationSec,
-            peakCount: 8,
-            decodePcm: async () => ({
-                durationSec,
-                peakSource: silentPcm(durationSec),
-            }),
+            decode: async () => {
+                const peaks = extractPeaks(silentSamples(durationSec), 8);
+                return { durationSec, peaks, extractMs: 0 };
+            },
         });
 
         expect(result.status).toBe('ready');
@@ -258,10 +259,10 @@ describe('probeDecode', () => {
     test('should map named LOAD_FAILED throws without treating them as DECODE_FAILED', async () => {
         const error = new Error('network');
         error.name = 'LOAD_FAILED';
-        const result = await probeDecode({
+        const result = await runClientDecode({
             compressedBytes: 2048,
             durationSec: 8,
-            decodePcm: async () => {
+            decode: async () => {
                 throw error;
             },
         });
@@ -274,10 +275,10 @@ describe('probeDecode', () => {
     });
 
     test('should map decode throws to failed DECODE_FAILED', async () => {
-        const result = await probeDecode({
+        const result = await runClientDecode({
             compressedBytes: 2048,
             durationSec: 8,
-            decodePcm: async () => {
+            decode: async () => {
                 throw new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed');
             },
         });
@@ -291,17 +292,17 @@ describe('probeDecode', () => {
     });
 
     test('should cancel when the signal is already aborted', async () => {
-        const decodePcmFn = jest.fn();
+        const decodeToPeaksFn = jest.fn();
         const controller = new AbortController();
         controller.abort();
-        const result = await probeDecode({
+        const result = await runClientDecode({
             compressedBytes: 2048,
             durationSec: 8,
-            decodePcm: decodePcmFn,
+            decode: decodeToPeaksFn,
             signal: controller.signal,
         });
 
-        expect(decodePcmFn).not.toHaveBeenCalled();
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
         expect(result.status).toBe('cancelled');
         expect(result.isDecodeSkipped).toBe(true);
     });

--- a/src/lib/viewers/media/waveform/__tests__/decode-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/decode-test.ts
@@ -201,7 +201,7 @@ describe('runClientDecode', () => {
         expect(result.status).toBe('capped');
         expect(result.isDecodeSkipped).toBe(true);
         expect(result.reason).toBe('compressed_size');
-        expect(result.timings.decodeMs).toBeNull();
+        expect(result.timings.attemptMs).toBeNull();
         if (result.status === 'capped') {
             expect(result.error.code).toBe('CAP_EXCEEDED');
         }
@@ -247,7 +247,7 @@ describe('runClientDecode', () => {
 
         expect(result.status).toBe('ready');
         expect(result.isDecodeSkipped).toBe(false);
-        expect(result.timings.decodeMs).not.toBeNull();
+        expect(result.timings.attemptMs).not.toBeNull();
         expect(result.timings.extractMs).not.toBeNull();
         if (result.status === 'ready') {
             expect(result.payload.peaks).toBeInstanceOf(Float32Array);

--- a/src/lib/viewers/media/waveform/__tests__/decode-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/decode-test.ts
@@ -120,7 +120,6 @@ describe('decodePcm', () => {
             ) => {
                 success({
                     duration: 2,
-                    length: 3,
                     numberOfChannels: 1,
                     getChannelData: () => new Float32Array([0, 0.5, -1]),
                 });

--- a/src/lib/viewers/media/waveform/__tests__/validateWaveformPayload-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/validateWaveformPayload-test.ts
@@ -96,6 +96,14 @@ describe('validateWaveformPayload', () => {
             }
         });
 
+        test('should skip payload byte limit when isPayloadByteCheckSkipped is set', () => {
+            const result = validateWaveformPayload(readyOverview, {
+                maxPayloadBytes: 16,
+                isPayloadByteCheckSkipped: true,
+            });
+            expect(result.ok).toBe(true);
+        });
+
         test('should reject non-finite peak', () => {
             const peaks = [...readyOverview.peaks];
             peaks[2] = Number.NaN;

--- a/src/lib/viewers/media/waveform/constants.ts
+++ b/src/lib/viewers/media/waveform/constants.ts
@@ -13,3 +13,12 @@ export const DURATION_MISMATCH_TOLERANCE_SEC = 1;
 /** Peak values must live in this closed interval when peakScale is "unit". */
 export const PEAK_UNIT_MIN = 0;
 export const PEAK_UNIT_MAX = 1;
+
+/** Skip client PCM decode when the compressed file is larger than this. */
+export const CLIENT_DECODE_MAX_COMPRESSED_BYTES = 6 * 1024 * 1024;
+
+/** Skip client PCM decode when media duration is longer than this. */
+export const CLIENT_DECODE_MAX_DURATION_SEC = 5 * 60;
+
+/** Default overview resolution for client-generated peaks. */
+export const CLIENT_DECODE_PEAK_COUNT = 16384;

--- a/src/lib/viewers/media/waveform/constants.ts
+++ b/src/lib/viewers/media/waveform/constants.ts
@@ -14,10 +14,10 @@ export const DURATION_MISMATCH_TOLERANCE_SEC = 1;
 export const PEAK_UNIT_MIN = 0;
 export const PEAK_UNIT_MAX = 1;
 
-/** Skip client PCM decode when the compressed file is larger than this. */
+/** Skip client decode when the compressed file is larger than this. */
 export const CLIENT_DECODE_MAX_COMPRESSED_BYTES = 6 * 1024 * 1024;
 
-/** Skip client PCM decode when media duration is longer than this. */
+/** Skip client decode when media duration is longer than this. */
 export const CLIENT_DECODE_MAX_DURATION_SEC = 5 * 60;
 
 /** Default overview resolution for client-generated peaks. */

--- a/src/lib/viewers/media/waveform/createWaveformLoader.ts
+++ b/src/lib/viewers/media/waveform/createWaveformLoader.ts
@@ -27,14 +27,14 @@ type LoadGeneration = {
     signal: AbortSignal;
 };
 
-function isAbortError(error: unknown): boolean {
+export function isAbortError(error: unknown): boolean {
     return (
         (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
         (error instanceof Error && error.name === 'AbortError')
     );
 }
 
-function errorFromUnknown(error: unknown): WaveformError {
+export function errorFromUnknown(error: unknown, fallbackCode: WaveformErrorCode = 'LOAD_FAILED'): WaveformError {
     if (error instanceof WaveformLoadError) {
         return { code: error.code, message: error.message };
     }
@@ -48,7 +48,7 @@ function errorFromUnknown(error: unknown): WaveformError {
     }
 
     const message = error instanceof Error ? error.message : 'Waveform load failed';
-    return { code: 'LOAD_FAILED', message };
+    return { code: fallbackCode, message };
 }
 
 function failedLoadState(error: WaveformError): WaveformLoadState {

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -19,29 +19,22 @@ export type MediaInfo = {
     durationSec?: number;
 };
 
-export type ExtractedClientDecodeOutput = {
+export type ClientDecodeOutput = {
     durationSec: number;
     peaks: number[];
     extractMs: number;
 };
 
-export type DeferredClientDecodeOutput = {
-    durationSec: number;
-    peakSource: AudioBuffer | Float32Array[];
-};
-
-export type ClientDecodeOutput = ExtractedClientDecodeOutput | DeferredClientDecodeOutput;
-
 export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
 
-export type ProbeTimings = {
+export type DecodeTimings = {
     decodeMs: number | null;
     extractMs: number | null;
 };
 
-export type ProbeResult = WaveformLoadState & {
+export type ClientDecodeResult = WaveformLoadState & {
     isDecodeSkipped: boolean;
-    timings: ProbeTimings;
+    timings: DecodeTimings;
     reason?: DecodeSkipReason;
     error?: WaveformError;
 };
@@ -62,6 +55,20 @@ type DecodeAudioContext = {
     ) => Promise<AudioBuffer> | void;
 };
 
+const EMPTY_TIMINGS: DecodeTimings = { decodeMs: null, extractMs: null };
+
+function now(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function createAbortError(): DOMException {
+    return new DOMException('Aborted', 'AbortError');
+}
+
+function isPositiveFinite(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
 function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefined {
     if (typeof window === 'undefined') {
         return undefined;
@@ -71,10 +78,6 @@ function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefine
         webkitAudioContext?: new () => DecodeAudioContext;
     };
     return AudioContext || webkitAudioContext;
-}
-
-function isExtractedClientDecodeOutput(output: ClientDecodeOutput): output is ExtractedClientDecodeOutput {
-    return 'peaks' in output;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -94,14 +97,13 @@ function getDecodeSkipMessage(reason: DecodeSkipReason): string {
     return 'Compressed size or duration is missing; skipping client decode';
 }
 
-function createSkippedDecodeResult(reason: DecodeSkipReason): ProbeResult {
-    const emptyTimings: ProbeTimings = { decodeMs: null, extractMs: null };
+function createSkippedDecodeResult(reason: DecodeSkipReason): ClientDecodeResult {
     if (reason === 'missing_metadata') {
         return {
             status: 'unavailable',
             error: { code: 'UNAVAILABLE', message: getDecodeSkipMessage(reason) },
             isDecodeSkipped: true,
-            timings: emptyTimings,
+            timings: EMPTY_TIMINGS,
             reason,
         };
     }
@@ -109,7 +111,7 @@ function createSkippedDecodeResult(reason: DecodeSkipReason): ProbeResult {
     return {
         ...createCappedWaveformState(getDecodeSkipMessage(reason)),
         isDecodeSkipped: true,
-        timings: emptyTimings,
+        timings: EMPTY_TIMINGS,
         reason,
     };
 }
@@ -125,22 +127,32 @@ function errorFromUnknown(error: unknown): WaveformError {
     return { code: 'DECODE_FAILED', message };
 }
 
-function decodeWithContext(context: DecodeAudioContext, buffer: ArrayBuffer): Promise<AudioBuffer> {
+function decodeWithContext(
+    context: DecodeAudioContext,
+    buffer: ArrayBuffer,
+    signal?: AbortSignal,
+): Promise<AudioBuffer> {
     return new Promise((resolve, reject) => {
         let isSettled = false;
+        let onAbort: () => void = () => undefined;
+
         const succeed = (decoded: AudioBuffer) => {
-            if (!isSettled) {
-                isSettled = true;
-                resolve(decoded);
+            if (isSettled) {
+                return;
             }
+            isSettled = true;
+            signal?.removeEventListener('abort', onAbort);
+            resolve(decoded);
         };
+
         const fail = (error?: unknown) => {
             if (isSettled) {
                 return;
             }
             isSettled = true;
+            signal?.removeEventListener('abort', onAbort);
             if (isAbortError(error)) {
-                reject(error);
+                reject(error instanceof DOMException ? error : createAbortError());
                 return;
             }
             reject(
@@ -149,6 +161,15 @@ function decodeWithContext(context: DecodeAudioContext, buffer: ArrayBuffer): Pr
                     : new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed'),
             );
         };
+
+        onAbort = () => fail(createAbortError());
+
+        if (signal?.aborted) {
+            fail(createAbortError());
+            return;
+        }
+
+        signal?.addEventListener('abort', onAbort, { once: true });
 
         try {
             const maybePromise = context.decodeAudioData(buffer, succeed, fail);
@@ -163,21 +184,14 @@ function decodeWithContext(context: DecodeAudioContext, buffer: ArrayBuffer): Pr
 
 /**
  * Decide whether to run decodeAudioData. Either cap failing, or unknown size/duration,
- * skips decode so playback is never blocked by PCM expansion.
+ * skips decode so playback is never blocked by expanding the full audio buffer.
  */
-export function canDecode(media: MediaInfo, caps: WaveformCaps = {}): DecodeDecision {
+export function getDecodeDecision(media: MediaInfo, caps: WaveformCaps = {}): DecodeDecision {
     const maxCompressedBytes = caps.maxCompressedBytes ?? CLIENT_DECODE_MAX_COMPRESSED_BYTES;
     const maxDurationSec = caps.maxDurationSec ?? CLIENT_DECODE_MAX_DURATION_SEC;
     const { compressedBytes, durationSec } = media;
 
-    if (
-        typeof compressedBytes !== 'number' ||
-        !Number.isFinite(compressedBytes) ||
-        compressedBytes <= 0 ||
-        typeof durationSec !== 'number' ||
-        !Number.isFinite(durationSec) ||
-        durationSec <= 0
-    ) {
+    if (!isPositiveFinite(compressedBytes) || !isPositiveFinite(durationSec)) {
         return { isAllowed: false, reason: 'missing_metadata' };
     }
 
@@ -193,18 +207,16 @@ export function canDecode(media: MediaInfo, caps: WaveformCaps = {}): DecodeDeci
 }
 
 /**
- * Collapse PCM channels to one unsigned peak per time bucket (max abs, then clamp to unit).
+ * Collapse audio channels to one unsigned peak per time bucket (max abs, then clamp to unit).
  * Accepts an AudioBuffer so callers can extract before closing the AudioContext.
  */
 export function extractPeaks(
-    peakSource: AudioBuffer | Float32Array[],
+    audio: AudioBuffer | Float32Array[],
     peakCount: number = CLIENT_DECODE_PEAK_COUNT,
 ): number[] {
-    const channels: ArrayLike<number>[] = Array.isArray(peakSource)
-        ? peakSource
-        : Array.from({ length: peakSource.numberOfChannels }, (_, channelIndex) =>
-              peakSource.getChannelData(channelIndex),
-          );
+    const channels: ArrayLike<number>[] = Array.isArray(audio)
+        ? audio
+        : Array.from({ length: audio.numberOfChannels }, (_, channelIndex) => audio.getChannelData(channelIndex));
 
     if (peakCount <= 0 || channels.length === 0) {
         return [];
@@ -240,15 +252,15 @@ export function extractPeaks(
 
 /**
  * Decode compressed audio and extract unit peaks while the AudioBuffer is live.
- * Does not attach a media element or fetch a URL. Does not copy PCM channels.
+ * Does not attach a media element or fetch a URL. Does not copy channel data.
  */
-export async function decodePcm(
+export async function decodeToPeaks(
     arrayBuffer: ArrayBuffer,
     signal?: AbortSignal,
     peakCount: number = CLIENT_DECODE_PEAK_COUNT,
-): Promise<ExtractedClientDecodeOutput> {
+): Promise<ClientDecodeOutput> {
     if (signal?.aborted) {
-        throw new DOMException('Aborted', 'AbortError');
+        throw createAbortError();
     }
 
     const AudioContextConstructor = getAudioContextConstructor();
@@ -257,62 +269,26 @@ export async function decodePcm(
     }
 
     const context = new AudioContextConstructor();
-    let rejectForAbort: ((error: DOMException) => void) | undefined;
-    const abortDecode = (): void => {
-        context.close().catch(() => {
-            // Context may already be closed.
-        });
-        if (rejectForAbort) {
-            rejectForAbort(new DOMException('Aborted', 'AbortError'));
-        }
-    };
-
-    if (signal) {
-        signal.addEventListener('abort', abortDecode, { once: true });
-    }
 
     try {
-        const audioBuffer = await new Promise<AudioBuffer>((resolve, reject) => {
-            if (signal?.aborted) {
-                reject(new DOMException('Aborted', 'AbortError'));
-                return;
-            }
-
-            rejectForAbort = reject;
-
-            const fail = (error?: unknown): void => {
-                if (signal?.aborted || isAbortError(error)) {
-                    reject(error instanceof DOMException ? error : new DOMException('Aborted', 'AbortError'));
-                    return;
-                }
-                reject(error);
-            };
-
-            decodeWithContext(context, arrayBuffer.slice(0)).then(resolve, fail);
-        });
-
+        const audioBuffer = await decodeWithContext(context, arrayBuffer.slice(0), signal);
         if (signal?.aborted) {
-            throw new DOMException('Aborted', 'AbortError');
+            throw createAbortError();
         }
 
-        const extractStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const extractStarted = now();
         const peaks = extractPeaks(audioBuffer, peakCount);
-        const extractMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - extractStarted;
-
         return {
             durationSec: audioBuffer.duration,
             peaks,
-            extractMs,
+            extractMs: now() - extractStarted,
         };
     } catch (error) {
         if (signal?.aborted || isAbortError(error)) {
-            throw error instanceof DOMException ? error : new DOMException('Aborted', 'AbortError');
+            throw createAbortError();
         }
         throw error;
     } finally {
-        if (signal) {
-            signal.removeEventListener('abort', abortDecode);
-        }
         try {
             await context.close();
         } catch {
@@ -322,19 +298,17 @@ export async function decodePcm(
 }
 
 /**
- * Measures a client-decode attempt against the V1 waveform contract.
+ * Run a client-decode attempt against the V1 waveform contract.
  * Decode is not invoked when size or duration is over the cap (or unknown).
  */
-export async function probeDecode(options: {
+export async function runClientDecode(options: {
     compressedBytes?: number;
     durationSec?: number;
-    decodePcm: DecodeToPeaksFn;
-    peakCount?: number;
+    decode: DecodeToPeaksFn;
     caps?: WaveformCaps;
     signal?: AbortSignal;
-}): Promise<ProbeResult> {
-    const emptyTimings: ProbeTimings = { decodeMs: null, extractMs: null };
-    const decision = canDecode(
+}): Promise<ClientDecodeResult> {
+    const decision = getDecodeDecision(
         { compressedBytes: options.compressedBytes, durationSec: options.durationSec },
         options.caps,
     );
@@ -344,18 +318,18 @@ export async function probeDecode(options: {
     }
 
     if (options.signal?.aborted) {
-        return { status: 'cancelled', isDecodeSkipped: true, timings: emptyTimings };
+        return { status: 'cancelled', isDecodeSkipped: true, timings: EMPTY_TIMINGS };
     }
 
     const signal = options.signal ?? new AbortController().signal;
-    const decodeStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const decodeStarted = now();
 
     let decodeOutput: ClientDecodeOutput;
     try {
-        decodeOutput = await options.decodePcm(signal);
+        decodeOutput = await options.decode(signal);
     } catch (error) {
         if (signal.aborted || isAbortError(error)) {
-            return { status: 'cancelled', isDecodeSkipped: false, timings: emptyTimings };
+            return { status: 'cancelled', isDecodeSkipped: false, timings: EMPTY_TIMINGS };
         }
         const waveformError = errorFromUnknown(error);
         return {
@@ -364,13 +338,13 @@ export async function probeDecode(options: {
             retryable: isRetryableWaveformError(waveformError.code),
             isDecodeSkipped: false,
             timings: {
-                decodeMs: (typeof performance !== 'undefined' ? performance.now() : Date.now()) - decodeStarted,
+                decodeMs: now() - decodeStarted,
                 extractMs: null,
             },
         };
     }
 
-    const decodeMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - decodeStarted;
+    const decodeMs = now() - decodeStarted;
 
     if (signal.aborted) {
         return {
@@ -380,21 +354,11 @@ export async function probeDecode(options: {
         };
     }
 
-    let peaks: number[];
-    let extractMs: number;
-    if (isExtractedClientDecodeOutput(decodeOutput)) {
-        ({ peaks, extractMs } = decodeOutput);
-    } else {
-        const extractStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
-        peaks = extractPeaks(decodeOutput.peakSource, options.peakCount ?? CLIENT_DECODE_PEAK_COUNT);
-        extractMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - extractStarted;
-    }
-
     const validation = validateWaveformPayload(
         {
             version: WAVEFORM_PAYLOAD_VERSION,
             durationSec: options.durationSec ?? decodeOutput.durationSec,
-            peaks,
+            peaks: decodeOutput.peaks,
         },
         { isPayloadByteCheckSkipped: true },
     );
@@ -405,16 +369,15 @@ export async function probeDecode(options: {
             error: validation.error,
             retryable: isRetryableWaveformError(validation.error.code),
             isDecodeSkipped: false,
-            timings: { decodeMs, extractMs },
+            timings: { decodeMs, extractMs: decodeOutput.extractMs },
         };
     }
 
-    const { payload } = validation;
     return {
         status: 'ready',
-        payload,
+        payload: validation.payload,
         isDecodeSkipped: false,
-        timings: { decodeMs, extractMs },
+        timings: { decodeMs, extractMs: decodeOutput.extractMs },
     };
 }
 
@@ -422,14 +385,14 @@ export async function probeDecode(options: {
  * Gate, fetch, decode, and extract in-viewer peaks. Skips decode when over cap.
  * Playback must not await this.
  */
-export function loadPeaks(request: ClientDecodeRequest): Promise<ProbeResult> {
-    return probeDecode({
+export function loadPeaks(request: ClientDecodeRequest): Promise<ClientDecodeResult> {
+    return runClientDecode({
         compressedBytes: request.compressedBytes,
         durationSec: request.durationSec,
         signal: request.signal,
-        decodePcm: async signal => {
+        decode: async signal => {
             const arrayBuffer = await request.fetchArrayBuffer(signal);
-            return decodePcm(arrayBuffer, signal);
+            return decodeToPeaks(arrayBuffer, signal);
         },
     });
 }

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -1,0 +1,435 @@
+import {
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    CLIENT_DECODE_PEAK_COUNT,
+    PEAK_UNIT_MAX,
+    PEAK_UNIT_MIN,
+    WAVEFORM_PAYLOAD_VERSION,
+} from './constants';
+import { createCappedWaveformState, WaveformLoadError } from './createWaveformLoader';
+import { isWaveformErrorCode, WaveformCaps, WaveformError, WaveformLoadState } from './types';
+import { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
+
+export type DecodeSkipReason = 'missing_metadata' | 'compressed_size' | 'duration';
+
+export type DecodeDecision = { isAllowed: true } | { isAllowed: false; reason: DecodeSkipReason };
+
+export type MediaInfo = {
+    compressedBytes?: number;
+    durationSec?: number;
+};
+
+export type ExtractedClientDecodeOutput = {
+    durationSec: number;
+    peaks: number[];
+    extractMs: number;
+};
+
+export type DeferredClientDecodeOutput = {
+    durationSec: number;
+    peakSource: AudioBuffer | Float32Array[];
+};
+
+export type ClientDecodeOutput = ExtractedClientDecodeOutput | DeferredClientDecodeOutput;
+
+export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
+
+export type ProbeTimings = {
+    decodeMs: number | null;
+    extractMs: number | null;
+};
+
+export type ProbeResult = WaveformLoadState & {
+    isDecodeSkipped: boolean;
+    timings: ProbeTimings;
+    reason?: DecodeSkipReason;
+    error?: WaveformError;
+};
+
+export type ClientDecodeRequest = {
+    compressedBytes?: number;
+    durationSec?: number;
+    fetchArrayBuffer: (signal: AbortSignal) => Promise<ArrayBuffer>;
+    signal?: AbortSignal;
+};
+
+type DecodeAudioContext = {
+    close: () => Promise<void>;
+    decodeAudioData: (
+        buffer: ArrayBuffer,
+        successCallback?: (decoded: AudioBuffer) => void,
+        errorCallback?: (error?: unknown) => void,
+    ) => Promise<AudioBuffer> | void;
+};
+
+function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefined {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+    const { AudioContext, webkitAudioContext } = (window as unknown) as {
+        AudioContext?: new () => DecodeAudioContext;
+        webkitAudioContext?: new () => DecodeAudioContext;
+    };
+    return AudioContext || webkitAudioContext;
+}
+
+function isExtractedClientDecodeOutput(output: ClientDecodeOutput): output is ExtractedClientDecodeOutput {
+    return 'peaks' in output;
+}
+
+function isAbortError(error: unknown): boolean {
+    return (
+        (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
+        (error instanceof Error && error.name === 'AbortError')
+    );
+}
+
+function getDecodeSkipMessage(reason: DecodeSkipReason): string {
+    if (reason === 'compressed_size') {
+        return 'Compressed size exceeds client decode limit';
+    }
+    if (reason === 'duration') {
+        return 'Duration exceeds client decode limit';
+    }
+    return 'Compressed size or duration is missing; skipping client decode';
+}
+
+function createSkippedDecodeResult(reason: DecodeSkipReason): ProbeResult {
+    const emptyTimings: ProbeTimings = { decodeMs: null, extractMs: null };
+    if (reason === 'missing_metadata') {
+        return {
+            status: 'unavailable',
+            error: { code: 'UNAVAILABLE', message: getDecodeSkipMessage(reason) },
+            isDecodeSkipped: true,
+            timings: emptyTimings,
+            reason,
+        };
+    }
+
+    return {
+        ...createCappedWaveformState(getDecodeSkipMessage(reason)),
+        isDecodeSkipped: true,
+        timings: emptyTimings,
+        reason,
+    };
+}
+
+function errorFromUnknown(error: unknown): WaveformError {
+    if (error instanceof WaveformLoadError) {
+        return { code: error.code, message: error.message };
+    }
+    if (error instanceof Error && isWaveformErrorCode(error.name)) {
+        return { code: error.name, message: error.message };
+    }
+    const message = error instanceof Error ? error.message : 'Client decode failed';
+    return { code: 'DECODE_FAILED', message };
+}
+
+function decodeWithContext(context: DecodeAudioContext, buffer: ArrayBuffer): Promise<AudioBuffer> {
+    return new Promise((resolve, reject) => {
+        let isSettled = false;
+        const succeed = (decoded: AudioBuffer) => {
+            if (!isSettled) {
+                isSettled = true;
+                resolve(decoded);
+            }
+        };
+        const fail = (error?: unknown) => {
+            if (isSettled) {
+                return;
+            }
+            isSettled = true;
+            if (isAbortError(error)) {
+                reject(error);
+                return;
+            }
+            reject(
+                error instanceof WaveformLoadError
+                    ? error
+                    : new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed'),
+            );
+        };
+
+        try {
+            const maybePromise = context.decodeAudioData(buffer, succeed, fail);
+            if (maybePromise && typeof maybePromise.then === 'function') {
+                maybePromise.then(succeed, fail);
+            }
+        } catch (error) {
+            fail(error);
+        }
+    });
+}
+
+/**
+ * Decide whether to run decodeAudioData. Either cap failing, or unknown size/duration,
+ * skips decode so playback is never blocked by PCM expansion.
+ */
+export function canDecode(media: MediaInfo, caps: WaveformCaps = {}): DecodeDecision {
+    const maxCompressedBytes = caps.maxCompressedBytes ?? CLIENT_DECODE_MAX_COMPRESSED_BYTES;
+    const maxDurationSec = caps.maxDurationSec ?? CLIENT_DECODE_MAX_DURATION_SEC;
+    const { compressedBytes, durationSec } = media;
+
+    if (
+        typeof compressedBytes !== 'number' ||
+        !Number.isFinite(compressedBytes) ||
+        compressedBytes <= 0 ||
+        typeof durationSec !== 'number' ||
+        !Number.isFinite(durationSec) ||
+        durationSec <= 0
+    ) {
+        return { isAllowed: false, reason: 'missing_metadata' };
+    }
+
+    if (compressedBytes > maxCompressedBytes) {
+        return { isAllowed: false, reason: 'compressed_size' };
+    }
+
+    if (durationSec > maxDurationSec) {
+        return { isAllowed: false, reason: 'duration' };
+    }
+
+    return { isAllowed: true };
+}
+
+/**
+ * Collapse PCM channels to one unsigned peak per time bucket (max abs, then clamp to unit).
+ * Accepts an AudioBuffer so callers can extract before closing the AudioContext.
+ */
+export function extractPeaks(
+    peakSource: AudioBuffer | Float32Array[],
+    peakCount: number = CLIENT_DECODE_PEAK_COUNT,
+): number[] {
+    const channels: ArrayLike<number>[] = Array.isArray(peakSource)
+        ? peakSource
+        : Array.from({ length: peakSource.numberOfChannels }, (_, channelIndex) =>
+              peakSource.getChannelData(channelIndex),
+          );
+
+    if (peakCount <= 0 || channels.length === 0) {
+        return [];
+    }
+
+    const sampleCount = channels[0].length;
+    if (sampleCount === 0) {
+        return [];
+    }
+
+    const peaks = new Array(peakCount);
+    const bucketWidth = sampleCount / peakCount;
+
+    for (let i = 0; i < peakCount; i += 1) {
+        const start = Math.floor(i * bucketWidth);
+        const end = Math.max(start + 1, Math.floor((i + 1) * bucketWidth));
+        let maxAbs = 0;
+
+        for (let sampleIndex = start; sampleIndex < end && sampleIndex < sampleCount; sampleIndex += 1) {
+            for (let channelIndex = 0; channelIndex < channels.length; channelIndex += 1) {
+                const value = Math.abs(channels[channelIndex][sampleIndex]);
+                if (value > maxAbs) {
+                    maxAbs = value;
+                }
+            }
+        }
+
+        peaks[i] = Math.min(PEAK_UNIT_MAX, Math.max(PEAK_UNIT_MIN, maxAbs));
+    }
+
+    return peaks;
+}
+
+/**
+ * Decode compressed audio and extract unit peaks while the AudioBuffer is live.
+ * Does not attach a media element or fetch a URL. Does not copy PCM channels.
+ */
+export async function decodePcm(
+    arrayBuffer: ArrayBuffer,
+    signal?: AbortSignal,
+    peakCount: number = CLIENT_DECODE_PEAK_COUNT,
+): Promise<ExtractedClientDecodeOutput> {
+    if (signal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+    }
+
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) {
+        throw new WaveformLoadError('DECODE_FAILED', 'AudioContext is not available');
+    }
+
+    const context = new AudioContextConstructor();
+    let rejectForAbort: ((error: DOMException) => void) | undefined;
+    const abortDecode = (): void => {
+        context.close().catch(() => {
+            // Context may already be closed.
+        });
+        if (rejectForAbort) {
+            rejectForAbort(new DOMException('Aborted', 'AbortError'));
+        }
+    };
+
+    if (signal) {
+        signal.addEventListener('abort', abortDecode, { once: true });
+    }
+
+    try {
+        const audioBuffer = await new Promise<AudioBuffer>((resolve, reject) => {
+            if (signal?.aborted) {
+                reject(new DOMException('Aborted', 'AbortError'));
+                return;
+            }
+
+            rejectForAbort = reject;
+
+            const fail = (error?: unknown): void => {
+                if (signal?.aborted || isAbortError(error)) {
+                    reject(error instanceof DOMException ? error : new DOMException('Aborted', 'AbortError'));
+                    return;
+                }
+                reject(error);
+            };
+
+            decodeWithContext(context, arrayBuffer.slice(0)).then(resolve, fail);
+        });
+
+        if (signal?.aborted) {
+            throw new DOMException('Aborted', 'AbortError');
+        }
+
+        const extractStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const peaks = extractPeaks(audioBuffer, peakCount);
+        const extractMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - extractStarted;
+
+        return {
+            durationSec: audioBuffer.duration,
+            peaks,
+            extractMs,
+        };
+    } catch (error) {
+        if (signal?.aborted || isAbortError(error)) {
+            throw error instanceof DOMException ? error : new DOMException('Aborted', 'AbortError');
+        }
+        throw error;
+    } finally {
+        if (signal) {
+            signal.removeEventListener('abort', abortDecode);
+        }
+        try {
+            await context.close();
+        } catch {
+            // Context may already be closed.
+        }
+    }
+}
+
+/**
+ * Measures a client-decode attempt against the V1 waveform contract.
+ * Decode is not invoked when size or duration is over the cap (or unknown).
+ */
+export async function probeDecode(options: {
+    compressedBytes?: number;
+    durationSec?: number;
+    decodePcm: DecodeToPeaksFn;
+    peakCount?: number;
+    caps?: WaveformCaps;
+    signal?: AbortSignal;
+}): Promise<ProbeResult> {
+    const emptyTimings: ProbeTimings = { decodeMs: null, extractMs: null };
+    const decision = canDecode(
+        { compressedBytes: options.compressedBytes, durationSec: options.durationSec },
+        options.caps,
+    );
+
+    if (!decision.isAllowed) {
+        return createSkippedDecodeResult(decision.reason);
+    }
+
+    if (options.signal?.aborted) {
+        return { status: 'cancelled', isDecodeSkipped: true, timings: emptyTimings };
+    }
+
+    const signal = options.signal ?? new AbortController().signal;
+    const decodeStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+    let decodeOutput: ClientDecodeOutput;
+    try {
+        decodeOutput = await options.decodePcm(signal);
+    } catch (error) {
+        if (signal.aborted || isAbortError(error)) {
+            return { status: 'cancelled', isDecodeSkipped: false, timings: emptyTimings };
+        }
+        const waveformError = errorFromUnknown(error);
+        return {
+            status: 'failed',
+            error: waveformError,
+            retryable: isRetryableWaveformError(waveformError.code),
+            isDecodeSkipped: false,
+            timings: {
+                decodeMs: (typeof performance !== 'undefined' ? performance.now() : Date.now()) - decodeStarted,
+                extractMs: null,
+            },
+        };
+    }
+
+    const decodeMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - decodeStarted;
+
+    if (signal.aborted) {
+        return {
+            status: 'cancelled',
+            isDecodeSkipped: false,
+            timings: { decodeMs, extractMs: null },
+        };
+    }
+
+    let peaks: number[];
+    let extractMs: number;
+    if (isExtractedClientDecodeOutput(decodeOutput)) {
+        ({ peaks, extractMs } = decodeOutput);
+    } else {
+        const extractStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        peaks = extractPeaks(decodeOutput.peakSource, options.peakCount ?? CLIENT_DECODE_PEAK_COUNT);
+        extractMs = (typeof performance !== 'undefined' ? performance.now() : Date.now()) - extractStarted;
+    }
+
+    const validation = validateWaveformPayload(
+        {
+            version: WAVEFORM_PAYLOAD_VERSION,
+            durationSec: options.durationSec ?? decodeOutput.durationSec,
+            peaks,
+        },
+        { isPayloadByteCheckSkipped: true },
+    );
+
+    if (!validation.ok) {
+        return {
+            status: 'failed',
+            error: validation.error,
+            retryable: isRetryableWaveformError(validation.error.code),
+            isDecodeSkipped: false,
+            timings: { decodeMs, extractMs },
+        };
+    }
+
+    const { payload } = validation;
+    return {
+        status: 'ready',
+        payload,
+        isDecodeSkipped: false,
+        timings: { decodeMs, extractMs },
+    };
+}
+
+/**
+ * Gate, fetch, decode, and extract in-viewer peaks. Skips decode when over cap.
+ * Playback must not await this.
+ */
+export function loadPeaks(request: ClientDecodeRequest): Promise<ProbeResult> {
+    return probeDecode({
+        compressedBytes: request.compressedBytes,
+        durationSec: request.durationSec,
+        signal: request.signal,
+        decodePcm: async signal => {
+            const arrayBuffer = await request.fetchArrayBuffer(signal);
+            return decodePcm(arrayBuffer, signal);
+        },
+    });
+}

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -6,8 +6,8 @@ import {
     PEAK_UNIT_MIN,
     WAVEFORM_PAYLOAD_VERSION,
 } from './constants';
-import { createCappedWaveformState, WaveformLoadError } from './createWaveformLoader';
-import { isWaveformErrorCode, WaveformCaps, WaveformError, WaveformLoadState } from './types';
+import { createCappedWaveformState, errorFromUnknown, isAbortError, WaveformLoadError } from './createWaveformLoader';
+import { WaveformCaps, WaveformError, WaveformLoadState } from './types';
 import { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
 
 export type DecodeSkipReason = 'missing_metadata' | 'compressed_size' | 'duration';
@@ -28,7 +28,7 @@ export type ClientDecodeOutput = {
 export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
 
 export type DecodeTimings = {
-    decodeMs: number | null;
+    attemptMs: number | null;
     extractMs: number | null;
 };
 
@@ -55,7 +55,7 @@ type DecodeAudioContext = {
     ) => Promise<AudioBuffer> | void;
 };
 
-const EMPTY_TIMINGS: DecodeTimings = { decodeMs: null, extractMs: null };
+const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
 
 function now(): number {
     return typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -78,13 +78,6 @@ function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefine
         webkitAudioContext?: new () => DecodeAudioContext;
     };
     return AudioContext || webkitAudioContext;
-}
-
-function isAbortError(error: unknown): boolean {
-    return (
-        (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
-        (error instanceof Error && error.name === 'AbortError')
-    );
 }
 
 function getDecodeSkipMessage(reason: DecodeSkipReason): string {
@@ -114,17 +107,6 @@ function createSkippedDecodeResult(reason: DecodeSkipReason): ClientDecodeResult
         timings: EMPTY_TIMINGS,
         reason,
     };
-}
-
-function errorFromUnknown(error: unknown): WaveformError {
-    if (error instanceof WaveformLoadError) {
-        return { code: error.code, message: error.message };
-    }
-    if (error instanceof Error && isWaveformErrorCode(error.name)) {
-        return { code: error.name, message: error.message };
-    }
-    const message = error instanceof Error ? error.message : 'Client decode failed';
-    return { code: 'DECODE_FAILED', message };
 }
 
 function decodeWithContext(
@@ -331,26 +313,26 @@ export async function runClientDecode(options: {
         if (signal.aborted || isAbortError(error)) {
             return { status: 'cancelled', isDecodeSkipped: false, timings: EMPTY_TIMINGS };
         }
-        const waveformError = errorFromUnknown(error);
+        const waveformError = errorFromUnknown(error, 'DECODE_FAILED');
         return {
             status: 'failed',
             error: waveformError,
             retryable: isRetryableWaveformError(waveformError.code),
             isDecodeSkipped: false,
             timings: {
-                decodeMs: now() - decodeStarted,
+                attemptMs: now() - decodeStarted,
                 extractMs: null,
             },
         };
     }
 
-    const decodeMs = now() - decodeStarted;
+    const attemptMs = now() - decodeStarted;
 
     if (signal.aborted) {
         return {
             status: 'cancelled',
             isDecodeSkipped: false,
-            timings: { decodeMs, extractMs: null },
+            timings: { attemptMs, extractMs: null },
         };
     }
 
@@ -369,7 +351,7 @@ export async function runClientDecode(options: {
             error: validation.error,
             retryable: isRetryableWaveformError(validation.error.code),
             isDecodeSkipped: false,
-            timings: { decodeMs, extractMs: decodeOutput.extractMs },
+            timings: { attemptMs, extractMs: decodeOutput.extractMs },
         };
     }
 
@@ -377,7 +359,7 @@ export async function runClientDecode(options: {
         status: 'ready',
         payload: validation.payload,
         isDecodeSkipped: false,
-        timings: { decodeMs, extractMs: decodeOutput.extractMs },
+        timings: { attemptMs, extractMs: decodeOutput.extractMs },
     };
 }
 

--- a/src/lib/viewers/media/waveform/index.ts
+++ b/src/lib/viewers/media/waveform/index.ts
@@ -5,6 +5,9 @@ export {
     PEAK_UNIT_MAX,
     PEAK_UNIT_MIN,
     WAVEFORM_PAYLOAD_VERSION,
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    CLIENT_DECODE_PEAK_COUNT,
 } from './constants';
 export { createCappedWaveformState, createWaveformLoader, WaveformLoadError } from './createWaveformLoader';
 export { isWaveformErrorCode, WAVEFORM_ERROR_CODES } from './types';

--- a/src/lib/viewers/media/waveform/index.ts
+++ b/src/lib/viewers/media/waveform/index.ts
@@ -9,6 +9,12 @@ export {
     CLIENT_DECODE_MAX_DURATION_SEC,
     CLIENT_DECODE_PEAK_COUNT,
 } from './constants';
-export { createCappedWaveformState, createWaveformLoader, WaveformLoadError } from './createWaveformLoader';
+export {
+    createCappedWaveformState,
+    createWaveformLoader,
+    errorFromUnknown,
+    isAbortError,
+    WaveformLoadError,
+} from './createWaveformLoader';
 export { isWaveformErrorCode, WAVEFORM_ERROR_CODES } from './types';
 export { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -85,6 +85,8 @@ export type WaveformValidationOptions = {
     /** Override default caps (used in tests and perf harness). */
     maxPeakCount?: number;
     maxPayloadBytes?: number;
+    /** Skip JSON byte-length check (in-memory client peaks, not wire JSON). */
+    isPayloadByteCheckSkipped?: boolean;
 };
 
 export type WaveformCaps = {

--- a/src/lib/viewers/media/waveform/validateWaveformPayload.ts
+++ b/src/lib/viewers/media/waveform/validateWaveformPayload.ts
@@ -92,14 +92,17 @@ function asWaveformPayloadV1(raw: Record<string, unknown>): WaveformPayloadV1 | 
 function readPayloadObject(
     raw: unknown,
     maxPayloadBytes: number,
+    isPayloadByteCheckSkipped = false,
 ): { ok: true; value: Record<string, unknown> } | WaveformValidationFailure {
     if (raw === null || raw === undefined) {
         return fail('INVALID_PAYLOAD', 'Payload is null or undefined');
     }
 
-    const byteLength = payloadByteLength(raw);
-    if (byteLength > maxPayloadBytes) {
-        return fail('PAYLOAD_TOO_LARGE', `Payload size ${byteLength} exceeds limit ${maxPayloadBytes}`);
+    if (!isPayloadByteCheckSkipped) {
+        const byteLength = payloadByteLength(raw);
+        if (byteLength > maxPayloadBytes) {
+            return fail('PAYLOAD_TOO_LARGE', `Payload size ${byteLength} exceeds limit ${maxPayloadBytes}`);
+        }
     }
 
     if (!isPlainObject(raw)) {
@@ -183,7 +186,7 @@ export function validateWaveformPayload(
     const maxPeakCount = options.maxPeakCount ?? MAX_PEAK_COUNT;
     const maxPayloadBytes = options.maxPayloadBytes ?? MAX_PAYLOAD_BYTES;
 
-    const objectResult = readPayloadObject(raw, maxPayloadBytes);
+    const objectResult = readPayloadObject(raw, maxPayloadBytes, options.isPayloadByteCheckSkipped === true);
     if (!objectResult.ok) {
         return objectResult;
     }


### PR DESCRIPTION
## Summary
- Decode compressed audio on the client into waveform peaks when the file is under 6 MiB and 5 minutes. Skip decode (fail-closed) if size or duration is missing or over cap. Playback does not wait on decode.
- Lazy-load the decode chunk. Prefer an already-fetched blob URL; otherwise GET the representation with an Authorization header. Safari plays first so AudioContext has a user gesture; overlay play retries decode once.
- Emit `media_metric_waveform_decode` only when decode is capped, unavailable, or failed — not on success.
- Chrome in this slice: rounded playhead (`border-radius: 999px`), waveform track padding `40px` → `60px`, v2 control bar padding `48px/20px` → `58px/25px`.

## Flow
Open MP3 → placeholder → metadata → decode in the background (play is not blocked)
  under cap → peaks replace the placeholder
  over cap / missing size or duration → placeholder stays, metric fires
  fetch/decode failure → placeholder stays, metric fires; overlay play retries once