### PR TITLE
feat(text): enable preview for vtt files

### DIFF
--- a/src/lib/extensions.js
+++ b/src/lib/extensions.js
@@ -1,7 +1,7 @@
 // If changes are made to this file to support more extensions that are "highlightable", then make sure to
 // check if we need to upgrade the highlightjs custom build to add language grammar for that new extension language.
 // See build/upgrade_highlightjs.sh
-export const NON_CODE_EXTENSIONS = ['csv', 'log', 'md', 'tsv', 'txt'];
+export const NON_CODE_EXTENSIONS = ['csv', 'log', 'md', 'tsv', 'txt', 'vtt'];
 
 export const HTML_EXTENSIONS = ['htm', 'html', 'xhtml', 'xml', 'xsd', 'xsl']; // These types do not have an appropriate extracted text representation for preview
 


### PR DESCRIPTION
Add vtt to NON_CODE_EXTENSIONS so WebVTT files open as text.