### PR TITLE
feat(audio): load client waveform peaks into the MP3 viewer

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -133,6 +133,7 @@ export const MEDIA_METRIC = {
 export const MEDIA_METRIC_EVENTS = {
     bufferFill: 'media_metric_buffer_fill',
     endPlayback: 'media_metric_end_playback',
+    waveformDecode: 'media_metric_waveform_decode',
 };
 
 export const REPORT_ACI = 'advanced_insights_report';

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -133,7 +133,6 @@ export const MEDIA_METRIC = {
 export const MEDIA_METRIC_EVENTS = {
     bufferFill: 'media_metric_buffer_fill',
     endPlayback: 'media_metric_end_playback',
-    waveformDecode: 'media_metric_waveform_decode',
 };
 
 export const REPORT_ACI = 'advanced_insights_report';

--- a/src/lib/viewers/media/MP3ControlsV2.scss
+++ b/src/lib/viewers/media/MP3ControlsV2.scss
@@ -74,7 +74,7 @@
     align-items: center;
     justify-content: space-between;
     min-height: 32px;
-    padding: 30px 48px 20px;
+    padding: 30px 58px 25px;
     background: linear-gradient(to top, rgb(0 0 0 / 100%), rgb(0 0 0 / 0%));
     pointer-events: auto;
 }

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -245,7 +245,7 @@ class MP3Viewer extends MediaBaseViewer {
      */
     async startClientWaveformDecode() {
         if (!this.isAudioPlayerV2 || this.destroyed) {
-            return Promise.resolve();
+            return;
         }
 
         this.abortClientWaveformDecode();
@@ -253,39 +253,36 @@ class MP3Viewer extends MediaBaseViewer {
         this.waveformDecodeController = controller;
         const { signal } = controller;
 
-        return this.importWaveformDecode()
-            .then(mod => {
-                if (this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
-                    return null;
-                }
+        try {
+            const decodeModule = await this.importWaveformDecode();
+            if (this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
+                return;
+            }
 
-                return mod.loadPeaks({
-                    compressedBytes: this.options.file && this.options.file.size,
-                    durationSec: this.mediaEl && this.mediaEl.duration,
-                    fetchArrayBuffer: innerSignal => this.fetchAudioArrayBuffer(innerSignal || signal),
-                    signal,
-                });
-            })
-            .then(result => {
-                this.handleClientWaveformDecodeResult(result, controller, signal);
-            })
-            .catch(error => {
-                if (isAbortError(error)) {
-                    this.handleClientWaveformDecodeResult({ status: 'cancelled' }, controller, signal);
-                    return;
-                }
-
-                const waveformError = errorFromUnknown(error, 'LOAD_FAILED');
-                this.handleClientWaveformDecodeResult(
-                    {
-                        status: 'failed',
-                        error: waveformError,
-                        retryable: isRetryableWaveformError(waveformError.code),
-                    },
-                    controller,
-                    signal,
-                );
+            const result = await decodeModule.loadPeaks({
+                compressedBytes: this.options.file && this.options.file.size,
+                durationSec: this.mediaEl && this.mediaEl.duration,
+                fetchArrayBuffer: fetchSignal => this.fetchAudioArrayBuffer(fetchSignal || signal),
+                signal,
             });
+            this.handleClientWaveformDecodeResult(result, controller, signal);
+        } catch (error) {
+            if (isAbortError(error)) {
+                this.handleClientWaveformDecodeResult({ status: 'cancelled' }, controller, signal);
+                return;
+            }
+
+            const waveformError = errorFromUnknown(error, 'LOAD_FAILED');
+            this.handleClientWaveformDecodeResult(
+                {
+                    error: waveformError,
+                    retryable: isRetryableWaveformError(waveformError.code),
+                    status: 'failed',
+                },
+                controller,
+                signal,
+            );
+        }
     }
 
     /**
@@ -324,14 +321,17 @@ class MP3Viewer extends MediaBaseViewer {
      * @return {void}
      */
     emitWaveformDecodeMetric(result) {
-        const data = {
-            status: result.status,
-            code: result.error && result.error.code,
-        };
-        if (result.reason) {
-            data.reason = result.reason;
-        }
-        this.emitMetric(MEDIA_METRIC_EVENTS.waveformDecode, data);
+        const metricData = result.reason
+            ? {
+                  code: result.error && result.error.code,
+                  reason: result.reason,
+                  status: result.status,
+              }
+            : {
+                  code: result.error && result.error.code,
+                  status: result.status,
+              };
+        this.emitMetric(MEDIA_METRIC_EVENTS.waveformDecode, metricData);
     }
 
     /**

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -103,17 +103,17 @@ class MP3Viewer extends MediaBaseViewer {
     /**
      * @return {Promise<{ loadPeaks: Function }>} client-decode helpers
      */
-    importWaveformDecode() {
+    async importWaveformDecode() {
         if (!this.waveformDecodeImport) {
-            this.waveformDecodeImport = import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode').catch(
-                error => {
-                    this.waveformDecodeImport = null;
-                    throw error;
-                },
-            );
+            this.waveformDecodeImport = import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode');
         }
 
-        return this.waveformDecodeImport;
+        try {
+            return await this.waveformDecodeImport;
+        } catch (error) {
+            this.waveformDecodeImport = null;
+            throw error;
+        }
     }
 
     /**
@@ -263,7 +263,7 @@ class MP3Viewer extends MediaBaseViewer {
             const result = await decodeModule.loadPeaks({
                 compressedBytes: this.options.file && this.options.file.size,
                 durationSec: this.mediaEl && this.mediaEl.duration,
-                fetchArrayBuffer: fetchSignal => this.fetchAudioArrayBuffer(fetchSignal || signal),
+                fetchArrayBuffer: fetchSignal => this.fetchAudioArrayBuffer(fetchSignal),
                 signal,
             });
             this.handleClientWaveformDecodeResult(result, controller, signal);
@@ -291,7 +291,7 @@ class MP3Viewer extends MediaBaseViewer {
     /**
      * Apply peaks, or record a retryable failure for overlay play.
      *
-     * @param {Object} result loadPeaks / runClientDecode result
+     * @param {import('./waveform/types').ClientDecodeResult} result
      * @param {AbortController} controller in-flight controller for this attempt
      * @param {AbortSignal} signal
      * @return {void}

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../events';
+import { VIEWER_EVENT } from '../../events';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
@@ -286,7 +286,7 @@ class MP3Viewer extends MediaBaseViewer {
     }
 
     /**
-     * Apply peaks, record a retryable failure for overlay play, or emit a degrade metric.
+     * Apply peaks, or record a retryable failure for overlay play.
      *
      * @param {Object} result loadPeaks / runClientDecode result
      * @param {AbortController} controller in-flight controller for this attempt
@@ -312,26 +312,6 @@ class MP3Viewer extends MediaBaseViewer {
         if (result.status === 'failed' && result.retryable && !this.hasUsedWaveformDecodePlayRetry) {
             this.isWaveformDecodeRetryPending = true;
         }
-
-        this.emitWaveformDecodeMetric(result);
-    }
-
-    /**
-     * @param {Object} result capped or failed loadPeaks result
-     * @return {void}
-     */
-    emitWaveformDecodeMetric(result) {
-        const metricData = result.reason
-            ? {
-                  code: result.error && result.error.code,
-                  reason: result.reason,
-                  status: result.status,
-              }
-            : {
-                  code: result.error && result.error.code,
-                  status: result.status,
-              };
-        this.emitMetric(MEDIA_METRIC_EVENTS.waveformDecode, metricData);
     }
 
     /**

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import { VIEWER_EVENT } from '../../events';
+import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../events';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
+import { errorFromUnknown, isAbortError, WaveformLoadError } from './waveform/createWaveformLoader';
+import { isRetryableWaveformError } from './waveform/validateWaveformPayload';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
@@ -28,6 +30,7 @@ class MP3Viewer extends MediaBaseViewer {
             this.wrapperEl.classList.add('bp-media--v2');
             this.mediaContainerEl.classList.add('bp-media-container--v2');
             this.ensureV2Controls();
+            this.importWaveformDecode();
         }
 
         // Audio element
@@ -94,6 +97,30 @@ class MP3Viewer extends MediaBaseViewer {
     }
 
     /**
+     * @return {Promise<{ loadPeaks: Function }>} client-decode helpers
+     */
+    importWaveformDecode() {
+        if (!this.waveformDecodeImport) {
+            this.waveformDecodeImport = import(/* webpackChunkName: "mp3-waveform-decode" */ './waveform/decode').catch(
+                error => {
+                    this.waveformDecodeImport = null;
+                    throw error;
+                },
+            );
+        }
+
+        return this.waveformDecodeImport;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    destroy() {
+        this.abortClientWaveformDecode();
+        super.destroy();
+    }
+
+    /**
      * @inheritdoc
      */
     load() {
@@ -138,9 +165,16 @@ class MP3Viewer extends MediaBaseViewer {
     loadeddataHandler() {
         super.loadeddataHandler();
 
-        if (this.isAudioPlayerV2 && this.userRequestedPlay) {
+        if (!this.isAudioPlayerV2) {
+            return;
+        }
+
+        // Play first so Safari has a user gesture before AudioContext is created.
+        if (this.userRequestedPlay) {
             this.play();
         }
+
+        this.startClientWaveformDecode();
     }
 
     /**
@@ -149,7 +183,156 @@ class MP3Viewer extends MediaBaseViewer {
     handlePlayRequest = () => {
         this.userRequestedPlay = true;
         this.togglePlay();
+
+        if (this.isWaveformDecodeRetryPending && !this.hasUsedWaveformDecodePlayRetry) {
+            this.hasUsedWaveformDecodePlayRetry = true;
+            this.isWaveformDecodeRetryPending = false;
+            this.startClientWaveformDecode();
+        }
     };
+
+    /**
+     * Fetch compressed audio bytes for client decode. Prefers an already-fetched blob URL.
+     *
+     * @param {AbortSignal} signal
+     * @return {Promise<ArrayBuffer>}
+     */
+    async fetchAudioArrayBuffer(signal) {
+        if (this.mediaBlobUrl) {
+            return fetch(this.mediaBlobUrl, { signal }).then(response => {
+                if (!response.ok) {
+                    throw new WaveformLoadError('LOAD_FAILED', `Waveform fetch failed (${response.status})`);
+                }
+                return response.arrayBuffer();
+            });
+        }
+
+        const template =
+            this.options.representation &&
+            this.options.representation.content &&
+            this.options.representation.content.url_template;
+        if (!template) {
+            return Promise.reject(new WaveformLoadError('LOAD_FAILED', 'Waveform fetch URL is missing'));
+        }
+
+        const request = this.api.get(this.createContentUrlV2(template), {
+            headers: this.appendAuthHeader(),
+            signal,
+            type: 'arraybuffer',
+        });
+
+        return request.then(data => {
+            if (data instanceof ArrayBuffer) {
+                return data;
+            }
+            throw new WaveformLoadError('LOAD_FAILED', 'Waveform fetch did not return binary data');
+        });
+    }
+
+    abortClientWaveformDecode() {
+        if (!this.waveformDecodeController) {
+            return;
+        }
+        this.waveformDecodeController.abort();
+        this.waveformDecodeController = null;
+    }
+
+    /**
+     * Decode peaks in the background when the file is under size and duration caps.
+     * Does not block playback. Capped or failed decode keeps the placeholder waveform.
+     *
+     * @return {Promise<void>}
+     */
+    async startClientWaveformDecode() {
+        if (!this.isAudioPlayerV2 || this.destroyed) {
+            return Promise.resolve();
+        }
+
+        this.abortClientWaveformDecode();
+        const controller = new AbortController();
+        this.waveformDecodeController = controller;
+        const { signal } = controller;
+
+        return this.importWaveformDecode()
+            .then(mod => {
+                if (this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
+                    return null;
+                }
+
+                return mod.loadPeaks({
+                    compressedBytes: this.options.file && this.options.file.size,
+                    durationSec: this.mediaEl && this.mediaEl.duration,
+                    fetchArrayBuffer: innerSignal => this.fetchAudioArrayBuffer(innerSignal || signal),
+                    signal,
+                });
+            })
+            .then(result => {
+                this.handleClientWaveformDecodeResult(result, controller, signal);
+            })
+            .catch(error => {
+                if (isAbortError(error)) {
+                    this.handleClientWaveformDecodeResult({ status: 'cancelled' }, controller, signal);
+                    return;
+                }
+
+                const waveformError = errorFromUnknown(error, 'LOAD_FAILED');
+                this.handleClientWaveformDecodeResult(
+                    {
+                        status: 'failed',
+                        error: waveformError,
+                        retryable: isRetryableWaveformError(waveformError.code),
+                    },
+                    controller,
+                    signal,
+                );
+            });
+    }
+
+    /**
+     * Apply peaks, record a retryable failure for overlay play, or emit a degrade metric.
+     *
+     * @param {Object} result loadPeaks / runClientDecode result
+     * @param {AbortController} controller in-flight controller for this attempt
+     * @param {AbortSignal} signal
+     * @return {void}
+     */
+    handleClientWaveformDecodeResult(result, controller, signal) {
+        if (!result || this.destroyed || signal.aborted || this.waveformDecodeController !== controller) {
+            return;
+        }
+
+        if (result.status === 'ready') {
+            this.waveformPeaks = result.payload.peaks;
+            this.isWaveformDecodeRetryPending = false;
+            this.renderUI();
+            return;
+        }
+
+        if (result.status === 'cancelled') {
+            return;
+        }
+
+        if (result.status === 'failed' && result.retryable && !this.hasUsedWaveformDecodePlayRetry) {
+            this.isWaveformDecodeRetryPending = true;
+        }
+
+        this.emitWaveformDecodeMetric(result);
+    }
+
+    /**
+     * @param {Object} result capped or failed loadPeaks result
+     * @return {void}
+     */
+    emitWaveformDecodeMetric(result) {
+        const data = {
+            status: result.status,
+            code: result.error && result.error.code,
+        };
+        if (result.reason) {
+            data.reason = result.reason;
+        }
+        this.emitMetric(MEDIA_METRIC_EVENTS.waveformDecode, data);
+    }
 
     /**
      * @inheritdoc

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -3,11 +3,15 @@ import { VIEWER_EVENT } from '../../events';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
-import { errorFromUnknown, isAbortError, WaveformLoadError } from './waveform/createWaveformLoader';
-import { isRetryableWaveformError } from './waveform/validateWaveformPayload';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
+
+function createLoadFailedError(message) {
+    const error = new Error(message);
+    error.name = 'LOAD_FAILED';
+    return error;
+}
 
 class MP3Viewer extends MediaBaseViewer {
     /**
@@ -199,12 +203,11 @@ class MP3Viewer extends MediaBaseViewer {
      */
     async fetchAudioArrayBuffer(signal) {
         if (this.mediaBlobUrl) {
-            return fetch(this.mediaBlobUrl, { signal }).then(response => {
-                if (!response.ok) {
-                    throw new WaveformLoadError('LOAD_FAILED', `Waveform fetch failed (${response.status})`);
-                }
-                return response.arrayBuffer();
-            });
+            const response = await fetch(this.mediaBlobUrl, { signal });
+            if (!response.ok) {
+                throw createLoadFailedError(`Waveform fetch failed (${response.status})`);
+            }
+            return response.arrayBuffer();
         }
 
         const template =
@@ -212,21 +215,19 @@ class MP3Viewer extends MediaBaseViewer {
             this.options.representation.content &&
             this.options.representation.content.url_template;
         if (!template) {
-            return Promise.reject(new WaveformLoadError('LOAD_FAILED', 'Waveform fetch URL is missing'));
+            throw createLoadFailedError('Waveform fetch URL is missing');
         }
 
-        const request = this.api.get(this.createContentUrlV2(template), {
+        const data = await this.api.get(this.createContentUrlV2(template), {
             headers: this.appendAuthHeader(),
             signal,
             type: 'arraybuffer',
         });
 
-        return request.then(data => {
-            if (data instanceof ArrayBuffer) {
-                return data;
-            }
-            throw new WaveformLoadError('LOAD_FAILED', 'Waveform fetch did not return binary data');
-        });
+        if (data instanceof ArrayBuffer) {
+            return data;
+        }
+        throw createLoadFailedError('Waveform fetch did not return binary data');
     }
 
     abortClientWaveformDecode() {
@@ -267,16 +268,18 @@ class MP3Viewer extends MediaBaseViewer {
             });
             this.handleClientWaveformDecodeResult(result, controller, signal);
         } catch (error) {
-            if (isAbortError(error)) {
+            if (error && error.name === 'AbortError') {
                 this.handleClientWaveformDecodeResult({ status: 'cancelled' }, controller, signal);
                 return;
             }
 
-            const waveformError = errorFromUnknown(error, 'LOAD_FAILED');
             this.handleClientWaveformDecodeResult(
                 {
-                    error: waveformError,
-                    retryable: isRetryableWaveformError(waveformError.code),
+                    error: {
+                        code: 'LOAD_FAILED',
+                        message: error instanceof Error ? error.message : 'Waveform decode failed',
+                    },
+                    retryable: true,
                     status: 'failed',
                 },
                 controller,

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -6,11 +6,11 @@ import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
 import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../../events';
-import { loadPeaks } from '../waveform/decode';
 import { WaveformLoadError } from '../waveform/createWaveformLoader';
+import { loadPeaks } from '../waveform/decode';
 
 jest.mock('../waveform/decode', () => ({
-    loadPeaks: jest.fn(() => Promise.resolve({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } })),
+    loadPeaks: jest.fn(() => Promise.resolve({ error: { code: 'CAP_EXCEEDED', message: 'skip' }, status: 'capped' })),
 }));
 
 let mp3;
@@ -395,7 +395,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
     describe('startClientWaveformDecode()', () => {
         beforeEach(() => {
             loadPeaks.mockReset();
-            loadPeaks.mockResolvedValue({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } });
+            loadPeaks.mockResolvedValue({ error: { code: 'CAP_EXCEEDED', message: 'skip' }, status: 'capped' });
             mp3.isAudioPlayerV2 = true;
             mp3.waveformPeaks = [];
             mp3.mediaEl = { duration: 30 };
@@ -406,8 +406,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
         test('should apply decoded peaks when loadPeaks is ready', async () => {
             loadPeaks.mockResolvedValue({
-                status: 'ready',
                 payload: { peaks: [0.2, 0.8] },
+                status: 'ready',
             });
 
             await mp3.startClientWaveformDecode();
@@ -423,16 +423,16 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.renderUI).not.toBeCalled();
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                status: 'capped',
                 code: 'CAP_EXCEEDED',
+                status: 'capped',
             });
         });
 
         test('should include skip reason on the metric when metadata is missing', async () => {
             loadPeaks.mockResolvedValue({
-                status: 'unavailable',
                 error: { code: 'UNAVAILABLE', message: 'missing' },
                 reason: 'missing_metadata',
+                status: 'unavailable',
             });
 
             await mp3.startClientWaveformDecode();
@@ -440,17 +440,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                status: 'unavailable',
                 code: 'UNAVAILABLE',
                 reason: 'missing_metadata',
+                status: 'unavailable',
             });
         });
 
         test('should keep empty peaks when decode fails', async () => {
             loadPeaks.mockResolvedValue({
-                status: 'failed',
                 error: { code: 'LOAD_FAILED', message: 'network' },
                 retryable: true,
+                status: 'failed',
             });
 
             await mp3.startClientWaveformDecode();
@@ -459,8 +459,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.renderUI).not.toBeCalled();
             expect(mp3.isWaveformDecodeRetryPending).toBe(true);
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                status: 'failed',
                 code: 'LOAD_FAILED',
+                status: 'failed',
             });
         });
 
@@ -480,8 +480,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.isWaveformDecodeRetryPending).toBe(true);
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                status: 'failed',
                 code: 'LOAD_FAILED',
+                status: 'failed',
             });
         });
 
@@ -492,8 +492,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
             expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                status: 'failed',
                 code: 'INVALID_PAYLOAD',
+                status: 'failed',
             });
         });
 

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -6,7 +6,6 @@ import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
 import { VIEWER_EVENT } from '../../../events';
