### PR TITLE
feat(audio): request waveform representation when v2 is enabled

### DIFF
--- a/src/lib/Preview.js
+++ b/src/lib/Preview.js
@@ -54,7 +54,9 @@ import {
     X_REP_HINT_VIDEO_DASH,
     X_REP_HINT_VIDEO_DASH_EXTRACTED_TEXT,
     X_REP_HINT_VIDEO_MP4,
+    X_REP_HINT_WAVEFORM,
     AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES,
+    AUDIO_PLAYER_V2,
     FILE_OPTION_FILE_VERSION_ID,
     VIDEO_VIEWER_NAMES,
 } from './constants';
@@ -2000,8 +2002,13 @@ class Preview extends EventEmitter {
             videoHint += X_REP_HINT_VIDEO_DASH_EXTRACTED_TEXT;
         }
 
+        let hints = `${X_REP_HINT_BASE}${X_REP_HINT_DOC_THUMBNAIL}${X_REP_HINT_IMAGE}${videoHint}`;
+        if (isFeatureEnabled(this.options.features, AUDIO_PLAYER_V2)) {
+            hints += X_REP_HINT_WAVEFORM;
+        }
+
         const headers = {
-            'X-Rep-Hints': `${X_REP_HINT_BASE}${X_REP_HINT_DOC_THUMBNAIL}${X_REP_HINT_IMAGE}${videoHint}`,
+            'X-Rep-Hints': hints,
         };
 
         return getHeaders(

--- a/src/lib/__tests__/Preview-test.js
+++ b/src/lib/__tests__/Preview-test.js
@@ -3259,12 +3259,38 @@ describe('lib/Preview', () => {
 
         test('should add extracted_text hint when ai transcription for video subtitles is enabled', () => {
             stubs.canPlayDash.mockReturnValue(true);
-            isFeatureEnabled.mockReturnValue(true);
+            isFeatureEnabled.mockImplementation((_, feature) => feature === 'aiTranscriptionForVideoSubtitles');
             stubs.headers['X-Rep-Hints'] += '[dash,mp4][filmstrip][extracted_text]';
 
             preview.getRequestHeaders();
             expect(stubs.getHeaders).toHaveBeenCalledWith(stubs.headers, 'previewtoken', 'link', 'Passw0rd!');
             expect(isFeatureEnabled).toHaveBeenCalledWith(preview.options.features, 'aiTranscriptionForVideoSubtitles');
+        });
+
+        test('should add waveform hint when audio player v2 is enabled', () => {
+            isFeatureEnabled.mockImplementation((_, feature) => feature === 'audioPlayerV2.enabled');
+            stubs.headers['X-Rep-Hints'] += '[mp4][waveform]';
+
+            preview.getRequestHeaders();
+            expect(stubs.getHeaders).toHaveBeenCalledWith(stubs.headers, 'previewtoken', 'link', 'Passw0rd!');
+            expect(isFeatureEnabled).toHaveBeenCalledWith(preview.options.features, 'audioPlayerV2.enabled');
+        });
+
+        test('should add waveform hint with dash filmstrip when audio player v2 is enabled', () => {
+            stubs.canPlayDash.mockReturnValue(true);
+            isFeatureEnabled.mockImplementation((_, feature) => feature === 'audioPlayerV2.enabled');
+            stubs.headers['X-Rep-Hints'] += '[dash,mp4][filmstrip][waveform]';
+
+            preview.getRequestHeaders();
+            expect(stubs.getHeaders).toHaveBeenCalledWith(stubs.headers, 'previewtoken', 'link', 'Passw0rd!');
+        });
+
+        test('should not add waveform hint when audio player v2 is disabled', () => {
+            isFeatureEnabled.mockReturnValue(false);
+            stubs.headers['X-Rep-Hints'] += '[mp4]';
+
+            preview.getRequestHeaders();
+            expect(stubs.getHeaders).toHaveBeenCalledWith(stubs.headers, 'previewtoken', 'link', 'Passw0rd!');
         });
 
         test('should not add extracted_text hint when ai transcription for video subtitles is disabled', () => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -104,6 +104,7 @@ export const X_REP_HINT_IMAGE = '[jpg?dimensions=2048x2048,png?dimensions=2048x2
 export const X_REP_HINT_VIDEO_DASH = '[dash,mp4][filmstrip]';
 export const X_REP_HINT_VIDEO_DASH_EXTRACTED_TEXT = '[extracted_text]';
 export const X_REP_HINT_VIDEO_MP4 = '[mp4]';
+export const X_REP_HINT_WAVEFORM = '[waveform]';
 
 export const AI_TRANSCRIPTION_FOR_VIDEO_SUBTITLES = 'aiTranscriptionForVideoSubtitles';
 export const AUDIO_PLAYER_V2 = 'audioPlayerV2.enabled';


### PR DESCRIPTION
## Summary
When audio player v2 is enabled, `getRequestHeaders()` appends `[waveform]` to `X-Rep-Hints` so the Files API can start (or return) the conversion representation.

This is the Preview SDK path only. Hosts that set `skipServerUpdate` (ContentPreview, prefetch in preview-client / EndUserApp) send their own hinted GET and need matching follow-ups.

Also tightens the extracted_text header test so a true `isFeatureEnabled` mock cannot accidentally add `[waveform]`.

## Test plan
- [ ] v2 on: file GET includes `[waveform]` (with mp4, and with dash + filmstrip).
- [ ] v2 off: header is unchanged.
- [ ] Transcription hint still adds `[extracted_text]` without `[waveform]` when v2 is off.