### PR TITLE
feat(audio): load waveform peaks from conversion JSON

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -89,6 +89,7 @@ export const APP_HOST = 'https://app.box.com';
 export const ORIGINAL_REP_NAME = 'ORIGINAL';
 export const PRELOAD_REP_NAME = 'jpg';
 export const PRELOAD_PAGED_REP_NAME = 'webp';
+export const WAVEFORM_REP_NAME = 'waveform';
 export const VIDEO_VIEWER_NAMES = ['Dash', 'MP4'];
 export const STATUS_ERROR = 'error';
 export const STATUS_NONE = 'none';
@@ -105,6 +106,7 @@ export const X_REP_HINT_VIDEO_DASH_EXTRACTED_TEXT = '[extracted_text]';
 export const X_REP_HINT_VIDEO_MP4 = '[mp4]';
 
 export const AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES = 'aiTranscriptionForVideoSubtitles';
+export const AUDIO_PLAYER_V2 = 'audioPlayerV2.enabled';
 
 export const PDFJS_CSS_UNITS = 96.0 / 72.0; // Should match CSS_UNITS in pdf_viewer.js
 export const PDFJS_MAX_AUTO_SCALE = 1.25; // Should match MAX_AUTO_SCALE in pdf_viewer.js

--- a/src/lib/viewers/media/MP3ControlsV2.tsx
+++ b/src/lib/viewers/media/MP3ControlsV2.tsx
@@ -51,14 +51,16 @@ export default function MP3ControlsV2({
     volume,
 }: Props): JSX.Element {
     const durationValue = typeof durationTime === 'number' && isFinite(durationTime) ? durationTime : 0;
+    const mediaDuration = mediaEl ? mediaEl.duration : NaN;
+    const hasMediaMetadata = typeof mediaDuration === 'number' && Number.isFinite(mediaDuration) && mediaDuration > 0;
+    const hasWaveformDuration = durationValue > 0;
     const [zoomLevel, setZoomLevel] = useState(WAVEFORM_ZOOM_MIN);
     const [maxZoom, setMaxZoom] = useState(WAVEFORM_ZOOM_MIN);
     const [isZoomRevealed, setIsZoomRevealed] = useState(false);
     const zoomRevealTimerRef = useRef(0);
     const hasRealPeaks = !!(peaks && peaks.length);
     const waveformPeaks = hasRealPeaks ? peaks : PLACEHOLDER_PEAKS;
-    const hasMetadata = durationValue > 0;
-    const waveformDurationSec = hasMetadata ? durationValue : PLACEHOLDER_DURATION_SEC;
+    const waveformDurationSec = hasWaveformDuration ? durationValue : PLACEHOLDER_DURATION_SEC;
     const [playRequested, setPlayRequested] = useState(false);
     const [viewport, setViewport] = useState<WaveformViewport | null>(null);
     const handleViewportChange = useCallback((next: WaveformViewport) => {
@@ -119,11 +121,11 @@ export default function MP3ControlsV2({
         [onCommentMarkerClick, onPlayPause, onTimeChange],
     );
 
-    const isWaveformInteractive = playRequested && hasMetadata;
-    const isWaitingToPlay = playRequested && !hasMetadata;
+    const isWaveformInteractive = playRequested && hasMediaMetadata;
+    const isWaitingToPlay = playRequested && !hasMediaMetadata;
     const showPlayOverlay = !playRequested && !isPlaying;
     const hasZoomHandlers = hasRealPeaks && !showPlayOverlay;
-    const hasZoomControl = hasZoomHandlers && hasMetadata && maxZoom > WAVEFORM_ZOOM_MIN;
+    const hasZoomControl = hasZoomHandlers && hasMediaMetadata && maxZoom > WAVEFORM_ZOOM_MIN;
 
     return (
         <div className="bp-MP3ControlsV2" data-testid="media-controls-wrapper-v2">
@@ -143,7 +145,7 @@ export default function MP3ControlsV2({
                     />
                     <WaveformCommentMarkers
                         commentMarkers={waveformMarkers}
-                        durationSec={hasMetadata ? durationValue : 0}
+                        durationSec={hasWaveformDuration ? durationValue : 0}
                         onCommentMarkerClick={handleCommentMarkerClick}
                         selectedId={selectedMarkerId}
                         viewport={viewport}
@@ -176,7 +178,7 @@ export default function MP3ControlsV2({
                     <div className="bp-media-buffering-spinner" data-testid="bp-MP3ControlsV2-loading" />
                 )}
             </div>
-            {hasMetadata && (
+            {hasMediaMetadata && (
                 <div className="bp-MP3ControlsV2-bar" data-testid="bp-MP3ControlsV2-bar">
                     <div className="bp-MP3ControlsV2-group">
                         <PlayPauseToggle hasSkipButtons={false} isPlaying={isPlaying} onPlayPause={onPlayPause} />

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -11,6 +11,7 @@ import {
     DURATION_MISMATCH_TOLERANCE_SEC,
 } from './waveform/constants';
 import { createWaveformLoader } from './waveform/createWaveformLoader';
+import { isPositiveFinite } from './waveform/validateWaveformPayload';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
@@ -19,10 +20,6 @@ function createLoadFailedError(message) {
     const error = new Error(message);
     error.name = 'LOAD_FAILED';
     return error;
-}
-
-function isPositiveFinite(value) {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 class MP3Viewer extends MediaBaseViewer {

--- a/src/lib/viewers/media/MP3Viewer.js
+++ b/src/lib/viewers/media/MP3Viewer.js
@@ -1,8 +1,16 @@
 import React from 'react';
+import { AUDIO_PLAYER_V2, STATUS_ERROR, WAVEFORM_REP_NAME } from '../../constants';
 import { VIEWER_EVENT } from '../../events';
+import { getRepresentation } from '../../file';
 import MediaBaseViewer from './MediaBaseViewer';
 import MP3Controls from './MP3Controls';
 import MP3ControlsRoot from './MP3ControlsRoot';
+import {
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    DURATION_MISMATCH_TOLERANCE_SEC,
+} from './waveform/constants';
+import { createWaveformLoader } from './waveform/createWaveformLoader';
 import './MP3.scss';
 
 const CSS_CLASS_MP3 = 'bp-media-mp3';
@@ -11,6 +19,10 @@ function createLoadFailedError(message) {
     const error = new Error(message);
     error.name = 'LOAD_FAILED';
     return error;
+}
+
+function isPositiveFinite(value) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 class MP3Viewer extends MediaBaseViewer {
@@ -30,17 +42,30 @@ class MP3Viewer extends MediaBaseViewer {
 
         this.isAudioPlayerV2 = this.getIsAudioPlayerV2();
         this.waveformPeaks = [];
+        this.waveformPeaksSource = null;
+        this.waveformDurationSec = 0;
         if (this.isAudioPlayerV2) {
             this.wrapperEl.classList.add('bp-media--v2');
             this.mediaContainerEl.classList.add('bp-media-container--v2');
             this.ensureV2Controls();
             this.importWaveformDecode();
+            // Listen on the loading shell. The waveform is on
+            // screen before the audio blob is playable; getViewer() is still null.
+            this.bindCommentMarkersListener();
         }
 
         // Audio element
         this.mediaEl = this.mediaContainerEl.appendChild(document.createElement('audio'));
         this.mediaEl.setAttribute('preload', 'auto');
         this.commentMarkers = [];
+    }
+
+    bindCommentMarkersListener() {
+        if (!this.isAudioPlayerV2) {
+            return;
+        }
+        this.removeListener('comment_markers', this.handleCommentMarkersUpdated);
+        this.addListener('comment_markers', this.handleCommentMarkersUpdated);
     }
 
     /**
@@ -50,7 +75,7 @@ class MP3Viewer extends MediaBaseViewer {
      * @return {boolean} whether v2 treatment is on
      */
     getIsAudioPlayerV2() {
-        return this.featureEnabled('audioPlayerV2.enabled') && this.useReactControls();
+        return this.featureEnabled(AUDIO_PLAYER_V2) && this.useReactControls();
     }
 
     /**
@@ -86,6 +111,7 @@ class MP3Viewer extends MediaBaseViewer {
      */
     fallbackToV1Controls() {
         this.isAudioPlayerV2 = false;
+        this.abortWaveformLoads();
         if (this.wrapperEl) {
             this.wrapperEl.classList.remove('bp-media--v2');
         }
@@ -122,7 +148,7 @@ class MP3Viewer extends MediaBaseViewer {
      */
     destroy() {
         this.removeListener('comment_markers', this.handleCommentMarkersUpdated);
-        this.abortClientWaveformDecode();
+        this.abortWaveformLoads();
         super.destroy();
     }
 
@@ -132,6 +158,7 @@ class MP3Viewer extends MediaBaseViewer {
     load() {
         if (this.isAudioPlayerV2) {
             this.showAudioLoadingShell();
+            this.startConversionWaveformLoad();
         }
 
         return super.load();
@@ -169,6 +196,10 @@ class MP3Viewer extends MediaBaseViewer {
      * @inheritdoc
      */
     loadeddataHandler() {
+        if (this.isAudioPlayerV2) {
+            this.dropConversionPeaksOnDurationMismatch();
+        }
+
         super.loadeddataHandler();
 
         if (!this.isAudioPlayerV2) {
@@ -182,7 +213,193 @@ class MP3Viewer extends MediaBaseViewer {
             this.play();
         }
 
-        this.startClientWaveformDecode();
+        if (this.shouldRaceClientWaveformDecode()) {
+            this.startClientWaveformDecode();
+        }
+    }
+
+    /**
+     * Client decode races conversion until some source applies peaks. Size and
+     * duration caps still apply. First source to apply peaks wins; later
+     * results are ignored.
+     *
+     * @return {boolean}
+     */
+    shouldRaceClientWaveformDecode() {
+        if (!this.isAudioPlayerV2 || this.destroyed || this.waveformPeaksSource) {
+            return false;
+        }
+
+        const compressedBytes = this.options.file?.size;
+        const durationSec = this.mediaEl?.duration;
+        return (
+            isPositiveFinite(compressedBytes) &&
+            compressedBytes <= CLIENT_DECODE_MAX_COMPRESSED_BYTES &&
+            isPositiveFinite(durationSec) &&
+            durationSec <= CLIENT_DECODE_MAX_DURATION_SEC
+        );
+    }
+
+    /**
+     * @param {number} durationSec
+     * @return {boolean}
+     */
+    isConversionDurationMismatch(durationSec) {
+        const mediaDuration = this.mediaEl?.duration;
+        return (
+            isPositiveFinite(mediaDuration) &&
+            isPositiveFinite(durationSec) &&
+            Math.abs(durationSec - mediaDuration) > DURATION_MISMATCH_TOLERANCE_SEC
+        );
+    }
+
+    /**
+     * Conversion JSON fetched before metadata skipped duration matching. Drop
+     * those peaks once media duration is known if they disagree.
+     *
+     * @return {void}
+     */
+    dropConversionPeaksOnDurationMismatch() {
+        if (this.waveformPeaksSource !== 'conversion' || !this.isConversionDurationMismatch(this.waveformDurationSec)) {
+            return;
+        }
+
+        this.waveformPeaks = [];
+        this.waveformPeaksSource = null;
+        this.waveformDurationSec = 0;
+        this.renderUI();
+    }
+
+    /**
+     * Poll the conversion waveform representation and fetch its JSON.
+     * Missing, failed, or unloadable conversion falls back to client decode
+     * when the file is under size and duration caps.
+     *
+     * @return {Promise<void>}
+     */
+    async startConversionWaveformLoad() {
+        if (!this.isAudioPlayerV2 || this.destroyed) {
+            return;
+        }
+
+        const { file } = this.options;
+        const waveform = file?.representations?.entries ? getRepresentation(file, WAVEFORM_REP_NAME) : null;
+        const template = waveform?.content?.url_template;
+        const conversionStatus = waveform?.status;
+        const statusState = conversionStatus && typeof conversionStatus === 'object' ? conversionStatus.state : null;
+        if (!waveform || !template || !statusState || statusState === STATUS_ERROR) {
+            this.startClientWaveformDecode();
+            return;
+        }
+
+        this.abortConversionWaveformLoad();
+        this.waveformStatus = this.getRepStatus(waveform);
+        this.waveformStatus.removeListener('conversionpending', this.resetLoadTimeout);
+        const status = this.waveformStatus;
+
+        try {
+            await status.getPromise();
+            if (this.destroyed || this.waveformStatus !== status || this.waveformPeaksSource) {
+                return;
+            }
+            const result = await this.loadConversionWaveformPayload(template);
+            this.handleConversionWaveformResult(result, status);
+        } catch {
+            this.startClientWaveformDecode();
+        }
+    }
+
+    /**
+     * Fetch and validate conversion waveform JSON after the rep is ready.
+     * `{+asset_path}` is empty. Auth is a header, not a query token.
+     *
+     * @param {string} template - content URL template
+     * @return {Promise<import('./waveform/types').WaveformLoadState>}
+     */
+    loadConversionWaveformPayload(template) {
+        const url = this.createContentUrlV2(template);
+        const durationSec = this.mediaEl?.duration;
+        const source = createWaveformLoader(
+            signal =>
+                this.api.get(url, {
+                    headers: this.appendAuthHeader(),
+                    signal,
+                }),
+            Number.isFinite(durationSec) ? { expectedDurationSec: durationSec } : {},
+        );
+        this.waveformSource = source;
+        return source.load();
+    }
+
+    abortWaveformLoads() {
+        this.abortConversionWaveformLoad();
+        this.abortClientWaveformDecode();
+    }
+
+    abortConversionWaveformLoad() {
+        if (this.waveformSource) {
+            this.waveformSource.abort();
+            this.waveformSource = null;
+        }
+        if (this.waveformStatus) {
+            this.waveformStatus.destroy();
+            this.waveformStatus = null;
+        }
+    }
+
+    /**
+     * First source to apply peaks wins. Later results are ignored.
+     *
+     * @param {'conversion'|'client'} source
+     * @param {{ peaks: ArrayLike<number>, durationSec?: number }} payload
+     * @return {boolean} true when this source claimed peaks
+     */
+    applyWaveformPeaks(source, payload) {
+        if (this.waveformPeaksSource) {
+            return false;
+        }
+
+        this.waveformPeaks = payload.peaks;
+        this.waveformPeaksSource = source;
+        this.isWaveformDecodeRetryPending = false;
+        if (source === 'conversion') {
+            this.waveformDurationSec = payload.durationSec;
+            this.abortClientWaveformDecode();
+        } else if (this.waveformSource) {
+            // RepStatus.destroy() does not reject getPromise().
+            this.waveformSource.abort();
+            this.waveformSource = null;
+        }
+        this.renderUI();
+        return true;
+    }
+
+    /**
+     * Apply conversion peaks when the load is still current. Ignored if client
+     * decode already applied peaks.
+     *
+     * @param {import('./waveform/types').WaveformLoadState} result
+     * @param {Object} status - RepStatus instance that started this load
+     * @return {void}
+     */
+    handleConversionWaveformResult(result, status) {
+        if (!result || this.destroyed || !this.isAudioPlayerV2 || this.waveformStatus !== status) {
+            return;
+        }
+
+        if (result.status !== 'ready') {
+            if (result.status !== 'cancelled') {
+                this.startClientWaveformDecode();
+            }
+            return;
+        }
+
+        if (this.isConversionDurationMismatch(result.payload.durationSec)) {
+            this.startClientWaveformDecode();
+            return;
+        }
+
+        this.applyWaveformPeaks('conversion', result.payload);
     }
 
     /**
@@ -192,7 +409,11 @@ class MP3Viewer extends MediaBaseViewer {
         this.userRequestedPlay = true;
         this.togglePlay();
 
-        if (this.isWaveformDecodeRetryPending && !this.hasUsedWaveformDecodePlayRetry) {
+        if (
+            this.shouldRaceClientWaveformDecode() &&
+            this.isWaveformDecodeRetryPending &&
+            !this.hasUsedWaveformDecodePlayRetry
+        ) {
             this.hasUsedWaveformDecodePlayRetry = true;
             this.isWaveformDecodeRetryPending = false;
             this.startClientWaveformDecode();
@@ -258,17 +479,21 @@ class MP3Viewer extends MediaBaseViewer {
     }
 
     /**
-     * Decode peaks in the background when the file is under size and duration caps.
-     * Does not block playback. Capped or failed decode keeps the placeholder waveform.
+     * Decode peaks in the background until conversion or client decode applies
+     * them, when the file is under size and duration caps. Does not block
+     * playback. First source to apply peaks wins.
      *
      * @return {Promise<void>}
      */
     async startClientWaveformDecode() {
-        if (!this.isAudioPlayerV2 || this.destroyed) {
+        if (!this.shouldRaceClientWaveformDecode()) {
             return;
         }
 
-        this.abortClientWaveformDecode();
+        if (this.waveformDecodeController && !this.waveformDecodeController.signal.aborted) {
+            return;
+        }
+
         const controller = new AbortController();
         this.waveformDecodeController = controller;
         const { signal } = controller;
@@ -321,9 +546,7 @@ class MP3Viewer extends MediaBaseViewer {
         }
 
         if (result.status === 'ready') {
-            this.waveformPeaks = result.payload.peaks;
-            this.isWaveformDecodeRetryPending = false;
-            this.renderUI();
+            this.applyWaveformPeaks('client', result.payload);
             return;
         }
 
@@ -355,11 +578,7 @@ class MP3Viewer extends MediaBaseViewer {
             this.controls = new MP3ControlsRoot({ containerEl: this.mediaContainerEl });
         }
 
-        if (this.isAudioPlayerV2) {
-            this.removeListener('comment_markers', this.handleCommentMarkersUpdated);
-            this.addListener('comment_markers', this.handleCommentMarkersUpdated);
-        }
-
+        this.bindCommentMarkersListener();
         this.renderUI();
     }
 
@@ -403,11 +622,11 @@ class MP3Viewer extends MediaBaseViewer {
 
     handleCommentMarkerClick = marker => {
         this.hostSelectedMarkerId = marker.id;
-        this.pendingHostSelectedSeek = null;
+        this.pendingHostSelectedSeek = marker;
         if (this.mediaEl) {
             this.mediaEl.pause();
-            this.mediaEl.currentTime = marker.time;
         }
+        this.applyPendingHostSelectedSeek();
         // Overlay paints the ring from click optimism until the host re-emits selected.
         this.emit('comment_marker_select', { id: marker.id, time: marker.time });
         this.renderUI();
@@ -421,11 +640,15 @@ class MP3Viewer extends MediaBaseViewer {
             return;
         }
 
+        const mediaDuration = this.mediaEl.duration;
+        const durationTime =
+            typeof mediaDuration === 'number' && mediaDuration > 0 ? mediaDuration : this.waveformDurationSec;
+
         const sharedProps = {
             autoplay: this.isAutoplayEnabled(),
             bufferedRange: this.mediaEl.buffered,
             currentTime: this.mediaEl.currentTime,
-            durationTime: this.mediaEl.duration,
+            durationTime,
             isPlaying: !this.mediaEl.paused,
             movePlayback: this.movePlayback,
             onAutoplayChange: this.setAutoplay,

--- a/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
@@ -142,12 +142,12 @@ describe('MP3ControlsV2', () => {
     }
 
     const getWrapper = (props: Partial<Props> = {}) => {
-        const resolved = { ...props };
+        const nextProps = { ...props };
         if (!('mediaEl' in props) && typeof props.durationTime === 'number' && props.durationTime > 0) {
-            resolved.mediaEl = mediaElWithDuration(props.durationTime);
+            nextProps.mediaEl = mediaElWithDuration(props.durationTime);
         }
 
-        return render(<MP3ControlsV2 {...defaultControlsProps} {...resolved} />);
+        return render(<MP3ControlsV2 {...defaultControlsProps} {...nextProps} />);
     };
 
     describe('render', () => {
@@ -210,12 +210,11 @@ describe('MP3ControlsV2', () => {
         test('should keep the waveform inert after overlay click until media metadata', async () => {
             const mediaEl = document.createElement('audio');
             Object.defineProperty(mediaEl, 'duration', { configurable: true, value: NaN });
-            const onPlayPause = jest.fn();
-            getWrapper({ durationTime: 180, mediaEl, onPlayPause, peaks: [0.2, 0.8] });
+            getWrapper({ durationTime: 180, mediaEl, peaks: [0.2, 0.8] });
 
             await userEvent.click(await screen.findByTestId('bp-MP3ControlsV2-play-overlay'));
 
-            expect(onPlayPause).toHaveBeenCalledWith(true);
+            expect(defaultControlsProps.onPlayPause).toHaveBeenCalledWith(true);
             expect(screen.getByTestId('bp-MP3ControlsV2-loading')).toBeInTheDocument();
             expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-interactive', 'false');
             expect(screen.queryByTestId('bp-MP3ControlsV2-bar')).not.toBeInTheDocument();

--- a/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
@@ -41,7 +41,11 @@ jest.mock('../waveform/WaveformView', () => {
             onViewportChange?.(overview);
         }, [durationSec, onViewportChange]);
         return (
-            <div data-interactive={interactive ? 'true' : 'false'} data-testid="bp-waveform-view">
+            <div
+                data-duration-sec={String(durationSec)}
+                data-interactive={interactive ? 'true' : 'false'}
+                data-testid="bp-waveform-view"
+            >
                 <button data-testid="bp-mock-waveform-zoom" onClick={() => onZoomChange?.(2)} type="button">
                     zoom
                 </button>
@@ -120,20 +124,31 @@ describe('MP3ControlsV2', () => {
         },
     ];
 
-    const getWrapper = (props: Partial<Props> = {}) =>
-        render(
-            <MP3ControlsV2
-                autoplay={false}
-                onAutoplayChange={jest.fn()}
-                onMuteChange={jest.fn()}
-                onPlayPause={jest.fn()}
-                onRateChange={jest.fn()}
-                onTimeChange={jest.fn()}
-                onVolumeChange={jest.fn()}
-                rate="1.0"
-                {...props}
-            />,
-        );
+    const defaultControlsProps = {
+        autoplay: false,
+        onAutoplayChange: jest.fn(),
+        onMuteChange: jest.fn(),
+        onPlayPause: jest.fn(),
+        onRateChange: jest.fn(),
+        onTimeChange: jest.fn(),
+        onVolumeChange: jest.fn(),
+        rate: '1.0',
+    };
+
+    function mediaElWithDuration(durationSec: number): HTMLAudioElement {
+        const mediaEl = document.createElement('audio');
+        Object.defineProperty(mediaEl, 'duration', { configurable: true, value: durationSec });
+        return mediaEl;
+    }
+
+    const getWrapper = (props: Partial<Props> = {}) => {
+        const resolved = { ...props };
+        if (!('mediaEl' in props) && typeof props.durationTime === 'number' && props.durationTime > 0) {
+            resolved.mediaEl = mediaElWithDuration(props.durationTime);
+        }
+
+        return render(<MP3ControlsV2 {...defaultControlsProps} {...resolved} />);
+    };
 
     describe('render', () => {
         test('should return a valid v2 wrapper', async () => {
@@ -179,6 +194,31 @@ describe('MP3ControlsV2', () => {
             expect(screen.getByTestId('bp-MP3ControlsV2-play-overlay')).toBeInTheDocument();
             expect(screen.queryByTestId('bp-MP3ControlsV2-bar')).not.toBeInTheDocument();
             expect(screen.queryByTestId('bp-MP3ControlsV2-loading')).not.toBeInTheDocument();
+        });
+
+        test('should lay out conversion duration without unlocking the bar before media metadata', async () => {
+            const mediaEl = document.createElement('audio');
+            Object.defineProperty(mediaEl, 'duration', { configurable: true, value: NaN });
+            getWrapper({ durationTime: 180, mediaEl, peaks: [0.2, 0.8] });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-duration-sec', '180');
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-interactive', 'false');
+            expect(screen.queryByTestId('bp-MP3ControlsV2-bar')).not.toBeInTheDocument();
+            expect(screen.getByTestId('bp-MP3ControlsV2-play-overlay')).toBeInTheDocument();
+        });
+
+        test('should keep the waveform inert after overlay click until media metadata', async () => {
+            const mediaEl = document.createElement('audio');
+            Object.defineProperty(mediaEl, 'duration', { configurable: true, value: NaN });
+            const onPlayPause = jest.fn();
+            getWrapper({ durationTime: 180, mediaEl, onPlayPause, peaks: [0.2, 0.8] });
+
+            await userEvent.click(await screen.findByTestId('bp-MP3ControlsV2-play-overlay'));
+
+            expect(onPlayPause).toHaveBeenCalledWith(true);
+            expect(screen.getByTestId('bp-MP3ControlsV2-loading')).toBeInTheDocument();
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-interactive', 'false');
+            expect(screen.queryByTestId('bp-MP3ControlsV2-bar')).not.toBeInTheDocument();
         });
 
         test('should keep the waveform inert after metadata until play is requested', async () => {
@@ -245,17 +285,11 @@ describe('MP3ControlsV2', () => {
 
             rerender(
                 <MP3ControlsV2
-                    autoplay={false}
+                    {...defaultControlsProps}
                     durationTime={8}
                     isPlaying={false}
-                    onAutoplayChange={jest.fn()}
-                    onMuteChange={jest.fn()}
-                    onPlayPause={jest.fn()}
-                    onRateChange={jest.fn()}
-                    onTimeChange={jest.fn()}
-                    onVolumeChange={jest.fn()}
+                    mediaEl={mediaElWithDuration(8)}
                     peaks={[0.2, 0.8]}
-                    rate="1.0"
                 />,
             );
 
@@ -452,17 +486,11 @@ describe('MP3ControlsV2', () => {
 
             rerender(
                 <MP3ControlsV2
-                    autoplay={false}
+                    {...defaultControlsProps}
                     commentMarkers={hostCommentMarkers}
                     durationTime={180}
-                    onAutoplayChange={jest.fn()}
-                    onMuteChange={jest.fn()}
-                    onPlayPause={jest.fn()}
-                    onRateChange={jest.fn()}
-                    onTimeChange={jest.fn()}
-                    onVolumeChange={jest.fn()}
+                    mediaEl={mediaElWithDuration(180)}
                     peaks={[0.2, 0.8]}
-                    rate="1.0"
                 />,
             );
 
@@ -485,18 +513,12 @@ describe('MP3ControlsV2', () => {
 
             rerender(
                 <MP3ControlsV2
-                    autoplay={false}
+                    {...defaultControlsProps}
                     commentMarkers={hostCommentMarkers}
                     durationTime={180}
                     isPlaying
-                    onAutoplayChange={jest.fn()}
-                    onMuteChange={jest.fn()}
-                    onPlayPause={jest.fn()}
-                    onRateChange={jest.fn()}
-                    onTimeChange={jest.fn()}
-                    onVolumeChange={jest.fn()}
+                    mediaEl={mediaElWithDuration(180)}
                     peaks={[0.2, 0.8]}
-                    rate="1.0"
                 />,
             );
 

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -6,6 +6,11 @@ import MP3ControlsRoot from '../MP3ControlsRoot';
 import MP3Viewer from '../MP3Viewer';
 import MediaBaseViewer from '../MediaBaseViewer';
 import { VIEWER_EVENT } from '../../../events';
+import {
+    CLIENT_DECODE_MAX_COMPRESSED_BYTES,
+    CLIENT_DECODE_MAX_DURATION_SEC,
+    DURATION_MISMATCH_TOLERANCE_SEC,
+} from '../waveform/constants';
 import { loadPeaks } from '../waveform/decode';
 
 jest.mock('../waveform/decode', () => ({
@@ -74,6 +79,16 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.importWaveformDecode).toBeCalled();
         });
 
+        test('should listen for comment_markers on the loading shell when v2 is on', () => {
+            mp3.options.features = { audioPlayerV2: { enabled: true } };
+            jest.spyOn(mp3, 'useReactControls').mockReturnValue(true);
+            jest.spyOn(mp3, 'addListener');
+
+            mp3.setup();
+
+            expect(mp3.addListener).toHaveBeenCalledWith('comment_markers', mp3.handleCommentMarkersUpdated);
+        });
+
         test('should not apply v2 classes when React controls are off', () => {
             mp3.options.features = { audioPlayerV2: { enabled: true } };
             jest.spyOn(mp3, 'useReactControls').mockReturnValue(false);
@@ -123,6 +138,25 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.emitFirstRenderMetric).toBeCalled();
             expect(mp3.emit).toBeCalledWith(VIEWER_EVENT.default, { event: VIEWER_EVENT.preload, data: {} });
             expect(MediaBaseViewer.prototype.load).toBeCalled();
+        });
+
+        test('should start conversion waveform load for v2', () => {
+            mp3.isAudioPlayerV2 = true;
+            jest.spyOn(mp3, 'showAudioLoadingShell').mockImplementation();
+            jest.spyOn(mp3, 'startConversionWaveformLoad').mockImplementation();
+
+            mp3.load();
+
+            expect(mp3.startConversionWaveformLoad).toBeCalled();
+        });
+
+        test('should not start conversion waveform load when v2 is off', () => {
+            mp3.isAudioPlayerV2 = false;
+            jest.spyOn(mp3, 'startConversionWaveformLoad').mockImplementation();
+
+            mp3.load();
+
+            expect(mp3.startConversionWaveformLoad).not.toBeCalled();
         });
 
         test('should not mount the v2 loading shell when audio player v2 is off', () => {
@@ -225,6 +259,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.options.features = { audioPlayerV2: { enabled: true } };
             jest.spyOn(mp3, 'useReactControls').mockReturnValue(true);
             mp3.importV2Controls.mockRejectedValue(new Error('chunk failed'));
+            jest.spyOn(mp3, 'abortConversionWaveformLoad');
+            jest.spyOn(mp3, 'abortClientWaveformDecode');
             mp3.setup();
             mp3.controls = {
                 destroy: jest.fn(),
@@ -241,6 +277,8 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.wrapperEl).not.toHaveClass('bp-media--v2');
             expect(mp3.mediaContainerEl).not.toHaveClass('bp-media-container--v2');
             expect(mp3.mp3ControlsV2Promise).toBeNull();
+            expect(mp3.abortConversionWaveformLoad).toBeCalled();
+            expect(mp3.abortClientWaveformDecode).toBeCalled();
             expect(mp3.controls.render).toHaveBeenCalledWith(expect.objectContaining({ type: MP3Controls }));
         });
     });
@@ -257,9 +295,10 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.startClientWaveformDecode).not.toBeCalled();
         });
 
-        test('should retry decode once after a retryable failure', () => {
+        test('should retry decode once after a retryable failure when conversion is still pending', () => {
             jest.spyOn(mp3, 'togglePlay').mockImplementation();
             jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            jest.spyOn(mp3, 'shouldRaceClientWaveformDecode').mockReturnValue(true);
             mp3.isWaveformDecodeRetryPending = true;
 
             mp3.handlePlayRequest();
@@ -268,6 +307,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.startClientWaveformDecode).toBeCalledTimes(1);
             expect(mp3.hasUsedWaveformDecodePlayRetry).toBe(true);
             expect(mp3.isWaveformDecodeRetryPending).toBe(false);
+        });
+
+        test('should not retry decode when peaks are already applied', () => {
+            jest.spyOn(mp3, 'togglePlay').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            jest.spyOn(mp3, 'shouldRaceClientWaveformDecode').mockReturnValue(false);
+            mp3.isWaveformDecodeRetryPending = true;
+
+            mp3.handlePlayRequest();
+
+            expect(mp3.startClientWaveformDecode).not.toBeCalled();
         });
     });
 
@@ -300,6 +350,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
             mp3.userRequestedPlay = true;
             const order = [];
             jest.spyOn(mp3, 'play').mockImplementation(() => order.push('play'));
+            jest.spyOn(mp3, 'shouldRaceClientWaveformDecode').mockReturnValue(true);
             jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation(() => order.push('decode'));
 
             mp3.loadeddataHandler();
@@ -318,17 +369,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
             expect(mp3.play).not.toBeCalled();
         });
 
-        test('should start client decode for v2 after metadata', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
-            jest.spyOn(mp3, 'play').mockImplementation();
-
-            mp3.loadeddataHandler();
-
-            expect(mp3.startClientWaveformDecode).toBeCalled();
-        });
-
         test('should apply a pending host-selected seek after metadata', () => {
             Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
             mp3.isAudioPlayerV2 = true;
@@ -342,6 +382,55 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.mediaEl.currentTime).toBe(41.2);
             expect(mp3.pendingHostSelectedSeek).toBeNull();
+        });
+
+        test('should start client decode after metadata when peaks are not applied yet', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaksSource = null;
+            mp3.options.file = { id: 1, size: 1024 };
+            mp3.mediaEl = { duration: 30 };
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+
+            mp3.loadeddataHandler();
+
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should drop conversion peaks when media duration mismatches', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaks = [0.2, 0.8];
+            mp3.waveformPeaksSource = 'conversion';
+            mp3.waveformDurationSec = 180;
+            mp3.options.file = { id: 1, size: 1024 };
+            mp3.mediaEl = { duration: 30 };
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+
+            mp3.loadeddataHandler();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should keep conversion peaks when media duration is within tolerance', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaks = [0.2, 0.8];
+            mp3.waveformPeaksSource = 'conversion';
+            mp3.waveformDurationSec = 30 + DURATION_MISMATCH_TOLERANCE_SEC;
+            mp3.options.file = { id: 1, size: 1024 };
+            mp3.mediaEl = { duration: 30 };
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+
+            mp3.loadeddataHandler();
+
+            expect(mp3.waveformPeaks).toEqual([0.2, 0.8]);
+            expect(mp3.waveformPeaksSource).toBe('conversion');
+            expect(mp3.startClientWaveformDecode).not.toBeCalled();
         });
     });
 
@@ -392,6 +481,17 @@ describe('lib/viewers/media/MP3Viewer', () => {
             });
         });
 
+        test('should use conversion duration when the audio blob has no metadata yet', () => {
+            mp3.isAudioPlayerV2 = true;
+            mp3.MP3ControlsV2 = MP3ControlsV2;
+            mp3.waveformDurationSec = 180;
+            Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: NaN });
+
+            mp3.renderUI();
+
+            expect(getProps(mp3).durationTime).toBe(180);
+        });
+
         test('should wait for the v2 controls chunk before rendering', () => {
             mp3.isAudioPlayerV2 = true;
             mp3.ensureV2Controls = jest.fn().mockReturnValue(new Promise(() => {}));
@@ -399,14 +499,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.ensureV2Controls).toBeCalled();
             expect(mp3.controls.render).not.toBeCalled();
-        });
-
-        test('should render MP3ControlsV2 when audio player v2 is on', () => {
-            mp3.isAudioPlayerV2 = true;
-            mp3.MP3ControlsV2 = MP3ControlsV2;
-            mp3.renderUI();
-
-            expect(mp3.controls.render).toHaveBeenCalledWith(expect.objectContaining({ type: MP3ControlsV2 }));
         });
 
         test('should render MP3Controls when audio player v2 is off', () => {
@@ -535,12 +627,40 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
 
         test('should pause, seek, and emit comment_marker_select', () => {
+            Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: 180 });
+
             mp3.handleCommentMarkerClick({ id: '507397', time: 72.729, type: 'comment' });
 
             expect(mp3.mediaEl.pause).toBeCalled();
             expect(mp3.mediaEl.currentTime).toBe(72.729);
+            expect(mp3.pendingHostSelectedSeek).toBeNull();
             expect(mp3.emit).toHaveBeenCalledWith('comment_marker_select', { id: '507397', time: 72.729 });
             expect(mp3.renderUI).toBeCalled();
+        });
+
+        test('should queue a marker click until media duration is known', () => {
+            Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: NaN });
+
+            mp3.handleCommentMarkerClick({ id: 'comment-1', time: 41.2, type: 'comment' });
+
+            expect(mp3.mediaEl.pause).toBeCalled();
+            expect(mp3.mediaEl.currentTime).toBe(0);
+            expect(mp3.pendingHostSelectedSeek).toEqual(expect.objectContaining({ id: 'comment-1', time: 41.2 }));
+            expect(mp3.emit).toHaveBeenCalledWith('comment_marker_select', { id: 'comment-1', time: 41.2 });
+        });
+
+        test('should seek to a marker clicked before metadata once duration is known', () => {
+            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
+            mp3.isAudioPlayerV2 = true;
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: NaN });
+
+            mp3.handleCommentMarkerClick({ id: 'comment-1', time: 41.2, type: 'comment' });
+            Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: 180 });
+            mp3.loadeddataHandler();
+
+            expect(mp3.mediaEl.currentTime).toBe(41.2);
+            expect(mp3.pendingHostSelectedSeek).toBeNull();
         });
 
         test('should not seek again when the host acks the clicked marker', () => {
@@ -587,12 +707,62 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
     });
 
+    describe('shouldRaceClientWaveformDecode()', () => {
+        beforeEach(() => {
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaksSource = null;
+            mp3.options.file = { id: 1, size: 1024 };
+            mp3.mediaEl = { duration: 30 };
+        });
+
+        test('should race when size and duration are under the cap and peaks are not applied', () => {
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(true);
+        });
+
+        test('should not race when conversion peaks are already applied', () => {
+            mp3.waveformPeaksSource = 'conversion';
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+
+        test('should not race when client peaks are already applied', () => {
+            mp3.waveformPeaksSource = 'client';
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+
+        test('should not race when compressed size is over the cap', () => {
+            mp3.options.file = { id: 1, size: CLIENT_DECODE_MAX_COMPRESSED_BYTES + 1 };
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+
+        test('should not race when duration is over the cap', () => {
+            mp3.mediaEl = { duration: CLIENT_DECODE_MAX_DURATION_SEC + 1 };
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+
+        test('should not race when file size is missing', () => {
+            mp3.options.file = { id: 1 };
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+
+        test('should not race when duration is not yet known', () => {
+            mp3.mediaEl = { duration: Number.NaN };
+
+            expect(mp3.shouldRaceClientWaveformDecode()).toBe(false);
+        });
+    });
+
     describe('startClientWaveformDecode()', () => {
         beforeEach(() => {
             loadPeaks.mockReset();
             loadPeaks.mockResolvedValue({ error: { code: 'CAP_EXCEEDED', message: 'skip' }, status: 'capped' });
             mp3.isAudioPlayerV2 = true;
             mp3.waveformPeaks = [];
+            mp3.waveformPeaksSource = null;
             mp3.mediaEl = { duration: 30 };
             mp3.options.file = { id: 1, size: 1024 };
             jest.spyOn(mp3, 'renderUI').mockImplementation();
@@ -607,6 +777,7 @@ describe('lib/viewers/media/MP3Viewer', () => {
             await mp3.startClientWaveformDecode();
 
             expect(mp3.waveformPeaks).toEqual([0.2, 0.8]);
+            expect(mp3.waveformPeaksSource).toBe('client');
             expect(mp3.renderUI).toBeCalled();
         });
 
@@ -694,6 +865,262 @@ describe('lib/viewers/media/MP3Viewer', () => {
 
             expect(mp3.removeListener).toHaveBeenCalledWith('comment_markers', mp3.handleCommentMarkersUpdated);
             superDestroy.mockRestore();
+        });
+    });
+
+    describe('startConversionWaveformLoad()', () => {
+        const WAVEFORM_TEMPLATE = 'https://dl.boxcloud.com/waveform/content/{+asset_path}';
+        const WAVEFORM_URL = 'https://dl.boxcloud.com/waveform/content/';
+        const WAVEFORM_JSON = { version: 1, durationSec: 8, peaks: [0.2, 0.8] };
+
+        const conversionRep = (overrides = {}) => ({
+            representation: 'waveform',
+            content: { url_template: WAVEFORM_TEMPLATE },
+            status: { state: 'success' },
+            ...overrides,
+        });
+
+        beforeEach(() => {
+            mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaks = [];
+            mp3.waveformPeaksSource = null;
+            mp3.mediaEl = { duration: 8 };
+            mp3.options.file = {
+                id: 1,
+                size: 1024,
+                representations: {
+                    entries: [conversionRep()],
+                },
+            };
+            mp3.api = { get: jest.fn().mockResolvedValue(WAVEFORM_JSON) };
+            jest.spyOn(mp3, 'createContentUrlV2').mockReturnValue(WAVEFORM_URL);
+            jest.spyOn(mp3, 'appendAuthHeader').mockReturnValue({ Authorization: 'Bearer token' });
+            jest.spyOn(mp3, 'getRepStatus').mockReturnValue({
+                destroy: jest.fn(),
+                getPromise: () => Promise.resolve(),
+                removeListener: jest.fn(),
+            });
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+            jest.spyOn(mp3, 'abortClientWaveformDecode');
+            jest.spyOn(mp3, 'startClientWaveformDecode');
+        });
+
+        test('should not fetch when v2 is off', async () => {
+            mp3.isAudioPlayerV2 = false;
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).not.toBeCalled();
+            expect(mp3.api.get).not.toBeCalled();
+        });
+
+        test('should not fetch when the waveform representation is missing', async () => {
+            mp3.options.file.representations.entries = [];
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).not.toBeCalled();
+            expect(mp3.api.get).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should not fetch when the content URL template is missing', async () => {
+            mp3.options.file.representations.entries = [conversionRep({ content: {} })];
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).not.toBeCalled();
+            expect(mp3.api.get).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should fall back to client decode when conversion status is error', async () => {
+            mp3.options.file.representations.entries = [conversionRep({ status: { state: 'error' } })];
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).not.toBeCalled();
+            expect(mp3.api.get).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should fall back to client decode when conversion status data is missing', async () => {
+            mp3.options.file.representations.entries = [conversionRep({ status: undefined })];
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).not.toBeCalled();
+            expect(mp3.api.get).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should poll the waveform rep then fetch JSON with header auth', async () => {
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.getRepStatus).toHaveBeenCalledWith(expect.objectContaining({ representation: 'waveform' }));
+            expect(mp3.waveformStatus.removeListener).toHaveBeenCalledWith('conversionpending', mp3.resetLoadTimeout);
+            expect(mp3.createContentUrlV2).toHaveBeenCalledWith(WAVEFORM_TEMPLATE);
+            expect(mp3.api.get).toHaveBeenCalledWith(WAVEFORM_URL, {
+                headers: { Authorization: 'Bearer token' },
+                signal: expect.any(AbortSignal),
+            });
+            expect(mp3.waveformPeaks).toEqual(Float32Array.from([0.2, 0.8]));
+            expect(mp3.waveformPeaksSource).toBe('conversion');
+            expect(mp3.waveformDurationSec).toBe(8);
+            expect(mp3.abortClientWaveformDecode).toBeCalled();
+            expect(mp3.renderUI).toBeCalled();
+            expect(mp3.startClientWaveformDecode).not.toBeCalled();
+        });
+
+        test('should keep empty peaks when conversion status rejects', async () => {
+            mp3.getRepStatus.mockReturnValue({
+                destroy: jest.fn(),
+                getPromise: () => Promise.reject(new Error('conversion failed')),
+                removeListener: jest.fn(),
+            });
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.api.get).not.toBeCalled();
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should keep empty peaks when the JSON fetch fails', async () => {
+            mp3.api.get.mockRejectedValue(new Error('network'));
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should keep empty peaks when the payload is invalid', async () => {
+            mp3.api.get.mockResolvedValue({ version: 1 });
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            expect(mp3.renderUI).not.toBeCalled();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should fall back to client decode when conversion duration mismatches media', async () => {
+            mp3.mediaEl = { duration: 30 };
+            mp3.api.get.mockResolvedValue({ version: 1, durationSec: 180, peaks: [0.2, 0.8] });
+
+            await mp3.startConversionWaveformLoad();
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            expect(mp3.startClientWaveformDecode).toBeCalled();
+        });
+
+        test('should not apply peaks after destroy mid-fetch', async () => {
+            let resolveFetch;
+            mp3.api.get.mockReturnValue(
+                new Promise(resolve => {
+                    resolveFetch = resolve;
+                }),
+            );
+            const superDestroy = jest.spyOn(MediaBaseViewer.prototype, 'destroy').mockImplementation();
+
+            const pending = mp3.startConversionWaveformLoad();
+            mp3.destroy();
+            resolveFetch(WAVEFORM_JSON);
+            await pending;
+
+            expect(mp3.waveformPeaks).toEqual([]);
+            expect(mp3.waveformPeaksSource).toBeNull();
+            superDestroy.mockRestore();
+        });
+
+        test('should not let a later client decode overwrite conversion peaks', async () => {
+            loadPeaks.mockResolvedValue({
+                payload: { peaks: [0.9, 0.1] },
+                status: 'ready',
+            });
+
+            await mp3.startConversionWaveformLoad();
+            await mp3.startClientWaveformDecode();
+
+            expect(loadPeaks).not.toBeCalled();
+            expect(mp3.waveformPeaks).toEqual(Float32Array.from([0.2, 0.8]));
+            expect(mp3.waveformPeaksSource).toBe('conversion');
+        });
+
+        test('should keep client peaks when client decode wins the race', async () => {
+            mp3.options.file.representations.entries = [conversionRep({ status: { state: 'pending' } })];
+            loadPeaks.mockResolvedValue({
+                payload: { peaks: [0.9, 0.1] },
+                status: 'ready',
+            });
+            let resolveStatus;
+            const status = {
+                destroy: jest.fn(),
+                getPromise: () =>
+                    new Promise(resolve => {
+                        resolveStatus = resolve;
+                    }),
+                removeListener: jest.fn(),
+            };
+            mp3.getRepStatus.mockReturnValue(status);
+
+            const conversion = mp3.startConversionWaveformLoad();
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([0.9, 0.1]);
+            expect(mp3.waveformPeaksSource).toBe('client');
+
+            mp3.abortClientWaveformDecode.mockClear();
+            resolveStatus();
+            await conversion;
+
+            expect(mp3.waveformPeaks).toEqual([0.9, 0.1]);
+            expect(mp3.waveformPeaksSource).toBe('client');
+            expect(mp3.api.get).not.toBeCalled();
+            expect(status.destroy).not.toBeCalled();
+            expect(mp3.abortClientWaveformDecode).not.toBeCalled();
+        });
+
+        test('should keep client peaks when client decode wins while conversion JSON is in flight', async () => {
+            loadPeaks.mockResolvedValue({
+                payload: { peaks: [0.9, 0.1] },
+                status: 'ready',
+            });
+            let resolveFetch;
+            mp3.api.get.mockReturnValue(
+                new Promise(resolve => {
+                    resolveFetch = resolve;
+                }),
+            );
+            const status = {
+                destroy: jest.fn(),
+                getPromise: () => Promise.resolve(),
+                removeListener: jest.fn(),
+            };
+            mp3.getRepStatus.mockReturnValue(status);
+
+            const conversion = mp3.startConversionWaveformLoad();
+            await Promise.resolve();
+            expect(mp3.api.get).toBeCalled();
+
+            await mp3.startClientWaveformDecode();
+
+            expect(mp3.waveformPeaks).toEqual([0.9, 0.1]);
+            expect(mp3.waveformPeaksSource).toBe('client');
+
+            resolveFetch(WAVEFORM_JSON);
+            await conversion;
+
+            expect(mp3.waveformPeaks).toEqual([0.9, 0.1]);
+            expect(mp3.waveformPeaksSource).toBe('client');
+            expect(status.destroy).not.toBeCalled();
         });
     });
 

--- a/src/lib/viewers/media/__tests__/MP3Viewer-test.js
+++ b/src/lib/viewers/media/__tests__/MP3Viewer-test.js
@@ -344,14 +344,22 @@ describe('lib/viewers/media/MP3Viewer', () => {
     });
 
     describe('loadeddataHandler()', () => {
-        test('should start playback when play was requested before metadata', () => {
+        beforeEach(() => {
             Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
             mp3.isAudioPlayerV2 = true;
+            mp3.waveformPeaksSource = null;
+            mp3.options.file = { id: 1, size: 1024 };
+            mp3.mediaEl = { duration: 30 };
+            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
+            jest.spyOn(mp3, 'renderUI').mockImplementation();
+        });
+
+        test('should start playback when play was requested before metadata', () => {
             mp3.userRequestedPlay = true;
             const order = [];
             jest.spyOn(mp3, 'play').mockImplementation(() => order.push('play'));
             jest.spyOn(mp3, 'shouldRaceClientWaveformDecode').mockReturnValue(true);
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation(() => order.push('decode'));
+            mp3.startClientWaveformDecode.mockImplementation(() => order.push('decode'));
 
             mp3.loadeddataHandler();
 
@@ -360,8 +368,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
 
         test('should not auto-start playback when play was not requested', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
             jest.spyOn(mp3, 'play').mockImplementation();
 
             mp3.loadeddataHandler();
@@ -370,9 +376,6 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
 
         test('should apply a pending host-selected seek after metadata', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
             mp3.mediaEl = document.createElement('audio');
             jest.spyOn(mp3.mediaEl, 'pause').mockImplementation();
             Object.defineProperty(mp3.mediaEl, 'duration', { configurable: true, value: 180 });
@@ -385,28 +388,15 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
 
         test('should start client decode after metadata when peaks are not applied yet', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
-            mp3.waveformPeaksSource = null;
-            mp3.options.file = { id: 1, size: 1024 };
-            mp3.mediaEl = { duration: 30 };
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
-
             mp3.loadeddataHandler();
 
             expect(mp3.startClientWaveformDecode).toBeCalled();
         });
 
         test('should drop conversion peaks when media duration mismatches', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
             mp3.waveformPeaks = [0.2, 0.8];
             mp3.waveformPeaksSource = 'conversion';
             mp3.waveformDurationSec = 180;
-            mp3.options.file = { id: 1, size: 1024 };
-            mp3.mediaEl = { duration: 30 };
-            jest.spyOn(mp3, 'renderUI').mockImplementation();
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
 
             mp3.loadeddataHandler();
 
@@ -416,15 +406,9 @@ describe('lib/viewers/media/MP3Viewer', () => {
         });
 
         test('should keep conversion peaks when media duration is within tolerance', () => {
-            Object.defineProperty(MediaBaseViewer.prototype, 'loadeddataHandler', { value: jest.fn() });
-            mp3.isAudioPlayerV2 = true;
             mp3.waveformPeaks = [0.2, 0.8];
             mp3.waveformPeaksSource = 'conversion';
             mp3.waveformDurationSec = 30 + DURATION_MISMATCH_TOLERANCE_SEC;
-            mp3.options.file = { id: 1, size: 1024 };
-            mp3.mediaEl = { duration: 30 };
-            jest.spyOn(mp3, 'renderUI').mockImplementation();
-            jest.spyOn(mp3, 'startClientWaveformDecode').mockImplementation();
 
             mp3.loadeddataHandler();
 

--- a/src/lib/viewers/media/waveform/decode.ts
+++ b/src/lib/viewers/media/waveform/decode.ts
@@ -19,7 +19,7 @@ import {
     MediaInfo,
     WaveformCaps,
 } from './types';
-import { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
+import { isPositiveFinite, isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
 
 type DecodeAudioContext = {
     close: () => Promise<void>;
@@ -34,10 +34,6 @@ const EMPTY_TIMINGS: DecodeTimings = { attemptMs: null, extractMs: null };
 
 function createAbortError(): DOMException {
     return new DOMException('Aborted', 'AbortError');
-}
-
-function isPositiveFinite(value: unknown): value is number {
-    return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 function getAudioContextConstructor(): (new () => DecodeAudioContext) | undefined {

--- a/src/lib/viewers/media/waveform/index.ts
+++ b/src/lib/viewers/media/waveform/index.ts
@@ -17,4 +17,4 @@ export {
     WaveformLoadError,
 } from './createWaveformLoader';
 export { isWaveformErrorCode, WAVEFORM_ERROR_CODES } from './types';
-export { isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';
+export { isPositiveFinite, isRetryableWaveformError, validateWaveformPayload } from './validateWaveformPayload';

--- a/src/lib/viewers/media/waveform/validateWaveformPayload.ts
+++ b/src/lib/viewers/media/waveform/validateWaveformPayload.ts
@@ -30,6 +30,10 @@ function fail(code: WaveformError['code'], message: string, retryable = false): 
     return { ok: false, error: { code, message }, retryable };
 }
 
+export function isPositiveFinite(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -129,7 +133,7 @@ function checkVersion(raw: Record<string, unknown>): WaveformValidationFailure |
 }
 
 function checkDuration(payload: WaveformPayloadV1, expectedDurationSec?: number): WaveformValidationFailure | null {
-    if (!Number.isFinite(payload.durationSec) || payload.durationSec <= 0) {
+    if (!isPositiveFinite(payload.durationSec)) {
         return fail('INVALID_DURATION', 'durationSec must be a positive finite number');
     }
 


### PR DESCRIPTION
## Summary
Audio player v2 can paint waveform peaks from conversion JSON (`waveform` representation) or from client decode. Playback does not wait on either. The first source to apply peaks wins; later results are ignored.

### Conversion load
- `load()` paints the v2 shell and starts conversion in parallel with the audio blob.
- Look up the `waveform` representation. Missing template, missing status, or `error` falls through to client decode.
- `none` / `pending` / `success` poll `RepStatus`, then GET the JSON with header auth and an `AbortSignal`.
- Conversion `durationSec` can lay out peaks and markers before the blob has metadata. The transport bar, seek, and zoom stay locked until `mediaEl.duration` is known.

### Client decode race
- After `loadeddata`, client decode starts if v2 is on, no source has applied peaks yet, and the file is under the compressed-size and duration caps (6MB / 5 minutes).
- It races even while conversion is still polling or the JSON GET is in flight.
- Retryable client-decode failures can retry once on overlay play, only while peaks are still unset.

### First-wins and mismatch
- Applying conversion peaks aborts in-flight client decode. Applying client peaks aborts the JSON fetch only (not `RepStatus`, which does not reject `getPromise()`).
- If conversion JSON arrives before metadata, duration matching is skipped. Once media duration is known, conversion peaks that disagree by more than 1s are dropped and client decode may start.
- Destroy and v1 fallback abort both loads.

## Test plan
- [ ] Conversion JSON applies peaks; client decode does not overwrite them.
- [ ] Client decode wins while conversion is still pending (no JSON GET).
- [ ] Client decode wins while conversion JSON is in flight; late JSON is ignored.
- [ ] Missing / error / invalid conversion falls back to client decode when under cap.
- [ ] Over size or duration cap: no client decode; placeholder remains if conversion never applies.
- [ ] Conversion peaks before metadata: waveform lays out, bar stays locked; bar unlocks after metadata.
- [ ] Conversion duration disagrees with media duration: peaks dropped, client decode starts.
- [ ] Marker click on the loading shell seeks once duration is known.
- [ ] Destroy mid-fetch does not apply peaks.