-import { WaveformLoadError } from '../waveform/createWaveformLoader';
 import { loadPeaks } from '../waveform/decode';
 
 jest.mock('../waveform/decode', () => ({
@@ -466,8 +465,12 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.isWaveformDecodeRetryPending).toBe(true);
         });
 
-        test('should not retry overlay play when the thrown error is not retryable', async () => {
-            mp3.importWaveformDecode.mockRejectedValue(new WaveformLoadError('INVALID_PAYLOAD', 'bad payload'));
+        test('should not retry overlay play when decode failure is not retryable', async () => {
+            loadPeaks.mockResolvedValue({
+                error: { code: 'INVALID_PAYLOAD', message: 'bad payload' },
+                retryable: false,
+                status: 'failed',
+            });
 
             await mp3.startClientWaveformDecode();
 
@@ -517,9 +520,31 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.mediaBlobUrl = null;
             mp3.options.representation = {};
 
-            await expect(mp3.fetchAudioArrayBuffer(new AbortController().signal)).rejects.toBeInstanceOf(
-                WaveformLoadError,
-            );
+            await expect(mp3.fetchAudioArrayBuffer(new AbortController().signal)).rejects.toMatchObject({
+                name: 'LOAD_FAILED',
+            });
+        });
+
+        test('should fetch via authenticated GET when no blob URL is available', async () => {
+            const buffer = new ArrayBuffer(8);
+            const { signal } = new AbortController();
+            mp3.mediaBlobUrl = null;
+            mp3.options.representation = {
+                content: { url_template: 'https://example.com/audio.mp3' },
+            };
+            mp3.api = { get: jest.fn().mockResolvedValue(buffer) };
+            jest.spyOn(mp3, 'createContentUrlV2').mockReturnValue('https://example.com/audio.mp3?auth');
+            jest.spyOn(mp3, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer t' });
+
+            const result = await mp3.fetchAudioArrayBuffer(signal);
+
+            expect(result).toBe(buffer);
+            expect(mp3.createContentUrlV2).toHaveBeenCalledWith('https://example.com/audio.mp3');
+            expect(mp3.api.get).toHaveBeenCalledWith('https://example.com/audio.mp3?auth', {
+                headers: { Authorization: 'Bearer t' },
+                signal,
+                type: 'arraybuffer',
+            });
         });
     });
 });

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -5,7 +5,13 @@ import MP3ControlsV2 from '../MP3ControlsV2';
 import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
