### PR TITLE
feat(audio): decode client waveform peaks under size and duration caps

### DIFF
--- a/src/lib/viewers/media/waveform/__tests__/decode-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/decode-test.ts
@@ -1,0 +1,389 @@
+import { CLIENT_DECODE_MAX_COMPRESSED_BYTES, CLIENT_DECODE_MAX_DURATION_SEC } from '../constants';
+import { WaveformLoadError } from '../createWaveformLoader';
+import { getDecodeDecision, decodeToPeaks, extractPeaks, loadPeaks, runClientDecode } from '../decode';
+
+function silentSamples(durationSec: number): Float32Array[] {
+    const samples = Math.max(8, Math.floor(durationSec * 100));
+    return [new Float32Array(samples)];
+}
+
+describe('getDecodeDecision', () => {
+    const underCap = {
+        compressedBytes: 1024 * 1024,
+        durationSec: 60,
+    };
+
+    test('should allow decode when size and duration are within limits', () => {
+        expect(getDecodeDecision(underCap)).toEqual({ isAllowed: true });
+    });
+
+    test('should allow decode at exact cap boundaries', () => {
+        expect(
+            getDecodeDecision({
+                compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+                durationSec: CLIENT_DECODE_MAX_DURATION_SEC,
+            }),
+        ).toEqual({ isAllowed: true });
+    });
+
+    test('should reject when compressed size is over the cap', () => {
+        expect(
+            getDecodeDecision({
+                ...underCap,
+                compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            }),
+        ).toEqual({ isAllowed: false, reason: 'compressed_size' });
+    });
+
+    test('should reject when duration is over the cap', () => {
+        expect(
+            getDecodeDecision({
+                ...underCap,
+                durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 0.1,
+            }),
+        ).toEqual({ isAllowed: false, reason: 'duration' });
+    });
+
+    test('should reject when metadata is missing', () => {
+        expect(getDecodeDecision({})).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+        expect(getDecodeDecision({ compressedBytes: 1000 })).toEqual({
+            isAllowed: false,
+            reason: 'missing_metadata',
+        });
+        expect(getDecodeDecision({ durationSec: 10 })).toEqual({ isAllowed: false, reason: 'missing_metadata' });
+    });
+
+    test('should honor cap overrides', () => {
+        expect(getDecodeDecision(underCap, { maxCompressedBytes: 512 })).toEqual({
+            isAllowed: false,
+            reason: 'compressed_size',
+        });
+    });
+});
+
+describe('extractPeaks', () => {
+    test('should return empty peaks when there are no samples', () => {
+        expect(extractPeaks([new Float32Array(0)], 8)).toEqual([]);
+    });
+
+    test('should take max abs across stereo channels per bucket', () => {
+        const left = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+        const right = new Float32Array([0.5, 0.05, -0.9, 0.1]);
+        const peaks = extractPeaks([left, right], 2);
+
+        expect(peaks).toHaveLength(2);
+        expect(peaks[0]).toBeCloseTo(0.5);
+        expect(peaks[1]).toBeCloseTo(0.9);
+    });
+
+    test('should extract from an AudioBuffer without copying channels', () => {
+        const left = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+        const right = new Float32Array([0.5, 0.05, -0.9, 0.1]);
+        const audioBuffer = ({
+            numberOfChannels: 2,
+            getChannelData: (channelIndex: number) => (channelIndex === 0 ? left : right),
+        } as unknown) as AudioBuffer;
+
+        const peaks = extractPeaks(audioBuffer, 2);
+
+        expect(peaks).toHaveLength(2);
+        expect(peaks[0]).toBeCloseTo(0.5);
+        expect(peaks[1]).toBeCloseTo(0.9);
+    });
+
+    test('should clamp values above 1', () => {
+        const peaks = extractPeaks([new Float32Array([1.5, 1.5])], 1);
+        expect(peaks[0]).toBe(1);
+    });
+});
+
+describe('decodeToPeaks', () => {
+    const audioWindow = window as Window & {
+        AudioContext?: unknown;
+        webkitAudioContext?: unknown;
+    };
+    const originalAudioContext = audioWindow.AudioContext;
+    const originalWebkitAudioContext = audioWindow.webkitAudioContext;
+    let close: jest.Mock;
+    let decodeAudioData: jest.Mock;
+
+    beforeEach(() => {
+        close = jest.fn().mockResolvedValue(undefined);
+        decodeAudioData = jest.fn(
+            (
+                buffer: ArrayBuffer,
+                success: (decoded: {
+                    duration: number;
+                    numberOfChannels: number;
+                    getChannelData: () => Float32Array;
+                }) => void,
+            ) => {
+                success({
+                    duration: 2,
+                    numberOfChannels: 1,
+                    getChannelData: () => new Float32Array([0, 0.5, -1]),
+                });
+            },
+        );
+        audioWindow.AudioContext = jest.fn(() => ({
+            close,
+            decodeAudioData,
+        }));
+        audioWindow.webkitAudioContext = undefined;
+    });
+
+    afterEach(() => {
+        audioWindow.AudioContext = originalAudioContext;
+        audioWindow.webkitAudioContext = originalWebkitAudioContext;
+    });
+
+    test('should extract peaks from decodeAudioData before closing the context', async () => {
+        const result = await decodeToPeaks(new ArrayBuffer(8), undefined, 3);
+
+        expect(result.durationSec).toBe(2);
+        expect(result.peaks).toEqual([0, 0.5, 1]);
+        expect('peakSource' in result).toBe(false);
+        expect(close).toHaveBeenCalled();
+    });
+
+    test('should throw DECODE_FAILED when AudioContext is missing', async () => {
+        audioWindow.AudioContext = undefined;
+        audioWindow.webkitAudioContext = undefined;
+
+        await expect(decodeToPeaks(new ArrayBuffer(8))).rejects.toEqual(
+            expect.objectContaining({ code: 'DECODE_FAILED' }),
+        );
+    });
+
+    test('should throw when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        await expect(decodeToPeaks(new ArrayBuffer(8), controller.signal)).rejects.toMatchObject({
+            name: 'AbortError',
+        });
+        expect(audioWindow.AudioContext).not.toHaveBeenCalled();
+    });
+
+    test('should close AudioContext when aborted during decode', async () => {
+        decodeAudioData.mockImplementation(() => new Promise(() => undefined));
+        const controller = new AbortController();
+        const pending = decodeToPeaks(new ArrayBuffer(8), controller.signal);
+
+        await Promise.resolve();
+        expect(audioWindow.AudioContext).toHaveBeenCalled();
+
+        controller.abort();
+
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+        expect(close).toHaveBeenCalled();
+    });
+
+    test('should map decode failure to DECODE_FAILED', async () => {
+        decodeAudioData.mockImplementation((buffer: ArrayBuffer, success: unknown, error: (err: Error) => void) => {
+            error(new Error('bad mp3'));
+        });
+
+        await expect(decodeToPeaks(new ArrayBuffer(8))).rejects.toBeInstanceOf(WaveformLoadError);
+    });
+});
+
+describe('runClientDecode', () => {
+    test('should skip decode when compressed size is over the cap', async () => {
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
+            compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            durationSec: 30,
+            decode: decodeToPeaksFn,
+        });
+
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('compressed_size');
+        expect(result.timings.attemptMs).toBeNull();
+        if (result.status === 'capped') {
+            expect(result.error.code).toBe('CAP_EXCEEDED');
+        }
+    });
+
+    test('should skip decode when duration is over the cap', async () => {
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
+            compressedBytes: 1024,
+            durationSec: CLIENT_DECODE_MAX_DURATION_SEC + 1,
+            decode: decodeToPeaksFn,
+        });
+
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('duration');
+    });
+
+    test('should skip decode as unavailable when metadata is missing', async () => {
+        const decodeToPeaksFn = jest.fn();
+        const result = await runClientDecode({
+            decode: decodeToPeaksFn,
+        });
+
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('unavailable');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('missing_metadata');
+        expect(result.error && result.error.code).toBe('UNAVAILABLE');
+    });
+
+    test('should extract and validate peaks when under the cap', async () => {
+        const durationSec = 8;
+        const result = await runClientDecode({
+            compressedBytes: 2048,
+            durationSec,
+            decode: async () => {
+                const peaks = extractPeaks(silentSamples(durationSec), 8);
+                return { durationSec, peaks, extractMs: 0 };
+            },
+        });
+
+        expect(result.status).toBe('ready');
+        expect(result.isDecodeSkipped).toBe(false);
+        expect(result.timings.attemptMs).not.toBeNull();
+        expect(result.timings.extractMs).not.toBeNull();
+        if (result.status === 'ready') {
+            expect(result.payload.peaks).toBeInstanceOf(Float32Array);
+            expect(result.payload.peaks.length).toBe(8);
+            expect(result.payload.durationSec).toBe(durationSec);
+        }
+    });
+
+    test('should map named LOAD_FAILED throws without treating them as DECODE_FAILED', async () => {
+        const error = new Error('network');
+        error.name = 'LOAD_FAILED';
+        const result = await runClientDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decode: async () => {
+                throw error;
+            },
+        });
+
+        expect(result.status).toBe('failed');
+        if (result.status === 'failed') {
+            expect(result.error.code).toBe('LOAD_FAILED');
+            expect(result.retryable).toBe(true);
+        }
+    });
+
+    test('should map decode throws to failed DECODE_FAILED', async () => {
+        const result = await runClientDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decode: async () => {
+                throw new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed');
+            },
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.isDecodeSkipped).toBe(false);
+        if (result.status === 'failed') {
+            expect(result.error.code).toBe('DECODE_FAILED');
+            expect(result.retryable).toBe(true);
+        }
+    });
+
+    test('should cancel when the signal is already aborted', async () => {
+        const decodeToPeaksFn = jest.fn();
+        const controller = new AbortController();
+        controller.abort();
+        const result = await runClientDecode({
+            compressedBytes: 2048,
+            durationSec: 8,
+            decode: decodeToPeaksFn,
+            signal: controller.signal,
+        });
+
+        expect(decodeToPeaksFn).not.toHaveBeenCalled();
+        expect(result.status).toBe('cancelled');
+        expect(result.isDecodeSkipped).toBe(true);
+    });
+});
+
+describe('loadPeaks', () => {
+    const audioWindow = window as Window & {
+        AudioContext?: unknown;
+        webkitAudioContext?: unknown;
+    };
+    const originalAudioContext = audioWindow.AudioContext;
+    const originalWebkitAudioContext = audioWindow.webkitAudioContext;
+
+    beforeEach(() => {
+        audioWindow.AudioContext = jest.fn(() => ({
+            close: jest.fn().mockResolvedValue(undefined),
+            decodeAudioData: (
+                buffer: ArrayBuffer,
+                success: (decoded: {
+                    duration: number;
+                    numberOfChannels: number;
+                    getChannelData: () => Float32Array;
+                }) => void,
+            ) => {
+                success({
+                    duration: 8,
+                    numberOfChannels: 1,
+                    getChannelData: () => new Float32Array(800),
+                });
+            },
+        }));
+        audioWindow.webkitAudioContext = undefined;
+    });
+
+    afterEach(() => {
+        audioWindow.AudioContext = originalAudioContext;
+        audioWindow.webkitAudioContext = originalWebkitAudioContext;
+    });
+
+    test('should not fetch or decode when over the compressed size cap', async () => {
+        const fetchArrayBuffer = jest.fn();
+        const result = await loadPeaks({
+            compressedBytes: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1,
+            durationSec: 30,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).not.toHaveBeenCalled();
+        expect(result.status).toBe('capped');
+        expect(result.isDecodeSkipped).toBe(true);
+        expect(result.reason).toBe('compressed_size');
+    });
+
+    test('should not fetch or decode when size or duration is missing', async () => {
+        const fetchArrayBuffer = jest.fn();
+        const result = await loadPeaks({
+            durationSec: 30,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).not.toHaveBeenCalled();
+        expect(result.status).toBe('unavailable');
+        expect(result.reason).toBe('missing_metadata');
+        expect(result.error && result.error.code).toBe('UNAVAILABLE');
+    });
+
+    test('should fetch, decode, and return validated peaks when under the cap', async () => {
+        const durationSec = 8;
+        const fetchArrayBuffer = jest.fn().mockResolvedValue(new ArrayBuffer(16));
+
+        const result = await loadPeaks({
+            compressedBytes: 2048,
+            durationSec,
+            fetchArrayBuffer,
+        });
+
+        expect(fetchArrayBuffer).toHaveBeenCalled();
+        expect(result.status).toBe('ready');
+        if (result.status === 'ready') {
+            expect(result.payload.peaks.length).toBeGreaterThan(0);
+            expect(result.payload.durationSec).toBe(durationSec);
+        }
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/validateWaveformPayload-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/validateWaveformPayload-test.ts
@@ -96,6 +96,14 @@ describe('validateWaveformPayload', () => {
             }
         });
 
+        test('should skip payload byte limit when isPayloadByteCheckSkipped is set', () => {
+            const result = validateWaveformPayload(readyOverview, {
+                maxPayloadBytes: 16,
+                isPayloadByteCheckSkipped: true,
+            });
+            expect(result.ok).toBe(true);
+        });
+
         test('should reject non-finite peak', () => {
             const peaks = [...readyOverview.peaks];
             peaks[2] = Number.NaN;

--- a/src/lib/viewers/media/waveform/constants.ts
+++ b/src/lib/viewers/media/waveform/constants.ts
@@ -13,3 +13,12 @@ export const DURATION_MISMATCH_TOLERANCE_SEC = 1;
 /** Peak values must live in this closed interval when peakScale is "unit". */
 export const PEAK_UNIT_MIN = 0;
 export const PEAK_UNIT_MAX = 1;
+
+/** Skip client decode when the compressed file is larger than this. */
+export const CLIENT_DECODE_MAX_COMPRESSED_BYTES = 6 * 1024 * 1024;
+
+/** Skip client decode when media duration is longer than this. */
+export const CLIENT_DECODE_MAX_DURATION_SEC = 5 * 60;
+
+/** Default overview resolution for client-generated peaks. */
+export const CLIENT_DECODE_PEAK_COUNT = 16384;

--- a/src/lib/viewers/media/waveform/createWaveformLoader.ts
+++ b/src/lib/viewers/media/waveform/createWaveformLoader.ts
@@ -27,14 +27,14 @@ type LoadGeneration = {
     signal: AbortSignal;
 };
 
-function isAbortError(error: unknown): boolean {
+export function isAbortError(error: unknown): boolean {
     return (
         (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
         (error instanceof Error && error.name === 'AbortError')
     );
 }
 
-function errorFromUnknown(error: unknown): WaveformError {
+export function errorFromUnknown(error: unknown, fallbackCode: WaveformErrorCode = 'LOAD_FAILED'): WaveformError {
     if (error instanceof WaveformLoadError) {
         return { code: error.code, message: error.message };
     }
@@ -48,7 +48,7 @@ function errorFromUnknown(error: unknown): WaveformError {
     }
 
     const message = error instanceof Error ? error.message : 'Waveform load failed';
-    return { code: 'LOAD_FAILED', message };
+    return { code: fallbackCode, message };
 }
 
 function failedLoadState(error: WaveformError): WaveformLoadState {

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -7,44 +7,18 @@ import {
     WAVEFORM_PAYLOAD_VERSION,
 } from './constants';
 import { createCappedWaveformState, errorFromUnknown, isAbortError, WaveformLoadError } from './createWaveformLoader';
-import { WaveformCaps, WaveformError, WaveformLoadState } from './types';
+import {
+    ClientDecodeOutput,
+    ClientDecodeRequest,
+    ClientDecodeResult,
+    DecodeDecision,
+    DecodeSkipReason,
+    DecodeTimings,
+    DecodeToPeaksFn,
+    MediaInfo,
+    WaveformCaps,
+} from './types';
 import { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
-
-export type DecodeSkipReason = 'missing_metadata' | 'compressed_size' | 'duration';
-
-export type DecodeDecision = { isAllowed: true } | { isAllowed: false; reason: DecodeSkipReason };
-
-export type MediaInfo = {
-    compressedBytes?: number;
-    durationSec?: number;
-};
-
-export type ClientDecodeOutput = {
-    durationSec: number;
-    peaks: number[];
-    extractMs: number;
-};
-
-export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
-
-export type DecodeTimings = {
-    attemptMs: number | null;
-    extractMs: number | null;
-};
-
-export type ClientDecodeResult = WaveformLoadState & {
-    isDecodeSkipped: boolean;
-    timings: DecodeTimings;
-    reason?: DecodeSkipReason;
-    error?: WaveformError;
-};
-
-export type ClientDecodeRequest = {
-    compressedBytes?: number;
-    durationSec?: number;
-    fetchArrayBuffer: (signal: AbortSignal) => Promise<ArrayBuffer>;
-    signal?: AbortSignal;
-};
 
 type DecodeAudioContext = {
     close: () => Promise<void>;

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -1,0 +1,380 @@
+import {
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    CLIENT_DECODE_PEAK_COUNT,
+    PEAK_UNIT_MAX,
+    PEAK_UNIT_MIN,
+    WAVEFORM_PAYLOAD_VERSION,
+} from './constants';
+import { createCappedWaveformState, errorFromUnknown, isAbortError, WaveformLoadError } from './createWaveformLoader';
+import { WaveformCaps, WaveformError, WaveformLoadState } from './types';
+import { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
+
+export type DecodeSkipReason = 'missing_metadata' | 'compressed_size' | 'duration';
+
+export type DecodeDecision = { isAllowed: true } | { isAllowed: false; reason: DecodeSkipReason };
+
+export type MediaInfo = {
+    compressedBytes?: number;
+    durationSec?: number;
+};
+
+export type ClientDecodeOutput = {
+    durationSec: number;
+    peaks: number[];
+    extractMs: number;
+};
+
+export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
+
+export type DecodeTimings = {
+    attemptMs: number | null;
+    extractMs: number | null;
+};
+
+export type ClientDecodeResult = WaveformLoadState & {
+    isDecodeSkipped: boolean;
+    timings: DecodeTimings;
+    reason?: DecodeSkipReason;
+    error?: WaveformError;
+};
+
+export type ClientDecodeRequest = {
+    compressedBytes?: number;
+    durationSec?: number;
+    fetchArrayBuffer: (signal: AbortSignal) => Promise<ArrayBuffer>;
+    signal?: AbortSignal;
+};
+
+type DecodeAudioContext = {
+    close: () => Promise<void>;
+    decodeAudioData: (
+        buffer: ArrayBuffer,
+        successCallback?: (decoded: AudioBuffer) => void,
+        errorCallback?: (error?: unknown) => void,
+    ) => Promise<AudioBuffer> | void;
+};
+
+const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
+
+function now(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function createAbortError(): DOMException {
+    return new DOMException('Aborted', 'AbortError');
+}
+
+function isPositiveFinite(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefined {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+    const { AudioContext, webkitAudioContext } = (window as unknown) as {
+        AudioContext?: new () => DecodeAudioContext;
+        webkitAudioContext?: new () => DecodeAudioContext;
+    };
+    return AudioContext || webkitAudioContext;
+}
+
+function getDecodeSkipMessage(reason: DecodeSkipReason): string {
+    if (reason === 'compressed_size') {
+        return 'Compressed size exceeds client decode limit';
+    }
+    if (reason === 'duration') {
+        return 'Duration exceeds client decode limit';
+    }
+    return 'Compressed size or duration is missing; skipping client decode';
+}
+
+function createSkippedDecodeResult(reason: DecodeSkipReason): ClientDecodeResult {
+    if (reason === 'missing_metadata') {
+        return {
+            status: 'unavailable',
+            error: { code: 'UNAVAILABLE', message: getDecodeSkipMessage(reason) },
+            isDecodeSkipped: true,
+            timings: EMPTY_TIMINGS,
+            reason,
+        };
+    }
+
+    return {
+        ...createCappedWaveformState(getDecodeSkipMessage(reason)),
+        isDecodeSkipped: true,
+        timings: EMPTY_TIMINGS,
+        reason,
+    };
+}
+
+function decodeWithContext(
+    context: DecodeAudioContext,
+    buffer: ArrayBuffer,
+    signal?: AbortSignal,
+): Promise<AudioBuffer> {
+    return new Promise((resolve, reject) => {
+        let isSettled = false;
+        let onAbort: () => void = () => undefined;
+
+        const succeed = (decoded: AudioBuffer) => {
+            if (isSettled) {
+                return;
+            }
+            isSettled = true;
+            signal?.removeEventListener('abort', onAbort);
+            resolve(decoded);
+        };
+
+        const fail = (error?: unknown) => {
+            if (isSettled) {
+                return;
+            }
+            isSettled = true;
+            signal?.removeEventListener('abort', onAbort);
+            if (isAbortError(error)) {
+                reject(error instanceof DOMException ? error : createAbortError());
+                return;
+            }
+            reject(
+                error instanceof WaveformLoadError
+                    ? error
+                    : new WaveformLoadError('DECODE_FAILED', 'decodeAudioData failed'),
+            );
+        };
+
+        onAbort = () => fail(createAbortError());
+
+        if (signal?.aborted) {
+            fail(createAbortError());
+            return;
+        }
+
+        signal?.addEventListener('abort', onAbort, { once: true });
+
+        try {
+            const maybePromise = context.decodeAudioData(buffer, succeed, fail);
+            if (maybePromise && typeof maybePromise.then === 'function') {
+                maybePromise.then(succeed, fail);
+            }
+        } catch (error) {
+            fail(error);
+        }
+    });
+}
+
+/**
+ * Decide whether to run decodeAudioData. Either cap failing, or unknown size/duration,
+ * skips decode so playback is never blocked by expanding the full audio buffer.
+ */
+export function getDecodeDecision(media: MediaInfo, caps: WaveformCaps = {}): DecodeDecision {
+    const maxCompressedBytes = caps.maxCompressedBytes ?? CLIENT_DECODE_MAX_COMPRESSED_BYTES;
+    const maxDurationSec = caps.maxDurationSec ?? CLIENT_DECODE_MAX_DURATION_SEC;
+    const { compressedBytes, durationSec } = media;
+
+    if (!isPositiveFinite(compressedBytes) || !isPositiveFinite(durationSec)) {
+        return { isAllowed: false, reason: 'missing_metadata' };
+    }
+
+    if (compressedBytes > maxCompressedBytes) {
+        return { isAllowed: false, reason: 'compressed_size' };
+    }
+
+    if (durationSec > maxDurationSec) {
+        return { isAllowed: false, reason: 'duration' };
+    }
+
+    return { isAllowed: true };
+}
+
+/**
+ * Collapse audio channels to one unsigned peak per time bucket (max abs, then clamp to unit).
+ * Accepts an AudioBuffer so callers can extract before closing the AudioContext.
+ */
+export function extractPeaks(
+    audio: AudioBuffer | Float32Array[],
+    peakCount: number = CLIENT_DECODE_PEAK_COUNT,
+): number[] {
+    const channels: ArrayLike<number>[] = Array.isArray(audio)
+        ? audio
+        : Array.from({ length: audio.numberOfChannels }, (_, channelIndex) => audio.getChannelData(channelIndex));
+
+    if (peakCount <= 0 || channels.length === 0) {
+        return [];
+    }
+
+    const sampleCount = channels[0].length;
+    if (sampleCount === 0) {
+        return [];
+    }
+
+    const peaks = new Array(peakCount);
+    const bucketWidth = sampleCount / peakCount;
+
+    for (let i = 0; i < peakCount; i += 1) {
+        const start = Math.floor(i * bucketWidth);
+        const end = Math.max(start + 1, Math.floor((i + 1) * bucketWidth));
+        let maxAbs = 0;
+
+        for (let sampleIndex = start; sampleIndex < end && sampleIndex < sampleCount; sampleIndex += 1) {
+            for (let channelIndex = 0; channelIndex < channels.length; channelIndex += 1) {
+                const value = Math.abs(channels[channelIndex][sampleIndex]);
+                if (value > maxAbs) {
+                    maxAbs = value;
+                }
+            }
+        }
+
+        peaks[i] = Math.min(PEAK_UNIT_MAX, Math.max(PEAK_UNIT_MIN, maxAbs));
+    }
+
+    return peaks;
+}
+
+/**
+ * Decode compressed audio and extract unit peaks while the AudioBuffer is live.
+ * Does not attach a media element or fetch a URL. Does not copy channel data.
+ */
+export async function decodeToPeaks(
+    arrayBuffer: ArrayBuffer,
+    signal?: AbortSignal,
+    peakCount: number = CLIENT_DECODE_PEAK_COUNT,
+): Promise<ClientDecodeOutput> {
+    if (signal?.aborted) {
+        throw createAbortError();
+    }
+
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) {
+        throw new WaveformLoadError('DECODE_FAILED', 'AudioContext is not available');
+    }
+
+    const context = new AudioContextConstructor();
+
+    try {
+        const audioBuffer = await decodeWithContext(context, arrayBuffer.slice(0), signal);
+        if (signal?.aborted) {
+            throw createAbortError();
+        }
+
+        const extractStarted = now();
+        const peaks = extractPeaks(audioBuffer, peakCount);
+        return {
+            durationSec: audioBuffer.duration,
+            peaks,
+            extractMs: now() - extractStarted,
+        };
+    } catch (error) {
+        if (signal?.aborted || isAbortError(error)) {
+            throw createAbortError();
+        }
+        throw error;
+    } finally {
+        try {
+            await context.close();
+        } catch {
+            // Context may already be closed.
+        }
+    }
+}
+
+/**
+ * Run a client-decode attempt against the V1 waveform contract.
+ * Decode is not invoked when size or duration is over the cap (or unknown).
+ */
+export async function runClientDecode(options: {
+    compressedBytes?: number;
+    durationSec?: number;
+    decode: DecodeToPeaksFn;
+    caps?: WaveformCaps;
+    signal?: AbortSignal;
+}): Promise<ClientDecodeResult> {
+    const decision = getDecodeDecision(
+        { compressedBytes: options.compressedBytes, durationSec: options.durationSec },
+        options.caps,
+    );
+
+    if (!decision.isAllowed) {
+        return createSkippedDecodeResult(decision.reason);
+    }
+
+    if (options.signal?.aborted) {
+        return { status: 'cancelled', isDecodeSkipped: true, timings: EMPTY_TIMINGS };
+    }
+
+    const signal = options.signal ?? new AbortController().signal;
+    const decodeStarted = now();
+
+    let decodeOutput: ClientDecodeOutput;
+    try {
+        decodeOutput = await options.decode(signal);
+    } catch (error) {
+        if (signal.aborted || isAbortError(error)) {
+            return { status: 'cancelled', isDecodeSkipped: false, timings: EMPTY_TIMINGS };
+        }
+        const waveformError = errorFromUnknown(error, 'DECODE_FAILED');
+        return {
+            status: 'failed',
+            error: waveformError,
+            retryable: isRetryableWaveformError(waveformError.code),
+            isDecodeSkipped: false,
+            timings: {
+                attemptMs: now() - decodeStarted,
+                extractMs: null,
+            },
+        };
+    }
+
+    const attemptMs = now() - decodeStarted;
+
+    if (signal.aborted) {
+        return {
+            status: 'cancelled',
+            isDecodeSkipped: false,
+            timings: { attemptMs, extractMs: null },
+        };
+    }
+
+    const validation = validateWaveformPayload(
+        {
+            version: WAVEFORM_PAYLOAD_VERSION,
+            durationSec: options.durationSec ?? decodeOutput.durationSec,
+            peaks: decodeOutput.peaks,
+        },
+        { isPayloadByteCheckSkipped: true },
+    );
+
+    if (!validation.ok) {
+        return {
+            status: 'failed',
+            error: validation.error,
+            retryable: isRetryableWaveformError(validation.error.code),
+            isDecodeSkipped: false,
+            timings: { attemptMs, extractMs: decodeOutput.extractMs },
+        };
+    }
+
+    return {
+        status: 'ready',
+        payload: validation.payload,
+        isDecodeSkipped: false,
+        timings: { attemptMs, extractMs: decodeOutput.extractMs },
+    };
+}
+
+/**
+ * Gate, fetch, decode, and extract in-viewer peaks. Skips decode when over cap.
+ * Playback must not await this.
+ */
+export function loadPeaks(request: ClientDecodeRequest): Promise<ClientDecodeResult> {
+    return runClientDecode({
+        compressedBytes: request.compressedBytes,
+        durationSec: request.durationSec,
+        signal: request.signal,
+        decode: async signal => {
+            const arrayBuffer = await request.fetchArrayBuffer(signal);
+            return decodeToPeaks(arrayBuffer, signal);
+        },
+    });
+}

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -57,7 +57,7 @@ type DecodeAudioContext = {
 
 const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
 
-function now(): number {
+function timestampMs(): number {
     return typeof performance !== 'undefined' ? performance.now() : Date.now();
 }
 
@@ -258,12 +258,12 @@ export async function decodeToPeaks(
             throw createAbortError();
         }
 
-        const extractStarted = now();
+        const extractStarted = timestampMs();
         const peaks = extractPeaks(audioBuffer, peakCount);
         return {
             durationSec: audioBuffer.duration,
             peaks,
-            extractMs: now() - extractStarted,
+            extractMs: timestampMs() - extractStarted,
         };
     } catch (error) {
         if (signal?.aborted || isAbortError(error)) {
@@ -304,7 +304,7 @@ export async function runClientDecode(options: {
     }
 
     const signal = options.signal ?? new AbortController().signal;
-    const decodeStarted = now();
+    const decodeStarted = timestampMs();
 
     let decodeOutput: ClientDecodeOutput;
     try {
@@ -320,13 +320,13 @@ export async function runClientDecode(options: {
             retryable: isRetryableWaveformError(waveformError.code),
             isDecodeSkipped: false,
             timings: {
-                attemptMs: now() - decodeStarted,
+                attemptMs: timestampMs() - decodeStarted,
                 extractMs: null,
             },
         };
     }
 
-    const attemptMs = now() - decodeStarted;
+    const attemptMs = timestampMs() - decodeStarted;
 
     if (signal.aborted) {
         return {

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -31,7 +31,7 @@ type DecodeAudioContext = {
 
 const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
 
-function timestampMs(): number {
+function getCurrentTimeMs(): number {
     return typeof performance !== 'undefined' ? performance.now() : Date.now();
 }
 
@@ -92,7 +92,7 @@ function decodeWithContext(
         let isSettled = false;
         let onAbort: () => void = () => undefined;
 
-        const succeed = (decoded: AudioBuffer) => {
+        const onSuccess = (decoded: AudioBuffer) => {
             if (isSettled) {
                 return;
             }
@@ -101,7 +101,7 @@ function decodeWithContext(
             resolve(decoded);
         };
 
-        const fail = (error?: unknown) => {
+        const onFailure = (error?: unknown) => {
             if (isSettled) {
                 return;
             }
@@ -118,22 +118,22 @@ function decodeWithContext(
             );
         };
 
-        onAbort = () => fail(createAbortError());
+        onAbort = () => onFailure(createAbortError());
 
         if (signal?.aborted) {
-            fail(createAbortError());
+            onFailure(createAbortError());
             return;
         }
 
         signal?.addEventListener('abort', onAbort, { once: true });
 
         try {
-            const maybePromise = context.decodeAudioData(buffer, succeed, fail);
+            const maybePromise = context.decodeAudioData(buffer, onSuccess, onFailure);
             if (maybePromise && typeof maybePromise.then === 'function') {
-                maybePromise.then(succeed, fail);
+                maybePromise.then(onSuccess, onFailure);
             }
         } catch (error) {
-            fail(error);
+            onFailure(error);
         }
     });
 }
@@ -232,12 +232,12 @@ export async function decodeToPeaks(
             throw createAbortError();
         }
 
-        const extractStarted = timestampMs();
+        const extractStarted = getCurrentTimeMs();
         const peaks = extractPeaks(audioBuffer, peakCount);
         return {
             durationSec: audioBuffer.duration,
             peaks,
-            extractMs: timestampMs() - extractStarted,
+            extractMs: getCurrentTimeMs() - extractStarted,
         };
     } catch (error) {
         if (signal?.aborted || isAbortError(error)) {
@@ -278,7 +278,7 @@ export async function runClientDecode(options: {
     }
 
     const signal = options.signal ?? new AbortController().signal;
-    const decodeStarted = timestampMs();
+    const decodeStarted = getCurrentTimeMs();
 
     let decodeOutput: ClientDecodeOutput;
     try {
@@ -294,13 +294,13 @@ export async function runClientDecode(options: {
             retryable: isRetryableWaveformError(waveformError.code),
             isDecodeSkipped: false,
             timings: {
-                attemptMs: timestampMs() - decodeStarted,
+                attemptMs: getCurrentTimeMs() - decodeStarted,
                 extractMs: null,
             },
         };
     }
 
-    const attemptMs = timestampMs() - decodeStarted;
+    const attemptMs = getCurrentTimeMs() - decodeStarted;
 
     if (signal.aborted) {
         return {

--- a/src/lib/viewers/media/waveform/index.ts
+++ b/src/lib/viewers/media/waveform/index.ts
@@ -5,7 +5,16 @@ export {
     PEAK_UNIT_MAX,
     PEAK_UNIT_MIN,
     WAVEFORM_PAYLOAD_VERSION,
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    CLIENT_DECODE_PEAK_COUNT,
 } from './constants';
-export { createCappedWaveformState, createWaveformLoader, WaveformLoadError } from './createWaveformLoader';
+export {
+    createCappedWaveformState,
+    createWaveformLoader,
+    errorFromUnknown,
+    isAbortError,
+    WaveformLoadError,
+} from './createWaveformLoader';
 export { isWaveformErrorCode, WAVEFORM_ERROR_CODES } from './types';
 export { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -94,6 +94,42 @@ export type WaveformCaps = {
     maxCompressedBytes?: number;
 };
 
+export type DecodeSkipReason = 'missing_metadata' | 'compressed_size' | 'duration';
+
+export type DecodeDecision = { isAllowed: true } | { isAllowed: false; reason: DecodeSkipReason };
+
+export type MediaInfo = {
+    compressedBytes?: number;
+    durationSec?: number;
+};
+
+export type ClientDecodeOutput = {
+    durationSec: number;
+    peaks: number[];
+    extractMs: number;
+};
+
+export type DecodeToPeaksFn = (signal: AbortSignal) => Promise<ClientDecodeOutput>;
+
+export type DecodeTimings = {
+    attemptMs: number | null;
+    extractMs: number | null;
+};
+
+export type ClientDecodeResult = WaveformLoadState & {
+    isDecodeSkipped: boolean;
+    timings: DecodeTimings;
+    reason?: DecodeSkipReason;
+    error?: WaveformError;
+};
+
+export type ClientDecodeRequest = {
+    compressedBytes?: number;
+    durationSec?: number;
+    fetchArrayBuffer: (signal: AbortSignal) => Promise<ArrayBuffer>;
+    signal?: AbortSignal;
+};
+
 /**
  * Async boundary for waveform data. Implementations may fetch fixtures, decode client-side,
  * or load Conversion reps — callers only observe WaveformLoadState.

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -85,6 +85,8 @@ export type WaveformValidationOptions = {
     /** Override default caps (used in tests and perf harness). */
     maxPeakCount?: number;
     maxPayloadBytes?: number;
+    /** Skip JSON byte-length check (in-memory client peaks, not wire JSON). */
+    isPayloadByteCheckSkipped?: boolean;
 };
 
 export type WaveformCaps = {

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -82,11 +82,11 @@ export type WaveformLoadState =
 export type WaveformValidationOptions = {
     /** When set, payload duration must agree within tolerance. */
     expectedDurationSec?: number;
+    /** Skip JSON byte-length check (in-memory client peaks, not wire JSON). */
+    isPayloadByteCheckSkipped?: boolean;
     /** Override default caps (used in tests and perf harness). */
     maxPeakCount?: number;
     maxPayloadBytes?: number;
-    /** Skip JSON byte-length check (in-memory client peaks, not wire JSON). */
-    isPayloadByteCheckSkipped?: boolean;
 };
 
 export type WaveformCaps = {

--- a/src/lib/viewers/media/waveform/validateWaveformPayload.ts
+++ b/src/lib/viewers/media/waveform/validateWaveformPayload.ts
@@ -92,14 +92,17 @@ function asWaveformPayloadV1(raw: Record<string, unknown>): WaveformPayloadV1 | 
 function readPayloadObject(
     raw: unknown,
     maxPayloadBytes: number,
+    isPayloadByteCheckSkipped = false,
 ): { ok: true; value: Record<string, unknown> } | WaveformValidationFailure {
     if (raw === null || raw === undefined) {
         return fail('INVALID_PAYLOAD', 'Payload is null or undefined');
     }
 
-    const byteLength = payloadByteLength(raw);
-    if (byteLength > maxPayloadBytes) {
-        return fail('PAYLOAD_TOO_LARGE', `Payload size ${byteLength} exceeds limit ${maxPayloadBytes}`);
+    if (!isPayloadByteCheckSkipped) {
+        const byteLength = payloadByteLength(raw);
+        if (byteLength > maxPayloadBytes) {
+            return fail('PAYLOAD_TOO_LARGE', `Payload size ${byteLength} exceeds limit ${maxPayloadBytes}`);
+        }
     }
 
     if (!isPlainObject(raw)) {
@@ -183,7 +186,7 @@ export function validateWaveformPayload(
     const maxPeakCount = options.maxPeakCount ?? MAX_PEAK_COUNT;
     const maxPayloadBytes = options.maxPayloadBytes ?? MAX_PAYLOAD_BYTES;
 
-    const objectResult = readPayloadObject(raw, maxPayloadBytes);
+    const objectResult = readPayloadObject(raw, maxPayloadBytes, options.isPayloadByteCheckSkipped === true);
     if (!objectResult.ok) {
         return objectResult;
     }


### PR DESCRIPTION
## Summary
- Add a client decode path that turns compressed audio into waveform peaks when the file is under **6 MiB and 5 minutes**. Skip decode (fail-closed) if size or duration is missing or over cap.
- Caps, skip reasons, and peak extract live in `waveform/decode.ts`. No viewer wiring in this PR — the chunk is not loaded yet.
- In-memory peaks skip the JSON byte-length check. Shared `isAbortError` / `errorFromUnknown` so decode and the later viewer use the same mapping.

## Out of scope
MP3Viewer, `media_metric_waveform_decode`, and waveform CSS. Those land in the follow-up stacked on this branch.