### PR TITLE
chore(deps): upgrade fast-uri from 3.1.5 to 3.1.7

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,9 +6735,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"


### PR DESCRIPTION
## Summary

Upgrades the locked `fast-uri` resolution from 3.1.5 to 3.1.7. The package remains a transitive of `ajv`; `package.json` is unchanged.

## Why

`ajv` requests `fast-uri ^3.0.1`. The lockfile now resolves that range to 3.1.7.

## Test plan

- [ ] CI green on this lockfile-only change
