### PR TITLE
feat(audio): add waveform zoom

### DIFF
--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -166,6 +166,10 @@ media_guides_fullscreen=Fullscreen
 media_guides_ultrawide=Ultrawide
 # Label for volume slider in media player
 media_volume_slider=Volume Slider
+# Label for zoom button on the audio waveform
+media_zoom=Zoom
+# Label for zoom slider on the audio waveform
+media_zoom_slider=Zoom Slider
 # Label for time slider in media player
 media_time_slider=Media Slider
 # Label for comment marker on video scrubber bar

--- a/src/lib/__tests__/util-test.js
+++ b/src/lib/__tests__/util-test.js
@@ -613,6 +613,14 @@ describe('lib/util', () => {
         });
     });
 
+    describe('getCurrentTimeMs()', () => {
+        test('should use performance.now when it is available', () => {
+            jest.spyOn(performance, 'now').mockReturnValue(12.5);
+
+            expect(util.getCurrentTimeMs()).toBe(12.5);
+        });
+    });
+
     describe('getClosestPageToPinch()', () => {
         test('should find the closest page', () => {
             const page1 = {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -639,6 +639,16 @@ export function getDistance(x1, y1, x2, y2) {
 }
 
 /**
+ * Monotonic clock in milliseconds. Falls back to wall time when performance is missing.
+ *
+ * @public
+ * @return {number} Current time in milliseconds
+ */
+export function getCurrentTimeMs() {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+/**
  * Returns the closest visible page to a pinch event
  *
  * @public

--- a/src/lib/viewers/controls/icons/IconZoom24.tsx
+++ b/src/lib/viewers/controls/icons/IconZoom24.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+function IconZoom24(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg data-testid="IconZoom24" focusable={false} height={24} viewBox="0 0 24 24" width={24} {...props}>
+            <path
+                d="M2 12h20M6 8l-4 4 4 4M18 8l4 4-4 4"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+            />
+        </svg>
+    );
+}
+
+export default IconZoom24;

--- a/src/lib/viewers/controls/icons/IconZoom24.tsx
+++ b/src/lib/viewers/controls/icons/IconZoom24.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-function IconZoom24(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+function IconZoom24(): JSX.Element {
     return (
-        <svg data-testid="IconZoom24" focusable={false} height={24} viewBox="0 0 24 24" width={24} {...props}>
+        <svg focusable={false} height={24} viewBox="0 0 24 24" width={24}>
             <path
                 d="M2 12h20M6 8l-4 4 4 4M18 8l4 4-4 4"
                 fill="none"

--- a/src/lib/viewers/media/MP3ControlsV2.scss
+++ b/src/lib/viewers/media/MP3ControlsV2.scss
@@ -34,6 +34,18 @@
     }
 }
 
+.bp-MP3ControlsV2-waveformZoom {
+    position: absolute;
+    top: 48px;
+    right: 48px;
+    z-index: 3;
+    pointer-events: none;
+
+    .bp-WaveformZoomControl {
+        pointer-events: auto;
+    }
+}
+
 .bp-MP3ControlsV2-playOverlay {
     position: absolute;
     top: 50%;

--- a/src/lib/viewers/media/MP3ControlsV2.tsx
+++ b/src/lib/viewers/media/MP3ControlsV2.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import isFinite from 'lodash/isFinite';
 import { Props as DurationLabelsProps } from '../controls/media/DurationLabels';
 import MediaSettings, { Props as MediaSettingsProps } from '../controls/media/MediaSettings';
@@ -7,8 +7,11 @@ import { Props as TimeControlsProps } from '../controls/media/TimeControls';
 import TimestampControl from '../controls/media/TimestampControl';
 import VolumeControls, { Props as VolumeControlsProps } from '../controls/media/VolumeControls';
 import { ICON_PLAY_LARGE } from '../../icons';
+import { WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_MIN } from './waveform/constants';
 import { PLACEHOLDER_DURATION_SEC, placeholderPeaks } from './waveform/peaks';
+import { WaveformViewport } from './waveform/types';
 import WaveformView from './waveform/WaveformView';
+import WaveformZoomControl from './waveform/WaveformZoomControl';
 import './MP3ControlsV2.scss';
 
 const PLACEHOLDER_PEAKS = placeholderPeaks();
@@ -41,11 +44,37 @@ export default function MP3ControlsV2({
     volume,
 }: Props): JSX.Element {
     const durationValue = typeof durationTime === 'number' && isFinite(durationTime) ? durationTime : 0;
+    const [zoomLevel, setZoomLevel] = useState(WAVEFORM_ZOOM_MIN);
+    const [maxZoom, setMaxZoom] = useState(WAVEFORM_ZOOM_MIN);
+    const [isZoomRevealed, setIsZoomRevealed] = useState(false);
+    const zoomRevealTimerRef = useRef(0);
     const hasRealPeaks = !!(peaks && peaks.length);
     const waveformPeaks = hasRealPeaks ? peaks : PLACEHOLDER_PEAKS;
     const hasMetadata = durationValue > 0;
     const waveformDurationSec = hasMetadata ? durationValue : PLACEHOLDER_DURATION_SEC;
     const [playRequested, setPlayRequested] = useState(false);
+    const handleViewportChange = useCallback((viewport: WaveformViewport) => {
+        setMaxZoom(viewport.maxZoom);
+    }, []);
+
+    const revealZoomControl = useCallback(() => {
+        setIsZoomRevealed(true);
+        window.clearTimeout(zoomRevealTimerRef.current);
+        zoomRevealTimerRef.current = window.setTimeout(() => {
+            setIsZoomRevealed(false);
+            zoomRevealTimerRef.current = 0;
+        }, WAVEFORM_ZOOM_DISMISS_MS);
+    }, []);
+
+    const handleWaveformZoom = useCallback(
+        (nextZoom: number) => {
+            setZoomLevel(nextZoom);
+            revealZoomControl();
+        },
+        [revealZoomControl],
+    );
+
+    useEffect(() => () => window.clearTimeout(zoomRevealTimerRef.current), []);
 
     useEffect(() => {
         if (isPlaying) {
@@ -61,6 +90,8 @@ export default function MP3ControlsV2({
     const isWaveformInteractive = playRequested && hasMetadata;
     const isWaitingToPlay = playRequested && !hasMetadata;
     const showPlayOverlay = !playRequested && !isPlaying;
+    const hasZoomHandlers = hasRealPeaks && !showPlayOverlay;
+    const hasZoomControl = hasZoomHandlers && hasMetadata && maxZoom > WAVEFORM_ZOOM_MIN;
 
     return (
         <div className="bp-MP3ControlsV2" data-testid="media-controls-wrapper-v2">
@@ -72,8 +103,21 @@ export default function MP3ControlsV2({
                     interactive={isWaveformInteractive}
                     mediaEl={mediaEl}
                     onSeek={isWaveformInteractive ? onTimeChange : undefined}
+                    onViewportChange={hasRealPeaks ? handleViewportChange : undefined}
+                    onZoomChange={hasZoomHandlers ? handleWaveformZoom : undefined}
                     peaks={waveformPeaks}
+                    zoomLevel={hasZoomHandlers ? zoomLevel : WAVEFORM_ZOOM_MIN}
                 />
+                {hasZoomControl && (
+                    <div className="bp-MP3ControlsV2-waveformZoom">
+                        <WaveformZoomControl
+                            isRevealed={isZoomRevealed}
+                            maxZoom={maxZoom}
+                            onZoomChange={setZoomLevel}
+                            zoomLevel={zoomLevel}
+                        />
+                    </div>
+                )}
                 {showPlayOverlay && (
                     <button
                         className="bp-MP3ControlsV2-playOverlay"

--- a/src/lib/viewers/media/MP3ControlsV2.tsx
+++ b/src/lib/viewers/media/MP3ControlsV2.tsx
@@ -10,6 +10,7 @@ import { ICON_PLAY_LARGE } from '../../icons';
 import { WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_MIN } from './waveform/constants';
 import { PLACEHOLDER_DURATION_SEC, placeholderPeaks } from './waveform/peaks';
 import { WaveformViewport } from './waveform/types';
+import { clampWaveformZoom } from './waveform/viewport';
 import WaveformView from './waveform/WaveformView';
 import WaveformZoomControl from './waveform/WaveformZoomControl';
 import './MP3ControlsV2.scss';
@@ -73,6 +74,10 @@ export default function MP3ControlsV2({
         },
         [revealZoomControl],
     );
+
+    useEffect(() => {
+        setZoomLevel(prev => clampWaveformZoom(prev, maxZoom));
+    }, [maxZoom]);
 
     useEffect(() => () => window.clearTimeout(zoomRevealTimerRef.current), []);
 

--- a/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
@@ -1,17 +1,39 @@
-import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import React, { useEffect as mockUseEffect } from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MP3ControlsV2, { Props } from '../MP3ControlsV2';
+import { WAVEFORM_ZOOM_DISMISS_MS } from '../waveform/constants';
 
 jest.mock('../waveform/WaveformView', () => {
-    function MockWaveformView({ interactive }: { interactive?: boolean }): JSX.Element {
-        return <div data-interactive={interactive ? 'true' : 'false'} data-testid="bp-waveform-view" />;
+    function MockWaveformView({
+        interactive,
+        onViewportChange,
+        onZoomChange,
+    }: {
+        interactive?: boolean;
+        onViewportChange?: (viewport: { maxZoom: number; widthPx: number }) => void;
+        onZoomChange?: (zoomLevel: number) => void;
+    }): JSX.Element {
+        mockUseEffect(() => {
+            onViewportChange?.({ maxZoom: 4, widthPx: 800 });
+        }, [onViewportChange]);
+        return (
+            <div data-interactive={interactive ? 'true' : 'false'} data-testid="bp-waveform-view">
+                <button data-testid="bp-mock-waveform-zoom" onClick={() => onZoomChange?.(2)} type="button">
+                    zoom
+                </button>
+            </div>
+        );
     }
 
     return MockWaveformView;
 });
 
 describe('MP3ControlsV2', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     const getWrapper = (props: Partial<Props> = {}) =>
         render(
             <MP3ControlsV2
@@ -137,6 +159,60 @@ describe('MP3ControlsV2', () => {
             );
 
             expect(screen.queryByTestId('bp-MP3ControlsV2-play-overlay')).not.toBeInTheDocument();
+        });
+
+        test('should not show zoom while the play overlay is visible', async () => {
+            getWrapper({ durationTime: 8, peaks: [0.2, 0.8] });
+
+            expect(await screen.findByTestId('bp-MP3ControlsV2-play-overlay')).toBeInTheDocument();
+            expect(screen.queryByTestId('bp-waveform-zoom')).not.toBeInTheDocument();
+        });
+
+        test('should show zoom after play once real peaks report a max above 1x', async () => {
+            getWrapper({ durationTime: 8, isPlaying: true, peaks: [0.2, 0.8] });
+
+            expect(screen.queryByTestId('bp-MP3ControlsV2-play-overlay')).not.toBeInTheDocument();
+            expect(await screen.findByTestId('bp-waveform-zoom')).toBeInTheDocument();
+        });
+
+        test('should hide zoom until real peaks load', async () => {
+            getWrapper({ durationTime: 8 });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toBeInTheDocument();
+            expect(screen.queryByTestId('bp-waveform-zoom')).not.toBeInTheDocument();
+        });
+
+        test('should keep zoom hidden after play when only placeholder peaks are present', async () => {
+            getWrapper({ durationTime: 8, isPlaying: true });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-interactive', 'true');
+            expect(screen.queryByTestId('bp-MP3ControlsV2-play-overlay')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('bp-waveform-zoom')).not.toBeInTheDocument();
+        });
+
+        test('should open the zoom slider on waveform zoom and dismiss after the delay', async () => {
+            jest.useFakeTimers();
+            getWrapper({ durationTime: 8, isPlaying: true, peaks: [0.2, 0.8] });
+
+            const control = await screen.findByTestId('bp-waveform-zoom');
+            expect(control).not.toHaveClass('bp-is-open');
+
+            fireEvent.click(screen.getByTestId('bp-mock-waveform-zoom'));
+            expect(control).toHaveClass('bp-is-open');
+            expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveAttribute(
+                'aria-valuenow',
+                '33',
+            );
+
+            act(() => {
+                jest.advanceTimersByTime(WAVEFORM_ZOOM_DISMISS_MS - 1);
+            });
+            expect(control).toHaveClass('bp-is-open');
+
+            act(() => {
+                jest.advanceTimersByTime(1);
+            });
+            expect(control).not.toHaveClass('bp-is-open');
         });
     });
 });

--- a/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect as mockUseEffect } from 'react';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MP3ControlsV2, { Props } from '../MP3ControlsV2';
 import { WAVEFORM_ZOOM_DISMISS_MS } from '../waveform/constants';
@@ -21,6 +21,13 @@ jest.mock('../waveform/WaveformView', () => {
             <div data-interactive={interactive ? 'true' : 'false'} data-testid="bp-waveform-view">
                 <button data-testid="bp-mock-waveform-zoom" onClick={() => onZoomChange?.(2)} type="button">
                     zoom
+                </button>
+                <button
+                    data-testid="bp-mock-waveform-max-zoom"
+                    onClick={() => onViewportChange?.({ maxZoom: 1.2, widthPx: 1600 })}
+                    type="button"
+                >
+                    resize
                 </button>
             </div>
         );
@@ -197,7 +204,8 @@ describe('MP3ControlsV2', () => {
             const control = await screen.findByTestId('bp-waveform-zoom');
             expect(control).not.toHaveClass('bp-is-open');
 
-            fireEvent.click(screen.getByTestId('bp-mock-waveform-zoom'));
+            const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+            await user.click(screen.getByTestId('bp-mock-waveform-zoom'));
             expect(control).toHaveClass('bp-is-open');
             expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveAttribute(
                 'aria-valuenow',
@@ -212,6 +220,24 @@ describe('MP3ControlsV2', () => {
             act(() => {
                 jest.advanceTimersByTime(1);
             });
+            expect(control).not.toHaveClass('bp-is-open');
+        });
+
+        test('should not open the zoom slider when max zoom drops on resize', async () => {
+            jest.useFakeTimers();
+            getWrapper({ durationTime: 8, isPlaying: true, peaks: [0.2, 0.8] });
+
+            const control = await screen.findByTestId('bp-waveform-zoom');
+            const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+            await user.click(screen.getByTestId('bp-mock-waveform-zoom'));
+            expect(control).toHaveClass('bp-is-open');
+
+            act(() => {
+                jest.advanceTimersByTime(WAVEFORM_ZOOM_DISMISS_MS);
+            });
+            expect(control).not.toHaveClass('bp-is-open');
+
+            await user.click(screen.getByTestId('bp-mock-waveform-max-zoom'));
             expect(control).not.toHaveClass('bp-is-open');
         });
     });

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -8,6 +8,16 @@
     padding: 0 60px;
     overflow: visible;
     background: none;
+
+    &.bp-WaveformView--zoomed {
+        padding: 0;
+
+        .bp-WaveformView-canvas {
+            overflow: hidden;
+            -webkit-mask-image: linear-gradient(to right, transparent, #000 60px, #000 calc(100% - 60px), transparent);
+            mask-image: linear-gradient(to right, transparent, #000 60px, #000 calc(100% - 60px), transparent);
+        }
+    }
 }
 
 .bp-WaveformView-track {

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -14,8 +14,8 @@
 
         .bp-WaveformView-canvas {
             overflow: hidden;
-            -webkit-mask-image: linear-gradient(to right, transparent, #000 60px, #000 calc(100% - 60px), transparent);
-            mask-image: linear-gradient(to right, transparent, #000 60px, #000 calc(100% - 60px), transparent);
+            -webkit-mask-image: linear-gradient(to right, transparent, #000 92px, #000 calc(100% - 92px), transparent);
+            mask-image: linear-gradient(to right, transparent, #000 92px, #000 calc(100% - 92px), transparent);
         }
     }
 }

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -11,6 +11,7 @@
 
     &.bp-WaveformView--zoomed {
         padding: 0;
+        touch-action: none;
 
         .bp-WaveformView-canvas {
             overflow: hidden;

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -1,41 +1,70 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import WaveSurfer from 'wavesurfer.js';
 import {
     getBufferedProgress,
     getWaveformFills,
+    tintWaveformTiles,
     toCanvasFill,
     WAVEFORM_COLOR_PLAYED,
     WAVEFORM_COLOR_UNPLAYED,
 } from './colors';
+import {
+    WAVEFORM_BAR_GAP,
+    WAVEFORM_BAR_MIN_HEIGHT,
+    WAVEFORM_BAR_RADIUS,
+    WAVEFORM_BAR_WIDTH,
+    WAVEFORM_HEIGHT,
+    WAVEFORM_ZOOM_MIN,
+} from './constants';
 import { formatTime, morphPeaks, toChannels, WAVEFORM_PEAK_TRANSITION_MS } from './peaks';
+import { WaveformFills, WaveformViewProps, WaveformViewport } from './types';
+import {
+    clampWaveformZoom,
+    createWaveformViewport,
+    getViewportAtScroll,
+    getWaveformZoomMax,
+    getZoomedPixelsPerSecond,
+    positionPxFromTime,
+    timeFromPositionPx,
+} from './viewport';
 import './WaveformView.scss';
 
-export type WaveformViewProps = {
-    bufferedRange?: TimeRanges;
-    currentTime?: number;
-    durationSec: number;
-    height?: number;
-    interactive?: boolean;
-    mediaEl?: HTMLMediaElement | null;
-    onSeek?: (timeSec: number) => void;
-    peaks: ArrayLike<number>;
+/** Pointer X in the view and the media time under it; zoom keeps this point fixed. */
+type ZoomOrigin = {
+    pointerX: number;
+    timeSec: number;
 };
 
-export const WAVEFORM_BAR_GAP = 2;
-export const WAVEFORM_BAR_WIDTH = 2;
-export const WAVEFORM_BAR_RADIUS = WAVEFORM_BAR_WIDTH / 2;
-/** Total bar height so the top and bottom radii meet as a circle on the mirror. */
-export const WAVEFORM_BAR_MIN_HEIGHT = WAVEFORM_BAR_WIDTH;
-export const WAVEFORM_HEIGHT = 140;
-
-function leftPercent(timeSec: number, durationSec: number): string {
-    const progress = durationSec > 0 ? Math.min(1, Math.max(0, timeSec / durationSec)) : 0;
-    return `${progress * 100}%`;
-}
-
-function fillWidth(widthCssPx: number): number {
+/** CSS width × devicePixelRatio, for canvas gradient fills. */
+function devicePixelWidth(widthCssPx: number): number {
     const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
     return widthCssPx * pixelRatio;
+}
+
+/** Monotonic clock for peak-morph animations. */
+function timestampMs(): number {
+    return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function prefersReducedMotion(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+}
+
+function getScrollLeft(wavesurfer: WaveSurfer | null, fallback = 0): number {
+    return wavesurfer && wavesurfer.getScroll ? wavesurfer.getScroll() : fallback;
+}
+
+/** CSS left % of the playhead from the left of the visible window. */
+function timeLeftPercent(timeSec: number, durationSec: number, viewport: WaveformViewport): string {
+    if (viewport.widthPx > 0 && viewport.pixelsPerSecond > 0) {
+        return `${(positionPxFromTime(timeSec, viewport) / viewport.widthPx) * 100}%`;
+    }
+    const progress = durationSec > 0 ? Math.min(1, Math.max(0, timeSec / durationSec)) : 0;
+    return `${progress * 100}%`;
 }
 
 function applyPeaks(wavesurfer: WaveSurfer, peaks: ArrayLike<number>, durationSec: number): void {
@@ -43,6 +72,47 @@ function applyPeaks(wavesurfer: WaveSurfer, peaks: ArrayLike<number>, durationSe
         return;
     }
     wavesurfer.load('', toChannels(peaks), durationSec);
+}
+
+/** Tint WaveSurfer's zoomed tiles with played/unplayed/hover/buffer colors. */
+function tintZoomedWaveform(wavesurfer: WaveSurfer, fills: WaveformFills, replaceSnapshot = false): void {
+    const wrapper = wavesurfer.getWrapper ? wavesurfer.getWrapper() : null;
+    if (!wrapper || !(wrapper.clientWidth > 0)) {
+        return;
+    }
+    tintWaveformTiles({
+        fills,
+        host: wrapper,
+        replaceSnapshot,
+        totalWidthCss: wrapper.clientWidth,
+    });
+}
+
+function touchDistance(touches: TouchList): number {
+    if (touches.length < 2) {
+        return 0;
+    }
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.hypot(dx, dy);
+}
+
+/** Time under the pointer, plus its X in the view, so zoom can keep that point fixed. */
+function zoomOriginAtPointer(
+    pointerX: number,
+    wavesurfer: WaveSurfer | null,
+    durationSec: number,
+    fallbackWidth: number,
+): ZoomOrigin | null {
+    if (!(fallbackWidth > 0) || !(durationSec > 0) || !Number.isFinite(pointerX)) {
+        return null;
+    }
+    const wrapper = wavesurfer && wavesurfer.getWrapper ? wavesurfer.getWrapper() : null;
+    const fullWidth = wrapper && wrapper.clientWidth ? wrapper.clientWidth : fallbackWidth;
+    if (!(fullWidth > 0)) {
+        return null;
+    }
+    return { pointerX, timeSec: ((getScrollLeft(wavesurfer) + pointerX) / fullWidth) * durationSec };
 }
 
 /**
@@ -56,28 +126,94 @@ export default function WaveformView({
     interactive = true,
     mediaEl,
     onSeek,
+    onViewportChange,
+    onZoomChange,
     peaks,
+    zoomLevel: zoomLevelProp,
 }: WaveformViewProps): JSX.Element {
     const containerRef = useRef<HTMLDivElement>(null);
+    const trackRef = useRef<HTMLDivElement>(null);
     const playheadRef = useRef<HTMLDivElement>(null);
-    const playheadRafRef = useRef(0);
+    const playheadAnimationRef = useRef(0);
     const wavesurferRef = useRef<WaveSurfer | null>(null);
     const onSeekRef = useRef(onSeek);
     const interactiveRef = useRef(interactive);
+    const hasZoomHandlersRef = useRef(false);
     const currentTimeRef = useRef(currentTime);
     const peaksRef = useRef(peaks);
     const displayedPeaksRef = useRef<ArrayLike<number> | null>(null);
-    const peakTransitionRafRef = useRef(0);
+    const peakTransitionAnimationRef = useRef(0);
     const durationSecRef = useRef(durationSec);
+    const zoomOriginRef = useRef<ZoomOrigin | null>(null);
+    const pinchStartRef = useRef<{ distance: number; zoom: number } | null>(null);
+    const bufferProgressRef = useRef(0);
+    const hoverProgressRef = useRef<number | null>(null);
+    const programmaticScrollRef = useRef(false);
+    const onViewportChangeRef = useRef(onViewportChange);
     onSeekRef.current = onSeek;
     interactiveRef.current = interactive;
     currentTimeRef.current = currentTime;
     peaksRef.current = peaks;
     durationSecRef.current = durationSec;
+    onViewportChangeRef.current = onViewportChange;
 
+    const [internalZoom, setInternalZoom] = useState(WAVEFORM_ZOOM_MIN);
     const [hoverProgress, setHoverProgress] = useState<number | null>(null);
     const [canvasWidthPx, setCanvasWidthPx] = useState(0);
+    const [scrollLeft, setScrollLeft] = useState(0);
+    const isControlled = typeof zoomLevelProp === 'number';
+    const maxZoom = getWaveformZoomMax({
+        durationSec,
+        peakCount: peaks.length,
+        viewWidthPx: canvasWidthPx,
+    });
+    hasZoomHandlersRef.current =
+        maxZoom > WAVEFORM_ZOOM_MIN && (typeof onZoomChange === 'function' || typeof zoomLevelProp !== 'number');
+    const zoomLevel = clampWaveformZoom(isControlled ? zoomLevelProp : internalZoom, maxZoom);
+    const zoomRef = useRef(zoomLevel);
+    zoomRef.current = zoomLevel;
+    const prevZoomRef = useRef<number | null>(null);
+    const isZoomed = zoomLevel > WAVEFORM_ZOOM_MIN;
     const bufferProgress = getBufferedProgress(bufferedRange, durationSec);
+    bufferProgressRef.current = bufferProgress;
+    hoverProgressRef.current = hoverProgress;
+
+    const viewport = useMemo(
+        () =>
+            createWaveformViewport({
+                durationSec,
+                heightPx: height,
+                maxZoom,
+                scrollLeftPx: scrollLeft,
+                widthPx: canvasWidthPx,
+                zoomLevel,
+            }),
+        [canvasWidthPx, durationSec, height, maxZoom, scrollLeft, zoomLevel],
+    );
+    const viewportRef = useRef(viewport);
+    viewportRef.current = viewport;
+
+    const setZoomLevel = useCallback(
+        (nextZoom: number) => {
+            const zoom = clampWaveformZoom(nextZoom, maxZoom);
+            if (!isControlled) {
+                setInternalZoom(zoom);
+            }
+            onZoomChange?.(zoom);
+        },
+        [isControlled, maxZoom, onZoomChange],
+    );
+
+    const syncViewport = useCallback(() => {
+        const wavesurfer = wavesurferRef.current;
+        if (!wavesurfer) {
+            return;
+        }
+        const scrollLeftPx = getScrollLeft(wavesurfer);
+        viewportRef.current = getViewportAtScroll(viewportRef.current, scrollLeftPx);
+        onViewportChangeRef.current?.(viewportRef.current);
+        setScrollLeft(scrollLeftPx);
+    }, []);
 
     const updatePlayheadPosition = useCallback((timeSec: number): void => {
         const playhead = playheadRef.current;
@@ -85,11 +221,29 @@ export default function WaveformView({
             return;
         }
 
-        playhead.style.left = leftPercent(timeSec, durationSecRef.current);
+        playhead.style.left = timeLeftPercent(timeSec, durationSecRef.current, viewportRef.current);
 
         const wavesurfer = wavesurferRef.current;
         if (wavesurfer && wavesurfer.setTime) {
             wavesurfer.setTime(timeSec);
+        }
+    }, []);
+
+    const applyScrollLeft = useCallback((scrollLeftPx: number, shouldCommitState: boolean): void => {
+        const wavesurfer = wavesurferRef.current;
+        if (!wavesurfer || !wavesurfer.setScroll) {
+            return;
+        }
+        programmaticScrollRef.current = true;
+        wavesurfer.setScroll(scrollLeftPx);
+        viewportRef.current = getViewportAtScroll(viewportRef.current, getScrollLeft(wavesurfer, scrollLeftPx));
+        window.requestAnimationFrame(() => {
+            // Keep the flag through delayed `scroll` after a zoom setScroll.
+            programmaticScrollRef.current = false;
+        });
+        if (shouldCommitState) {
+            onViewportChangeRef.current?.(viewportRef.current);
+            setScrollLeft(getScrollLeft(wavesurfer, scrollLeftPx));
         }
     }, []);
 
@@ -124,18 +278,45 @@ export default function WaveformView({
             }
             onSeekRef.current?.(relativeX * durationSecRef.current);
         });
+        const unsubscribeScroll = wavesurfer.on('scroll', () => {
+            if (programmaticScrollRef.current) {
+                viewportRef.current = getViewportAtScroll(viewportRef.current, getScrollLeft(wavesurfer));
+                return;
+            }
+            syncViewport();
+        });
+        const unsubscribeZoom = wavesurfer.on('zoom', () => {
+            syncViewport();
+        });
+        const unsubscribeRedraw = wavesurfer.on('redrawcomplete', () => {
+            if (!(zoomRef.current > WAVEFORM_ZOOM_MIN)) {
+                return;
+            }
+            tintZoomedWaveform(
+                wavesurfer,
+                getWaveformFills({
+                    bufferProgress: bufferProgressRef.current,
+                    hoverProgress: hoverProgressRef.current,
+                }),
+                true,
+            );
+        });
 
         wavesurferRef.current = wavesurfer;
         displayedPeaksRef.current = peaksRef.current;
+        syncViewport();
 
         return () => {
-            window.cancelAnimationFrame(peakTransitionRafRef.current);
+            window.cancelAnimationFrame(peakTransitionAnimationRef.current);
             unsubscribeClick();
+            unsubscribeScroll();
+            unsubscribeZoom();
+            unsubscribeRedraw();
             wavesurfer.destroy();
             wavesurferRef.current = null;
             displayedPeaksRef.current = null;
         };
-    }, [height]);
+    }, [height, syncViewport]);
 
     useLayoutEffect(() => {
         const el = containerRef.current;
@@ -149,10 +330,27 @@ export default function WaveformView({
             entries.forEach(entry => {
                 setCanvasWidthPx(entry.contentRect.width);
             });
+            syncViewport();
         });
         observer.observe(el);
         return () => observer.disconnect();
-    }, []);
+    }, [syncViewport]);
+
+    useEffect(() => {
+        const rawZoom = isControlled ? zoomLevelProp : internalZoom;
+        const clamped = clampWaveformZoom(typeof rawZoom === 'number' ? rawZoom : WAVEFORM_ZOOM_MIN, maxZoom);
+        if (clamped === rawZoom) {
+            return;
+        }
+        if (!isControlled) {
+            setInternalZoom(clamped);
+        }
+        onZoomChange?.(clamped);
+    }, [internalZoom, isControlled, maxZoom, onZoomChange, zoomLevelProp]);
+
+    useEffect(() => {
+        onViewportChange?.(viewport);
+    }, [onViewportChange, viewport]);
 
     useEffect(() => {
         const wavesurfer = wavesurferRef.current;
@@ -162,13 +360,53 @@ export default function WaveformView({
         wavesurfer.setOptions({ interact: interactive });
     }, [interactive]);
 
+    useEffect(() => {
+        const wavesurfer = wavesurferRef.current;
+        const container = containerRef.current;
+        if (!wavesurfer || !wavesurfer.setOptions || !container) {
+            return;
+        }
+
+        const viewWidthPx = wavesurfer.getWidth ? wavesurfer.getWidth() : container.clientWidth;
+        const minPxPerSec = getZoomedPixelsPerSecond({ durationSec, maxZoom, viewWidthPx, zoomLevel });
+        wavesurfer.setOptions({
+            autoScroll: false,
+            minPxPerSec,
+            ...(zoomLevel > WAVEFORM_ZOOM_MIN
+                ? {
+                      progressColor: WAVEFORM_COLOR_PLAYED,
+                      waveColor: WAVEFORM_COLOR_UNPLAYED,
+                  }
+                : {}),
+        });
+
+        const origin = zoomOriginRef.current;
+        zoomOriginRef.current = null;
+        const didZoomChange = prevZoomRef.current !== zoomLevel;
+        prevZoomRef.current = zoomLevel;
+        if (minPxPerSec > 0) {
+            if (origin) {
+                applyScrollLeft(origin.timeSec * minPxPerSec - origin.pointerX, true);
+            } else if (didZoomChange) {
+                const maxScroll = Math.max(0, durationSec * minPxPerSec - viewWidthPx);
+                applyScrollLeft(
+                    Math.min(maxScroll, Math.max(0, currentTimeRef.current * minPxPerSec - viewWidthPx / 2)),
+                    true,
+                );
+            }
+        }
+
+        wavesurfer.setTime(currentTimeRef.current);
+        syncViewport();
+    }, [applyScrollLeft, durationSec, maxZoom, syncViewport, zoomLevel]);
+
     useLayoutEffect(() => {
         if (mediaEl && !mediaEl.paused) {
             updatePlayheadPosition(mediaEl.currentTime);
             return;
         }
         updatePlayheadPosition(currentTime);
-    }, [currentTime, durationSec, mediaEl, updatePlayheadPosition]);
+    }, [currentTime, durationSec, mediaEl, updatePlayheadPosition, viewport]);
 
     useEffect(() => {
         const media = mediaEl;
@@ -180,16 +418,16 @@ export default function WaveformView({
             if (!media.paused) {
                 updatePlayheadPosition(media.currentTime);
             }
-            playheadRafRef.current = window.requestAnimationFrame(tick);
+            playheadAnimationRef.current = window.requestAnimationFrame(tick);
         };
 
         const startLoop = (): void => {
-            window.cancelAnimationFrame(playheadRafRef.current);
-            playheadRafRef.current = window.requestAnimationFrame(tick);
+            window.cancelAnimationFrame(playheadAnimationRef.current);
+            playheadAnimationRef.current = window.requestAnimationFrame(tick);
         };
 
         const stopLoop = (): void => {
-            window.cancelAnimationFrame(playheadRafRef.current);
+            window.cancelAnimationFrame(playheadAnimationRef.current);
             updatePlayheadPosition(media.currentTime);
         };
 
@@ -202,12 +440,14 @@ export default function WaveformView({
         }
 
         media.addEventListener('play', startLoop);
+        media.addEventListener('playing', startLoop);
         media.addEventListener('pause', stopLoop);
         media.addEventListener('seeked', handleSeeked);
 
         return () => {
-            window.cancelAnimationFrame(playheadRafRef.current);
+            window.cancelAnimationFrame(playheadAnimationRef.current);
             media.removeEventListener('play', startLoop);
+            media.removeEventListener('playing', startLoop);
             media.removeEventListener('pause', stopLoop);
             media.removeEventListener('seeked', handleSeeked);
         };
@@ -219,35 +459,30 @@ export default function WaveformView({
             return undefined;
         }
 
+        window.cancelAnimationFrame(peakTransitionAnimationRef.current);
+
         const fromPeaks = displayedPeaksRef.current;
-        const reduceMotion =
-            typeof window !== 'undefined' &&
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        window.cancelAnimationFrame(peakTransitionRafRef.current);
-
-        if (!fromPeaks || fromPeaks === peaks || reduceMotion) {
+        if (!fromPeaks || fromPeaks === peaks || prefersReducedMotion()) {
             displayedPeaksRef.current = peaks;
             applyPeaks(wavesurfer, peaks, durationSec);
             return undefined;
         }
 
-        const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const start = timestampMs();
         const tick = (now: number): void => {
             const elapsedMs = now - start;
             const framePeaks = morphPeaks(fromPeaks, peaks, elapsedMs);
             displayedPeaksRef.current = framePeaks;
             applyPeaks(wavesurfer, framePeaks, durationSec);
             if (elapsedMs < WAVEFORM_PEAK_TRANSITION_MS) {
-                peakTransitionRafRef.current = window.requestAnimationFrame(tick);
+                peakTransitionAnimationRef.current = window.requestAnimationFrame(tick);
             } else {
                 displayedPeaksRef.current = peaks;
             }
         };
-        peakTransitionRafRef.current = window.requestAnimationFrame(tick);
+        peakTransitionAnimationRef.current = window.requestAnimationFrame(tick);
 
-        return () => window.cancelAnimationFrame(peakTransitionRafRef.current);
+        return () => window.cancelAnimationFrame(peakTransitionAnimationRef.current);
     }, [durationSec, peaks]);
 
     useEffect(() => {
@@ -257,12 +492,99 @@ export default function WaveformView({
         }
 
         const fills = getWaveformFills({ bufferProgress, hoverProgress });
+        if (isZoomed) {
+            tintZoomedWaveform(wavesurfer, fills);
+            return;
+        }
+
         wavesurfer.setOptions({
-            progressColor: toCanvasFill(fills.progressColor, fillWidth(canvasWidthPx)),
-            waveColor: toCanvasFill(fills.waveColor, fillWidth(canvasWidthPx)),
+            progressColor: toCanvasFill(fills.progressColor, devicePixelWidth(canvasWidthPx)),
+            waveColor: toCanvasFill(fills.waveColor, devicePixelWidth(canvasWidthPx)),
         });
         wavesurfer.setTime(currentTimeRef.current);
-    }, [bufferProgress, canvasWidthPx, hoverProgress]);
+    }, [bufferProgress, canvasWidthPx, hoverProgress, isZoomed]);
+
+    useEffect(() => {
+        const track = trackRef.current;
+        if (!track) {
+            return undefined;
+        }
+
+        /** Remember the time under this pointer so pinch/wheel zoom stays anchored. */
+        const captureZoomOrigin = (clientX: number): void => {
+            const rect = track.getBoundingClientRect();
+            zoomOriginRef.current = zoomOriginAtPointer(
+                clientX - rect.left,
+                wavesurferRef.current,
+                durationSec,
+                rect.width,
+            );
+        };
+
+        /** Zoom origin at the midpoint of a two-finger pinch. */
+        const zoomOriginFromPinch = (touches: TouchList): ZoomOrigin | null => {
+            if (touches.length < 2) {
+                return null;
+            }
+            const rect = track.getBoundingClientRect();
+            const pointerX = (touches[0].clientX + touches[1].clientX) / 2 - rect.left;
+            return zoomOriginAtPointer(pointerX, wavesurferRef.current, durationSec, rect.width);
+        };
+
+        /** Ctrl/meta + wheel zooms around the pointer. */
+        const onZoomWheel = (event: WheelEvent): void => {
+            if (!interactiveRef.current || !hasZoomHandlersRef.current || (!event.ctrlKey && !event.metaKey)) {
+                return;
+            }
+            event.preventDefault();
+            captureZoomOrigin(event.clientX);
+            setZoomLevel(zoomRef.current * Math.exp(-event.deltaY * 0.01));
+        };
+
+        const onTouchStart = (event: TouchEvent): void => {
+            if (!interactiveRef.current || !hasZoomHandlersRef.current || event.touches.length !== 2) {
+                pinchStartRef.current = null;
+                return;
+            }
+            zoomOriginRef.current = zoomOriginFromPinch(event.touches);
+            pinchStartRef.current = { distance: touchDistance(event.touches), zoom: zoomRef.current };
+        };
+
+        const onTouchMove = (event: TouchEvent): void => {
+            const pinch = pinchStartRef.current;
+            if (
+                !interactiveRef.current ||
+                !hasZoomHandlersRef.current ||
+                !pinch ||
+                event.touches.length !== 2 ||
+                !(pinch.distance > 0)
+            ) {
+                return;
+            }
+            event.preventDefault();
+            zoomOriginRef.current = zoomOriginFromPinch(event.touches);
+            setZoomLevel(pinch.zoom * (touchDistance(event.touches) / pinch.distance));
+        };
+
+        const onTouchEnd = (event: TouchEvent): void => {
+            if (event.touches.length < 2) {
+                pinchStartRef.current = null;
+            }
+        };
+
+        track.addEventListener('wheel', onZoomWheel, { passive: false });
+        track.addEventListener('touchstart', onTouchStart, { passive: true });
+        track.addEventListener('touchmove', onTouchMove, { passive: false });
+        track.addEventListener('touchend', onTouchEnd);
+        track.addEventListener('touchcancel', onTouchEnd);
+        return () => {
+            track.removeEventListener('wheel', onZoomWheel);
+            track.removeEventListener('touchstart', onTouchStart);
+            track.removeEventListener('touchmove', onTouchMove);
+            track.removeEventListener('touchend', onTouchEnd);
+            track.removeEventListener('touchcancel', onTouchEnd);
+        };
+    }, [durationSec, setZoomLevel]);
 
     const onHoverMove = useCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {
@@ -273,11 +595,16 @@ export default function WaveformView({
             if (!(rect.width > 0) || !(durationSec > 0)) {
                 return;
             }
-            const x = event.clientX - rect.left;
-            if (!Number.isFinite(x)) {
+            const pointerX = event.clientX - rect.left;
+            if (!Number.isFinite(pointerX)) {
                 return;
             }
-            setHoverProgress(Math.min(1, Math.max(0, x / rect.width)));
+            const vp = viewportRef.current;
+            if (vp.pixelsPerSecond > 0) {
+                setHoverProgress(Math.min(1, Math.max(0, timeFromPositionPx(pointerX, vp) / durationSec)));
+                return;
+            }
+            setHoverProgress(Math.min(1, Math.max(0, pointerX / rect.width)));
         },
         [durationSec, interactive],
     );
@@ -286,14 +613,18 @@ export default function WaveformView({
         setHoverProgress(null);
     }, []);
 
-    const hoverLeft = hoverProgress == null ? null : `${hoverProgress * 100}%`;
+    const hoverLeft =
+        hoverProgress == null ? null : timeLeftPercent(hoverProgress * durationSec, durationSec, viewportRef.current);
 
     return (
         <div
-            className={`bp-WaveformView${interactive ? '' : ' bp-WaveformView--inert'}`}
+            className={`bp-WaveformView${interactive ? '' : ' bp-WaveformView--inert'}${
+                isZoomed ? ' bp-WaveformView--zoomed' : ''
+            }`}
             data-testid="bp-waveform-view"
         >
             <div
+                ref={trackRef}
                 className="bp-WaveformView-track"
                 onMouseLeave={interactive ? onHoverLeave : undefined}
                 onMouseMove={interactive ? onHoverMove : undefined}

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import WaveSurfer from 'wavesurfer.js';
+import { getCurrentTimeMs } from '../../../util';
 import {
     getBufferedProgress,
     getWaveformFills,
@@ -39,11 +40,6 @@ type ZoomOrigin = {
 function devicePixelWidth(widthCssPx: number): number {
     const pixelRatio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
     return widthCssPx * pixelRatio;
-}
-
-/** Monotonic clock for peak-morph animations. */
-function timestampMs(): number {
-    return typeof performance !== 'undefined' ? performance.now() : Date.now();
 }
 
 function prefersReducedMotion(): boolean {
@@ -345,8 +341,7 @@ export default function WaveformView({
         if (!isControlled) {
             setInternalZoom(clamped);
         }
-        onZoomChange?.(clamped);
-    }, [internalZoom, isControlled, maxZoom, onZoomChange, zoomLevelProp]);
+    }, [internalZoom, isControlled, maxZoom, zoomLevelProp]);
 
     useEffect(() => {
         onViewportChange?.(viewport);
@@ -468,7 +463,7 @@ export default function WaveformView({
             return undefined;
         }
 
-        const start = timestampMs();
+        const start = getCurrentTimeMs();
         const tick = (now: number): void => {
             const elapsedMs = now - start;
             const framePeaks = morphPeaks(fromPeaks, peaks, elapsedMs);

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.scss
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.scss
@@ -8,7 +8,7 @@ $bp-WaveformZoom-track-width: 103px;
 $bp-WaveformZoom-track-height: 8px;
 $bp-WaveformZoom-fill-range: $bp-WaveformZoom-track-width - $bp-WaveformZoom-track-height;
 $bp-WaveformZoom-icon: 40px;
-$bp-WaveformZoom-glyph: 20px;
+$bp-WaveformZoom-glyph: 24px;
 
 .bp-WaveformZoomControl {
     display: flex;

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.scss
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.scss
@@ -1,0 +1,103 @@
+@import '../../controls/media/styles';
+
+$bp-WaveformZoom-size: 48px;
+$bp-WaveformZoom-open-width: 178px;
+$bp-WaveformZoom-padding: 4px;
+$bp-WaveformZoom-gap: 8px;
+$bp-WaveformZoom-track-width: 103px;
+$bp-WaveformZoom-track-height: 8px;
+$bp-WaveformZoom-fill-range: $bp-WaveformZoom-track-width - $bp-WaveformZoom-track-height;
+$bp-WaveformZoom-icon: 40px;
+$bp-WaveformZoom-glyph: 20px;
+
+.bp-WaveformZoomControl {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+    align-items: center;
+    justify-content: flex-end;
+    width: $bp-WaveformZoom-size;
+    height: $bp-WaveformZoom-size;
+    padding: $bp-WaveformZoom-padding;
+    overflow: hidden;
+    background: rgb(255 255 255 / 10%);
+    border-radius: 32px;
+    box-shadow: 0 2px 12px rgb(0 0 0 / 8%);
+    backdrop-filter: blur(60px);
+    transition: width 150ms ease-out, gap 150ms ease-out;
+
+    &.bp-is-open {
+        gap: $bp-WaveformZoom-gap;
+        width: $bp-WaveformZoom-open-width;
+    }
+}
+
+.bp-WaveformZoomControl-flyout {
+    flex: 0 0 auto;
+    width: 0;
+    height: $bp-WaveformZoom-track-height;
+    overflow: hidden;
+    transition: width 150ms ease-out;
+
+    &.bp-is-open {
+        width: $bp-WaveformZoom-track-width;
+    }
+}
+
+.bp-WaveformZoomControl-slider {
+    width: $bp-WaveformZoom-track-width;
+    height: $bp-WaveformZoom-track-height;
+
+    .bp-SliderControl-track {
+        height: $bp-WaveformZoom-track-height;
+        margin: 0;
+        background: rgb(255 255 255 / 30%);
+        background-image: none;
+        border-radius: 20px;
+
+        &::after {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: calc(#{$bp-WaveformZoom-track-height} + #{$bp-WaveformZoom-fill-range} * var(--bp-zoom-t, 0));
+            height: $bp-WaveformZoom-track-height;
+            background: rgb(255 255 255 / 90%);
+            border-radius: 20px;
+            content: '';
+        }
+    }
+
+    .bp-SliderControl-thumb {
+        display: none;
+    }
+}
+
+.bp-WaveformZoomControl-toggle {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex: 0 0 $bp-WaveformZoom-icon;
+    align-items: center;
+    justify-content: center;
+    width: $bp-WaveformZoom-icon;
+    height: $bp-WaveformZoom-icon;
+    padding: 0;
+    color: rgb(255 255 255 / 80%);
+    background: transparent;
+    border: 0;
+    border-radius: 50%;
+    cursor: pointer;
+
+    svg {
+        width: $bp-WaveformZoom-glyph;
+        height: $bp-WaveformZoom-glyph;
+        padding: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .bp-WaveformZoomControl,
+    .bp-WaveformZoomControl-flyout {
+        transition: none;
+    }
+}

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
@@ -91,6 +91,7 @@ export default function WaveformZoomControl({
                 <SliderControl
                     aria-hidden={!isOpen}
                     className="bp-WaveformZoomControl-slider"
+                    data-resin-target="waveformZoomSlider"
                     id={sliderId}
                     max={WAVEFORM_ZOOM_SLIDER_MAX}
                     min={0}
@@ -106,6 +107,7 @@ export default function WaveformZoomControl({
                 aria-controls={sliderId}
                 aria-expanded={isOpen}
                 className="bp-WaveformZoomControl-toggle"
+                data-resin-target="waveformZoom"
                 onClick={handleToggleClick}
                 title={__('media_zoom')}
             >

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
@@ -1,0 +1,124 @@
+import classNames from 'classnames';
+import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import MediaToggle from '../../controls/media/MediaToggle';
+import SliderControl from '../../controls/slider';
+import { WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_SLIDER_MAX } from './constants';
+import { WaveformZoomControlProps } from './types';
+import { clampWaveformZoom, sliderValueFromZoom, zoomFromSliderValue } from './viewport';
+import './WaveformZoomControl.scss';
+
+export default function WaveformZoomControl({
+    isRevealed = false,
+    maxZoom,
+    onZoomChange,
+    zoomLevel,
+}: WaveformZoomControlProps): JSX.Element {
+    const [isHovered, setHovered] = useState(false);
+    const [isFocused, setFocused] = useState(false);
+    const dismissTimerRef = useRef(0);
+    const flyoutRef = useRef<HTMLDivElement>(null);
+    const shouldFocusSliderRef = useRef(false);
+    const sliderId = `bp-waveform-zoom-slider${useId()}`;
+    const zoom = clampWaveformZoom(zoomLevel, maxZoom);
+    const zoomValue = Math.round(sliderValueFromZoom(zoom, maxZoom));
+    const isOpen = isHovered || isFocused || isRevealed;
+
+    const clearDismiss = useCallback(() => {
+        window.clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = 0;
+    }, []);
+
+    useEffect(() => () => window.clearTimeout(dismissTimerRef.current), []);
+
+    useLayoutEffect(() => {
+        if (!isOpen || !shouldFocusSliderRef.current) {
+            return;
+        }
+        shouldFocusSliderRef.current = false;
+        flyoutRef.current?.querySelector<HTMLElement>('[role="slider"]')?.focus();
+    }, [isOpen]);
+
+    const handleSlider = useCallback(
+        (newValue: number): void => {
+            onZoomChange(zoomFromSliderValue(newValue, maxZoom));
+        },
+        [maxZoom, onZoomChange],
+    );
+
+    const handleToggleClick = useCallback((): void => {
+        clearDismiss();
+        if (isOpen) {
+            shouldFocusSliderRef.current = false;
+            setFocused(false);
+            setHovered(false);
+            return;
+        }
+        shouldFocusSliderRef.current = true;
+        setFocused(true);
+    }, [clearDismiss, isOpen]);
+
+    return (
+        <div
+            className={classNames('bp-WaveformZoomControl', { 'bp-is-open': isOpen })}
+            data-testid="bp-waveform-zoom"
+            onBlur={event => {
+                if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                    return;
+                }
+                setFocused(false);
+            }}
+            onFocus={() => {
+                clearDismiss();
+                setFocused(true);
+            }}
+            onMouseEnter={() => {
+                clearDismiss();
+                setHovered(true);
+            }}
+            onMouseLeave={() => {
+                clearDismiss();
+                dismissTimerRef.current = window.setTimeout(() => {
+                    setHovered(false);
+                }, WAVEFORM_ZOOM_DISMISS_MS);
+            }}
+        >
+            <div
+                ref={flyoutRef}
+                aria-hidden={!isOpen}
+                className={classNames('bp-WaveformZoomControl-flyout', { 'bp-is-open': isOpen })}
+            >
+                <SliderControl
+                    aria-hidden={!isOpen}
+                    className="bp-WaveformZoomControl-slider"
+                    id={sliderId}
+                    max={WAVEFORM_ZOOM_SLIDER_MAX}
+                    min={0}
+                    onUpdate={handleSlider}
+                    step={1}
+                    style={{ '--bp-zoom-t': zoomValue / WAVEFORM_ZOOM_SLIDER_MAX } as React.CSSProperties}
+                    tabIndex={isOpen ? 0 : -1}
+                    title={__('media_zoom_slider')}
+                    value={zoomValue}
+                />
+            </div>
+            <MediaToggle
+                aria-controls={sliderId}
+                aria-expanded={isOpen}
+                className="bp-WaveformZoomControl-toggle"
+                onClick={handleToggleClick}
+                title={__('media_zoom')}
+            >
+                <svg aria-hidden="true" focusable="false" height="20" viewBox="0 0 24 24" width="20">
+                    <path
+                        d="M4 12h16M7 9l-3 3 3 3M17 9l3 3-3 3"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.75"
+                    />
+                </svg>
+            </MediaToggle>
+        </div>
+    );
+}

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import IconZoom24 from '../../controls/icons/IconZoom24';
 import MediaToggle from '../../controls/media/MediaToggle';
 import SliderControl from '../../controls/slider';
 import { WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_SLIDER_MAX } from './constants';
@@ -108,16 +109,7 @@ export default function WaveformZoomControl({
                 onClick={handleToggleClick}
                 title={__('media_zoom')}
             >
-                <svg aria-hidden="true" focusable="false" height="20" viewBox="0 0 24 24" width="20">
-                    <path
-                        d="M4 12h16M7 9l-3 3 3 3M17 9l3 3-3 3"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.75"
-                    />
-                </svg>
+                <IconZoom24 />
             </MediaToggle>
         </div>
     );

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -17,10 +17,10 @@ const mockSetScrollTime = jest.fn();
 const mockObserve = jest.fn();
 const mockDisconnect = jest.fn();
 let clickHandler: ((relativeX: number) => void) | undefined;
-let scrollHandler: (() => void) | undefined;
+let scrollHandler: ((relativeX?: number) => void) | undefined;
 let resizeCallback: ResizeObserverCallback | undefined;
 
-const mockOn = jest.fn((event: string, handler: (relativeX: number) => void) => {
+const mockOn = jest.fn((event: string, handler: (relativeX?: number) => void) => {
     if (event === 'click') {
         clickHandler = handler;
     }

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -295,11 +295,11 @@ describe('WaveformView', () => {
     });
 
     test('should recompute fills when the canvas width changes', () => {
-        const bufferedRange = ({
+        const bufferedRange = {
             end: () => 4,
             length: 1,
             start: () => 0,
-        } as unknown) as TimeRanges;
+        } as TimeRanges;
 
         render(<WaveformView bufferedRange={bufferedRange} durationSec={8} peaks={[0.2, 0.8]} />);
 

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -1,26 +1,31 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import WaveSurfer from 'wavesurfer.js';
-import WaveformView, {
-    WAVEFORM_BAR_GAP,
-    WAVEFORM_BAR_RADIUS,
-    WAVEFORM_BAR_WIDTH,
-    WAVEFORM_HEIGHT,
-} from '../WaveformView';
+import WaveformView from '../WaveformView';
+import { WAVEFORM_BAR_GAP, WAVEFORM_BAR_RADIUS, WAVEFORM_BAR_WIDTH, WAVEFORM_HEIGHT } from '../constants';
 import { WAVEFORM_COLOR_PLAYED, WAVEFORM_COLOR_UNPLAYED } from '../colors';
 
 const mockDestroy = jest.fn();
 const mockLoad = jest.fn();
 const mockSetOptions = jest.fn();
 const mockSetTime = jest.fn();
+const mockGetScroll = jest.fn(() => 0);
+const mockGetWidth = jest.fn(() => 200);
+const mockGetWrapper = jest.fn(() => ({ clientWidth: 200 }));
+const mockSetScroll = jest.fn();
+const mockSetScrollTime = jest.fn();
 const mockObserve = jest.fn();
 const mockDisconnect = jest.fn();
 let clickHandler: ((relativeX: number) => void) | undefined;
+let scrollHandler: (() => void) | undefined;
 let resizeCallback: ResizeObserverCallback | undefined;
 
 const mockOn = jest.fn((event: string, handler: (relativeX: number) => void) => {
     if (event === 'click') {
         clickHandler = handler;
+    }
+    if (event === 'scroll') {
+        scrollHandler = handler;
     }
     return jest.fn();
 });
@@ -40,9 +45,14 @@ jest.mock('wavesurfer.js', () => ({
     default: {
         create: jest.fn(() => ({
             destroy: mockDestroy,
+            getScroll: mockGetScroll,
+            getWidth: mockGetWidth,
+            getWrapper: mockGetWrapper,
             load: mockLoad,
             on: mockOn,
             setOptions: mockSetOptions,
+            setScroll: mockSetScroll,
+            setScrollTime: mockSetScrollTime,
             setTime: mockSetTime,
         })),
     },
@@ -59,6 +69,7 @@ describe('WaveformView', () => {
 
     beforeEach(() => {
         clickHandler = undefined;
+        scrollHandler = undefined;
         resizeCallback = undefined;
         jest.clearAllMocks();
     });
@@ -101,22 +112,22 @@ describe('WaveformView', () => {
         Object.defineProperty(mediaEl, 'paused', { configurable: true, value: false });
         Object.defineProperty(mediaEl, 'currentTime', { configurable: true, value: 1, writable: true });
 
-        const rafCallbacks: FrameRequestCallback[] = [];
-        const cancelRaf = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(jest.fn());
+        const animationCallbacks: FrameRequestCallback[] = [];
+        const cancelAnimation = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(jest.fn());
         jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
-            rafCallbacks.push(cb);
-            return rafCallbacks.length;
+            animationCallbacks.push(cb);
+            return animationCallbacks.length;
         });
 
         render(<WaveformView currentTime={1} durationSec={8} mediaEl={mediaEl} peaks={[0.2, 0.8]} />);
 
-        cancelRaf.mockClear();
+        cancelAnimation.mockClear();
         mockSetTime.mockClear();
 
         mediaEl.currentTime = 4;
         mediaEl.dispatchEvent(new Event('seeked'));
 
-        expect(cancelRaf).not.toHaveBeenCalled();
+        expect(cancelAnimation).not.toHaveBeenCalled();
         expect(mockSetTime).toHaveBeenCalledWith(4);
     });
 
@@ -138,6 +149,27 @@ describe('WaveformView', () => {
         fireEvent.mouseMove(track, { clientX: 50 });
 
         expect(screen.getByTestId('bp-waveform-hover-time')).toHaveTextContent('0:02.00');
+        expect(screen.getByTestId('bp-waveform-hover')).toHaveStyle({ left: '25%' });
+    });
+
+    test('should show the hover time chip while zoomed', () => {
+        render(<WaveformView durationSec={8} peaks={new Array(800).fill(0.5)} zoomLevel={2} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.mouseMove(track, { clientX: 50 });
+
+        expect(screen.getByTestId('bp-waveform-hover-time')).toHaveTextContent('0:01.00');
         expect(screen.getByTestId('bp-waveform-hover')).toHaveStyle({ left: '25%' });
     });
 
@@ -288,5 +320,91 @@ describe('WaveformView', () => {
         });
 
         expect(mockSetOptions).toHaveBeenCalled();
+    });
+
+    test('should emit viewport zoom limits from peak density, duration, and viewport width', () => {
+        const onViewportChange = jest.fn();
+        render(<WaveformView durationSec={60} onViewportChange={onViewportChange} peaks={new Array(800).fill(0.5)} />);
+
+        expect(onViewportChange).toHaveBeenCalledWith(expect.objectContaining({ maxZoom: 4, widthPx: 200 }));
+    });
+
+    test('should not allow zoom when the file is shorter than the minimum window floor', () => {
+        const onViewportChange = jest.fn();
+        render(<WaveformView durationSec={2} onViewportChange={onViewportChange} peaks={new Array(16384).fill(0.5)} />);
+
+        expect(onViewportChange).toHaveBeenCalledWith(expect.objectContaining({ maxZoom: 1, widthPx: 200 }));
+    });
+
+    test('should apply minPxPerSec and the zoomed class when zoomed in', () => {
+        render(<WaveformView durationSec={8} peaks={new Array(800).fill(0.5)} zoomLevel={2} />);
+
+        expect(screen.getByTestId('bp-waveform-view')).toHaveClass('bp-WaveformView--zoomed');
+        expect(mockSetOptions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                autoScroll: false,
+                minPxPerSec: 50,
+            }),
+        );
+    });
+
+    test('should not recenter when only the peak-derived max zoom changes', () => {
+        render(<WaveformView currentTime={10} durationSec={300} peaks={new Array(16384).fill(0.5)} zoomLevel={2} />);
+
+        mockSetScroll.mockClear();
+        mockSetScrollTime.mockClear();
+        act(() => {
+            resizeCallback?.(
+                [
+                    ({
+                        contentRect: { width: 800 },
+                    } as unknown) as ResizeObserverEntry,
+                ],
+                ({} as unknown) as ResizeObserver,
+            );
+        });
+
+        expect(mockSetScroll).not.toHaveBeenCalled();
+        expect(mockSetScrollTime).not.toHaveBeenCalled();
+    });
+
+    test('should zoom around the pointer on ctrl+wheel', () => {
+        const onZoomChange = jest.fn();
+        render(
+            <WaveformView durationSec={8} onZoomChange={onZoomChange} peaks={new Array(800).fill(0.5)} zoomLevel={1} />,
+        );
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+
+        fireEvent.wheel(track, { clientX: 50, ctrlKey: true, deltaY: -100 });
+
+        expect(onZoomChange).toHaveBeenCalled();
+        expect(onZoomChange.mock.calls[0][0]).toBeGreaterThan(1);
+    });
+
+    test('should not zoom on ctrl+wheel when zoom is not enabled', () => {
+        render(<WaveformView durationSec={8} peaks={new Array(800).fill(0.5)} zoomLevel={1} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+
+        fireEvent.wheel(track, { clientX: 50, ctrlKey: true, deltaY: -100 });
+
+        expect(screen.getByTestId('bp-waveform-view')).not.toHaveClass('bp-WaveformView--zoomed');
+    });
+
+    test('should not zoom on ctrl+wheel when the minimum window floor leaves no zoom headroom', () => {
+        const onZoomChange = jest.fn();
+        render(
+            <WaveformView
+                durationSec={2}
+                onZoomChange={onZoomChange}
+                peaks={new Array(16384).fill(0.5)}
+                zoomLevel={1}
+            />,
+        );
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+
+        fireEvent.wheel(track, { clientX: 50, ctrlKey: true, deltaY: -100 });
+
+        expect(onZoomChange).not.toHaveBeenCalled();
+        expect(screen.getByTestId('bp-waveform-view')).not.toHaveClass('bp-WaveformView--zoomed');
     });
 });

--- a/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WAVEFORM_ZOOM_DISMISS_MS } from '../constants';
 import WaveformZoomControl from '../WaveformZoomControl';
@@ -82,19 +82,21 @@ describe('WaveformZoomControl', () => {
         expect(control).not.toHaveClass('bp-is-open');
     });
 
-    test('should keep the slider out of the tab order until the control opens', () => {
+    test('should keep the slider out of the tab order until the control opens', async () => {
+        const user = userEvent.setup();
         render(<WaveformZoomControl maxZoom={4} onZoomChange={jest.fn()} zoomLevel={1} />);
 
         const toggle = screen.getByRole('button', { name: __('media_zoom') });
         expect(toggle).toHaveAttribute('aria-expanded', 'false');
         expect(screen.queryByRole('slider', { name: __('media_zoom_slider') })).not.toBeInTheDocument();
 
-        fireEvent.click(toggle);
+        await user.tab();
 
+        expect(toggle).toHaveFocus();
         expect(toggle).toHaveAttribute('aria-expanded', 'true');
-        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveFocus();
+        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toBeInTheDocument();
 
-        fireEvent.click(toggle);
+        await user.keyboard('{Enter}');
 
         expect(toggle).toHaveAttribute('aria-expanded', 'false');
         expect(screen.queryByRole('slider', { name: __('media_zoom_slider') })).not.toBeInTheDocument();

--- a/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { WAVEFORM_ZOOM_DISMISS_MS } from '../constants';
 import WaveformZoomControl from '../WaveformZoomControl';
 
@@ -8,7 +9,8 @@ describe('WaveformZoomControl', () => {
         jest.useRealTimers();
     });
 
-    test('should expand on hover and report slider zoom changes', () => {
+    test('should expand on hover and report slider zoom changes', async () => {
+        const user = userEvent.setup();
         const onZoomChange = jest.fn();
         render(<WaveformZoomControl maxZoom={4} onZoomChange={onZoomChange} zoomLevel={1} />);
 
@@ -16,30 +18,37 @@ describe('WaveformZoomControl', () => {
         const flyout = control.querySelector('.bp-WaveformZoomControl-flyout');
         expect(control).not.toHaveClass('bp-is-open');
         expect(flyout).not.toHaveClass('bp-is-open');
+        expect(screen.getByRole('button', { name: __('media_zoom') })).toHaveAttribute(
+            'data-resin-target',
+            'waveformZoom',
+        );
 
-        fireEvent.mouseEnter(control);
+        await user.hover(control);
         expect(control).toHaveClass('bp-is-open');
         expect(flyout).toHaveClass('bp-is-open');
 
         const slider = screen.getByRole('slider', { name: __('media_zoom_slider') });
-        fireEvent.keyDown(slider, { key: 'ArrowRight' });
+        expect(slider).toHaveAttribute('data-resin-target', 'waveformZoomSlider');
+        await user.tab();
+        await user.keyboard('{ArrowRight}');
 
         expect(onZoomChange).toHaveBeenCalled();
         expect(onZoomChange.mock.calls[0][0]).toBeGreaterThan(1);
     });
 
-    test('should keep the slider open through the dismiss delay after mouse leave', () => {
+    test('should keep the slider open through the dismiss delay after mouse leave', async () => {
         jest.useFakeTimers();
+        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
         const onZoomChange = jest.fn();
         render(<WaveformZoomControl maxZoom={4} onZoomChange={onZoomChange} zoomLevel={1} />);
 
         const control = screen.getByTestId('bp-waveform-zoom');
         const flyout = control.querySelector('.bp-WaveformZoomControl-flyout');
-        fireEvent.mouseEnter(control);
+        await user.hover(control);
         expect(control).toHaveClass('bp-is-open');
         expect(flyout).toHaveClass('bp-is-open');
 
-        fireEvent.mouseLeave(control);
+        await user.unhover(control);
         expect(control).toHaveClass('bp-is-open');
         expect(flyout).toHaveClass('bp-is-open');
 

--- a/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { WAVEFORM_ZOOM_DISMISS_MS } from '../constants';
+import WaveformZoomControl from '../WaveformZoomControl';
+
+describe('WaveformZoomControl', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('should expand on hover and report slider zoom changes', () => {
+        const onZoomChange = jest.fn();
+        render(<WaveformZoomControl maxZoom={4} onZoomChange={onZoomChange} zoomLevel={1} />);
+
+        const control = screen.getByTestId('bp-waveform-zoom');
+        const flyout = control.querySelector('.bp-WaveformZoomControl-flyout');
+        expect(control).not.toHaveClass('bp-is-open');
+        expect(flyout).not.toHaveClass('bp-is-open');
+
+        fireEvent.mouseEnter(control);
+        expect(control).toHaveClass('bp-is-open');
+        expect(flyout).toHaveClass('bp-is-open');
+
+        const slider = screen.getByRole('slider', { name: __('media_zoom_slider') });
+        fireEvent.keyDown(slider, { key: 'ArrowRight' });
+
+        expect(onZoomChange).toHaveBeenCalled();
+        expect(onZoomChange.mock.calls[0][0]).toBeGreaterThan(1);
+    });
+
+    test('should keep the slider open through the dismiss delay after mouse leave', () => {
+        jest.useFakeTimers();
+        const onZoomChange = jest.fn();
+        render(<WaveformZoomControl maxZoom={4} onZoomChange={onZoomChange} zoomLevel={1} />);
+
+        const control = screen.getByTestId('bp-waveform-zoom');
+        const flyout = control.querySelector('.bp-WaveformZoomControl-flyout');
+        fireEvent.mouseEnter(control);
+        expect(control).toHaveClass('bp-is-open');
+        expect(flyout).toHaveClass('bp-is-open');
+
+        fireEvent.mouseLeave(control);
+        expect(control).toHaveClass('bp-is-open');
+        expect(flyout).toHaveClass('bp-is-open');
+
+        act(() => {
+            jest.advanceTimersByTime(WAVEFORM_ZOOM_DISMISS_MS - 1);
+        });
+        expect(flyout).toHaveClass('bp-is-open');
+
+        act(() => {
+            jest.advanceTimersByTime(1);
+        });
+        expect(flyout).not.toHaveClass('bp-is-open');
+        expect(control).not.toHaveClass('bp-is-open');
+    });
+
+    test('should stay open while revealed from a trackpad zoom and follow the zoom level', () => {
+        const onZoomChange = jest.fn();
+        const { rerender } = render(
+            <WaveformZoomControl isRevealed maxZoom={4} onZoomChange={onZoomChange} zoomLevel={1} />,
+        );
+
+        const control = screen.getByTestId('bp-waveform-zoom');
+        expect(control).toHaveClass('bp-is-open');
+        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveAttribute('aria-valuenow', '0');
+
+        rerender(<WaveformZoomControl isRevealed maxZoom={4} onZoomChange={onZoomChange} zoomLevel={2.5} />);
+        expect(control).toHaveClass('bp-is-open');
+        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveAttribute('aria-valuenow', '50');
+
+        rerender(<WaveformZoomControl isRevealed={false} maxZoom={4} onZoomChange={onZoomChange} zoomLevel={2.5} />);
+        expect(control).not.toHaveClass('bp-is-open');
+    });
+
+    test('should keep the slider out of the tab order until the control opens', () => {
+        render(<WaveformZoomControl maxZoom={4} onZoomChange={jest.fn()} zoomLevel={1} />);
+
+        const toggle = screen.getByRole('button', { name: __('media_zoom') });
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByRole('slider', { name: __('media_zoom_slider') })).not.toBeInTheDocument();
+
+        fireEvent.click(toggle);
+
+        expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toHaveFocus();
+
+        fireEvent.click(toggle);
+
+        expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByRole('slider', { name: __('media_zoom_slider') })).not.toBeInTheDocument();
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/colors-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/colors-test.ts
@@ -1,6 +1,8 @@
 import {
+    fillForTile,
     getBufferedProgress,
     getWaveformFills,
+    tintWaveformTiles,
     WAVEFORM_COLOR_BUFFER,
     WAVEFORM_COLOR_HOVER_AREA,
     WAVEFORM_COLOR_HOVER_BUFFER,
@@ -77,5 +79,149 @@ describe('colors', () => {
     test('should treat missing buffered ranges as fully loaded', () => {
         expect(getBufferedProgress(undefined, 8)).toBe(1);
         expect(getBufferedProgress(mockBufferedRange(4), 8)).toBe(0.5);
+    });
+});
+
+describe('tintWaveformTiles', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('should offset each tile gradient into global waveform coordinates', () => {
+        const host = document.createElement('div');
+        host.innerHTML = `
+            <div class="canvases">
+                <canvas class="start" style="left: 0px; width: 200px;"></canvas>
+                <canvas class="end" style="left: 200px; width: 200px;"></canvas>
+            </div>
+            <div class="progress">
+                <canvas class="start" style="left: 0px; width: 200px;"></canvas>
+                <canvas class="end" style="left: 200px; width: 200px;"></canvas>
+            </div>
+        `;
+
+        const gradients: Array<{ left: string; x0: number; x1: number }> = [];
+        jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function getContext(
+            this: HTMLCanvasElement,
+        ) {
+            Object.defineProperty(this, 'width', { configurable: true, value: 200 });
+            Object.defineProperty(this, 'height', { configurable: true, value: 10 });
+            return ({
+                createLinearGradient: (x0: number, _y0: number, x1: number) => {
+                    gradients.push({ left: this.style.left, x0, x1 });
+                    return { addColorStop: jest.fn() };
+                },
+                fillRect: jest.fn(),
+                restore: jest.fn(),
+                save: jest.fn(),
+                fillStyle: '',
+                globalCompositeOperation: 'source-over',
+            } as unknown) as CanvasRenderingContext2D;
+        });
+
+        tintWaveformTiles({
+            fills: getWaveformFills({ bufferProgress: 1, hoverProgress: 0.25 }),
+            host,
+            totalWidthCss: 400,
+        });
+
+        expect(gradients).toEqual(
+            expect.arrayContaining([
+                { left: '0px', x0: 0, x1: 400 },
+                { left: '200px', x0: -200, x1: 200 },
+            ]),
+        );
+    });
+
+    test('should shift a fill by the tile offset in device pixels', () => {
+        const canvas = document.createElement('canvas');
+        canvas.style.width = '100px';
+        Object.defineProperty(canvas, 'width', { configurable: true, value: 200 });
+        const createLinearGradient = jest.fn(() => ({ addColorStop: jest.fn() }));
+        const context = ({ createLinearGradient } as unknown) as CanvasRenderingContext2D;
+
+        fillForTile(
+            context,
+            [
+                { color: '#fff', offset: 0 },
+                { color: '#000', offset: 1 },
+            ],
+            400,
+            200,
+            canvas,
+        );
+
+        expect(createLinearGradient).toHaveBeenCalledWith(-400, 0, 400, 0);
+    });
+
+    test('should restore the captured bar mask before a second source-in tint', () => {
+        const host = document.createElement('div');
+        host.innerHTML = `
+            <div class="canvases">
+                <canvas style="left: 0px; width: 200px;"></canvas>
+            </div>
+        `;
+
+        const getImageData = jest.fn(() => ({ data: new Uint8ClampedArray(8) }));
+        const putImageData = jest.fn();
+        jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function getContext(
+            this: HTMLCanvasElement,
+        ) {
+            Object.defineProperty(this, 'width', { configurable: true, value: 200 });
+            Object.defineProperty(this, 'height', { configurable: true, value: 10 });
+            return ({
+                createLinearGradient: () => ({ addColorStop: jest.fn() }),
+                fillRect: jest.fn(),
+                getImageData,
+                putImageData,
+                restore: jest.fn(),
+                save: jest.fn(),
+                fillStyle: '',
+                globalCompositeOperation: 'source-over',
+            } as unknown) as CanvasRenderingContext2D;
+        });
+
+        const fills = getWaveformFills({ bufferProgress: 1, hoverProgress: 0.25 });
+        tintWaveformTiles({ fills, host, totalWidthCss: 200 });
+        expect(getImageData).toHaveBeenCalled();
+        expect(putImageData).not.toHaveBeenCalled();
+
+        tintWaveformTiles({ fills, host, totalWidthCss: 200 });
+        expect(putImageData).toHaveBeenCalled();
+    });
+
+    test('should not tint canvases outside the waveform host', () => {
+        const host = document.createElement('div');
+        host.innerHTML = `<div class="canvases"><canvas style="width: 200px;"></canvas></div>`;
+
+        const outsider = document.createElement('div');
+        outsider.className = 'canvases';
+        outsider.innerHTML = '<canvas style="width: 200px;"></canvas>';
+        document.body.appendChild(outsider);
+
+        const fillRect = jest.fn();
+        jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function getContext(
+            this: HTMLCanvasElement,
+        ) {
+            Object.defineProperty(this, 'width', { configurable: true, value: 200 });
+            Object.defineProperty(this, 'height', { configurable: true, value: 10 });
+            return ({
+                createLinearGradient: () => ({ addColorStop: jest.fn() }),
+                fillRect,
+                restore: jest.fn(),
+                save: jest.fn(),
+                fillStyle: '',
+                globalCompositeOperation: 'source-over',
+            } as unknown) as CanvasRenderingContext2D;
+        });
+
+        tintWaveformTiles({
+            fills: getWaveformFills({ bufferProgress: 1, hoverProgress: null }),
+            host,
+            totalWidthCss: 200,
+        });
+
+        expect(fillRect).toHaveBeenCalledTimes(1);
+        outsider.remove();
     });
 });

--- a/src/lib/viewers/media/waveform/__tests__/viewport-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/viewport-test.ts
@@ -1,0 +1,103 @@
+import { WAVEFORM_MIN_VIEW_WINDOW_SEC, WAVEFORM_ZOOM_MAX } from '../constants';
+import {
+    clampWaveformZoom,
+    createWaveformViewport,
+    getWaveformZoomMax,
+    getZoomedPixelsPerSecond,
+    isTimeInView,
+    positionPxFromTime,
+    sliderValueFromZoom,
+    timeFromPositionPx,
+    zoomFromSliderValue,
+} from '../viewport';
+
+describe('viewport', () => {
+    const overview = createWaveformViewport({
+        durationSec: 8,
+        heightPx: 140,
+        maxZoom: 4,
+        scrollLeftPx: 0,
+        widthPx: 200,
+        zoomLevel: 1,
+    });
+
+    test('should map time to the full width at zoom 1', () => {
+        expect(overview.startSec).toBe(0);
+        expect(overview.endSec).toBe(8);
+        expect(positionPxFromTime(2, overview)).toBe(50);
+        expect(timeFromPositionPx(50, overview)).toBe(2);
+        expect(isTimeInView(2, overview)).toBe(true);
+    });
+
+    test('should keep the time under the pointer after a scrolled zoom window', () => {
+        const zoomed = createWaveformViewport({
+            durationSec: 8,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 200,
+            widthPx: 200,
+            zoomLevel: 2,
+        });
+
+        expect(zoomed.startSec).toBe(4);
+        expect(zoomed.endSec).toBe(8);
+        expect(positionPxFromTime(6, zoomed)).toBe(100);
+        expect(timeFromPositionPx(100, zoomed)).toBe(6);
+        expect(isTimeInView(2, zoomed)).toBe(false);
+        expect(isTimeInView(6, zoomed)).toBe(true);
+    });
+
+    test('should cap max zoom at 24x, by peak density, and by the minimum window', () => {
+        const longFile = { durationSec: 3600, viewWidthPx: 800 };
+        expect(getWaveformZoomMax({ ...longFile, peakCount: 2048 })).toBe(2);
+        expect(getWaveformZoomMax({ ...longFile, peakCount: 16384 })).toBe(20);
+        expect(getWaveformZoomMax({ ...longFile, peakCount: 24000 })).toBe(WAVEFORM_ZOOM_MAX);
+        expect(getWaveformZoomMax({ durationSec: 3600, peakCount: 3600, viewWidthPx: 900 })).toBe(4);
+        expect(getWaveformZoomMax({ durationSec: 3600, peakCount: 0, viewWidthPx: 800 })).toBe(1);
+
+        expect(getWaveformZoomMax({ durationSec: 2, peakCount: 16384, viewWidthPx: 800 })).toBe(1);
+        expect(
+            getWaveformZoomMax({
+                durationSec: WAVEFORM_MIN_VIEW_WINDOW_SEC,
+                peakCount: 16384,
+                viewWidthPx: 800,
+            }),
+        ).toBe(1);
+        expect(getWaveformZoomMax({ durationSec: 10, peakCount: 16384, viewWidthPx: 800 })).toBeCloseTo(
+            10 / WAVEFORM_MIN_VIEW_WINDOW_SEC,
+        );
+        expect(getWaveformZoomMax({ durationSec: 60, peakCount: 16384, viewWidthPx: 400 })).toBe(
+            Math.min(WAVEFORM_ZOOM_MAX, Math.floor(16384 / 400), 60 / WAVEFORM_MIN_VIEW_WINDOW_SEC),
+        );
+        expect(getWaveformZoomMax({ durationSec: 60, peakCount: 16384, viewWidthPx: 800 })).toBe(
+            Math.min(20, 60 / WAVEFORM_MIN_VIEW_WINDOW_SEC),
+        );
+        expect(getWaveformZoomMax({ durationSec: 300, peakCount: 16384, viewWidthPx: 800 })).toBe(20);
+    });
+
+    test('should clamp zoom to fit-to-width and the peak-derived max', () => {
+        expect(clampWaveformZoom(0, 4)).toBe(1);
+        expect(clampWaveformZoom(8, 4)).toBe(4);
+        expect(clampWaveformZoom(2, 4)).toBe(2);
+    });
+
+    test('should use 0 px/sec at fit-to-width so wavesurfer fills the parent', () => {
+        expect(getZoomedPixelsPerSecond({ durationSec: 10, maxZoom: 4, viewWidthPx: 900, zoomLevel: 1 })).toBe(0);
+        expect(getZoomedPixelsPerSecond({ durationSec: 10, maxZoom: 4, viewWidthPx: 900, zoomLevel: 2 })).toBe(180);
+        expect(getZoomedPixelsPerSecond({ durationSec: 10, maxZoom: 4, viewWidthPx: 900, zoomLevel: 4 })).toBe(360);
+    });
+
+    test('should round-trip slider values against the peak-derived max', () => {
+        const maxZoom = 4;
+        expect(zoomFromSliderValue(0, maxZoom)).toBe(1);
+        expect(zoomFromSliderValue(100, maxZoom)).toBe(4);
+        expect(sliderValueFromZoom(1, maxZoom)).toBe(0);
+        expect(sliderValueFromZoom(4, maxZoom)).toBe(100);
+        expect(zoomFromSliderValue(sliderValueFromZoom(2.5, maxZoom), maxZoom)).toBe(2.5);
+    });
+
+    test('should keep the slider at fit-to-width when zoom cannot exceed 1x', () => {
+        expect(sliderValueFromZoom(1, 1)).toBe(0);
+        expect(zoomFromSliderValue(100, 1)).toBe(1);
+    });
+});

--- a/src/lib/viewers/media/waveform/colors.ts
+++ b/src/lib/viewers/media/waveform/colors.ts
@@ -4,6 +4,8 @@
  * the unplayed bars — rgba whites would make the played region darker, not brighter.
  */
 
+import { GradientStop, WaveformFills } from './types';
+
 function whiteOnBlack(alpha: number): string {
     const channel = Math.round(255 * alpha);
     return `rgb(${channel}, ${channel}, ${channel})`;
@@ -16,21 +18,6 @@ export const WAVEFORM_COLOR_HOVER_PLAYED = whiteOnBlack(0.9);
 export const WAVEFORM_COLOR_HOVER_AREA = whiteOnBlack(0.6);
 export const WAVEFORM_COLOR_HOVER_UNPLAYED = whiteOnBlack(0.3);
 export const WAVEFORM_COLOR_HOVER_BUFFER = whiteOnBlack(0.16);
-
-/** One canvas linear-gradient stop. `offset` is 0–1 along the bar. */
-export type GradientStop = {
-    color: string;
-    offset: number;
-};
-
-/**
- * Wavesurfer's two paints: left of the playhead (`progressColor`) and right of it (`waveColor`).
- * A string is a solid fill; a stop list is a left-to-right step gradient.
- */
-export type WaveformFills = {
-    progressColor: string | GradientStop[];
-    waveColor: string | GradientStop[];
-};
 
 type ColorRange = {
     color: string;
@@ -158,4 +145,116 @@ export function toCanvasFill(color: string | GradientStop[], widthPx: number): s
     });
 
     return gradient;
+}
+
+/** Untinted bar pixels for each WaveSurfer tile, so hover can re-tint without stacking. */
+const tileBarSnapshots = new WeakMap<HTMLCanvasElement, ImageData>();
+
+/** Restore the last bar snapshot, or take a new one after WaveSurfer redraws. */
+function restoreOrSnapshotTile(
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D,
+    replaceSnapshot: boolean,
+): void {
+    if (!(canvas.width > 0) || !(canvas.height > 0) || !context.getImageData) {
+        return;
+    }
+
+    const stored = tileBarSnapshots.get(canvas);
+    if (!replaceSnapshot && stored && context.putImageData) {
+        context.putImageData(stored, 0, 0);
+        return;
+    }
+
+    try {
+        tileBarSnapshots.set(canvas, context.getImageData(0, 0, canvas.width, canvas.height));
+    } catch {
+        // Tainted or zero-size canvases cannot snapshot; tint in place.
+    }
+}
+
+/** CSS width of a tile canvas (style.width, then clientWidth, then bitmap width). */
+function tileWidthCss(canvas: HTMLCanvasElement): number {
+    const styled = parseFloat(canvas.style.width);
+    if (styled > 0) {
+        return styled;
+    }
+    if (canvas.clientWidth > 0) {
+        return canvas.clientWidth;
+    }
+    return canvas.width;
+}
+
+/** Solid color, or a gradient aligned to the full waveform and shifted to this tile. */
+export function fillForTile(
+    context: CanvasRenderingContext2D,
+    color: string | GradientStop[],
+    totalWidthCss: number,
+    offsetCss: number,
+    canvas: HTMLCanvasElement,
+): string | CanvasGradient {
+    if (typeof color === 'string') {
+        return color;
+    }
+    const cssWidth = tileWidthCss(canvas);
+    const scale = cssWidth > 0 ? canvas.width / cssWidth : 1;
+    if (!(totalWidthCss > 0) || !(scale > 0)) {
+        return color[0] ? color[0].color : WAVEFORM_COLOR_UNPLAYED;
+    }
+
+    const x0 = -offsetCss * scale || 0;
+    const x1 = (totalWidthCss - offsetCss) * scale;
+    const gradient = context.createLinearGradient(x0, 0, x1, 0);
+    let lastOffset = -1;
+    color.forEach(stop => {
+        let offset = clampTo0And1(stop.offset);
+        if (offset <= lastOffset) {
+            offset = Math.min(1, lastOffset + 1e-6);
+        }
+        lastOffset = offset;
+        gradient.addColorStop(offset, stop.color);
+    });
+    return gradient;
+}
+
+/**
+ * Wavesurfer splits a zoomed waveform into viewport-sized tiles and paints each
+ * from x=0. Re-tint with a gradient in global waveform space so hover/buffer
+ * colors do not repeat on the last tile.
+ */
+export function tintWaveformTiles({
+    fills,
+    host,
+    replaceSnapshot = false,
+    totalWidthCss,
+}: {
+    fills: WaveformFills;
+    host: HTMLElement;
+    replaceSnapshot?: boolean;
+    totalWidthCss: number;
+}): void {
+    if (!(totalWidthCss > 0) || !host.querySelectorAll) {
+        return;
+    }
+
+    const groups: Array<{ canvases: NodeListOf<HTMLCanvasElement>; color: string | GradientStop[] }> = [
+        { canvases: host.querySelectorAll('.canvases canvas'), color: fills.waveColor },
+        { canvases: host.querySelectorAll('.progress canvas'), color: fills.progressColor },
+    ];
+
+    groups.forEach(({ canvases, color }) => {
+        canvases.forEach(canvas => {
+            const context = canvas.getContext('2d');
+            if (!context) {
+                return;
+            }
+            restoreOrSnapshotTile(canvas, context, replaceSnapshot);
+            const offsetCss = parseFloat(canvas.style.left) || 0;
+            context.save();
+            context.globalCompositeOperation = 'source-in';
+            context.fillStyle = fillForTile(context, color, totalWidthCss, offsetCss, canvas);
+            context.fillRect(0, 0, canvas.width, canvas.height);
+            context.restore();
+        });
+    });
 }

--- a/src/lib/viewers/media/waveform/constants.ts
+++ b/src/lib/viewers/media/waveform/constants.ts
@@ -22,3 +22,17 @@ export const CLIENT_DECODE_MAX_DURATION_SEC = 5 * 60;
 
 /** Default overview resolution for client-generated peaks. */
 export const CLIENT_DECODE_PEAK_COUNT = 16384;
+
+export const WAVEFORM_ZOOM_MIN = 1;
+export const WAVEFORM_ZOOM_MAX = 24;
+/** Visible window never shorter than this. */
+export const WAVEFORM_MIN_VIEW_WINDOW_SEC = 4;
+export const WAVEFORM_ZOOM_SLIDER_MAX = 100;
+export const WAVEFORM_ZOOM_DISMISS_MS = 250;
+
+export const WAVEFORM_BAR_GAP = 2;
+export const WAVEFORM_BAR_WIDTH = 2;
+export const WAVEFORM_BAR_RADIUS = WAVEFORM_BAR_WIDTH / 2;
+/** Total bar height so the top and bottom radii meet as a circle on the mirror. */
+export const WAVEFORM_BAR_MIN_HEIGHT = WAVEFORM_BAR_WIDTH;
+export const WAVEFORM_HEIGHT = 140;

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -1,3 +1,4 @@
+import { getCurrentTimeMs } from '../../../util';
 import {
     CLIENT_DECODE_MAX_COMPRESSED_BYTES,
     CLIENT_DECODE_MAX_DURATION_SEC,
@@ -30,10 +31,6 @@ type DecodeAudioContext = {
 };
 
 const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
-
-function getCurrentTimeMs(): number {
-    return typeof performance !== 'undefined' ? performance.now() : Date.now();
-}
 
 function createAbortError(): DOMException {
     return new DOMException('Aborted', 'AbortError');

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -144,3 +144,54 @@ export type WaveformLoaderFactory = (
     fetchPayload: (signal: AbortSignal) => Promise<unknown>,
     options?: WaveformValidationOptions,
 ) => WaveformSource;
+
+/** Visible slice of the timeline. Emitted whenever zoom, scroll, or width changes. */
+export type WaveformViewport = {
+    durationSec: number;
+    endSec: number;
+    heightPx: number;
+    maxZoom: number;
+    pixelsPerSecond: number;
+    scrollLeftPx: number;
+    startSec: number;
+    widthPx: number;
+    zoomLevel: number;
+};
+
+export type WaveformViewportInput = Omit<WaveformViewport, 'endSec' | 'pixelsPerSecond' | 'startSec'>;
+
+export type WaveformViewProps = {
+    bufferedRange?: TimeRanges;
+    currentTime?: number;
+    durationSec: number;
+    height?: number;
+    interactive?: boolean;
+    mediaEl?: HTMLMediaElement | null;
+    onSeek?: (timeSec: number) => void;
+    onViewportChange?: (viewport: WaveformViewport) => void;
+    onZoomChange?: (zoomLevel: number) => void;
+    peaks: ArrayLike<number>;
+    zoomLevel?: number;
+};
+
+export type WaveformZoomControlProps = {
+    isRevealed?: boolean;
+    maxZoom: number;
+    onZoomChange: (zoomLevel: number) => void;
+    zoomLevel: number;
+};
+
+/** One canvas linear-gradient stop. `offset` is 0–1 along the bar. */
+export type GradientStop = {
+    color: string;
+    offset: number;
+};
+
+/**
+ * Wavesurfer's two paints: left of the playhead (`progressColor`) and right of it (`waveColor`).
+ * A string is a solid fill; a stop list is a left-to-right step gradient.
+ */
+export type WaveformFills = {
+    progressColor: string | GradientStop[];
+    waveColor: string | GradientStop[];
+};

--- a/src/lib/viewers/media/waveform/viewport.ts
+++ b/src/lib/viewers/media/waveform/viewport.ts
@@ -1,0 +1,123 @@
+import {
+    WAVEFORM_MIN_VIEW_WINDOW_SEC,
+    WAVEFORM_ZOOM_MAX,
+    WAVEFORM_ZOOM_MIN,
+    WAVEFORM_ZOOM_SLIDER_MAX,
+} from './constants';
+import { WaveformViewport, WaveformViewportInput } from './types';
+
+export function createWaveformViewport({
+    durationSec,
+    heightPx,
+    maxZoom,
+    scrollLeftPx,
+    widthPx,
+    zoomLevel,
+}: WaveformViewportInput): WaveformViewport {
+    const zoom = Number.isFinite(zoomLevel) && zoomLevel > 0 ? zoomLevel : WAVEFORM_ZOOM_MIN;
+    const viewDurationSec = durationSec > 0 ? durationSec / zoom : 0; // seconds visible at this zoom
+    const pixelsPerSecond = viewDurationSec > 0 && widthPx > 0 ? widthPx / viewDurationSec : 0;
+    const maxStartSec = Math.max(0, durationSec - viewDurationSec); // last start that still fills the window
+    const startSec = pixelsPerSecond > 0 ? Math.min(maxStartSec, Math.max(0, scrollLeftPx / pixelsPerSecond)) : 0;
+
+    return {
+        durationSec,
+        endSec: startSec + viewDurationSec,
+        heightPx,
+        maxZoom,
+        pixelsPerSecond,
+        scrollLeftPx,
+        startSec,
+        widthPx,
+        zoomLevel: zoom,
+    };
+}
+
+/** Same viewport with a different scroll, so start/end times update. */
+export function getViewportAtScroll(viewport: WaveformViewport, scrollLeftPx: number): WaveformViewport {
+    return createWaveformViewport({ ...viewport, scrollLeftPx });
+}
+
+/** How many CSS pixels from the left of the visible window this time sits. */
+export function positionPxFromTime(timeSec: number, viewport: WaveformViewport): number {
+    return (timeSec - viewport.startSec) * viewport.pixelsPerSecond;
+}
+
+/** Media time under a point this many CSS pixels from the left of the visible window. */
+export function timeFromPositionPx(positionPx: number, viewport: WaveformViewport): number {
+    if (!(viewport.pixelsPerSecond > 0)) {
+        return viewport.startSec;
+    }
+    return viewport.startSec + positionPx / viewport.pixelsPerSecond;
+}
+
+/** True when this time sits inside the visible window. */
+export function isTimeInView(timeSec: number, viewport: WaveformViewport): boolean {
+    return timeSec >= viewport.startSec && timeSec <= viewport.endSec;
+}
+
+/** UI max zoom: 24×, ~1 peak per CSS pixel, and a minimum visible window. */
+export function getWaveformZoomMax({
+    durationSec,
+    peakCount,
+    viewWidthPx,
+}: {
+    durationSec: number;
+    peakCount: number;
+    viewWidthPx: number;
+}): number {
+    if (!(peakCount > 0) || !(viewWidthPx > 0)) {
+        return WAVEFORM_ZOOM_MIN;
+    }
+    const peakLimitedMax = Math.floor(peakCount / viewWidthPx);
+    const durationLimitedMax = durationSec > 0 ? durationSec / WAVEFORM_MIN_VIEW_WINDOW_SEC : WAVEFORM_ZOOM_MIN;
+    return Math.max(WAVEFORM_ZOOM_MIN, Math.min(WAVEFORM_ZOOM_MAX, peakLimitedMax, durationLimitedMax));
+}
+
+/** Keep zoom between 1× and this file's max. */
+export function clampWaveformZoom(zoomLevel: number, maxZoom: number = WAVEFORM_ZOOM_MIN): number {
+    const max = Math.max(WAVEFORM_ZOOM_MIN, maxZoom);
+    if (!Number.isFinite(zoomLevel)) {
+        return WAVEFORM_ZOOM_MIN;
+    }
+    return Math.min(max, Math.max(WAVEFORM_ZOOM_MIN, zoomLevel));
+}
+
+/** WaveSurfer zoom density. 0 = fit the whole file in the view. */
+export function getZoomedPixelsPerSecond({
+    durationSec,
+    maxZoom = WAVEFORM_ZOOM_MIN,
+    viewWidthPx,
+    zoomLevel,
+}: {
+    durationSec: number;
+    maxZoom?: number;
+    viewWidthPx: number;
+    zoomLevel: number;
+}): number {
+    const zoom = clampWaveformZoom(zoomLevel, maxZoom);
+    if (zoom <= WAVEFORM_ZOOM_MIN || !(durationSec > 0) || !(viewWidthPx > 0)) {
+        return 0;
+    }
+    return (viewWidthPx / durationSec) * zoom;
+}
+
+/** Map zoom (1…max) onto the 0–100 slider. */
+export function sliderValueFromZoom(zoomLevel: number, maxZoom: number = WAVEFORM_ZOOM_MIN): number {
+    const max = Math.max(WAVEFORM_ZOOM_MIN, maxZoom);
+    const zoom = clampWaveformZoom(zoomLevel, max);
+    if (max <= WAVEFORM_ZOOM_MIN) {
+        return 0;
+    }
+    return ((zoom - WAVEFORM_ZOOM_MIN) / (max - WAVEFORM_ZOOM_MIN)) * WAVEFORM_ZOOM_SLIDER_MAX;
+}
+
+/** Inverse of sliderValueFromZoom. */
+export function zoomFromSliderValue(value: number, maxZoom: number = WAVEFORM_ZOOM_MIN): number {
+    const max = Math.max(WAVEFORM_ZOOM_MIN, maxZoom);
+    if (max <= WAVEFORM_ZOOM_MIN) {
+        return WAVEFORM_ZOOM_MIN;
+    }
+    const t = Math.min(WAVEFORM_ZOOM_SLIDER_MAX, Math.max(0, value)) / WAVEFORM_ZOOM_SLIDER_MAX;
+    return clampWaveformZoom(WAVEFORM_ZOOM_MIN + t * (max - WAVEFORM_ZOOM_MIN), max);
+}


### PR DESCRIPTION
## Summary
You can zoom into the MP3 waveform after playback starts.

**How to zoom**
- Slider: the zoom control in the top-right opens a track (hover, focus, or click). Click the icon again to close it. Pinch or ctrl/meta + wheel on the waveform also zooms, and briefly opens the same control.
- Zoom stays anchored under the pointer (or pinch midpoint). Changing zoom with no pointer recenters on the playhead. A window resize that only changes the max zoom does not jump the view.

**Limits**
- Fit-to-width is 1×. Max is the smallest of 24×, about one peak per CSS pixel, and a 4 second visible window.
- The control is hidden when there is nothing to zoom (file shorter than 4s, or not enough peaks), while the placeholder waveform is showing, and while the play overlay is up.

**While zoomed**
- Click still seeks. There is no dedicated pan gesture; the native scrollbar is hidden. Hover time and buffer/played colors still work.
- WaveSurfer paints zoom as tiles. This PR recolors those tiles so hover and buffer do not repeat on the last tile
- The left and right edges fade (60px mask). Padding that frames the unzoomed waveform is removed while zoomed.

**Not in this PR**
- The playhead is not followed while playing zoomed, so it can walk off the right edge. Pause and inspect still work. A follow-up PR keeps the playhead in view.

## Test plan
- [ ] Long file: zoom control appears after play; slider, pinch, and ctrl/meta-wheel zoom around the pointer
- [ ] Short file (< 4s): no zoom, wheel does not zoom
- [ ] Placeholder / play overlay: zoom control hidden
- [ ] Hover and buffer colors stay correct at max zoom (no repeating last-tile gradient, no muddy stacked tint)
- [ ] Safari and Chrome: edge fade at max zoom, no black slab over the track
- [ ] Resize while zoomed does not jump the window unless zoom actually changed