### PR TITLE
feat(audio): add waveform comment marker overlay

### DIFF
--- a/src/lib/viewers/controls/media/MarkerAvatar.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatar.tsx
@@ -18,6 +18,8 @@ export type Props = {
     avatarUrl?: string;
     colorIndex?: number;
     initial?: string;
+    /** Diameter in CSS pixels. Video ticks use the stylesheet default (12px). */
+    size?: number;
 };
 
 function AnonymousAvatarIcon(): JSX.Element {
@@ -31,7 +33,7 @@ function AnonymousAvatarIcon(): JSX.Element {
     );
 }
 
-export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial }: Props): JSX.Element {
+export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial, size }: Props): JSX.Element {
     const safeIndex = Number.isFinite(colorIndex) ? Math.abs(colorIndex) % AVATAR_PALETTE.length : 0;
     const { bg: bgColor, fg: textColor } = AVATAR_PALETTE[safeIndex];
 
@@ -49,8 +51,17 @@ export default function MarkerAvatar({ avatarUrl, colorIndex = 0, initial }: Pro
         );
     }
 
+    const style: React.CSSProperties = {};
+    if (!showImage) {
+        style.backgroundColor = bgColor;
+    }
+    if (size) {
+        style.width = size;
+        style.height = size;
+    }
+
     return (
-        <span className="bp-MarkerAvatar" style={!showImage ? { backgroundColor: bgColor } : undefined}>
+        <span className="bp-MarkerAvatar" style={Object.keys(style).length > 0 ? style : undefined}>
             {avatar}
         </span>
     );

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.scss
@@ -19,7 +19,7 @@
     transition: margin 150ms;
 
     &:not(:first-child) {
-        margin-left: -6px;
+        margin-left: var(--bp-marker-stack-overlap, -6px);
     }
 
     .bp-MarkerAvatar {
@@ -44,6 +44,8 @@
 // Expand avatars when parent container is hovered or focused
 .bp-TimeControlsV2-marker--group:hover,
 .bp-TimeControlsV2-marker--group:focus-visible,
+.bp-WaveformCommentMarkers-marker--group:hover,
+.bp-WaveformCommentMarkers-marker--group:focus-within,
 .bp-MarkerCluster:hover,
 .bp-MarkerCluster:focus-within {
     .bp-MarkerAvatarStack-item:not(:first-child) {

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.scss
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.scss
@@ -44,8 +44,6 @@
 // Expand avatars when parent container is hovered or focused
 .bp-TimeControlsV2-marker--group:hover,
 .bp-TimeControlsV2-marker--group:focus-visible,
-.bp-WaveformCommentMarkers-marker--group:hover,
-.bp-WaveformCommentMarkers-marker--group:focus-within,
 .bp-MarkerCluster:hover,
 .bp-MarkerCluster:focus-within {
     .bp-MarkerAvatarStack-item:not(:first-child) {

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
@@ -8,18 +8,27 @@ const MAX_VISIBLE_AVATARS = 4;
 export type Props = {
     markers: CommentMarker[];
     onMarkerClick?: (marker: CommentMarker) => void;
+    /** Collapsed overlap in CSS pixels. Video ticks default to 6. */
+    overlapPx?: number;
+    selectedId?: string | null;
+    /** Diameter in CSS pixels, forwarded to each avatar. */
+    size?: number;
 };
 
-export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JSX.Element {
+export default function MarkerAvatarStack({ markers, onMarkerClick, overlapPx, selectedId, size }: Props): JSX.Element {
     const hasOverflow = markers.length > MAX_VISIBLE_AVATARS;
     const visibleMarkers = hasOverflow ? markers.slice(0, MAX_VISIBLE_AVATARS - 1) : markers;
+    const style =
+        overlapPx != null ? ({ '--bp-marker-stack-overlap': `-${overlapPx}px` } as React.CSSProperties) : undefined;
 
     return (
-        <span className="bp-MarkerAvatarStack">
+        <span className="bp-MarkerAvatarStack" style={style}>
             {visibleMarkers.map(marker => (
                 <button
                     key={marker.id}
-                    className="bp-MarkerAvatarStack-item"
+                    className={`bp-MarkerAvatarStack-item${
+                        marker.id === selectedId ? ' bp-MarkerAvatarStack-item--selected' : ''
+                    }`}
                     data-resin-target="commentMarkerStackAvatar"
                     onClick={(e): void => {
                         e.stopPropagation();
@@ -31,6 +40,7 @@ export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JS
                         avatarUrl={marker.avatarUrl}
                         colorIndex={marker.colorIndex}
                         initial={marker.initial}
+                        size={size}
                     />
                 </button>
             ))}
@@ -44,7 +54,10 @@ export default function MarkerAvatarStack({ markers, onMarkerClick }: Props): JS
                     }}
                     type="button"
                 >
-                    <span className="bp-MarkerAvatar bp-MarkerAvatarStack-overflowBadge">
+                    <span
+                        className="bp-MarkerAvatar bp-MarkerAvatarStack-overflowBadge"
+                        style={size ? { width: size, height: size } : undefined}
+                    >
                         <span className="bp-MarkerAvatar-initial">+{markers.length - (MAX_VISIBLE_AVATARS - 1)}</span>
                     </span>
                 </button>

--- a/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
+++ b/src/lib/viewers/controls/media/MarkerAvatarStack.tsx
@@ -18,6 +18,8 @@ export type Props = {
 export default function MarkerAvatarStack({ markers, onMarkerClick, overlapPx, selectedId, size }: Props): JSX.Element {
     const hasOverflow = markers.length > MAX_VISIBLE_AVATARS;
     const visibleMarkers = hasOverflow ? markers.slice(0, MAX_VISIBLE_AVATARS - 1) : markers;
+    const overflowMarkers = hasOverflow ? markers.slice(MAX_VISIBLE_AVATARS - 1) : [];
+    const isOverflowSelected = overflowMarkers.some(marker => marker.id === selectedId);
     const style =
         overlapPx != null ? ({ '--bp-marker-stack-overlap': `-${overlapPx}px` } as React.CSSProperties) : undefined;
 
@@ -26,6 +28,8 @@ export default function MarkerAvatarStack({ markers, onMarkerClick, overlapPx, s
             {visibleMarkers.map(marker => (
                 <button
                     key={marker.id}
+                    aria-label={__('media_comment_marker')}
+                    aria-pressed={marker.id === selectedId}
                     className={`bp-MarkerAvatarStack-item${
                         marker.id === selectedId ? ' bp-MarkerAvatarStack-item--selected' : ''
                     }`}
@@ -46,7 +50,11 @@ export default function MarkerAvatarStack({ markers, onMarkerClick, overlapPx, s
             ))}
             {hasOverflow && (
                 <button
-                    className="bp-MarkerAvatarStack-item bp-MarkerAvatarStack-overflow"
+                    aria-label={__('media_comment_marker')}
+                    aria-pressed={isOverflowSelected}
+                    className={`bp-MarkerAvatarStack-item bp-MarkerAvatarStack-overflow${
+                        isOverflowSelected ? ' bp-MarkerAvatarStack-item--selected' : ''
+                    }`}
                     data-resin-target="commentMarkerStackAvatarOverflow"
                     onClick={(e): void => {
                         e.stopPropagation();

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatar-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatar-test.tsx
@@ -56,6 +56,11 @@ describe('MarkerAvatar', () => {
             expect(initialEl).toHaveStyle({ color: '#fff' });
         });
 
+        test('should apply an explicit size', () => {
+            const { container } = render(<MarkerAvatar initial="A" size={20} />);
+            expect(container.querySelector('.bp-MarkerAvatar')).toHaveStyle({ width: '20px', height: '20px' });
+        });
+
         test('should wrap colorIndex using modulo', () => {
             const { container } = render(<MarkerAvatar colorIndex={11} initial="E" />);
             const avatar = container.querySelector('.bp-MarkerAvatar');

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
@@ -95,6 +95,25 @@ describe('MarkerAvatarStack', () => {
         expect(items[0]).not.toHaveClass('bp-MarkerAvatarStack-item--selected');
         expect(items[1]).toHaveClass('bp-MarkerAvatarStack-item--selected');
         expect(items[2]).not.toHaveClass('bp-MarkerAvatarStack-item--selected');
+        expect(items[0]).toHaveAttribute('aria-pressed', 'false');
+        expect(items[1]).toHaveAttribute('aria-pressed', 'true');
+        expect(items[1]).toHaveAttribute('aria-label', __('media_comment_marker'));
+    });
+
+    test('should mark the overflow chip when the selected id is in the hidden slice', () => {
+        const manyMarkers: CommentMarker[] = [
+            { id: 'm1', time: 10, initial: 'A', colorIndex: 0 },
+            { id: 'm2', time: 10, initial: 'B', colorIndex: 1 },
+            { id: 'm3', time: 10, initial: 'C', colorIndex: 2 },
+            { id: 'm4', time: 10, initial: 'D', colorIndex: 3 },
+            { id: 'm5', time: 10, initial: 'E', colorIndex: 4 },
+        ];
+        const { container } = render(<MarkerAvatarStack markers={manyMarkers} selectedId="m5" />);
+        const overflow = container.querySelector('.bp-MarkerAvatarStack-overflow');
+
+        expect(overflow).toHaveClass('bp-MarkerAvatarStack-item--selected');
+        expect(overflow).toHaveAttribute('aria-pressed', 'true');
+        expect(container.querySelectorAll('.bp-MarkerAvatarStack-item--selected')).toHaveLength(1);
     });
 
     test('should call onMarkerClick with correct marker when individual avatar is clicked', async () => {

--- a/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
+++ b/src/lib/viewers/controls/media/__tests__/MarkerAvatarStack-test.tsx
@@ -74,6 +74,29 @@ describe('MarkerAvatarStack', () => {
         });
     });
 
+    test('should forward size to each avatar', () => {
+        const { container } = render(<MarkerAvatarStack markers={markers} size={20} />);
+        container.querySelectorAll('.bp-MarkerAvatar').forEach(avatar => {
+            expect(avatar).toHaveStyle({ width: '20px', height: '20px' });
+        });
+    });
+
+    test('should set collapsed overlap as a CSS custom property', () => {
+        const { container } = render(<MarkerAvatarStack markers={markers} overlapPx={10} />);
+        expect(container.querySelector('.bp-MarkerAvatarStack')).toHaveStyle({
+            '--bp-marker-stack-overlap': '-10px',
+        });
+    });
+
+    test('should mark the selected avatar in a stack', () => {
+        const { container } = render(<MarkerAvatarStack markers={markers} selectedId="m2" />);
+        const items = container.querySelectorAll('.bp-MarkerAvatarStack-item');
+
+        expect(items[0]).not.toHaveClass('bp-MarkerAvatarStack-item--selected');
+        expect(items[1]).toHaveClass('bp-MarkerAvatarStack-item--selected');
+        expect(items[2]).not.toHaveClass('bp-MarkerAvatarStack-item--selected');
+    });
+
     test('should call onMarkerClick with correct marker when individual avatar is clicked', async () => {
         const user = userEvent.setup();
         const onMarkerClick = jest.fn();

--- a/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
+++ b/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
@@ -6,15 +6,9 @@ describe('buildClusters', () => {
         expect(buildClusters([], 60, 600)).toHaveLength(0);
     });
 
-    test('should place unclustered markers when trackWidth is 0', () => {
-        const markers: CommentMarker[] = [
-            { id: 'm1', time: 10 },
-            { id: 'm2', time: 30 },
-        ];
-        const clusters = buildClusters(markers, 60, 0);
-        expect(clusters).toHaveLength(2);
-        expect(clusters[0].markers).toHaveLength(1);
-        expect(clusters[1].markers).toHaveLength(1);
+    test('should return empty array when trackWidth is 0', () => {
+        const markers: CommentMarker[] = [{ id: 'm1', time: 10 }];
+        expect(buildClusters(markers, 60, 0)).toHaveLength(0);
     });
 
     test('should return empty array when durationValue is 0', () => {
@@ -38,19 +32,6 @@ describe('buildClusters', () => {
         const clusters = buildClusters(markers, 60, 600);
         expect(clusters).toHaveLength(2);
         expect(clusters[0].markers).toHaveLength(1);
-        expect(clusters[1].markers).toHaveLength(1);
-    });
-
-    test('should cluster the same timestamp even when trackWidth is 0', () => {
-        const markers: CommentMarker[] = [
-            { id: 'm1', time: 10 },
-            { id: 'm2', time: 10 },
-            { id: 'm3', time: 30 },
-        ];
-        const clusters = buildClusters(markers, 60, 0);
-        expect(clusters).toHaveLength(2);
-        expect(clusters[0].markers).toHaveLength(2);
-        expect(clusters[0].isSinglePoint).toBe(true);
         expect(clusters[1].markers).toHaveLength(1);
     });
 

--- a/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
+++ b/src/lib/viewers/controls/media/__tests__/buildClusters-test.ts
@@ -6,9 +6,15 @@ describe('buildClusters', () => {
         expect(buildClusters([], 60, 600)).toHaveLength(0);
     });
 
-    test('should return empty array when trackWidth is 0', () => {
-        const markers: CommentMarker[] = [{ id: 'm1', time: 10 }];
-        expect(buildClusters(markers, 60, 0)).toHaveLength(0);
+    test('should place unclustered markers when trackWidth is 0', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 30 },
+        ];
+        const clusters = buildClusters(markers, 60, 0);
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].markers).toHaveLength(1);
+        expect(clusters[1].markers).toHaveLength(1);
     });
 
     test('should return empty array when durationValue is 0', () => {
@@ -33,6 +39,28 @@ describe('buildClusters', () => {
         expect(clusters).toHaveLength(2);
         expect(clusters[0].markers).toHaveLength(1);
         expect(clusters[1].markers).toHaveLength(1);
+    });
+
+    test('should cluster the same timestamp even when trackWidth is 0', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 10 },
+            { id: 'm3', time: 30 },
+        ];
+        const clusters = buildClusters(markers, 60, 0);
+        expect(clusters).toHaveLength(2);
+        expect(clusters[0].markers).toHaveLength(2);
+        expect(clusters[0].isSinglePoint).toBe(true);
+        expect(clusters[1].markers).toHaveLength(1);
+    });
+
+    test('should honor a larger proximity threshold', () => {
+        const markers: CommentMarker[] = [
+            { id: 'm1', time: 10 },
+            { id: 'm2', time: 10.5 },
+        ];
+        expect(buildClusters(markers, 60, 600)).toHaveLength(2);
+        expect(buildClusters(markers, 60, 600, 20)).toHaveLength(1);
     });
 
     test('should cluster markers at the same timestamp', () => {

--- a/src/lib/viewers/controls/media/buildClusters.ts
+++ b/src/lib/viewers/controls/media/buildClusters.ts
@@ -2,7 +2,7 @@ import { ClusterData, CommentMarker } from './types';
 import { percent } from './utils';
 
 /** Max pixel distance between adjacent markers (sorted by time) for them to be grouped into a single cluster. */
-export const CLUSTER_THRESHOLD_PX = 2;
+const CLUSTER_THRESHOLD_PX = 2;
 
 /** Converts a group of markers into a ClusterData object with computed positions and metadata. */
 function finalizeCluster(group: CommentMarker[], durationValue: number): ClusterData {
@@ -31,22 +31,9 @@ export default function buildClusters(
     trackWidth: number,
     thresholdPx: number = CLUSTER_THRESHOLD_PX,
 ): ClusterData[] {
-    if (durationValue <= 0 || markers.length === 0) return [];
+    if (durationValue <= 0 || markers.length === 0 || trackWidth <= 0) return [];
 
     const sorted = [...markers].sort((a, b) => a.time - b.time);
-    // Width is unknown until layout. Still place badges, and stack exact same timestamps.
-    if (trackWidth <= 0) {
-        const groups: CommentMarker[][] = [];
-        sorted.forEach(marker => {
-            const last = groups[groups.length - 1];
-            if (last && last[last.length - 1].time === marker.time) {
-                last.push(marker);
-            } else {
-                groups.push([marker]);
-            }
-        });
-        return groups.map(group => finalizeCluster(group, durationValue));
-    }
     const clusters: ClusterData[] = [];
     let currentGroup: CommentMarker[] = [sorted[0]];
 

--- a/src/lib/viewers/controls/media/buildClusters.ts
+++ b/src/lib/viewers/controls/media/buildClusters.ts
@@ -2,7 +2,7 @@ import { ClusterData, CommentMarker } from './types';
 import { percent } from './utils';
 
 /** Max pixel distance between adjacent markers (sorted by time) for them to be grouped into a single cluster. */
-const CLUSTER_THRESHOLD_PX = 2;
+export const CLUSTER_THRESHOLD_PX = 2;
 
 /** Converts a group of markers into a ClusterData object with computed positions and metadata. */
 function finalizeCluster(group: CommentMarker[], durationValue: number): ClusterData {
@@ -29,10 +29,24 @@ export default function buildClusters(
     markers: CommentMarker[],
     durationValue: number,
     trackWidth: number,
+    thresholdPx: number = CLUSTER_THRESHOLD_PX,
 ): ClusterData[] {
-    if (durationValue <= 0 || markers.length === 0 || trackWidth <= 0) return [];
+    if (durationValue <= 0 || markers.length === 0) return [];
 
     const sorted = [...markers].sort((a, b) => a.time - b.time);
+    // Width is unknown until layout. Still place badges, and stack exact same timestamps.
+    if (trackWidth <= 0) {
+        const groups: CommentMarker[][] = [];
+        sorted.forEach(marker => {
+            const last = groups[groups.length - 1];
+            if (last && last[last.length - 1].time === marker.time) {
+                last.push(marker);
+            } else {
+                groups.push([marker]);
+            }
+        });
+        return groups.map(group => finalizeCluster(group, durationValue));
+    }
     const clusters: ClusterData[] = [];
     let currentGroup: CommentMarker[] = [sorted[0]];
 
@@ -40,7 +54,7 @@ export default function buildClusters(
         const prevPx = (sorted[i - 1].time / durationValue) * trackWidth;
         const currPx = (sorted[i].time / durationValue) * trackWidth;
 
-        if (currPx - prevPx <= CLUSTER_THRESHOLD_PX) {
+        if (currPx - prevPx <= thresholdPx) {
             currentGroup.push(sorted[i]);
         } else {
             clusters.push(finalizeCluster(currentGroup, durationValue));

--- a/src/lib/viewers/controls/media/types.ts
+++ b/src/lib/viewers/controls/media/types.ts
@@ -3,6 +3,8 @@ export type CommentMarker = {
     colorIndex?: number;
     id: string;
     initial?: string;
+    /** True when the host (activity feed) has this marker selected. */
+    selected?: boolean;
     time: number;
     type?: 'annotation' | 'comment';
 };

--- a/src/lib/viewers/controls/media/types.ts
+++ b/src/lib/viewers/controls/media/types.ts
@@ -3,8 +3,6 @@ export type CommentMarker = {
     colorIndex?: number;
     id: string;
     initial?: string;
-    /** True when the host (activity feed) has this marker selected. */
-    selected?: boolean;
     time: number;
     type?: 'annotation' | 'comment';
 };

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
@@ -103,6 +103,13 @@
 
 .bp-WaveformCommentMarkers-marker--group {
     width: auto;
+
+    &:hover,
+    &:focus-within {
+        .bp-MarkerAvatarStack-item:not(:first-child) {
+            margin-left: 2px;
+        }
+    }
 }
 
 .bp-WaveformCommentMarkers:hover .bp-MarkerAvatar::after,

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
@@ -1,0 +1,166 @@
+@import '../../../boxuiVariables';
+
+.bp-WaveformCommentMarkers {
+    position: absolute;
+    top: -2px;
+    right: 0;
+    left: 0;
+    z-index: 4;
+    box-sizing: border-box;
+    height: 24px;
+    padding: 0 60px;
+    overflow: visible;
+    pointer-events: auto;
+}
+
+.bp-WaveformCommentMarkers--zoomed {
+    padding: 0;
+
+    // Pair clip + visible so this overlay does not become a scroll container
+    overflow: clip visible;
+}
+
+.bp-WaveformCommentMarkers-track {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+}
+
+.bp-WaveformCommentMarkers--zoomed .bp-WaveformCommentMarkers-track {
+    overflow: clip visible;
+}
+
+.bp-WaveformCommentMarkers-marker {
+    position: absolute;
+    top: 50%;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    background: none;
+    border: 0;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    appearance: none;
+    pointer-events: auto;
+    transition: transform 150ms, box-shadow 150ms;
+
+    .bp-MarkerAvatar,
+    .bp-MarkerAvatarStack .bp-MarkerAvatar {
+        position: relative;
+        bottom: auto;
+        left: auto;
+        overflow: hidden;
+        isolation: isolate;
+        outline: none;
+        box-shadow: none;
+        transform: none;
+        transform-origin: center center;
+        cursor: pointer;
+
+        img {
+            cursor: pointer;
+        }
+
+        // Composite the dim onto this badge only, then paint the result as an opaque
+        // circle so overlapping avatars do not stack two translucent blacks.
+        &::after {
+            position: absolute;
+            z-index: 1;
+            inset: 0;
+            background: #000;
+            border-radius: 50%;
+            opacity: 0.4;
+            pointer-events: none;
+            content: '';
+            transition: opacity 150ms;
+        }
+    }
+
+    // Photo avatars only. Leave `.bp-MarkerAvatarStack-overflowBadge` on the
+    // video `$bdl-gray-65` fill — it still uses the dim overlay above.
+    .bp-MarkerAvatar:not(.bp-MarkerAvatarStack-overflowBadge),
+    .bp-MarkerAvatarStack .bp-MarkerAvatar:not(.bp-MarkerAvatarStack-overflowBadge) {
+        background-color: $black;
+    }
+
+    .bp-MarkerAvatar-initial {
+        font-size: 11px;
+    }
+
+    .bp-MarkerAvatarStack {
+        position: relative;
+        bottom: auto;
+        left: auto;
+        transform: none;
+    }
+}
+
+.bp-WaveformCommentMarkers-marker--group {
+    width: auto;
+}
+
+.bp-WaveformCommentMarkers:hover .bp-MarkerAvatar::after,
+.bp-WaveformCommentMarkers-marker:not(.bp-WaveformCommentMarkers-marker--group).bp-WaveformCommentMarkers-marker--selected .bp-MarkerAvatar::after,
+.bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item--selected .bp-MarkerAvatar::after {
+    opacity: 0;
+}
+
+.bp-WaveformCommentMarkers-marker--selected {
+    z-index: 3;
+}
+
+.bp-WaveformCommentMarkers-marker:hover,
+.bp-WaveformCommentMarkers-marker:focus-within {
+    z-index: 4;
+}
+
+.bp-WaveformCommentMarkers-marker:not(.bp-WaveformCommentMarkers-marker--group):hover,
+.bp-WaveformCommentMarkers-marker:not(.bp-WaveformCommentMarkers-marker--group):focus-visible {
+    transform: translate(-50%, -50%) scale(1.2);
+}
+
+.bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item {
+    border-radius: 50%;
+    transform-origin: center center;
+    cursor: pointer;
+    transition: margin 150ms, transform 150ms, box-shadow 150ms;
+
+    &:hover,
+    &:focus-visible {
+        z-index: 2;
+        transform: scale(1.2);
+    }
+}
+
+.bp-WaveformCommentMarkers-marker--selected:not(.bp-WaveformCommentMarkers-marker--group) {
+    box-shadow: 0 0 0 2px $white;
+}
+
+.bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item--selected {
+    z-index: 2;
+    box-shadow: 0 0 0 2px $white;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .bp-WaveformCommentMarkers-marker,
+    .bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item,
+    .bp-WaveformCommentMarkers-marker .bp-MarkerAvatar::after {
+        transition: none;
+    }
+
+    .bp-WaveformCommentMarkers-marker:not(.bp-WaveformCommentMarkers-marker--group):hover,
+    .bp-WaveformCommentMarkers-marker:not(.bp-WaveformCommentMarkers-marker--group):focus-visible {
+        transform: translate(-50%, -50%);
+    }
+
+    .bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item:hover,
+    .bp-WaveformCommentMarkers .bp-MarkerAvatarStack-item:focus-visible {
+        transform: none;
+    }
+}

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
@@ -94,7 +94,7 @@ export default function WaveformCommentMarkers({
             return undefined;
         }
 
-        const isOnSelectedMarker = (target: EventTarget | null): boolean => {
+        const isEventInsideSelectedBadge = (target: EventTarget | null): boolean => {
             if (!(target instanceof Element) || !overlayRef.current) {
                 return false;
             }
@@ -104,8 +104,8 @@ export default function WaveformCommentMarkers({
             return Boolean(selected && selected.contains(target));
         };
 
-        const dismiss = (event: Event): void => {
-            if (isOnSelectedMarker(event.target)) {
+        const clearSelection = (event: Event): void => {
+            if (isEventInsideSelectedBadge(event.target)) {
                 return;
             }
             setOptimisticSelectedId(null);
@@ -116,9 +116,9 @@ export default function WaveformCommentMarkers({
             }
         };
 
-        document.addEventListener('pointerdown', dismiss, true);
+        document.addEventListener('pointerdown', clearSelection, true);
         return () => {
-            document.removeEventListener('pointerdown', dismiss, true);
+            document.removeEventListener('pointerdown', clearSelection, true);
         };
     }, [selectedId]);
 

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import buildClusters from '../../controls/media/buildClusters';
 import MarkerAvatar from '../../controls/media/MarkerAvatar';
 import MarkerAvatarStack from '../../controls/media/MarkerAvatarStack';
-import { CommentMarker } from '../../controls/media/types';
+import { ClusterData, CommentMarker } from '../../controls/media/types';
 import { percent } from '../../controls/media/utils';
 import { WAVEFORM_ZOOM_MIN } from './constants';
 import { WaveformViewport } from './types';
@@ -31,6 +31,31 @@ function markerLeftPercent(time: number, durationSec: number, viewport?: Wavefor
     return percent(time - origin, span);
 }
 
+/** Width is unknown until layout. Still place badges, and stack exact same timestamps. */
+function clustersByExactTime(markers: CommentMarker[], durationSec: number): ClusterData[] {
+    const sorted = [...markers].sort((a, b) => a.time - b.time);
+    const groups: CommentMarker[][] = [];
+    sorted.forEach(marker => {
+        const last = groups[groups.length - 1];
+        if (last && last[last.length - 1].time === marker.time) {
+            last.push(marker);
+        } else {
+            groups.push([marker]);
+        }
+    });
+    return groups.map(group => {
+        const leftPercent = percent(group[0].time, durationSec);
+        const rightPercent = percent(group[group.length - 1].time, durationSec);
+        return {
+            id: group.map(m => m.id).join('|'),
+            isSinglePoint: leftPercent === rightPercent,
+            leftPercent,
+            markers: group,
+            rightPercent,
+        };
+    });
+}
+
 export default function WaveformCommentMarkers({
     commentMarkers,
     durationSec,
@@ -39,6 +64,7 @@ export default function WaveformCommentMarkers({
     viewport = null,
 }: WaveformCommentMarkersProps): JSX.Element | null {
     const overlayRef = useRef<HTMLDivElement>(null);
+    const trackRef = useRef<HTMLDivElement>(null);
     const [trackWidth, setTrackWidth] = useState(0);
     const [optimisticSelectedId, setOptimisticSelectedId] = useState<string | null>(null);
     const [isSelectionDismissed, setIsSelectionDismissed] = useState(false);
@@ -58,7 +84,7 @@ export default function WaveformCommentMarkers({
             return undefined;
         }
 
-        const el = overlayRef.current?.querySelector<HTMLDivElement>('.bp-WaveformCommentMarkers-track');
+        const el = trackRef.current;
         if (!el) {
             return undefined;
         }
@@ -76,6 +102,9 @@ export default function WaveformCommentMarkers({
 
     const clusters = useMemo(() => {
         const clusterWidth = trackWidth * Math.max(WAVEFORM_ZOOM_MIN, zoomLevel);
+        if (clusterWidth <= 0) {
+            return clustersByExactTime(commentMarkers, durationSec);
+        }
         return buildClusters(commentMarkers, durationSec, clusterWidth, WAVEFORM_MARKER_SIZE_PX);
     }, [commentMarkers, durationSec, trackWidth, zoomLevel]);
 
@@ -104,7 +133,7 @@ export default function WaveformCommentMarkers({
             return Boolean(selected && selected.contains(target));
         };
 
-        const clearSelection = (event: Event): void => {
+        const onDocumentPointerDown = (event: Event): void => {
             if (isEventInsideSelectedBadge(event.target)) {
                 return;
             }
@@ -116,9 +145,9 @@ export default function WaveformCommentMarkers({
             }
         };
 
-        document.addEventListener('pointerdown', clearSelection, true);
+        document.addEventListener('pointerdown', onDocumentPointerDown, true);
         return () => {
-            document.removeEventListener('pointerdown', clearSelection, true);
+            document.removeEventListener('pointerdown', onDocumentPointerDown, true);
         };
     }, [selectedId]);
 
@@ -132,7 +161,7 @@ export default function WaveformCommentMarkers({
             className={`bp-WaveformCommentMarkers${isZoomed ? ' bp-WaveformCommentMarkers--zoomed' : ''}`}
             data-testid="bp-waveform-comment-markers"
         >
-            <div className="bp-WaveformCommentMarkers-track">
+            <div ref={trackRef} className="bp-WaveformCommentMarkers-track">
                 {clusters.map(cluster => {
                     const marker = cluster.markers[0];
                     const isGroup = cluster.markers.length > 1;

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import buildClusters from '../../controls/media/buildClusters';
+import MarkerAvatar from '../../controls/media/MarkerAvatar';
+import MarkerAvatarStack from '../../controls/media/MarkerAvatarStack';
+import { CommentMarker } from '../../controls/media/types';
+import { percent } from '../../controls/media/utils';
+import { WAVEFORM_ZOOM_MIN } from './constants';
+import { WaveformViewport } from './types';
+import './WaveformCommentMarkers.scss';
+
+const WAVEFORM_MARKER_SIZE_PX = 20;
+
+export type WaveformCommentMarkersProps = {
+    commentMarkers: CommentMarker[];
+    durationSec: number;
+    onCommentMarkerClick?: (marker: CommentMarker) => void;
+    /** Host-selected marker (activity feed / BUE). */
+    selectedId?: string | null;
+    /** Live waveform window. Parent keeps this while the overlay is unmounted. */
+    viewport?: WaveformViewport | null;
+};
+
+function hasMappedWindow(viewport?: WaveformViewport | null): viewport is WaveformViewport {
+    return !!viewport && Number.isFinite(viewport.startSec) && viewport.endSec > viewport.startSec;
+}
+
+function markerLeftPercent(time: number, durationSec: number, viewport?: WaveformViewport | null): number {
+    const mapped = hasMappedWindow(viewport);
+    const origin = mapped ? viewport.startSec : 0;
+    const span = mapped ? viewport.endSec - viewport.startSec : durationSec;
+    return percent(time - origin, span);
+}
+
+export default function WaveformCommentMarkers({
+    commentMarkers,
+    durationSec,
+    onCommentMarkerClick,
+    selectedId: hostSelectedId = null,
+    viewport = null,
+}: WaveformCommentMarkersProps): JSX.Element | null {
+    const overlayRef = useRef<HTMLDivElement>(null);
+    const [trackWidth, setTrackWidth] = useState(0);
+    const [optimisticSelectedId, setOptimisticSelectedId] = useState<string | null>(null);
+    const [isSelectionDismissed, setIsSelectionDismissed] = useState(false);
+    const selectedId = optimisticSelectedId ?? (isSelectionDismissed ? null : hostSelectedId);
+    const canShowTrack = durationSec > 0 && commentMarkers.length > 0;
+    const zoomLevel = viewport?.zoomLevel ?? WAVEFORM_ZOOM_MIN;
+    const isZoomed = hasMappedWindow(viewport) && viewport.zoomLevel > WAVEFORM_ZOOM_MIN;
+
+    useEffect(() => {
+        setIsSelectionDismissed(false);
+        setOptimisticSelectedId(null);
+    }, [hostSelectedId]);
+
+    useLayoutEffect(() => {
+        if (!canShowTrack) {
+            setTrackWidth(0);
+            return undefined;
+        }
+
+        const el = overlayRef.current?.querySelector<HTMLDivElement>('.bp-WaveformCommentMarkers-track');
+        if (!el) {
+            return undefined;
+        }
+
+        setTrackWidth(el.clientWidth);
+
+        const observer = new ResizeObserver(entries => {
+            entries.forEach(entry => {
+                setTrackWidth(entry.contentRect.width);
+            });
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [canShowTrack]);
+
+    const clusters = useMemo(() => {
+        const clusterWidth = trackWidth * Math.max(WAVEFORM_ZOOM_MIN, zoomLevel);
+        return buildClusters(commentMarkers, durationSec, clusterWidth, WAVEFORM_MARKER_SIZE_PX);
+    }, [commentMarkers, durationSec, trackWidth, zoomLevel]);
+
+    const handleMarkerClick = useCallback(
+        (marker: CommentMarker, event?: React.MouseEvent) => {
+            event?.stopPropagation();
+            setIsSelectionDismissed(false);
+            setOptimisticSelectedId(marker.id);
+            onCommentMarkerClick?.(marker);
+        },
+        [onCommentMarkerClick],
+    );
+
+    useEffect(() => {
+        if (!selectedId) {
+            return undefined;
+        }
+
+        const isOnSelectedMarker = (target: EventTarget | null): boolean => {
+            if (!(target instanceof Element) || !overlayRef.current) {
+                return false;
+            }
+            const selected = overlayRef.current.querySelector(
+                '.bp-WaveformCommentMarkers-marker--selected, .bp-MarkerAvatarStack-item--selected',
+            );
+            return Boolean(selected && selected.contains(target));
+        };
+
+        const dismiss = (event: Event): void => {
+            if (isOnSelectedMarker(event.target)) {
+                return;
+            }
+            setOptimisticSelectedId(null);
+            setIsSelectionDismissed(true);
+            const active = document.activeElement;
+            if (active instanceof HTMLElement && overlayRef.current?.contains(active)) {
+                active.blur();
+            }
+        };
+
+        document.addEventListener('pointerdown', dismiss, true);
+        return () => {
+            document.removeEventListener('pointerdown', dismiss, true);
+        };
+    }, [selectedId]);
+
+    if (!(durationSec > 0) || commentMarkers.length === 0) {
+        return null;
+    }
+
+    return (
+        <div
+            ref={overlayRef}
+            className={`bp-WaveformCommentMarkers${isZoomed ? ' bp-WaveformCommentMarkers--zoomed' : ''}`}
+            data-testid="bp-waveform-comment-markers"
+        >
+            <div className="bp-WaveformCommentMarkers-track">
+                {clusters.map(cluster => {
+                    const marker = cluster.markers[0];
+                    const isGroup = cluster.markers.length > 1;
+                    const isSelected = cluster.markers.some(entry => entry.id === selectedId);
+                    const className = `bp-WaveformCommentMarkers-marker${
+                        isSelected ? ' bp-WaveformCommentMarkers-marker--selected' : ''
+                    }${isGroup ? ' bp-WaveformCommentMarkers-marker--group' : ''}`;
+                    const left = `${markerLeftPercent(marker.time, durationSec, viewport)}%`;
+
+                    if (isGroup) {
+                        return (
+                            <div
+                                key={cluster.id}
+                                className={className}
+                                data-testid="bp-waveform-comment-marker"
+                                style={{ left }}
+                            >
+                                <MarkerAvatarStack
+                                    markers={cluster.markers}
+                                    onMarkerClick={handleMarkerClick}
+                                    overlapPx={WAVEFORM_MARKER_SIZE_PX / 2}
+                                    selectedId={selectedId}
+                                    size={WAVEFORM_MARKER_SIZE_PX}
+                                />
+                            </div>
+                        );
+                    }
+
+                    return (
+                        <button
+                            key={cluster.id}
+                            aria-label={__('media_comment_marker')}
+                            aria-pressed={isSelected}
+                            className={className}
+                            data-resin-target="commentMarker"
+                            data-testid="bp-waveform-comment-marker"
+                            onClick={event => handleMarkerClick(marker, event)}
+                            style={{ left }}
+                            type="button"
+                        >
+                            <MarkerAvatar
+                                avatarUrl={marker.avatarUrl}
+                                colorIndex={marker.colorIndex}
+                                initial={marker.initial}
+                                size={WAVEFORM_MARKER_SIZE_PX}
+                            />
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
@@ -65,6 +65,7 @@ export default function WaveformCommentMarkers({
 }: WaveformCommentMarkersProps): JSX.Element | null {
     const overlayRef = useRef<HTMLDivElement>(null);
     const trackRef = useRef<HTMLDivElement>(null);
+    const dismissedIdRef = useRef<string | null>(null);
     const [trackWidth, setTrackWidth] = useState(0);
     const [optimisticSelectedId, setOptimisticSelectedId] = useState<string | null>(null);
     const [isSelectionDismissed, setIsSelectionDismissed] = useState(false);
@@ -74,8 +75,13 @@ export default function WaveformCommentMarkers({
     const isZoomed = hasMappedWindow(viewport) && viewport.zoomLevel > WAVEFORM_ZOOM_MIN;
 
     useEffect(() => {
-        setIsSelectionDismissed(false);
         setOptimisticSelectedId(null);
+        // Host ack of the dismissed id must not bring the ring back.
+        if (dismissedIdRef.current && hostSelectedId === dismissedIdRef.current) {
+            return;
+        }
+        dismissedIdRef.current = null;
+        setIsSelectionDismissed(false);
     }, [hostSelectedId]);
 
     useLayoutEffect(() => {
@@ -111,6 +117,7 @@ export default function WaveformCommentMarkers({
     const handleMarkerClick = useCallback(
         (marker: CommentMarker, event?: React.MouseEvent) => {
             event?.stopPropagation();
+            dismissedIdRef.current = null;
             setIsSelectionDismissed(false);
             setOptimisticSelectedId(marker.id);
             onCommentMarkerClick?.(marker);
@@ -137,6 +144,7 @@ export default function WaveformCommentMarkers({
             if (isEventInsideSelectedBadge(event.target)) {
                 return;
             }
+            dismissedIdRef.current = selectedId;
             setOptimisticSelectedId(null);
             setIsSelectionDismissed(true);
             const active = document.activeElement;

--- a/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
@@ -84,6 +84,29 @@ describe('WaveformCommentMarkers', () => {
         expect(screen.getByText('B')).toBeInTheDocument();
     });
 
+    test('should place badges and stack exact timestamps before the track is measured', () => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 });
+        try {
+            render(
+                <WaveformCommentMarkers
+                    commentMarkers={[
+                        { colorIndex: 0, id: 'same-a', initial: 'A', time: 10, type: 'comment' },
+                        { colorIndex: 1, id: 'same-b', initial: 'B', time: 10, type: 'comment' },
+                        { colorIndex: 2, id: 'far', initial: 'C', time: 30, type: 'comment' },
+                    ]}
+                    durationSec={60}
+                />,
+            );
+
+            const badges = screen.getAllByTestId('bp-waveform-comment-marker');
+            expect(badges).toHaveLength(2);
+            expect(badges[0]).toHaveClass('bp-WaveformCommentMarkers-marker--group');
+            expect(badges[1]).not.toHaveClass('bp-WaveformCommentMarkers-marker--group');
+        } finally {
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 600 });
+        }
+    });
+
     test('should use the video overflow chip when more than four markers share a cluster', () => {
         render(
             <WaveformCommentMarkers
@@ -176,20 +199,14 @@ describe('WaveformCommentMarkers', () => {
     });
 
     test('should show the ring when the host marks a comment selected', () => {
-        render(
-            <WaveformCommentMarkers
-                commentMarkers={[{ ...markers[0], selected: true }, markers[1]]}
-                durationSec={60}
-                selectedId="marker-1"
-            />,
-        );
+        render(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-1" />);
 
         expect(screen.getAllByTestId('bp-waveform-comment-marker')[0]).toHaveClass(
             'bp-WaveformCommentMarkers-marker--selected',
         );
     });
 
-    test('should drop the ring when pointer focus leaves the selected badge', async () => {
+    test('should drop the ring on pointerdown outside the selected badge', async () => {
         const user = userEvent.setup();
         render(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-1" />);
 

--- a/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { CommentMarker } from '../../../controls/media/types';
+import { createWaveformViewport } from '../viewport';
+import WaveformCommentMarkers from '../WaveformCommentMarkers';
+
+const mockResizeObserver = jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+}));
+((global as unknown) as { ResizeObserver: jest.Mock }).ResizeObserver = mockResizeObserver;
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 600 });
+});
+
+afterAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 });
+});
+
+describe('WaveformCommentMarkers', () => {
+    const markers: CommentMarker[] = [
+        {
+            avatarUrl: 'https://example.com/a.png',
+            colorIndex: 0,
+            id: 'marker-1',
+            initial: 'A',
+            time: 10,
+            type: 'comment',
+        },
+        { colorIndex: 1, id: 'marker-2', initial: 'B', time: 30, type: 'annotation' },
+    ];
+
+    const hostCommentMarker: CommentMarker = {
+        avatarUrl: 'https://example.com/a.png',
+        colorIndex: 9278424974,
+        id: '507397',
+        initial: 'A',
+        time: 72.729,
+        type: 'comment',
+    };
+
+    test('should not render when duration is 0', () => {
+        const { container } = render(<WaveformCommentMarkers commentMarkers={markers} durationSec={0} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('should not render when there are no markers', () => {
+        const { container } = render(<WaveformCommentMarkers commentMarkers={[]} durationSec={60} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('should draw badges when markers arrive after an empty mount', () => {
+        const { rerender } = render(<WaveformCommentMarkers commentMarkers={[]} durationSec={180} />);
+
+        expect(screen.queryByTestId('bp-waveform-comment-markers')).not.toBeInTheDocument();
+
+        rerender(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} />);
+
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({
+            left: `${(72.729 / 180) * 100}%`,
+        });
+    });
+
+    test('should stack avatars at the same timestamp', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[
+                    { colorIndex: 0, id: 'same-a', initial: 'A', time: 10, type: 'comment' },
+                    { colorIndex: 1, id: 'same-b', initial: 'B', time: 10, type: 'comment' },
+                ]}
+                durationSec={60}
+            />,
+        );
+
+        const badge = screen.getByTestId('bp-waveform-comment-marker');
+        expect(badge).toHaveClass('bp-WaveformCommentMarkers-marker--group');
+        expect(badge.querySelectorAll('.bp-MarkerAvatarStack-item')).toHaveLength(2);
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+    });
+
+    test('should use the video overflow chip when more than four markers share a cluster', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[
+                    { colorIndex: 0, id: 'o-a', initial: 'A', time: 10, type: 'comment' },
+                    { colorIndex: 1, id: 'o-b', initial: 'B', time: 10, type: 'comment' },
+                    { colorIndex: 2, id: 'o-c', initial: 'C', time: 10, type: 'comment' },
+                    { colorIndex: 3, id: 'o-d', initial: 'D', time: 10, type: 'comment' },
+                    { colorIndex: 4, id: 'o-e', initial: 'E', time: 10, type: 'comment' },
+                ]}
+                durationSec={60}
+            />,
+        );
+
+        expect(
+            screen.getByTestId('bp-waveform-comment-marker').querySelector('.bp-MarkerAvatarStack-overflowBadge'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('+2')).toBeInTheDocument();
+    });
+
+    test('should stack nearby avatars that would overlap', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[
+                    { colorIndex: 0, id: 'near-a', initial: 'A', time: 10, type: 'comment' },
+                    { colorIndex: 1, id: 'near-b', initial: 'B', time: 11, type: 'comment' },
+                ]}
+                durationSec={60}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveClass('bp-WaveformCommentMarkers-marker--group');
+        expect(
+            screen.getByTestId('bp-waveform-comment-marker').querySelectorAll('.bp-MarkerAvatarStack-item'),
+        ).toHaveLength(2);
+    });
+
+    test('should position avatar badges from the host comment_markers payload', () => {
+        render(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} />);
+
+        const badges = screen.getAllByTestId('bp-waveform-comment-marker');
+        expect(badges).toHaveLength(2);
+        expect(badges[0]).toHaveAttribute('data-resin-target', 'commentMarker');
+        expect(badges[0]).toHaveStyle({ left: '16.6667%' });
+        expect(badges[1]).toHaveStyle({ left: '50%' });
+        expect(badges[0].querySelector('img')).toHaveAttribute('src', 'https://example.com/a.png');
+    });
+
+    test('should keep a file-start marker centered at 0% so the 1x gutter can show the full badge', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[{ ...hostCommentMarker, id: 'start', time: 0 }]}
+                durationSec={180}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-comment-markers')).not.toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({ left: '0%' });
+    });
+
+    test('should place a host comment_markers entry at time over duration', () => {
+        render(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} />);
+
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({
+            left: `${(72.729 / 180) * 100}%`,
+        });
+        expect(screen.getByTestId('bp-waveform-comment-marker').querySelector('img')).toHaveAttribute(
+            'src',
+            hostCommentMarker.avatarUrl,
+        );
+    });
+
+    test('should select a badge with a white ring and notify the click handler', async () => {
+        const user = userEvent.setup();
+        const onCommentMarkerClick = jest.fn();
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={markers}
+                durationSec={60}
+                onCommentMarkerClick={onCommentMarkerClick}
+            />,
+        );
+
+        const badge = screen.getAllByTestId('bp-waveform-comment-marker')[0];
+        await user.click(badge);
+
+        expect(onCommentMarkerClick).toHaveBeenCalledWith(markers[0]);
+        expect(badge).toHaveClass('bp-WaveformCommentMarkers-marker--selected');
+        expect(badge).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('should show the ring when the host marks a comment selected', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[{ ...markers[0], selected: true }, markers[1]]}
+                durationSec={60}
+                selectedId="marker-1"
+            />,
+        );
+
+        expect(screen.getAllByTestId('bp-waveform-comment-marker')[0]).toHaveClass(
+            'bp-WaveformCommentMarkers-marker--selected',
+        );
+    });
+
+    test('should drop the ring when pointer focus leaves the selected badge', async () => {
+        const user = userEvent.setup();
+        render(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-1" />);
+
+        const badge = screen.getAllByTestId('bp-waveform-comment-marker')[0];
+        expect(badge).toHaveClass('bp-WaveformCommentMarkers-marker--selected');
+
+        await user.click(document.body);
+
+        expect(badge).not.toHaveClass('bp-WaveformCommentMarkers-marker--selected');
+    });
+
+    test('should restore the ring when the host selects a different comment', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-1" />,
+        );
+
+        await user.click(document.body);
+        expect(screen.getAllByTestId('bp-waveform-comment-marker')[0]).not.toHaveClass(
+            'bp-WaveformCommentMarkers-marker--selected',
+        );
+
+        rerender(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-2" />);
+
+        expect(screen.getAllByTestId('bp-waveform-comment-marker')[1]).toHaveClass(
+            'bp-WaveformCommentMarkers-marker--selected',
+        );
+    });
+
+    test('should follow the visible window when the waveform viewport changes', () => {
+        const zoomed = createWaveformViewport({
+            durationSec: 180,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 800,
+            zoomLevel: 2,
+        });
+        const { rerender } = render(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} />);
+
+        const badge = screen.getByTestId('bp-waveform-comment-marker');
+        expect(badge).toHaveStyle({
+            left: `${(72.729 / 180) * 100}%`,
+        });
+
+        rerender(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} viewport={zoomed} />);
+
+        expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(badge).toHaveStyle({
+            left: `${(72.729 / 90) * 100}%`,
+        });
+        expect(badge.querySelector('img')).toHaveAttribute('src', hostCommentMarker.avatarUrl);
+
+        const panned = createWaveformViewport({
+            durationSec: 180,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 800,
+            widthPx: 800,
+            zoomLevel: 2,
+        });
+        rerender(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} viewport={panned} />);
+
+        expect(badge).toBeInTheDocument();
+        expect(badge.querySelector('img')).toHaveAttribute('src', hostCommentMarker.avatarUrl);
+        expect(badge).toHaveStyle({
+            left: `${((72.729 - 90) / 90) * 100}%`,
+        });
+    });
+
+    test('should place badges in a zoomed window that already existed on mount', () => {
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[hostCommentMarker]}
+                durationSec={180}
+                viewport={createWaveformViewport({
+                    durationSec: 180,
+                    heightPx: 140,
+                    maxZoom: 4,
+                    scrollLeftPx: 800,
+                    widthPx: 800,
+                    zoomLevel: 2,
+                })}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({
+            left: `${((72.729 - 90) / 90) * 100}%`,
+        });
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
@@ -82,6 +82,10 @@ describe('WaveformCommentMarkers', () => {
         expect(badge.querySelectorAll('.bp-MarkerAvatarStack-item')).toHaveLength(2);
         expect(screen.getByText('A')).toBeInTheDocument();
         expect(screen.getByText('B')).toBeInTheDocument();
+        badge.querySelectorAll('.bp-MarkerAvatarStack-item').forEach(item => {
+            expect(item).toHaveAttribute('aria-label', __('media_comment_marker'));
+            expect(item).toHaveAttribute('aria-pressed', 'false');
+        });
     });
 
     test('should place badges and stack exact timestamps before the track is measured', () => {
@@ -234,6 +238,22 @@ describe('WaveformCommentMarkers', () => {
         expect(screen.getAllByTestId('bp-waveform-comment-marker')[1]).toHaveClass(
             'bp-WaveformCommentMarkers-marker--selected',
         );
+    });
+
+    test('should keep the ring off when the host acks the dismissed comment', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} />);
+
+        const badge = screen.getAllByTestId('bp-waveform-comment-marker')[0];
+        await user.click(badge);
+        expect(badge).toHaveClass('bp-WaveformCommentMarkers-marker--selected');
+
+        await user.click(document.body);
+        expect(badge).not.toHaveClass('bp-WaveformCommentMarkers-marker--selected');
+
+        rerender(<WaveformCommentMarkers commentMarkers={markers} durationSec={60} selectedId="marker-1" />);
+
+        expect(badge).not.toHaveClass('bp-WaveformCommentMarkers-marker--selected');
     });
 
     test('should follow the visible window when the waveform viewport changes', () => {


### PR DESCRIPTION
## Summary

Adds `WaveformCommentMarkers`, a waveform overlay that draws clustered comment avatars along the visible window. Placement is a % of the current viewport (full file at 1×, start/end when zoomed). Nearby badges stack using the shared video clustering helper, with a 20px avatar size.

Selection can come from the host (`selectedId`) or from a click (optimistic ring until the feed catches up). A pointer-down outside the selected badge drops the ring without snapping back to the still-selected host comment.

The overlay is not mounted in the MP3 player yet. Shared chrome (`MarkerAvatar` size, `MarkerAvatarStack`) is updated so audio can reuse it; video defaults are unchanged.

## Intentional

- **24px hover band.** The overlay strip uses `pointer-events: auto` so hovering anywhere in that band undims every badge. Clicks on badges still go to the marker; this is not a seek/pan hole until the overlay is mounted.
- **Unmeasured width.** Video `buildClusters` still returns `[]` when `trackWidth` is 0. The overlay places badges immediately and only stacks identical timestamps until layout measures the track.

## Test plan

- [ ] Unit: `WaveformCommentMarkers-test`, `buildClusters-test`, `MarkerAvatar-test`, `MarkerAvatarStack-test`, `TimeControlsV2-test`
- [ ] Overlay does not appear in the player (this PR does not wire `MP3ControlsV2` / `MP3Viewer`)
- [ ] Video comment ticks still cluster only after the scrubber has a width
- [ ] Follow-up PR will mount the overlay, pass `comment_markers`, and seek on click