-import { VIEWER_EVENT } from '../../../events';
+import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../../events';
+import { loadPeaks } from '../waveform/decode';
+import { WaveformLoadError } from '../waveform/createWaveformLoader';
+
+jest.mock('../waveform/decode', () => ({
+    loadPeaks: jest.fn(() => Promise.resolve({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } })),
+}));
 
 let mp3;
 
@@ -30,6 +36,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
         };
         mp3.containerEl = containerEl;
         jest.spyOn(MP3Viewer.prototype, 'importV2Controls').mockResolvedValue({ default: MP3ControlsV2 });
+        jest.spyOn(MP3Viewer.prototype, 'importWaveformDecode').mockResolvedValue({ loadPeaks });
     });
 
     afterEach(() => {
@@ -65,6 +72,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.wrapperEl).toHaveClass('bp-media--v2');
             expect(mp3.mediaContainerEl).toHaveClass('bp-media-container--v2');
             expect(mp3.isAudioPlayerV2).toBe(true);
+            expect(mp3.importWaveformDecode).toBeCalled();
         });
 
         test('should not apply v2 classes when React controls are off', () => {
@@ -211,11 +219,26 @@ describe('lib/viewers/media/MP3Viewer', () => {
     describe('handlePlayRequest()', () => {
         test('should remember the play request and toggle playback', () => {
             jest.spyOn(mp3, 'togglePlay').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
 
             mp3.handlePlayRequest();
 
             expect(mp3.userRequestedPlay).toBe(true);
             expect(mp3.togglePlay).toBeCalled();
+            expect(mp3.startClientWaveformDecode).not.toBeCalled();
+        });
+
+        test('should retry decode once after a retryable failure', () => {
+            jest.spyOn(mp3, 'togglePlay').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            mp3.isWaveformDecodeRetryPending = true;
+
+            mp3.handlePlayRequest();
+            mp3.handlePlayRequest();
+
+            expect(mp3.startClientWaveformDecode).toBeCalledTimes(1);
+            expect(mp3.hasUsedWaveformDecodePlayRetry).toBe(true);
+            expect(mp3.isWaveformDecodeRetryPending).toBe(false);
         });
     });
 
@@ -224,12 +247,14 @@ describe('lib/viewers/media/MP3Viewer', () => {
             Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
             mp3.isAudioPlayerV2 = true;
             mp3.userRequestedPlay = true;
-            jest.spyOn(mp3, 'play').mockImplementation();
+            const order = [];
+            jest.spyOn(mp3, 'play').mockImplementation(() => order.push('play'));
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation(() => order.push('decode'));
 
             mp3.loadeddataHandler();
 
             expect(MediaBaseViewer.prototype.loadeddataHandler).toBeCalled();
-            expect(mp3.play).toBeCalled();
+            expect(order).toEqual(['play', 'decode']);
         });
 
         test('should not auto-start playback when play was not requested', () => {
@@ -240,6 +265,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.loadeddataHandler();
 
             expect(mp3.play).not.toBeCalled();
+        });
+
+        test('should start client decode for v2 after metadata', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            jest.spyOn(mp3, 'play').mockImplementation();
+
+            mp3.loadeddataHandler();
+
+            expect(mp3.startClientWaveformDecode).toBeCalled();
         });
     });
 
@@ -353,6 +389,160 @@ describe('lib/viewers/media/MP3Viewer', () => {
             jest.spyOn(mp3, 'pause').mockImplementation();
             mp3.handleAutoplayFail();
             expect(mp3.pause).toBeCalled();
+        });
+    });
+
+    describe('startClientWaveformDecode()', () => {
+        beforeEach(() => {
+            loadPeaks.mockReset();
+            loadPeaks.mockResolvedValue({ status: 'capped', error: { code: 'CAP_EXCEEDED', message: 'skip' } });
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaks = [];
+            mp3.mediaEl = { duration: 30 };
+            mp3.options.file = { id: 1, size: 1024 };
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+            jest.spyOn(mp3, 'emitMetric').mockImplementation();
+        });
+
+        test('should apply decoded peaks when loadPeaks is ready', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'ready',
+                payload: { peaks: [0.2, 0.8] },
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([0.2, 0.8]);
+            expect(mp3.renderUI).toBeCalled();
+            expect(mp3.emitMetric).not.toBeCalled();
+        });
+
+        test('should keep empty peaks when decode is skipped as capped', async () => {
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'capped',
+                code: 'CAP_EXCEEDED',
+            });
+        });
+
+        test('should include skip reason on the metric when metadata is missing', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'unavailable',
+                error: { code: 'UNAVAILABLE', message: 'missing' },
+                reason: 'missing_metadata',
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'unavailable',
+                code: 'UNAVAILABLE',
+                reason: 'missing_metadata',
+            });
+        });
+
+        test('should keep empty peaks when decode fails', async () => {
+            loadPeaks.mockResolvedValue({
+                status: 'failed',
+                error: { code: 'LOAD_FAILED', message: 'network' },
+                retryable: true,
+            });
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.isWaveformDecodeRetryPending).toBe(true);
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'LOAD_FAILED',
+            });
+        });
+
+        test('should not decode when v2 is off', async () => {
+            mp3.isAudioPlayerV2 = false;
+
+            await mp3.startClientWaveformDecode();
+
+            expect(loadPeaks).not.toBeCalled();
+        });
+
+        test('should map a decode-chunk load failure to LOAD_FAILED', async () => {
+            mp3.importWaveformDecode.mockRejectedValue(new Error('chunk failed'));
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.isWaveformDecodeRetryPending).toBe(true);
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'LOAD_FAILED',
+            });
+        });
+
+        test('should not retry overlay play when the thrown error is not retryable', async () => {
+            mp3.importWaveformDecode.mockRejectedValue(new WaveformLoadError('INVALID_PAYLOAD', 'bad payload'));
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
+            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
+                status: 'failed',
+                code: 'INVALID_PAYLOAD',
+            });
+        });
+
+        test('should abort an in-flight decode on destroy', () => {
+            loadPeaks.mockReturnValue(new Promise(() => undefined));
+            const superDestroy = jest.spyOn(MediaBaseViewer.prototype, 'destroy').mockImplementation();
+
+            mp3.startClientWaveformDecode();
+            const { signal } = mp3.waveformDecodeController;
+            mp3.destroy();
+
+            expect(signal.aborted).toBe(true);
+            expect(mp3.waveformDecodeController).toBeNull();
+            superDestroy.mockRestore();
+        });
+    });
+
+    describe('fetchAudioArrayBuffer()', () => {
+        const originalFetch = global.fetch;
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+        });
+
+        test('should prefer an existing blob URL over a second API GET', async () => {
+            mp3.mediaBlobUrl = 'blob:audio';
+            mp3.api = { get: jest.fn() };
+            global.fetch = jest.fn().mockResolvedValue({
+                ok: true,
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+            });
+
+            const buffer = await mp3.fetchAudioArrayBuffer(new AbortController().signal);
+
+            expect(buffer).toBeInstanceOf(ArrayBuffer);
+            expect(global.fetch).toHaveBeenCalledWith(
+                'blob:audio',
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+            expect(mp3.api.get).not.toHaveBeenCalled();
+        });
+
+        test('should reject when neither a blob URL nor a representation URL is available', async () => {
+            mp3.mediaBlobUrl = null;
+            mp3.options.representation = {};
+
+            await expect(mp3.fetchAudioArrayBuffer(new AbortController().signal)).rejects.toBeInstanceOf(
+                WaveformLoadError,
+            );
         });
     });
 });

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -5,7 +5,7 @@ import MP3ControlsV2 from '../MP3ControlsV2';
 import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
-import { MEDIA_METRIC_EVENTS, VIEWER_EVENT } from '../../../events';
+import { VIEWER_EVENT } from '../../../events';
 import { WaveformLoadError } from '../waveform/createWaveformLoader';
 import { loadPeaks } from '../waveform/decode';
 
@@ -401,7 +401,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.mediaEl = { duration: 30 };
             mp3.options.file = { id: 1, size: 1024 };
             jest.spyOn(mp3, 'renderUI').mockImplementation();
-            jest.spyOn(mp3, 'emitMetric').mockImplementation();
         });
 
         test('should apply decoded peaks when loadPeaks is ready', async () => {
@@ -414,7 +413,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.waveformPeaks).toEqual([0.2, 0.8]);
             expect(mp3.renderUI).toBeCalled();
-            expect(mp3.emitMetric).not.toBeCalled();
         });
 
         test('should keep empty peaks when decode is skipped as capped', async () => {
@@ -422,13 +420,9 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.renderUI).not.toBeCalled();
-            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                code: 'CAP_EXCEEDED',
-                status: 'capped',
-            });
         });
 
-        test('should include skip reason on the metric when metadata is missing', async () => {
+        test('should keep empty peaks when metadata is missing', async () => {
             loadPeaks.mockResolvedValue({
                 error: { code: 'UNAVAILABLE', message: 'missing' },
                 reason: 'missing_metadata',
@@ -439,11 +433,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
-            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                code: 'UNAVAILABLE',
-                reason: 'missing_metadata',
-                status: 'unavailable',
-            });
         });
 
         test('should keep empty peaks when decode fails', async () => {
@@ -458,10 +447,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.renderUI).not.toBeCalled();
             expect(mp3.isWaveformDecodeRetryPending).toBe(true);
-            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                code: 'LOAD_FAILED',
-                status: 'failed',
-            });
         });
 
         test('should not decode when v2 is off', async () => {
@@ -479,10 +464,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.waveformPeaks).toEqual([]);
             expect(mp3.isWaveformDecodeRetryPending).toBe(true);
-            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                code: 'LOAD_FAILED',
-                status: 'failed',
-            });
         });
 
         test('should not retry overlay play when the thrown error is not retryable', async () => {
@@ -491,10 +472,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
             await mp3.startClientWaveformDecode();
 
             expect(mp3.isWaveformDecodeRetryPending).toBeUndefined();
-            expect(mp3.emitMetric).toBeCalledWith(MEDIA_METRIC_EVENTS.waveformDecode, {
-                code: 'INVALID_PAYLOAD',
-                status: 'failed',
-            });
         });
 
         test('should abort an in-flight decode on destroy', () => {

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -5,7 +5,7 @@
     width: 100%;
     height: 206px;
     min-height: 206px;
-    padding: 0 40px;
+    padding: 0 60px;
     overflow: visible;
     background: none;
 }
@@ -34,6 +34,7 @@
     height: 150px;
     pointer-events: none;
     background: linear-gradient(#2487ff, #006bed);
+    border-radius: 999px;
 
     // Spread stroke instead of border: border-box on .bp-container * would collapse the 2px fill.
     box-shadow: 0 0 0 1px #222, 0 0 10px 0 rgb(36 135 255 / 30%);

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -34,7 +34,7 @@
     height: 150px;
     pointer-events: none;
     background: linear-gradient(#2487ff, #006bed);
-    border-radius: 999px;
+    border-radius: 1px;
 
     // Spread stroke instead of border: border-box on .bp-container * would collapse the 2px fill.
     box-shadow: 0 0 0 1px #222, 0 0 10px 0 rgb(36 135 255 / 30%);


### PR DESCRIPTION
## Summary
- Wire the merged client decode path into `MP3Viewer` when audio player v2 is on. Lazy-load `loadPeaks` so playback never waits on the decode chunk.
- Prefer the blob URL playback already fetched; only fall back to an authenticated GET if that blob is missing. Overlay play retries decode once when the error is retryable (Safari user-gesture).
- Round the playhead and increase waveform / control-bar padding to match v2.

## Test plan
- [ ] MP3 under 6 MiB and 5 min: peaks replace the placeholder after metadata; play is not blocked
- [ ] File over either cap, or missing size/duration: placeholder stays
- [ ] Safari: first overlay play still starts audio; retryable decode failure retries once on the next overlay play
- [ ] Destroy / navigate away aborts an in-flight decode