### PR TITLE
feat(audio): add a pin-centered tape waveform for touch devices

### DIFF
--- a/src/lib/viewers/media/MP3ControlsV2.scss
+++ b/src/lib/viewers/media/MP3ControlsV2.scss
@@ -42,11 +42,21 @@
     overflow: visible;
 }
 
+// Tape: at least the desktop bar height (140px), and at least 25% of the player
+// stage (same box as `.bp-media-container`). Percentage on `.bp-WaveformView`
+// itself would resolve against this wrapper's shrink-wrapped height and collapse.
+.bp-MP3ControlsV2-stage:has(.bp-WaveformView--tape) .bp-MP3ControlsV2-waveform {
+    display: flex;
+    flex-direction: column;
+    height: max(var(--bp-waveform-bar-min, 140px), 25%);
+    min-height: 0;
+}
+
 .bp-MP3ControlsV2-waveformZoom {
     position: absolute;
     top: 48px;
     right: 48px;
-    z-index: 3;
+    z-index: 6;
     pointer-events: none;
 
     .bp-WaveformZoomControl {

--- a/src/lib/viewers/media/MP3ControlsV2.tsx
+++ b/src/lib/viewers/media/MP3ControlsV2.tsx
@@ -8,10 +8,11 @@ import TimestampControl from '../controls/media/TimestampControl';
 import { CommentMarker } from '../controls/media/markers';
 import VolumeControls, { Props as VolumeControlsProps } from '../controls/media/VolumeControls';
 import { ICON_PLAY_LARGE } from '../../icons';
-import { WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_MIN } from './waveform/constants';
+import { WAVEFORM_HEIGHT, WAVEFORM_ZOOM_DISMISS_MS, WAVEFORM_ZOOM_MIN } from './waveform/constants';
 import { PLACEHOLDER_DURATION_SEC, placeholderPeaks } from './waveform/peaks';
 import { WaveformViewport } from './waveform/types';
-import { clampWaveformZoom, viewportEquals } from './waveform/viewport';
+import { clampWaveformZoom, getTapeDefaultZoom, viewportEquals } from './waveform/viewport';
+import useTapeWaveform from './waveform/useTapeWaveform';
 import WaveformCommentMarkers from './waveform/WaveformCommentMarkers';
 import WaveformView from './waveform/WaveformView';
 import WaveformZoomControl from './waveform/WaveformZoomControl';
@@ -57,12 +58,15 @@ export default function MP3ControlsV2({
     const [zoomLevel, setZoomLevel] = useState(WAVEFORM_ZOOM_MIN);
     const [maxZoom, setMaxZoom] = useState(WAVEFORM_ZOOM_MIN);
     const [isZoomRevealed, setIsZoomRevealed] = useState(false);
-    const zoomRevealTimerRef = useRef(0);
+    const zoomRevealTimerRef = useRef(0); // hides the zoom flyout after WAVEFORM_ZOOM_DISMISS_MS
     const hasRealPeaks = !!(peaks && peaks.length);
     const waveformPeaks = hasRealPeaks ? peaks : PLACEHOLDER_PEAKS;
     const waveformDurationSec = hasWaveformDuration ? durationValue : PLACEHOLDER_DURATION_SEC;
     const [playRequested, setPlayRequested] = useState(false);
     const [viewport, setViewport] = useState<WaveformViewport | null>(null);
+    const isTape = useTapeWaveform();
+    const hasAppliedTapeDefaultZoomRef = useRef(false); // ~10s window applied; reset to 1× when leaving tape
+    const userChangedTapeZoomRef = useRef(false); // pinch/wheel zoom; skip re-applying the 10s default
     const handleViewportChange = useCallback((next: WaveformViewport) => {
         setMaxZoom(prev => (prev === next.maxZoom ? prev : next.maxZoom));
         setViewport(prev => (viewportEquals(prev, next) ? prev : next));
@@ -79,6 +83,7 @@ export default function MP3ControlsV2({
 
     const handleWaveformZoom = useCallback(
         (nextZoom: number) => {
+            userChangedTapeZoomRef.current = true;
             setZoomLevel(nextZoom);
             revealZoomControl();
         },
@@ -88,6 +93,27 @@ export default function MP3ControlsV2({
     useEffect(() => {
         setZoomLevel(prev => clampWaveformZoom(prev, maxZoom));
     }, [maxZoom]);
+
+    useEffect(() => {
+        if (!isTape) {
+            if (hasAppliedTapeDefaultZoomRef.current) {
+                hasAppliedTapeDefaultZoomRef.current = false;
+                userChangedTapeZoomRef.current = false;
+                setZoomLevel(WAVEFORM_ZOOM_MIN);
+            }
+            return;
+        }
+        if (!hasWaveformDuration || !hasRealPeaks || !viewport || !(viewport.widthPx > 0)) {
+            return;
+        }
+        if (userChangedTapeZoomRef.current) {
+            hasAppliedTapeDefaultZoomRef.current = true;
+            return;
+        }
+        const nextZoom = getTapeDefaultZoom(durationValue, Math.max(maxZoom, viewport.maxZoom));
+        hasAppliedTapeDefaultZoomRef.current = true;
+        setZoomLevel(prev => (prev === nextZoom ? prev : nextZoom));
+    }, [durationValue, hasRealPeaks, hasWaveformDuration, isTape, maxZoom, viewport]);
 
     useEffect(() => () => window.clearTimeout(zoomRevealTimerRef.current), []);
 
@@ -126,26 +152,35 @@ export default function MP3ControlsV2({
     const showPlayOverlay = !playRequested && !isPlaying;
     const hasZoomHandlers = hasRealPeaks && !showPlayOverlay;
     const hasZoomControl = hasZoomHandlers && hasMediaMetadata && maxZoom > WAVEFORM_ZOOM_MIN;
+    const waveformZoomLevel = isTape || hasZoomHandlers ? zoomLevel : WAVEFORM_ZOOM_MIN;
 
     return (
-        <div className="bp-MP3ControlsV2" data-testid="media-controls-wrapper-v2">
+        <div
+            className="bp-MP3ControlsV2"
+            data-testid="media-controls-wrapper-v2"
+            style={{ '--bp-waveform-bar-min': `${WAVEFORM_HEIGHT}px` } as React.CSSProperties}
+        >
             <div className="bp-MP3ControlsV2-stage">
                 <div className="bp-MP3ControlsV2-waveform">
                     <WaveformView
                         bufferedRange={bufferedRange}
+                        cameraMode={isTape ? 'tape' : 'desktop'}
                         currentTime={currentTime}
                         durationSec={waveformDurationSec}
                         interactive={isWaveformInteractive}
+                        isPlaying={isPlaying}
                         mediaEl={mediaEl}
+                        onPlayPause={isWaveformInteractive ? onPlayPause : undefined}
                         onSeek={isWaveformInteractive ? onTimeChange : undefined}
                         onViewportChange={hasRealPeaks ? handleViewportChange : undefined}
                         onZoomChange={hasZoomHandlers ? handleWaveformZoom : undefined}
                         peaks={waveformPeaks}
-                        zoomLevel={hasZoomHandlers ? zoomLevel : WAVEFORM_ZOOM_MIN}
+                        zoomLevel={waveformZoomLevel}
                     />
                     <WaveformCommentMarkers
                         commentMarkers={waveformMarkers}
                         durationSec={hasWaveformDuration ? durationValue : 0}
+                        isTape={isTape}
                         onCommentMarkerClick={handleCommentMarkerClick}
                         selectedId={selectedMarkerId}
                         viewport={viewport}
@@ -156,7 +191,7 @@ export default function MP3ControlsV2({
                         <WaveformZoomControl
                             isRevealed={isZoomRevealed}
                             maxZoom={maxZoom}
-                            onZoomChange={setZoomLevel}
+                            onZoomChange={handleWaveformZoom}
                             zoomLevel={zoomLevel}
                         />
                     </div>

--- a/src/lib/viewers/media/MediaBaseViewer.js
+++ b/src/lib/viewers/media/MediaBaseViewer.js
@@ -207,10 +207,9 @@ class MediaBaseViewer extends BaseViewer {
         this.mediaEl.addEventListener('error', this.errorHandler);
         this.mediaEl.setAttribute('title', this.options.file.name);
 
-        if (Browser.isIOS()) {
-            // iOS doesn't fire loadeddata event until some data loads
-            // Adding autoplay prevents this but won't actually autoplay the video.
-            // https://webkit.org/blog/6784/new-video-policies-for-ios/
+        if (Browser.isIOS() && this.mediaEl.tagName === 'VIDEO') {
+            // Unblocks loadeddata on iOS <video>. Do not set this on <audio>:
+            // after tap-to-open, Safari will start playback.
             this.mediaEl.autoplay = true;
         }
 

--- a/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
+++ b/src/lib/viewers/media/__tests__/MP3ControlsV2-test.tsx
@@ -3,19 +3,31 @@ import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MP3ControlsV2, { Props } from '../MP3ControlsV2';
 import { WAVEFORM_ZOOM_DISMISS_MS } from '../waveform/constants';
+import useTapeWaveform from '../waveform/useTapeWaveform';
+
+jest.mock('../waveform/useTapeWaveform', () => ({
+    __esModule: true,
+    default: jest.fn(() => false),
+}));
+
+const mockMountViewport = { maxZoom: 4, widthPx: 800 };
 
 jest.mock('../waveform/WaveformView', () => {
     function MockWaveformView({
+        cameraMode,
         durationSec = 0,
         interactive,
         onViewportChange,
         onZoomChange,
+        zoomLevel = 1,
     }: {
+        cameraMode?: string;
         durationSec?: number;
         interactive?: boolean;
         onViewportChange?: (viewport: {
             durationSec: number;
             endSec: number;
+            gutterPx: number;
             heightPx: number;
             maxZoom: number;
             pixelsPerSecond: number;
@@ -25,16 +37,19 @@ jest.mock('../waveform/WaveformView', () => {
             zoomLevel: number;
         }) => void;
         onZoomChange?: (zoomLevel: number) => void;
+        zoomLevel?: number;
     }): JSX.Element {
         const overview = {
             durationSec,
             endSec: durationSec,
+            gutterPx: 0,
             heightPx: 140,
-            maxZoom: 4,
-            pixelsPerSecond: durationSec > 0 ? 800 / durationSec : 0,
+            maxZoom: mockMountViewport.maxZoom,
+            pixelsPerSecond:
+                durationSec > 0 && mockMountViewport.widthPx > 0 ? mockMountViewport.widthPx / durationSec : 0,
             scrollLeftPx: 0,
             startSec: 0,
-            widthPx: 800,
+            widthPx: mockMountViewport.widthPx,
             zoomLevel: 1,
         };
         mockUseEffect(() => {
@@ -42,9 +57,12 @@ jest.mock('../waveform/WaveformView', () => {
         }, [durationSec, onViewportChange]);
         return (
             <div
+                className={cameraMode === 'tape' ? 'bp-WaveformView--tape' : undefined}
+                data-camera-mode={cameraMode || 'desktop'}
                 data-duration-sec={String(durationSec)}
                 data-interactive={interactive ? 'true' : 'false'}
                 data-testid="bp-waveform-view"
+                data-zoom-level={String(zoomLevel)}
             >
                 <button data-testid="bp-mock-waveform-zoom" onClick={() => onZoomChange?.(2)} type="button">
                     zoom
@@ -80,6 +98,20 @@ jest.mock('../waveform/WaveformView', () => {
                     viewport pan
                 </button>
                 <button
+                    data-testid="bp-mock-waveform-viewport-ready"
+                    onClick={() =>
+                        onViewportChange?.({
+                            ...overview,
+                            maxZoom: 4,
+                            pixelsPerSecond: durationSec > 0 ? 800 / durationSec : 0,
+                            widthPx: 800,
+                        })
+                    }
+                    type="button"
+                >
+                    ready
+                </button>
+                <button
                     data-testid="bp-mock-waveform-max-zoom"
                     onClick={() => onViewportChange?.({ ...overview, maxZoom: 1.2, widthPx: 1600 })}
                     type="button"
@@ -111,6 +143,9 @@ afterAll(() => {
 describe('MP3ControlsV2', () => {
     afterEach(() => {
         jest.useRealTimers();
+        mockMountViewport.maxZoom = 4;
+        mockMountViewport.widthPx = 800;
+        (useTapeWaveform as jest.Mock).mockReturnValue(false);
     });
 
     const hostCommentMarkers = [
@@ -155,6 +190,9 @@ describe('MP3ControlsV2', () => {
             getWrapper({ durationTime: 8, peaks: [0.2, 0.8] });
 
             expect(await screen.findByTestId('media-controls-wrapper-v2')).toHaveClass('bp-MP3ControlsV2');
+            expect(
+                screen.getByTestId('media-controls-wrapper-v2').style.getPropertyValue('--bp-waveform-bar-min'),
+            ).toBe('140px');
         });
 
         test('should render the waveform instead of the time slider', async () => {
@@ -322,6 +360,79 @@ describe('MP3ControlsV2', () => {
             expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-interactive', 'true');
             expect(screen.queryByTestId('bp-MP3ControlsV2-play-overlay')).not.toBeInTheDocument();
             expect(screen.queryByTestId('bp-waveform-zoom')).not.toBeInTheDocument();
+        });
+
+        test('should use the tape camera, a 10s default window, and keep the zoom control collapsed', async () => {
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            getWrapper({
+                commentMarkers: hostCommentMarkers,
+                durationTime: 100,
+                isPlaying: true,
+                peaks: new Array(800).fill(0.5),
+            });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-camera-mode', 'tape');
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '4');
+            expect(screen.getByTestId('bp-waveform-zoom')).toBeInTheDocument();
+            expect(screen.getByTestId('bp-waveform-zoom')).not.toHaveClass('bp-is-open');
+            expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--tape');
+        });
+
+        test('should load tape zoom at the 10s window before play', async () => {
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            getWrapper({ durationTime: 100, peaks: new Array(800).fill(0.5) });
+
+            expect(await screen.findByTestId('bp-MP3ControlsV2-play-overlay')).toBeInTheDocument();
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-camera-mode', 'tape');
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '4');
+        });
+
+        test('should load tape zoom at the 10s window before audio metadata', async () => {
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            const mediaEl = document.createElement('audio');
+            Object.defineProperty(mediaEl, 'duration', { configurable: true, value: NaN });
+            getWrapper({ durationTime: 100, mediaEl, peaks: new Array(800).fill(0.5) });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-duration-sec', '100');
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '4');
+            expect(screen.queryByTestId('bp-MP3ControlsV2-bar')).not.toBeInTheDocument();
+        });
+
+        test('should default short tape files to 1x zoom', async () => {
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            getWrapper({ durationTime: 8, isPlaying: true, peaks: new Array(800).fill(0.5) });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '1');
+        });
+
+        test('should apply the tape 10s window after the canvas reports a width', async () => {
+            mockMountViewport.maxZoom = 1;
+            mockMountViewport.widthPx = 0;
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            getWrapper({ durationTime: 100, isPlaying: true, peaks: new Array(800).fill(0.5) });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '1');
+
+            await userEvent.click(screen.getByTestId('bp-mock-waveform-viewport-ready'));
+
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '4');
+        });
+
+        test('should keep overlay zoom on tape after a later viewport pan', async () => {
+            (useTapeWaveform as jest.Mock).mockReturnValue(true);
+            getWrapper({ durationTime: 100, isPlaying: true, peaks: new Array(800).fill(0.5) });
+
+            expect(await screen.findByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', '4');
+
+            await userEvent.click(screen.getByTestId('bp-waveform-zoom-in'));
+            await userEvent.click(screen.getByTestId('bp-waveform-zoom-out'));
+
+            const zoomedOut = screen.getByTestId('bp-waveform-view').getAttribute('data-zoom-level');
+            expect(zoomedOut).not.toBe('4');
+
+            await userEvent.click(screen.getByTestId('bp-mock-waveform-viewport-pan'));
+
+            expect(screen.getByTestId('bp-waveform-view')).toHaveAttribute('data-zoom-level', zoomedOut);
         });
 
         test('should open the zoom slider on waveform zoom and dismiss after the delay', async () => {

--- a/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
+++ b/src/lib/viewers/media/__tests__/MediaBaseViewer-test.js
@@ -151,6 +151,18 @@ describe('lib/viewers/media/MediaBaseViewer', () => {
             });
         });
 
+        test('should not enable html autoplay on iOS for audio', () => {
+            jest.spyOn(Browser, 'isIOS').mockReturnValue(true);
+            jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });
+            jest.spyOn(media, 'createContentUrlV2').mockReturnValue('http://localhost/content');
+            jest.spyOn(media, 'fetchContentAsBlobUrl').mockResolvedValue('blob:media');
+            media.mediaEl = document.createElement('audio');
+
+            return media.load().then(() => {
+                expect(media.mediaEl.autoplay).toBe(false);
+            });
+        });
+
         test('should invoke startLoadTimer()', () => {
             jest.spyOn(media, 'startLoadTimer');
             jest.spyOn(media, 'getRepStatus').mockReturnValue({ getPromise: () => Promise.resolve() });

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.scss
@@ -13,11 +13,18 @@
     pointer-events: auto;
 }
 
-.bp-WaveformCommentMarkers--zoomed {
+.bp-WaveformCommentMarkers--zoomed,
+.bp-WaveformCommentMarkers--tape {
     padding: 0;
 
     // Pair clip + visible so this overlay does not become a scroll container
     overflow: clip visible;
+}
+
+.bp-WaveformCommentMarkers--tape {
+    top: auto;
+    bottom: 100%;
+    margin-bottom: 12px;
 }
 
 .bp-WaveformCommentMarkers-track {
@@ -27,7 +34,8 @@
     overflow: visible;
 }
 
-.bp-WaveformCommentMarkers--zoomed .bp-WaveformCommentMarkers-track {
+.bp-WaveformCommentMarkers--zoomed .bp-WaveformCommentMarkers-track,
+.bp-WaveformCommentMarkers--tape .bp-WaveformCommentMarkers-track {
     overflow: clip visible;
 }
 

--- a/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
+++ b/src/lib/viewers/media/waveform/WaveformCommentMarkers.tsx
@@ -17,6 +17,8 @@ const WAVEFORM_MARKER_SIZE_PX = 20;
 export type WaveformCommentMarkersProps = {
     commentMarkers: CommentMarker[];
     durationSec: number;
+    /** Tape camera: badges sit above the wave. Do not infer this from gutterPx. */
+    isTape?: boolean;
     onCommentMarkerClick?: (marker: CommentMarker) => void;
     /** Host-selected marker (activity feed / BUE). */
     selectedId?: string | null;
@@ -63,16 +65,18 @@ function clustersByExactTime(markers: CommentMarker[], durationSec: number): Clu
 export default function WaveformCommentMarkers({
     commentMarkers,
     durationSec,
+    isTape = false,
     onCommentMarkerClick,
     selectedId: hostSelectedId = null,
     viewport = null,
 }: WaveformCommentMarkersProps): JSX.Element | null {
-    const trackRef = useRef<HTMLDivElement>(null);
+    const trackRef = useRef<HTMLDivElement>(null); // width source for clustering overlapping badges
     const { containerRef, selectMarker, selectedId } = useDismissableMarkerSelection(hostSelectedId);
     const [trackWidth, setTrackWidth] = useState(0);
     const canShowTrack = durationSec > 0 && commentMarkers.length > 0;
     const zoomLevel = viewport?.zoomLevel ?? WAVEFORM_ZOOM_MIN;
-    const isZoomed = hasMappedWindow(viewport) && viewport.zoomLevel > WAVEFORM_ZOOM_MIN;
+    const alignsMarkersToVisibleWindow =
+        hasMappedWindow(viewport) && (viewport.zoomLevel > WAVEFORM_ZOOM_MIN || isTape);
 
     useLayoutEffect(() => {
         if (!canShowTrack) {
@@ -120,7 +124,9 @@ export default function WaveformCommentMarkers({
     return (
         <div
             ref={containerRef}
-            className={`bp-WaveformCommentMarkers${isZoomed ? ' bp-WaveformCommentMarkers--zoomed' : ''}`}
+            className={`bp-WaveformCommentMarkers${
+                alignsMarkersToVisibleWindow ? ' bp-WaveformCommentMarkers--zoomed' : ''
+            }${isTape ? ' bp-WaveformCommentMarkers--tape' : ''}`}
             data-testid="bp-waveform-comment-markers"
         >
             <div ref={trackRef} className="bp-WaveformCommentMarkers-track">

--- a/src/lib/viewers/media/waveform/WaveformView.scss
+++ b/src/lib/viewers/media/waveform/WaveformView.scss
@@ -8,8 +8,10 @@
     padding: 0 60px;
     overflow: visible;
     background: none;
+    -webkit-tap-highlight-color: transparent;
 
-    &.bp-WaveformView--zoomed {
+    &.bp-WaveformView--zoomed,
+    &.bp-WaveformView--tape {
         padding: 0;
         touch-action: none;
 
@@ -22,6 +24,26 @@
             > *::part(scroll) {
                 overscroll-behavior-x: none;
             }
+        }
+    }
+
+    &.bp-WaveformView--tape {
+        flex: 1 1 auto;
+        height: 100%;
+        min-height: 0;
+
+        .bp-WaveformView-canvas {
+            height: 100%;
+
+            // Beat WaveSurfer's inline overflow-x:hidden at tape 1x so gutter margins can pan.
+            > *::part(scroll) {
+                overflow-x: auto !important;
+                scrollbar-width: none;
+            }
+        }
+
+        .bp-WaveformView-playhead {
+            height: calc(100% + 10px);
         }
     }
 }
@@ -64,6 +86,14 @@
     margin-top: 4px;
     pointer-events: none;
     transform: translateX(-50%);
+}
+
+.bp-WaveformView-hover--tape {
+    // Center on the 24px comment row (12px gap + 12px to row midpoint).
+    top: -24px;
+    z-index: 5;
+    margin-top: 0;
+    transform: translate(-50%, -50%);
 }
 
 .bp-WaveformView-hoverTime {

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -92,7 +92,11 @@ function applyWaveformGutters(wavesurfer: WaveSurfer, gutterPx: number): void {
     const scroll = wrapper.parentElement;
     if (scroll && scroll.style) {
         scroll.style.overflowX = gutterPx > 0 ? 'auto' : '';
-        scroll.style.scrollbarWidth = gutterPx > 0 ? 'none' : '';
+        if (gutterPx > 0) {
+            scroll.style.setProperty('scrollbar-width', 'none');
+        } else {
+            scroll.style.removeProperty('scrollbar-width');
+        }
     }
 }
 

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import WaveSurfer from 'wavesurfer.js';
 import { getCurrentTimeMs } from '../../../util';
 import {
     getBufferedProgress,
+    getPlayedWaveformColor,
     getWaveformFills,
     tintWaveformTiles,
     toCanvasFill,
-    WAVEFORM_COLOR_PLAYED,
     WAVEFORM_COLOR_UNPLAYED,
 } from './colors';
 import {
@@ -14,7 +15,9 @@ import {
     WAVEFORM_BAR_MIN_HEIGHT,
     WAVEFORM_BAR_RADIUS,
     WAVEFORM_BAR_WIDTH,
+    WAVEFORM_FOLLOW_SCROLL_SETTLE_MS,
     WAVEFORM_HEIGHT,
+    WAVEFORM_TAPE_CLICK_SUPPRESS_MS,
     WAVEFORM_ZOOM_DISMISS_MS,
     WAVEFORM_ZOOM_MIN,
 } from './constants';
@@ -24,10 +27,12 @@ import usePlayheadCamera from './usePlayheadCamera';
 import {
     clampWaveformZoom,
     createWaveformViewport,
+    getCenteredScrollLeft,
+    getTapeGutterPx,
+    getTapePinnedPlayheadLeft,
     getViewportAtScroll,
     getWaveformZoomMax,
     getZoomedPixelsPerSecond,
-    maxScrollLeft,
     timeFromPositionPx,
     timeLeftPercent,
 } from './viewport';
@@ -73,6 +78,24 @@ function disableScrollOverscroll(container: HTMLElement): void {
     }
 }
 
+/** Half-view margins so t=0 and duration can sit under the center pin. */
+function applyWaveformGutters(wavesurfer: WaveSurfer, gutterPx: number): void {
+    const wrapper = wavesurfer.getWrapper ? wavesurfer.getWrapper() : null;
+    if (!wrapper || !wrapper.style) {
+        return;
+    }
+    const pad = gutterPx > 0 ? `${gutterPx}px` : '';
+    wrapper.style.marginLeft = pad;
+    wrapper.style.marginRight = pad;
+    // WaveSurfer sets overflow-x:hidden when duration * minPxPerSec <= view width
+    // (tape 1x). Gutters live in these margins, so the scroller must stay pan-able.
+    const scroll = wrapper.parentElement;
+    if (scroll && scroll.style) {
+        scroll.style.overflowX = gutterPx > 0 ? 'auto' : '';
+        scroll.style.scrollbarWidth = gutterPx > 0 ? 'none' : '';
+    }
+}
+
 /** Tint WaveSurfer's zoomed tiles with played/unplayed/hover/buffer colors. */
 function tintZoomedWaveform(wavesurfer: WaveSurfer, fills: WaveformFills, replaceSnapshot = false): void {
     const wrapper = wavesurfer.getWrapper ? wavesurfer.getWrapper() : null;
@@ -85,6 +108,17 @@ function tintZoomedWaveform(wavesurfer: WaveSurfer, fills: WaveformFills, replac
         replaceSnapshot,
         totalWidthCss: wrapper.clientWidth,
     });
+}
+
+/** Touch (and the compatibility mouse events Chrome sends after a tap) must not drive hover fills. */
+function isTouchHoverInput(event: { nativeEvent: Event; pointerType?: string }): boolean {
+    if (event.pointerType === 'touch') {
+        return true;
+    }
+    const native = event.nativeEvent as MouseEvent & {
+        sourceCapabilities?: { firesTouchEvents?: boolean };
+    };
+    return !!native.sourceCapabilities?.firesTouchEvents;
 }
 
 function touchDistance(touches: TouchList): number {
@@ -119,11 +153,14 @@ function zoomOriginAtPointer(
  */
 function WaveformView({
     bufferedRange,
+    cameraMode = 'desktop',
     currentTime = 0,
     durationSec,
     height = WAVEFORM_HEIGHT,
     interactive = true,
+    isPlaying = false,
     mediaEl,
+    onPlayPause,
     onSeek,
     onViewportChange,
     onZoomChange,
@@ -131,37 +168,51 @@ function WaveformView({
     zoomLevel: zoomLevelProp,
 }: WaveformViewProps): JSX.Element {
     // DOM / WaveSurfer
-    const containerRef = useRef<HTMLDivElement>(null);
-    const trackRef = useRef<HTMLDivElement>(null);
-    const playheadRef = useRef<HTMLDivElement>(null);
-    const playheadAnimationRef = useRef(0);
-    const wavesurferRef = useRef<WaveSurfer | null>(null);
+    const containerRef = useRef<HTMLDivElement>(null); // WaveSurfer canvas host
+    const trackRef = useRef<HTMLDivElement>(null); // hover / tap target around the canvas
+    const playheadRef = useRef<HTMLDivElement>(null); // playhead element the camera positions
+    const playheadAnimationRef = useRef(0); // animation frame id while the playhead follows playback
+    const wavesurferRef = useRef<WaveSurfer | null>(null); // WaveSurfer instance
 
     // Latest props for WaveSurfer + media listeners that must not re-subscribe each render.
-    const onSeekRef = useRef(onSeek);
-    const interactiveRef = useRef(interactive);
-    const hasZoomHandlersRef = useRef(false);
-    const currentTimeRef = useRef(currentTime);
-    const peaksRef = useRef(peaks);
-    const durationSecRef = useRef(durationSec);
-    const mediaElRef = useRef(mediaEl);
-    const onViewportChangeRef = useRef(onViewportChange);
+    const onSeekRef = useRef(onSeek); // latest onSeek; click/scroll handlers must not re-bind
+    const onPlayPauseRef = useRef(onPlayPause); // latest play/pause; tape tap must not re-bind
+    const interactiveRef = useRef(interactive); // latest interactive; WaveSurfer listeners read this
+    const isPlayingRef = useRef(isPlaying); // latest isPlaying; tape tap toggles from this
+    const cameraModeRef = useRef(cameraMode); // latest tape/desktop; WaveSurfer create() deps stay empty
+    const hasZoomHandlersRef = useRef(false); // parent can zoom; wheel/pinch check this
+    const currentTimeRef = useRef(currentTime); // latest media time; zoom recenter reads this
+    const peaksRef = useRef(peaks); // latest peaks; WaveSurfer create() + morph read this
+    const durationSecRef = useRef(durationSec); // latest duration; click-to-seek reads this
+    const mediaElRef = useRef(mediaEl); // latest <audio>/<video>; camera + playhead tick read this
+    const onViewportChangeRef = useRef(onViewportChange); // latest viewport callback; camera commits here
 
-    const displayedPeaksRef = useRef<ArrayLike<number> | null>(null);
-    const peakTransitionAnimationRef = useRef(0);
+    const displayedPeaksRef = useRef<ArrayLike<number> | null>(null); // peaks currently drawn (for morph)
+    const peakTransitionAnimationRef = useRef(0); // animation frame id while peaks morph in
     // Zoom / pinch / tile tint (read from pointer + WaveSurfer handlers)
-    const zoomOriginRef = useRef<ZoomOrigin | null>(null);
-    const pinchStartRef = useRef<{ distance: number; zoom: number } | null>(null);
-    const pointerZoomRef = useRef(false);
-    const pointerZoomClearTimerRef = useRef(0);
-    const applyZoomWindowRef = useRef<(() => void) | null>(null);
+    const zoomOriginRef = useRef<ZoomOrigin | null>(null); // pointer+time so zoom keeps that point fixed
+    const pinchStartRef = useRef<{ distance: number; zoom: number } | null>(null); // two-finger distance and zoom at pinch start
+    const pointerZoomRef = useRef(false); // pinch/wheel in progress; skip play/pause and tape recenter
+    const pointerZoomClearTimerRef = useRef(0); // clears pointerZoomRef after WAVEFORM_ZOOM_DISMISS_MS
+    const hideScrubTimeChipTimerRef = useRef(0); // hides the tape scrub time chip after scroll settles
+    const suppressNextTapPlayPauseRef = useRef(false); // swallow play/pause after a swipe or pinch
+    const suppressNextTapPlayPauseTimerRef = useRef(0); // clears suppressNextTapPlayPauseRef
+    const tapeSeekAnimationRef = useRef(0); // coalesces swipe seeks to one seek per animation frame
+    const queuedTapeSeekTimeSecRef = useRef<number | null>(null); // seek time waiting for the next animation frame
+    const applyZoomWindowRef = useRef<(() => void) | null>(null); // latest applyZoomWindow; resize observer calls this
+    const liveHeightRef = useRef(height); // canvas height last applied to WaveSurfer
+    const lastObservedWidthRef = useRef(0); // last ResizeObserver width; skip no-op resizes
+    const toggleTapePlaybackRef = useRef<(() => void) | null>(null); // latest tap play/pause; click/pointerup call this
     // WaveSurfer `setOptions` fires zoom/scroll before we apply the intended scroll.
-    const suppressViewportSyncRef = useRef(false);
-    const bufferProgressRef = useRef(0);
-    const hoverProgressRef = useRef<number | null>(null);
+    const suppressViewportSyncRef = useRef(false); // ignore WaveSurfer zoom/scroll while we setOptions
+    const bufferProgressRef = useRef(0); // latest buffer fill; zoomed tile tint reads this
+    const hoverProgressRef = useRef<number | null>(null); // latest hover fill; zoomed tile tint reads this
 
     onSeekRef.current = onSeek;
+    onPlayPauseRef.current = onPlayPause;
     interactiveRef.current = interactive;
+    isPlayingRef.current = isPlaying;
+    cameraModeRef.current = cameraMode;
     currentTimeRef.current = currentTime;
     peaksRef.current = peaks;
     durationSecRef.current = durationSec;
@@ -170,6 +221,8 @@ function WaveformView({
 
     const [internalZoom, setInternalZoom] = useState(WAVEFORM_ZOOM_MIN);
     const [hoverProgress, setHoverProgress] = useState<number | null>(null);
+    const [scrubPreviewTimeSec, setScrubPreviewTimeSec] = useState<number | null>(null);
+    const [overlayPortalHost, setOverlayPortalHost] = useState<HTMLElement | null>(null);
     const [canvasWidthPx, setCanvasWidthPx] = useState(0);
     const [scrollLeft, setScrollLeft] = useState(0);
     const isControlled = typeof zoomLevelProp === 'number';
@@ -183,8 +236,10 @@ function WaveformView({
     const zoomLevel = clampWaveformZoom(isControlled ? zoomLevelProp : internalZoom, maxZoom);
     const zoomRef = useRef(zoomLevel); // latest zoom for WaveSurfer redraw/zoom handlers
     zoomRef.current = zoomLevel;
-    const prevZoomRef = useRef<number | null>(null);
+    const prevZoomRef = useRef<number | null>(null); // last applied zoom; tape recenters only when this changes
+    const isTape = cameraMode === 'tape';
     const isZoomed = zoomLevel > WAVEFORM_ZOOM_MIN;
+    const isScrollableWindow = isZoomed || isTape;
     const bufferProgress = getBufferedProgress(bufferedRange, durationSec);
     bufferProgressRef.current = bufferProgress;
     hoverProgressRef.current = hoverProgress;
@@ -193,13 +248,14 @@ function WaveformView({
         () =>
             createWaveformViewport({
                 durationSec,
+                gutterPx: isTape ? getTapeGutterPx(canvasWidthPx) : 0,
                 heightPx: height,
                 maxZoom,
                 scrollLeftPx: scrollLeft,
                 widthPx: canvasWidthPx,
                 zoomLevel,
             }),
-        [canvasWidthPx, durationSec, height, maxZoom, scrollLeft, zoomLevel],
+        [canvasWidthPx, durationSec, height, isTape, maxZoom, scrollLeft, zoomLevel],
     );
     const viewportRef = useRef(viewport); // live scroll window; prefer this over render-state while the camera is moving
     const onViewportCommit = useCallback(
@@ -218,11 +274,13 @@ function WaveformView({
         clearFollowPin,
         handleScroll: handleCameraScroll,
         isFollowPinned,
+        isUserPanning,
         onSeek: onPlayheadSeek,
         onZoom,
         releaseUserPanHold,
         seekTo,
     } = usePlayheadCamera({
+        cameraMode,
         mediaElRef,
         onViewportCommit,
         playheadRef,
@@ -230,9 +288,33 @@ function WaveformView({
         wavesurferRef,
     });
 
+    const toggleTapePlayback = useCallback(() => {
+        if (!interactiveRef.current) {
+            return;
+        }
+        if (isUserPanning() || pointerZoomRef.current) {
+            return;
+        }
+        if (suppressNextTapPlayPauseRef.current) {
+            suppressNextTapPlayPauseRef.current = false;
+            window.clearTimeout(suppressNextTapPlayPauseTimerRef.current);
+            suppressNextTapPlayPauseTimerRef.current = 0;
+            return;
+        }
+        onPlayPauseRef.current?.(!isPlayingRef.current);
+        suppressNextTapPlayPauseRef.current = true;
+        window.clearTimeout(suppressNextTapPlayPauseTimerRef.current);
+        suppressNextTapPlayPauseTimerRef.current = window.setTimeout(() => {
+            suppressNextTapPlayPauseRef.current = false;
+            suppressNextTapPlayPauseTimerRef.current = 0;
+        }, WAVEFORM_TAPE_CLICK_SUPPRESS_MS);
+    }, [isUserPanning]);
+    toggleTapePlaybackRef.current = toggleTapePlayback;
+
     useLayoutEffect(() => {
         viewportRef.current = createWaveformViewport({
             durationSec: viewport.durationSec,
+            gutterPx: viewport.gutterPx,
             heightPx: viewport.heightPx,
             maxZoom: viewport.maxZoom,
             scrollLeftPx: viewportRef.current.scrollLeftPx,
@@ -279,7 +361,9 @@ function WaveformView({
                 return;
             }
 
-            if (!isFollowPinned()) {
+            if (isTape) {
+                playhead.style.left = getTapePinnedPlayheadLeft();
+            } else if (!isFollowPinned()) {
                 playhead.style.left = timeLeftPercent(timeSec, durationSecRef.current, viewportRef.current);
             }
 
@@ -288,7 +372,7 @@ function WaveformView({
                 wavesurfer.setTime(timeSec);
             }
         },
-        [isFollowPinned],
+        [isFollowPinned, isTape],
     );
 
     // Same zoom-window body as the zoom effect; extracted so resize can call it too.
@@ -300,8 +384,15 @@ function WaveformView({
         }
 
         const viewWidthPx = wavesurfer.getWidth ? wavesurfer.getWidth() : container.clientWidth;
-        const minPxPerSec = getZoomedPixelsPerSecond({ durationSec, maxZoom, viewWidthPx, zoomLevel });
-        const origin = zoomOriginRef.current;
+        const minPxPerSec = getZoomedPixelsPerSecond({
+            durationSec,
+            isTape,
+            maxZoom,
+            viewWidthPx,
+            zoomLevel,
+        });
+        const gutterPx = isTape ? getTapeGutterPx(viewWidthPx) : 0;
+        const origin = isTape ? null : zoomOriginRef.current;
         zoomOriginRef.current = null;
         const didZoomChange = prevZoomRef.current !== zoomLevel;
         if (origin || didZoomChange) {
@@ -312,33 +403,30 @@ function WaveformView({
         try {
             wavesurfer.setOptions({
                 autoScroll: false,
+                fillParent: !isTape,
                 minPxPerSec,
-                ...(zoomLevel > WAVEFORM_ZOOM_MIN
+                ...(isScrollableWindow
                     ? {
-                          progressColor: WAVEFORM_COLOR_PLAYED,
+                          progressColor: getPlayedWaveformColor(isTape),
                           waveColor: WAVEFORM_COLOR_UNPLAYED,
                       }
                     : {}),
             });
+            applyWaveformGutters(wavesurfer, gutterPx);
             if (minPxPerSec > 0) {
+                const windowViewport = createWaveformViewport({
+                    durationSec,
+                    gutterPx,
+                    heightPx: liveHeightRef.current || height,
+                    maxZoom,
+                    scrollLeftPx: 0,
+                    widthPx: viewWidthPx,
+                    zoomLevel,
+                });
                 if (origin) {
-                    applyScrollLeft(origin.timeSec * minPxPerSec - origin.pointerX, true);
-                } else if (didZoomChange && !pointerZoomRef.current) {
-                    const zoomedViewport = createWaveformViewport({
-                        durationSec,
-                        heightPx: height,
-                        maxZoom,
-                        scrollLeftPx: 0,
-                        widthPx: viewWidthPx,
-                        zoomLevel,
-                    });
-                    applyScrollLeft(
-                        Math.min(
-                            maxScrollLeft(zoomedViewport),
-                            Math.max(0, currentTimeRef.current * minPxPerSec - viewWidthPx / 2),
-                        ),
-                        true,
-                    );
+                    applyScrollLeft(origin.timeSec * minPxPerSec + gutterPx - origin.pointerX, true);
+                } else if (didZoomChange && (isTape || !pointerZoomRef.current)) {
+                    applyScrollLeft(getCenteredScrollLeft(currentTimeRef.current, windowViewport), true);
                 }
             }
             wavesurfer.setTime(currentTimeRef.current);
@@ -349,13 +437,32 @@ function WaveformView({
 
         syncViewport();
         updatePlayheadPosition(currentTimeRef.current);
-    }, [applyScrollLeft, durationSec, height, maxZoom, onZoom, syncViewport, updatePlayheadPosition, zoomLevel]);
+    }, [
+        applyScrollLeft,
+        durationSec,
+        height,
+        isScrollableWindow,
+        isTape,
+        maxZoom,
+        onZoom,
+        syncViewport,
+        updatePlayheadPosition,
+        zoomLevel,
+    ]);
     applyZoomWindowRef.current = applyZoomWindow;
 
     useEffect(() => {
         const container = containerRef.current;
         if (!container) {
             return undefined;
+        }
+
+        const measuredHeight =
+            cameraModeRef.current === 'tape' && container.clientHeight > 0
+                ? Math.round(container.clientHeight)
+                : height;
+        if (cameraModeRef.current === 'tape' && measuredHeight > 0) {
+            liveHeightRef.current = measuredHeight;
         }
 
         const wavesurfer = WaveSurfer.create({
@@ -368,17 +475,22 @@ function WaveformView({
             cursorWidth: 0,
             duration: durationSecRef.current,
             fillParent: true,
-            height,
+            height: measuredHeight,
             hideScrollbar: true,
-            interact: interactiveRef.current,
+            dragToSeek: false,
+            interact: interactiveRef.current && cameraModeRef.current !== 'tape',
             normalize: false,
             peaks: toChannels(peaksRef.current),
-            progressColor: WAVEFORM_COLOR_PLAYED,
+            progressColor: getPlayedWaveformColor(cameraModeRef.current === 'tape'),
             waveColor: WAVEFORM_COLOR_UNPLAYED,
         });
 
         const unsubscribeClick = wavesurfer.on('click', (relativeX: number) => {
             if (!interactiveRef.current) {
+                return;
+            }
+            if (cameraModeRef.current === 'tape') {
+                toggleTapePlaybackRef.current?.();
                 return;
             }
             onSeekRef.current?.(relativeX * durationSecRef.current);
@@ -387,7 +499,34 @@ function WaveformView({
             if (suppressViewportSyncRef.current) {
                 return;
             }
-            handleCameraScroll(() => {
+            handleCameraScroll(timeSec => {
+                if (cameraModeRef.current === 'tape' && !pointerZoomRef.current) {
+                    suppressNextTapPlayPauseRef.current = true;
+                    window.clearTimeout(suppressNextTapPlayPauseTimerRef.current);
+                    suppressNextTapPlayPauseTimerRef.current = window.setTimeout(() => {
+                        suppressNextTapPlayPauseRef.current = false;
+                        suppressNextTapPlayPauseTimerRef.current = 0;
+                    }, WAVEFORM_TAPE_CLICK_SUPPRESS_MS);
+                    queuedTapeSeekTimeSecRef.current = timeSec;
+                    if (!tapeSeekAnimationRef.current) {
+                        tapeSeekAnimationRef.current = window.requestAnimationFrame(() => {
+                            tapeSeekAnimationRef.current = 0;
+                            const next = queuedTapeSeekTimeSecRef.current;
+                            queuedTapeSeekTimeSecRef.current = null;
+                            if (next != null) {
+                                onSeekRef.current?.(next);
+                            }
+                        });
+                    }
+                    if (interactiveRef.current) {
+                        setScrubPreviewTimeSec(timeSec);
+                        window.clearTimeout(hideScrubTimeChipTimerRef.current);
+                        hideScrubTimeChipTimerRef.current = window.setTimeout(() => {
+                            setScrubPreviewTimeSec(null);
+                            hideScrubTimeChipTimerRef.current = 0;
+                        }, WAVEFORM_FOLLOW_SCROLL_SETTLE_MS);
+                    }
+                }
                 syncViewport();
             });
         });
@@ -398,14 +537,15 @@ function WaveformView({
             syncViewport();
         });
         const unsubscribeRedraw = wavesurfer.on('redrawcomplete', () => {
-            if (!(zoomRef.current > WAVEFORM_ZOOM_MIN)) {
+            if (!(zoomRef.current > WAVEFORM_ZOOM_MIN) && cameraModeRef.current !== 'tape') {
                 return;
             }
             tintZoomedWaveform(
                 wavesurfer,
                 getWaveformFills({
                     bufferProgress: bufferProgressRef.current,
-                    hoverProgress: hoverProgressRef.current,
+                    hoverProgress: cameraModeRef.current === 'tape' ? null : hoverProgressRef.current,
+                    isTape: cameraModeRef.current === 'tape',
                 }),
                 true,
             );
@@ -420,6 +560,9 @@ function WaveformView({
         return () => {
             releaseUserPanHold();
             cancelJump();
+            window.clearTimeout(hideScrubTimeChipTimerRef.current);
+            window.clearTimeout(suppressNextTapPlayPauseTimerRef.current);
+            window.cancelAnimationFrame(tapeSeekAnimationRef.current);
             window.cancelAnimationFrame(peakTransitionAnimationRef.current);
             unsubscribeClick();
             unsubscribeScroll();
@@ -429,7 +572,7 @@ function WaveformView({
             wavesurferRef.current = null;
             displayedPeaksRef.current = null;
         };
-    }, [cancelJump, handleCameraScroll, height, releaseUserPanHold, syncViewport]);
+    }, [cancelJump, handleCameraScroll, height, isUserPanning, releaseUserPanHold, syncViewport]);
 
     useLayoutEffect(() => {
         const el = containerRef.current;
@@ -438,12 +581,36 @@ function WaveformView({
         }
 
         setCanvasWidthPx(el.clientWidth);
+        lastObservedWidthRef.current = el.clientWidth;
+        const mountedHeight = Math.round(el.clientHeight);
+        if (cameraModeRef.current === 'tape' && mountedHeight > 0) {
+            liveHeightRef.current = mountedHeight;
+        }
 
         const observer = new ResizeObserver(entries => {
             entries.forEach(entry => {
-                setCanvasWidthPx(entry.contentRect.width);
+                const nextWidth = entry.contentRect.width;
+                const widthChanged = nextWidth !== lastObservedWidthRef.current;
+                lastObservedWidthRef.current = nextWidth;
+                setCanvasWidthPx(nextWidth);
+                const nextHeight = Math.round(entry.contentRect.height);
+                if (
+                    cameraModeRef.current === 'tape' &&
+                    Number.isFinite(nextHeight) &&
+                    nextHeight > 0 &&
+                    nextHeight !== liveHeightRef.current
+                ) {
+                    liveHeightRef.current = nextHeight;
+                    const wavesurfer = wavesurferRef.current;
+                    if (wavesurfer && wavesurfer.setOptions) {
+                        wavesurfer.setOptions({ height: nextHeight });
+                    }
+                }
+                syncViewport();
+                if (widthChanged) {
+                    applyZoomWindowRef.current?.();
+                }
             });
-            syncViewport();
         });
         observer.observe(el);
         return () => observer.disconnect();
@@ -470,7 +637,7 @@ function WaveformView({
         if (!wavesurfer || !wavesurfer.setOptions) {
             return;
         }
-        wavesurfer.setOptions({ interact: interactive });
+        wavesurfer.setOptions({ interact: interactive && cameraModeRef.current !== 'tape' });
     }, [interactive]);
 
     useLayoutEffect(() => {
@@ -506,14 +673,18 @@ function WaveformView({
             window.cancelAnimationFrame(playheadAnimationRef.current);
             cancelJump();
             releaseUserPanHold();
-            clearFollowPin();
+            if (cameraModeRef.current !== 'tape') {
+                clearFollowPin();
+            }
             syncViewport();
             updatePlayheadPosition(media.currentTime);
         };
 
         const handleSeeked = (): void => {
             onPlayheadSeek(media.currentTime);
-            seekTo(media.currentTime);
+            if (!isUserPanning()) {
+                seekTo(media.currentTime);
+            }
             updatePlayheadPosition(media.currentTime);
         };
 
@@ -545,6 +716,7 @@ function WaveformView({
         seekTo,
         syncViewport,
         updatePlayheadPosition,
+        isUserPanning,
     ]);
 
     useEffect(() => {
@@ -585,8 +757,12 @@ function WaveformView({
             return;
         }
 
-        const fills = getWaveformFills({ bufferProgress, hoverProgress });
-        if (isZoomed) {
+        const fills = getWaveformFills({
+            bufferProgress,
+            hoverProgress: isTape ? null : hoverProgress,
+            isTape,
+        });
+        if (isScrollableWindow) {
             tintZoomedWaveform(wavesurfer, fills);
             return;
         }
@@ -596,7 +772,7 @@ function WaveformView({
             waveColor: toCanvasFill(fills.waveColor, devicePixelWidth(canvasWidthPx)),
         });
         wavesurfer.setTime(currentTimeRef.current);
-    }, [bufferProgress, canvasWidthPx, hoverProgress, isZoomed]);
+    }, [bufferProgress, canvasWidthPx, hoverProgress, isScrollableWindow, isTape]);
 
     useEffect(() => {
         const track = trackRef.current;
@@ -685,8 +861,8 @@ function WaveformView({
     }, [durationSec, markPointerZoom, setZoomLevel]);
 
     const onHoverMove = useCallback(
-        (event: React.MouseEvent<HTMLDivElement>) => {
-            if (!interactive) {
+        (event: React.MouseEvent<HTMLDivElement> | React.PointerEvent<HTMLDivElement>) => {
+            if (!interactive || isTape || isTouchHoverInput(event)) {
                 return;
             }
             const rect = event.currentTarget.getBoundingClientRect();
@@ -704,28 +880,67 @@ function WaveformView({
             }
             setHoverProgress(Math.min(1, Math.max(0, pointerX / rect.width)));
         },
-        [durationSec, interactive],
+        [durationSec, interactive, isTape],
     );
 
     const onHoverLeave = useCallback(() => {
         setHoverProgress(null);
     }, []);
 
+    const bindOverlayPortalHost = useCallback((node: HTMLDivElement | null) => {
+        const host = node?.parentElement ?? null;
+        setOverlayPortalHost(prev => (prev === host ? prev : host));
+    }, []);
+
     const hoverLeft =
         hoverProgress == null ? null : timeLeftPercent(hoverProgress * durationSec, durationSec, viewportRef.current);
+    const scrubTimeChip =
+        isTape && scrubPreviewTimeSec != null ? (
+            <div
+                className="bp-WaveformView-hover bp-WaveformView-hover--tape"
+                data-testid="bp-waveform-hover"
+                style={{ left: getTapePinnedPlayheadLeft() }}
+            >
+                <div className="bp-WaveformView-hoverTime" data-testid="bp-waveform-hover-time">
+                    {formatTime(scrubPreviewTimeSec)}
+                </div>
+            </div>
+        ) : null;
 
     return (
         <div
+            ref={bindOverlayPortalHost}
             className={`bp-WaveformView${interactive ? '' : ' bp-WaveformView--inert'}${
                 isZoomed ? ' bp-WaveformView--zoomed' : ''
-            }`}
+            }${isTape ? ' bp-WaveformView--tape' : ''}`}
             data-testid="bp-waveform-view"
         >
             <div
                 ref={trackRef}
                 className="bp-WaveformView-track"
-                onMouseLeave={interactive ? onHoverLeave : undefined}
-                onMouseMove={interactive ? onHoverMove : undefined}
+                onMouseLeave={interactive && !isTape ? onHoverLeave : undefined}
+                onMouseMove={interactive && !isTape ? onHoverMove : undefined}
+                onPointerMove={
+                    interactive && !isTape
+                        ? event => {
+                              if (event.pointerType === 'touch') {
+                                  onHoverLeave();
+                                  return;
+                              }
+                              onHoverMove(event);
+                          }
+                        : undefined
+                }
+                onPointerUp={
+                    isTape
+                        ? event => {
+                              if (event.button > 0) {
+                                  return;
+                              }
+                              toggleTapePlaybackRef.current?.();
+                          }
+                        : undefined
+                }
             >
                 <div ref={containerRef} className="bp-WaveformView-canvas" />
                 <div
@@ -742,6 +957,7 @@ function WaveformView({
                     </div>
                 )}
             </div>
+            {scrubTimeChip && overlayPortalHost ? createPortal(scrubTimeChip, overlayPortalHost) : null}
         </div>
     );
 }

--- a/src/lib/viewers/media/waveform/WaveformView.tsx
+++ b/src/lib/viewers/media/waveform/WaveformView.tsx
@@ -91,12 +91,9 @@ function applyWaveformGutters(wavesurfer: WaveSurfer, gutterPx: number): void {
     // (tape 1x). Gutters live in these margins, so the scroller must stay pan-able.
     const scroll = wrapper.parentElement;
     if (scroll && scroll.style) {
-        scroll.style.overflowX = gutterPx > 0 ? 'auto' : '';
-        if (gutterPx > 0) {
-            scroll.style.setProperty('scrollbar-width', 'none');
-        } else {
-            scroll.style.removeProperty('scrollbar-width');
-        }
+        const scrollStyle = scroll.style as CSSStyleDeclaration & { scrollbarWidth?: string };
+        scrollStyle.overflowX = gutterPx > 0 ? 'auto' : '';
+        scrollStyle.scrollbarWidth = gutterPx > 0 ? 'none' : '';
     }
 }
 

--- a/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
+++ b/src/lib/viewers/media/waveform/WaveformZoomControl.tsx
@@ -17,11 +17,14 @@ export default function WaveformZoomControl({
 }: WaveformZoomControlProps): JSX.Element {
     const [isHovered, setHovered] = useState(false);
     const [isFocused, setFocused] = useState(false);
-    const dismissTimerRef = useRef(0);
+    const [isPinned, setPinned] = useState(false);
+    const wasFlyoutOpenOnPointerDownRef = useRef(true); // first tap on + pins the flyout instead of zooming
+    const zoomControlElRef = useRef<HTMLDivElement>(null); // root; outside pointerdown unpins the flyout
+    const dismissTimerRef = useRef(0); // delay before hover-close of the flyout
     const sliderId = `bp-waveform-zoom-slider${useId()}`;
     const zoom = clampWaveformZoom(zoomLevel, maxZoom);
     const zoomValue = Math.round(sliderValueFromZoom(zoom, maxZoom));
-    const isOpen = isHovered || isFocused || isRevealed;
+    const isOpen = isHovered || isFocused || isRevealed || isPinned;
     const isAtMinZoom = zoomValue <= 0;
     const isAtMaxZoom = zoomValue >= WAVEFORM_ZOOM_SLIDER_MAX;
 
@@ -31,6 +34,25 @@ export default function WaveformZoomControl({
     }, []);
 
     useEffect(() => () => window.clearTimeout(dismissTimerRef.current), []);
+
+    useEffect(() => {
+        if (!isPinned) {
+            return undefined;
+        }
+
+        const closeIfOutside = (event: PointerEvent): void => {
+            const zoomControlEl = zoomControlElRef.current;
+            if (!zoomControlEl || zoomControlEl.contains(event.target as Node | null)) {
+                return;
+            }
+            setPinned(false);
+            setFocused(false);
+            setHovered(false);
+        };
+
+        document.addEventListener('pointerdown', closeIfOutside);
+        return () => document.removeEventListener('pointerdown', closeIfOutside);
+    }, [isPinned]);
 
     const handleSlider = useCallback(
         (newValue: number): void => {
@@ -46,8 +68,23 @@ export default function WaveformZoomControl({
         [maxZoom, onZoomChange, zoomValue],
     );
 
+    const handleZoomInPointerDown = useCallback((): void => {
+        wasFlyoutOpenOnPointerDownRef.current = isHovered || isFocused || isRevealed || isPinned;
+    }, [isFocused, isHovered, isPinned, isRevealed]);
+
+    const handleZoomInClick = useCallback((): void => {
+        if (!wasFlyoutOpenOnPointerDownRef.current) {
+            setPinned(true);
+            return;
+        }
+        if (!isAtMaxZoom) {
+            handleStep(WAVEFORM_ZOOM_BUTTON_STEP);
+        }
+    }, [handleStep, isAtMaxZoom]);
+
     return (
         <div
+            ref={zoomControlElRef}
             aria-label={__('media_zoom')}
             className={classNames('bp-WaveformZoomControl', { 'bp-is-open': isOpen })}
             data-testid="bp-waveform-zoom"
@@ -56,6 +93,7 @@ export default function WaveformZoomControl({
                     return;
                 }
                 setFocused(false);
+                setPinned(false);
             }}
             onFocus={() => {
                 clearDismiss();
@@ -74,15 +112,12 @@ export default function WaveformZoomControl({
             role="group"
         >
             <MediaToggle
-                aria-disabled={isAtMaxZoom}
+                aria-disabled={isOpen && isAtMaxZoom}
                 className="bp-WaveformZoomControl-button"
                 data-resin-target="waveformZoomIn"
                 data-testid="bp-waveform-zoom-in"
-                onClick={() => {
-                    if (!isAtMaxZoom) {
-                        handleStep(WAVEFORM_ZOOM_BUTTON_STEP);
-                    }
-                }}
+                onClick={handleZoomInClick}
+                onPointerDown={handleZoomInPointerDown}
                 title={__('zoom_in')}
             >
                 <IconZoomIn24 />

--- a/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformCommentMarkers-test.tsx
@@ -171,6 +171,53 @@ describe('WaveformCommentMarkers', () => {
         expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({ left: '0%' });
     });
 
+    test('should place a file-start marker at the center pin when the tape viewport has half-view gutters', () => {
+        const tape = createWaveformViewport({
+            durationSec: 8,
+            gutterPx: 100,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 200,
+            zoomLevel: 1,
+        });
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[{ ...hostCommentMarker, id: 'start', time: 0 }]}
+                durationSec={8}
+                isTape
+                viewport={tape}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--tape');
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({ left: '50%' });
+    });
+
+    test('should not treat half-view gutters as tape without isTape', () => {
+        const windowed = createWaveformViewport({
+            durationSec: 8,
+            gutterPx: 100,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 200,
+            zoomLevel: 1,
+        });
+        render(
+            <WaveformCommentMarkers
+                commentMarkers={[{ ...hostCommentMarker, id: 'start', time: 0 }]}
+                durationSec={8}
+                viewport={windowed}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-comment-markers')).not.toHaveClass('bp-WaveformCommentMarkers--tape');
+        expect(screen.getByTestId('bp-waveform-comment-markers')).not.toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(screen.getByTestId('bp-waveform-comment-marker')).toHaveStyle({ left: '50%' });
+    });
+
     test('should place a host comment_markers entry at time over duration', () => {
         render(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} />);
 
@@ -275,6 +322,7 @@ describe('WaveformCommentMarkers', () => {
         rerender(<WaveformCommentMarkers commentMarkers={[hostCommentMarker]} durationSec={180} viewport={zoomed} />);
 
         expect(screen.getByTestId('bp-waveform-comment-markers')).toHaveClass('bp-WaveformCommentMarkers--zoomed');
+        expect(screen.getByTestId('bp-waveform-comment-markers')).not.toHaveClass('bp-WaveformCommentMarkers--tape');
         expect(badge).toHaveStyle({
             left: `${(72.729 / 90) * 100}%`,
         });

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -10,7 +10,7 @@ import {
     WAVEFORM_HEIGHT,
     WAVEFORM_PLAYHEAD_JUMP_MS,
 } from '../constants';
-import { WAVEFORM_COLOR_PLAYED, WAVEFORM_COLOR_UNPLAYED } from '../colors';
+import { WAVEFORM_COLOR_HOVER_PLAYED, WAVEFORM_COLOR_PLAYED, WAVEFORM_COLOR_UNPLAYED } from '../colors';
 import { getPinnedPlayheadLeft } from '../viewport';
 
 const mockDestroy = jest.fn();
@@ -49,6 +49,25 @@ function spyFollowScrollSettle(onSettle: (fn: () => void) => void): void {
         }
         return 0;
     }) as typeof window.setTimeout);
+}
+
+/** jsdom does not flush WaveSurfer scroll's rAF-queued tape seek. */
+function swipeTape(): void {
+    const queued: FrameRequestCallback[] = [];
+    const raf = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(((cb: FrameRequestCallback) => {
+        queued.push(cb);
+        return queued.length;
+    }) as typeof requestAnimationFrame);
+    try {
+        act(() => {
+            scrollHandler?.();
+        });
+        act(() => {
+            queued.splice(0).forEach(cb => cb(0));
+        });
+    } finally {
+        raf.mockRestore();
+    }
 }
 
 function renderZoomedWaveform({
@@ -250,6 +269,26 @@ describe('WaveformView', () => {
 
         expect(screen.getByTestId('bp-waveform-hover-time')).toHaveTextContent('0:02.00');
         expect(screen.getByTestId('bp-waveform-hover')).toHaveStyle({ left: '25%' });
+    });
+
+    test('should not apply hover fills from a touch pointer', () => {
+        render(<WaveformView durationSec={8} peaks={[0.2, 0.8]} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.pointerMove(track, { clientX: 50, pointerType: 'touch' });
+
+        expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
     });
 
     test('should show the hover time chip while zoomed', () => {
@@ -994,5 +1033,318 @@ describe('WaveformView', () => {
             />,
         );
         expect(playhead.style.left).toBe('50%');
+    });
+
+    test('should pin the playhead at center and not seek from a tap in tape mode', () => {
+        const onPlayPause = jest.fn();
+        const onSeek = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+
+        render(
+            <WaveformView
+                cameraMode="tape"
+                currentTime={0}
+                durationSec={8}
+                isPlaying={false}
+                onPlayPause={onPlayPause}
+                onSeek={onSeek}
+                peaks={new Array(800).fill(0.5)}
+            />,
+        );
+
+        expect(screen.getByTestId('bp-waveform-view')).toHaveClass('bp-WaveformView--tape');
+        expect(screen.getByTestId('bp-waveform-playhead')).toHaveStyle({ left: '50%' });
+        expect(WaveSurfer.create).toHaveBeenCalledWith(
+            expect.objectContaining({ interact: false, progressColor: WAVEFORM_COLOR_HOVER_PLAYED }),
+        );
+        expect(mockSetOptions).toHaveBeenCalledWith(expect.objectContaining({ minPxPerSec: 25 }));
+
+        clickHandler?.(0.25);
+        fireEvent.pointerUp(
+            screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement,
+            { button: 0, pointerType: 'touch' },
+        );
+
+        expect(onSeek).not.toHaveBeenCalled();
+        expect(onPlayPause).toHaveBeenCalledWith(true);
+        expect(onPlayPause).toHaveBeenCalledTimes(1);
+    });
+
+    test('should size tape WaveSurfer bars to the canvas box when the stage is taller than 206px', () => {
+        render(<WaveformView cameraMode="tape" durationSec={8} peaks={new Array(800).fill(0.5)} />);
+
+        mockSetOptions.mockClear();
+        act(() => {
+            resizeCallback?.(
+                [
+                    ({
+                        contentRect: { height: 320, width: 200 },
+                    } as unknown) as ResizeObserverEntry,
+                ],
+                ({} as unknown) as ResizeObserver,
+            );
+        });
+
+        expect(mockSetOptions).toHaveBeenCalledWith(expect.objectContaining({ height: 320 }));
+    });
+
+    test('should size tape WaveSurfer from the canvas height on first paint', () => {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 260 });
+        try {
+            render(<WaveformView cameraMode="tape" durationSec={8} peaks={new Array(800).fill(0.5)} />);
+
+            expect(WaveSurfer.create).toHaveBeenCalledWith(expect.objectContaining({ height: 260 }));
+        } finally {
+            Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 0 });
+        }
+    });
+
+    test('should not recenter the tape playhead when only the canvas size changes', () => {
+        render(<WaveformView cameraMode="tape" currentTime={2} durationSec={8} peaks={new Array(800).fill(0.5)} />);
+
+        mockSetScroll.mockClear();
+        act(() => {
+            resizeCallback?.(
+                [
+                    ({
+                        contentRect: { height: 320, width: 200 },
+                    } as unknown) as ResizeObserverEntry,
+                ],
+                ({} as unknown) as ResizeObserver,
+            );
+        });
+
+        expect(mockSetScroll).not.toHaveBeenCalled();
+    });
+
+    test('should seek to the time under the center pin when the tape waveform is swiped', () => {
+        const onSeek = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+        mockSetScroll.mockImplementation((scrollLeftPx: number) => {
+            mockGetScroll.mockReturnValue(scrollLeftPx);
+        });
+
+        render(
+            <WaveformView
+                cameraMode="tape"
+                currentTime={0}
+                durationSec={8}
+                onSeek={onSeek}
+                peaks={new Array(800).fill(0.5)}
+            />,
+        );
+
+        mockGetScroll.mockReturnValue(50);
+        swipeTape();
+
+        expect(onSeek).toHaveBeenCalledWith(2);
+        expect(screen.getByTestId('bp-waveform-playhead')).toHaveStyle({ left: '50%' });
+        const chip = screen.getByTestId('bp-waveform-hover');
+        expect(chip).toHaveClass('bp-WaveformView-hover--tape');
+        expect(chip).toHaveStyle({ left: '50%' });
+        expect(screen.getByTestId('bp-waveform-hover-time')).toHaveTextContent('0:02.00');
+    });
+
+    test('should keep the tape scroller pan-able at 1x so gutter swipes can seek', () => {
+        const onSeek = jest.fn();
+        const scrollStyle: { overflowX?: string; scrollbarWidth?: string } = {};
+        mockGetWrapper.mockReturnValue({
+            clientWidth: 200,
+            parentElement: { style: scrollStyle },
+            style: {},
+        });
+        mockSetScroll.mockImplementation((scrollLeftPx: number) => {
+            mockGetScroll.mockReturnValue(scrollLeftPx);
+        });
+
+        render(
+            <WaveformView
+                cameraMode="tape"
+                currentTime={0}
+                durationSec={8}
+                onSeek={onSeek}
+                peaks={new Array(800).fill(0.5)}
+                zoomLevel={1}
+            />,
+        );
+
+        expect(mockSetOptions).toHaveBeenCalledWith(expect.objectContaining({ fillParent: false, minPxPerSec: 25 }));
+        expect(scrollStyle.overflowX).toBe('auto');
+        expect(scrollStyle.scrollbarWidth).toBe('none');
+
+        mockGetScroll.mockReturnValue(50);
+        swipeTape();
+
+        expect(onSeek).toHaveBeenCalledWith(2);
+    });
+
+    test('should seek once per frame while the tape is swiped', () => {
+        const onSeek = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+        mockSetScroll.mockImplementation((scrollLeftPx: number) => {
+            mockGetScroll.mockReturnValue(scrollLeftPx);
+        });
+
+        render(
+            <WaveformView
+                cameraMode="tape"
+                currentTime={0}
+                durationSec={8}
+                onSeek={onSeek}
+                peaks={new Array(800).fill(0.5)}
+            />,
+        );
+
+        const queued: FrameRequestCallback[] = [];
+        const raf = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(((cb: FrameRequestCallback) => {
+            queued.push(cb);
+            return queued.length;
+        }) as typeof requestAnimationFrame);
+
+        try {
+            mockGetScroll.mockReturnValue(50);
+            act(() => {
+                scrollHandler?.();
+            });
+            mockGetScroll.mockReturnValue(75);
+            act(() => {
+                scrollHandler?.();
+            });
+
+            expect(onSeek).not.toHaveBeenCalled();
+
+            act(() => {
+                queued.forEach(cb => cb(0));
+            });
+
+            expect(onSeek).toHaveBeenCalledTimes(1);
+            expect(onSeek).toHaveBeenCalledWith(3);
+        } finally {
+            raf.mockRestore();
+        }
+    });
+
+    test('should not toggle play from a delayed click after a tape swipe', () => {
+        jest.useFakeTimers();
+        const onPlayPause = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+        mockSetScroll.mockImplementation((scrollLeftPx: number) => {
+            mockGetScroll.mockReturnValue(scrollLeftPx);
+        });
+
+        try {
+            render(
+                <WaveformView
+                    cameraMode="tape"
+                    currentTime={0}
+                    durationSec={8}
+                    isPlaying={false}
+                    onPlayPause={onPlayPause}
+                    peaks={new Array(800).fill(0.5)}
+                />,
+            );
+
+            mockGetScroll.mockReturnValue(50);
+            swipeTape();
+
+            act(() => {
+                jest.advanceTimersByTime(WAVEFORM_FOLLOW_SCROLL_SETTLE_MS);
+            });
+            clickHandler?.(0.25);
+            expect(onPlayPause).not.toHaveBeenCalled();
+
+            clickHandler?.(0.25);
+            expect(onPlayPause).toHaveBeenCalledTimes(1);
+            expect(onPlayPause).toHaveBeenCalledWith(true);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('should not toggle play from a delayed click after a tape pinch', () => {
+        jest.useFakeTimers();
+        const onPlayPause = jest.fn();
+        const onZoomChange = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+
+        try {
+            render(
+                <WaveformView
+                    cameraMode="tape"
+                    currentTime={0}
+                    durationSec={100}
+                    isPlaying={false}
+                    onPlayPause={onPlayPause}
+                    onZoomChange={onZoomChange}
+                    peaks={new Array(800).fill(0.5)}
+                />,
+            );
+
+            const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+            fireEvent.touchStart(track, {
+                touches: [
+                    { clientX: 40, clientY: 20, identifier: 1 },
+                    { clientX: 120, clientY: 20, identifier: 2 },
+                ],
+            });
+            fireEvent.touchEnd(track, { touches: [] });
+
+            clickHandler?.(0.25);
+            fireEvent.pointerUp(track, { button: 0 });
+            expect(onPlayPause).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('should not show a hover time chip from pointer move in tape mode', () => {
+        render(<WaveformView cameraMode="tape" durationSec={8} peaks={[0.2, 0.8]} />);
+        const track = screen.getByTestId('bp-waveform-view').querySelector('.bp-WaveformView-track') as HTMLElement;
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            bottom: 140,
+            height: 140,
+            left: 0,
+            right: 200,
+            toJSON: () => ({}),
+            top: 0,
+            width: 200,
+            x: 0,
+            y: 0,
+        });
+
+        fireEvent.mouseMove(track, { clientX: 50 });
+
+        expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
+    });
+
+    test('should hide the tape seek time chip after the swipe settles', () => {
+        jest.useFakeTimers();
+        const onSeek = jest.fn();
+        mockGetWrapper.mockReturnValue({ clientWidth: 200, style: {} });
+        mockSetScroll.mockImplementation((scrollLeftPx: number) => {
+            mockGetScroll.mockReturnValue(scrollLeftPx);
+        });
+
+        render(
+            <WaveformView
+                cameraMode="tape"
+                currentTime={0}
+                durationSec={8}
+                onSeek={onSeek}
+                peaks={new Array(800).fill(0.5)}
+            />,
+        );
+
+        mockGetScroll.mockReturnValue(50);
+        act(() => {
+            scrollHandler?.();
+        });
+        expect(screen.getByTestId('bp-waveform-hover-time')).toBeInTheDocument();
+
+        act(() => {
+            jest.advanceTimersByTime(WAVEFORM_FOLLOW_SCROLL_SETTLE_MS);
+        });
+        expect(screen.queryByTestId('bp-waveform-hover-time')).not.toBeInTheDocument();
+        jest.useRealTimers();
     });
 });

--- a/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformView-test.tsx
@@ -19,7 +19,11 @@ const mockSetOptions = jest.fn();
 const mockSetTime = jest.fn();
 const mockGetScroll = jest.fn(() => 0);
 const mockGetWidth = jest.fn(() => 200);
-const mockGetWrapper = jest.fn(() => ({ clientWidth: 200 }));
+const mockGetWrapper = jest.fn((): {
+    clientWidth: number;
+    parentElement?: { style: { overflowX?: string; scrollbarWidth?: string } } | null;
+    style?: Record<string, string>;
+} => ({ clientWidth: 200 }));
 const mockSetScroll = jest.fn();
 const mockSetScrollTime = jest.fn();
 const mockObserve = jest.fn();

--- a/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
+++ b/src/lib/viewers/media/waveform/__tests__/WaveformZoomControl-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WAVEFORM_ZOOM_DISMISS_MS } from '../constants';
 import WaveformZoomControl from '../WaveformZoomControl';
@@ -123,6 +123,43 @@ describe('WaveformZoomControl', () => {
         onZoomChange.mockClear();
         await user.click(screen.getByRole('button', { name: __('zoom_out') }));
         expect(onZoomChange).toHaveBeenCalledWith(2.2);
+    });
+
+    test('should open the slider on the first collapsed press and zoom on the next', () => {
+        const onZoomChange = jest.fn();
+        render(<WaveformZoomControl maxZoom={4} onZoomChange={onZoomChange} zoomLevel={2.5} />);
+
+        const control = screen.getByTestId('bp-waveform-zoom');
+        const zoomIn = screen.getByTestId('bp-waveform-zoom-in');
+        expect(control).not.toHaveClass('bp-is-open');
+
+        fireEvent.pointerDown(zoomIn, { pointerType: 'touch' });
+        fireEvent.click(zoomIn);
+        expect(control).toHaveClass('bp-is-open');
+        expect(onZoomChange).not.toHaveBeenCalled();
+        expect(screen.getByRole('slider', { name: __('media_zoom_slider') })).toBeInTheDocument();
+
+        const zoomOut = screen.getByRole('button', { name: __('zoom_out') });
+        fireEvent.pointerDown(zoomIn, { pointerType: 'touch' });
+        fireEvent.click(zoomIn);
+        expect(onZoomChange).toHaveBeenCalledWith(2.8);
+
+        onZoomChange.mockClear();
+        fireEvent.click(zoomOut);
+        expect(onZoomChange).toHaveBeenCalledWith(2.2);
+    });
+
+    test('should collapse a pinned zoom flyout when tapping outside', () => {
+        render(<WaveformZoomControl maxZoom={4} onZoomChange={jest.fn()} zoomLevel={2.5} />);
+
+        const control = screen.getByTestId('bp-waveform-zoom');
+        const zoomIn = screen.getByTestId('bp-waveform-zoom-in');
+        fireEvent.pointerDown(zoomIn, { pointerType: 'touch' });
+        fireEvent.click(zoomIn);
+        expect(control).toHaveClass('bp-is-open');
+
+        fireEvent.pointerDown(document.body);
+        expect(control).not.toHaveClass('bp-is-open');
     });
 
     test('should ignore zoom button clicks at the slider ends', async () => {

--- a/src/lib/viewers/media/waveform/__tests__/colors-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/colors-test.ts
@@ -30,6 +30,14 @@ describe('colors', () => {
         expect(rgbChannel(WAVEFORM_COLOR_PLAYED)).toBeGreaterThan(rgbChannel(WAVEFORM_COLOR_UNPLAYED));
     });
 
+    test('should use only brightest played and unplayed fills on tape', () => {
+        const fills = getWaveformFills({ bufferProgress: 0.5, hoverProgress: 0.4, isTape: true });
+
+        expect(fills.progressColor).toBe(WAVEFORM_COLOR_HOVER_PLAYED);
+        expect(rgbChannel(WAVEFORM_COLOR_HOVER_PLAYED)).toBeGreaterThan(rgbChannel(WAVEFORM_COLOR_PLAYED));
+        expect(fills.waveColor).toBe(WAVEFORM_COLOR_UNPLAYED);
+    });
+
     test('should use played / unplayed / buffer tokens at rest', () => {
         const fills = getWaveformFills({ bufferProgress: 0.5, hoverProgress: null });
 

--- a/src/lib/viewers/media/waveform/__tests__/useTapeWaveform-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/useTapeWaveform-test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import useTapeWaveform, {
+    isCoarsePrimaryPointer,
+    isIPadNavigator,
+    isTapeWaveformInput,
+    TAPE_POINTER_MQ,
+    TapeDetectionWindow,
+    TapeNavigator,
+} from '../useTapeWaveform';
+
+describe('useTapeWaveform', () => {
+    const coarseQuery = TAPE_POINTER_MQ;
+
+    function nav(overrides: Partial<TapeNavigator> = {}): TapeNavigator {
+        return {
+            maxTouchPoints: 0,
+            platform: 'MacIntel',
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15',
+            ...overrides,
+        };
+    }
+
+    function win(matches: boolean, tapeNavigator = nav()): TapeDetectionWindow {
+        return {
+            matchMedia: jest.fn((query: string) => ({
+                matches: query === coarseQuery && matches,
+            })) as Window['matchMedia'],
+            navigator: tapeNavigator,
+        };
+    }
+
+    test('should treat coarse primary pointer as tape', () => {
+        expect(isCoarsePrimaryPointer(win(true))).toBe(true);
+        expect(isTapeWaveformInput(win(true, nav({ platform: 'Win32' })))).toBe(true);
+    });
+
+    test('should not treat a fine pointer laptop as tape', () => {
+        expect(isCoarsePrimaryPointer(win(false))).toBe(false);
+        expect(isTapeWaveformInput(win(false))).toBe(false);
+    });
+
+    test('should treat iPad UA and iPadOS-as-Mac as tape even when the pointer is fine', () => {
+        expect(isIPadNavigator(nav({ userAgent: 'Mozilla/5.0 (iPad; CPU OS 17_0)' }))).toBe(true);
+        expect(isIPadNavigator(nav({ maxTouchPoints: 5, platform: 'MacIntel' }))).toBe(true);
+        expect(isTapeWaveformInput(win(false, nav({ maxTouchPoints: 5, platform: 'MacIntel' })))).toBe(true);
+        expect(isIPadNavigator(nav({ maxTouchPoints: 10, platform: 'Win32' }))).toBe(false);
+    });
+
+    test('should subscribe to the pointer media query', () => {
+        const listeners = new Set<(event: MediaQueryListEvent) => void>();
+        const mediaQuery = {
+            addEventListener: jest.fn((_event: string, listener: (event: MediaQueryListEvent) => void) => {
+                listeners.add(listener);
+            }),
+            matches: false,
+            media: coarseQuery,
+            removeEventListener: jest.fn((_event: string, listener: (event: MediaQueryListEvent) => void) => {
+                listeners.delete(listener);
+            }),
+        };
+        const matchMedia = jest.fn((query: string) => {
+            if (query === '(prefers-reduced-motion: reduce)') {
+                return { addEventListener: jest.fn(), matches: false, removeEventListener: jest.fn() };
+            }
+            return { ...mediaQuery, matches: query === coarseQuery && mediaQuery.matches };
+        });
+        const originalMatchMedia = window.matchMedia;
+        const originalNavigator = window.navigator;
+        Object.defineProperty(window, 'matchMedia', { configurable: true, value: matchMedia });
+        Object.defineProperty(window, 'navigator', {
+            configurable: true,
+            value: nav({ platform: 'Win32' }),
+        });
+
+        try {
+            const { result, unmount } = renderHook(() => useTapeWaveform());
+            expect(result.current).toBe(false);
+
+            mediaQuery.matches = true;
+            act(() => {
+                listeners.forEach(listener => listener({ matches: true } as MediaQueryListEvent));
+            });
+            expect(result.current).toBe(true);
+
+            unmount();
+            expect(mediaQuery.removeEventListener).toHaveBeenCalled();
+        } finally {
+            Object.defineProperty(window, 'matchMedia', { configurable: true, value: originalMatchMedia });
+            Object.defineProperty(window, 'navigator', { configurable: true, value: originalNavigator });
+        }
+    });
+});

--- a/src/lib/viewers/media/waveform/__tests__/useTapeWaveform-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/useTapeWaveform-test.ts
@@ -22,9 +22,9 @@ describe('useTapeWaveform', () => {
 
     function win(matches: boolean, tapeNavigator = nav()): TapeDetectionWindow {
         return {
-            matchMedia: jest.fn((query: string) => ({
+            matchMedia: (jest.fn((query: string) => ({
                 matches: query === coarseQuery && matches,
-            })) as Window['matchMedia'],
+            })) as unknown) as Window['matchMedia'],
             navigator: tapeNavigator,
         };
     }

--- a/src/lib/viewers/media/waveform/__tests__/viewport-test.ts
+++ b/src/lib/viewers/media/waveform/__tests__/viewport-test.ts
@@ -1,13 +1,18 @@
-import { WAVEFORM_MIN_VIEW_WINDOW_SEC, WAVEFORM_ZOOM_MAX } from '../constants';
+import { WAVEFORM_MIN_VIEW_WINDOW_SEC, WAVEFORM_TAPE_DEFAULT_WINDOW_SEC, WAVEFORM_ZOOM_MAX } from '../constants';
 import {
     clampWaveformZoom,
     createWaveformViewport,
     getPinnedPlayheadLeft,
     getPlayheadCameraAction,
     getSeekCameraAction,
+    getTapeCameraAction,
+    getTapeDefaultZoom,
+    getTapeGutterPx,
+    getTapePinnedPlayheadLeft,
     getWaveformZoomMax,
     getZoomedPixelsPerSecond,
     isTimeInView,
+    maxScrollLeft,
     positionPxFromTime,
     sliderValueFromZoom,
     timeFromPositionPx,
@@ -275,5 +280,95 @@ describe('viewport', () => {
     test('should keep the slider at fit-to-width when zoom cannot exceed 1x', () => {
         expect(sliderValueFromZoom(1, 1)).toBe(0);
         expect(zoomFromSliderValue(100, 1)).toBe(1);
+    });
+
+    test('should add half-view gutters so t=0 sits at the center pin', () => {
+        const tape = createWaveformViewport({
+            durationSec: 8,
+            gutterPx: 100,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 200,
+            zoomLevel: 1,
+        });
+
+        expect(tape.startSec).toBe(-4);
+        expect(tape.endSec).toBe(4);
+        expect(positionPxFromTime(0, tape)).toBe(100);
+        expect(timeFromPositionPx(100, tape)).toBe(0);
+        expect(timeLeftPercent(0, 8, tape)).toBe('50%');
+        expect(maxScrollLeft(tape)).toBe(200);
+        expect(getTapeGutterPx(200)).toBe(100);
+        expect(getTapePinnedPlayheadLeft()).toBe('50%');
+    });
+
+    test('should keep the playhead centered while following in tape mode', () => {
+        const tape = createWaveformViewport({
+            durationSec: 8,
+            gutterPx: 100,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 200,
+            zoomLevel: 1,
+        });
+
+        const follow = getPlayheadCameraAction({
+            cameraMode: 'tape',
+            isPlaying: true,
+            playJustStarted: false,
+            timeSec: 2,
+            viewport: tape,
+        });
+        expect(follow).toEqual(getTapeCameraAction({ timeSec: 2, viewport: tape }));
+        expect(follow.type).toBe('followRight');
+        if (follow.type === 'followRight') {
+            expect(follow.isPlayheadPinned).toBe(true);
+            expect(follow.scrollLeftPx).toBeCloseTo(50);
+        }
+
+        const paused = getPlayheadCameraAction({
+            cameraMode: 'tape',
+            isPlaying: false,
+            playJustStarted: false,
+            timeSec: 0,
+            viewport: tape,
+        });
+        expect(paused.type).toBe('followRight');
+        if (paused.type === 'followRight') {
+            expect(paused.scrollLeftPx).toBe(0);
+        }
+    });
+
+    test('should jump a tape seek to the center pin even when the time is already on screen', () => {
+        const tape = createWaveformViewport({
+            durationSec: 8,
+            gutterPx: 100,
+            heightPx: 140,
+            maxZoom: 4,
+            scrollLeftPx: 0,
+            widthPx: 200,
+            zoomLevel: 1,
+        });
+
+        const jump = getSeekCameraAction({ cameraMode: 'tape', timeSec: 2, viewport: tape });
+        expect(jump.type).toBe('jump');
+        if (jump.type === 'jump') {
+            expect(jump.scrollLeftPx).toBeCloseTo(50);
+        }
+
+        const centered = createWaveformViewport({ ...tape, scrollLeftPx: 50 });
+        expect(getSeekCameraAction({ cameraMode: 'tape', timeSec: 2, viewport: centered })).toEqual({ type: 'none' });
+    });
+
+    test('should default tape zoom to a 10s window and still allow 1x', () => {
+        expect(getTapeDefaultZoom(8, 24)).toBe(1);
+        expect(getTapeDefaultZoom(100, 24)).toBe(100 / WAVEFORM_TAPE_DEFAULT_WINDOW_SEC);
+        expect(getTapeDefaultZoom(100, 4)).toBe(4);
+        expect(
+            getZoomedPixelsPerSecond({ durationSec: 8, isTape: true, maxZoom: 4, viewWidthPx: 200, zoomLevel: 1 }),
+        ).toBe(25);
+        expect(getZoomedPixelsPerSecond({ durationSec: 8, maxZoom: 4, viewWidthPx: 200, zoomLevel: 1 })).toBe(0);
     });
 });

--- a/src/lib/viewers/media/waveform/colors.ts
+++ b/src/lib/viewers/media/waveform/colors.ts
@@ -81,6 +81,11 @@ export function getBufferedProgress(bufferedRange: TimeRanges | undefined, durat
     return clampTo0And1(bufferedRange.end(bufferedRange.length - 1) / durationSec);
 }
 
+/** Played bars: rest token on desktop, hover-played (brightest) on tape. Tape never uses hover or buffer fills. */
+export function getPlayedWaveformColor(isTape = false): string {
+    return isTape ? WAVEFORM_COLOR_HOVER_PLAYED : WAVEFORM_COLOR_PLAYED;
+}
+
 /**
  * progressColor paints left of the playhead (clipped by wavesurfer).
  * waveColor paints right of the playhead, including buffered vs not-yet-buffered.
@@ -88,15 +93,25 @@ export function getBufferedProgress(bufferedRange: TimeRanges | undefined, durat
 export function getWaveformFills({
     bufferProgress,
     hoverProgress,
+    isTape = false,
 }: {
     bufferProgress: number;
     hoverProgress: number | null;
+    isTape?: boolean;
 }): WaveformFills {
     const buffer = clampTo0And1(bufferProgress);
+    const playedColor = getPlayedWaveformColor(isTape);
+
+    if (isTape) {
+        return {
+            progressColor: playedColor,
+            waveColor: WAVEFORM_COLOR_UNPLAYED,
+        };
+    }
 
     if (hoverProgress == null) {
         return {
-            progressColor: WAVEFORM_COLOR_PLAYED,
+            progressColor: playedColor,
             waveColor: gradientStopsFromColorRanges([
                 { color: WAVEFORM_COLOR_UNPLAYED, end: buffer, start: 0 },
                 { color: WAVEFORM_COLOR_BUFFER, end: 1, start: buffer },

--- a/src/lib/viewers/media/waveform/constants.ts
+++ b/src/lib/viewers/media/waveform/constants.ts
@@ -27,6 +27,8 @@ export const WAVEFORM_ZOOM_MIN = 1;
 export const WAVEFORM_ZOOM_MAX = 24;
 /** Visible window never shorter than this. */
 export const WAVEFORM_MIN_VIEW_WINDOW_SEC = 4;
+/** Tape (phone/tablet) default: seconds of audio visible in the viewport. */
+export const WAVEFORM_TAPE_DEFAULT_WINDOW_SEC = 10;
 export const WAVEFORM_ZOOM_SLIDER_MAX = 100;
 /** One click on zoom in/out moves this many units on the 0–100 slider. */
 export const WAVEFORM_ZOOM_BUTTON_STEP = 10;
@@ -35,6 +37,8 @@ export const WAVEFORM_FOLLOW_INSET_PX = 200;
 export const WAVEFORM_PLAYHEAD_JUMP_MS = 400;
 /** After the last user pan, wait this long before the camera may pin again. */
 export const WAVEFORM_FOLLOW_SCROLL_SETTLE_MS = 150;
+/** Ignore a WaveSurfer click after a tape swipe (iOS delayed click). Must outlast the scrub-chip hide. */
+export const WAVEFORM_TAPE_CLICK_SUPPRESS_MS = 200;
 
 export const WAVEFORM_BAR_GAP = 2;
 export const WAVEFORM_BAR_WIDTH = 2;

--- a/src/lib/viewers/media/waveform/types.ts
+++ b/src/lib/viewers/media/waveform/types.ts
@@ -149,6 +149,8 @@ export type WaveformLoaderFactory = (
 export type WaveformViewport = {
     durationSec: number;
     endSec: number;
+    /** Empty leading/trailing px so t=0 and duration can sit under a center pin. */
+    gutterPx: number;
     heightPx: number;
     maxZoom: number;
     pixelsPerSecond: number;
@@ -158,7 +160,12 @@ export type WaveformViewport = {
     zoomLevel: number;
 };
 
-export type WaveformViewportInput = Omit<WaveformViewport, 'endSec' | 'pixelsPerSecond' | 'startSec'>;
+export type WaveformViewportInput = Omit<WaveformViewport, 'endSec' | 'gutterPx' | 'pixelsPerSecond' | 'startSec'> & {
+    gutterPx?: number;
+};
+
+/** Desktop walks then pins near the right inset. Tape keeps the playhead at center. */
+export type PlayheadCameraMode = 'desktop' | 'tape';
 
 export type PlayheadCameraAction =
     | { type: 'none' }
@@ -167,11 +174,14 @@ export type PlayheadCameraAction =
 
 export type WaveformViewProps = {
     bufferedRange?: TimeRanges;
+    cameraMode?: PlayheadCameraMode;
     currentTime?: number;
     durationSec: number;
     height?: number;
     interactive?: boolean;
+    isPlaying?: boolean;
     mediaEl?: HTMLMediaElement | null;
+    onPlayPause?: (isPlaying: boolean) => void;
     onSeek?: (timeSec: number) => void;
     onViewportChange?: (viewport: WaveformViewport) => void;
     onZoomChange?: (zoomLevel: number) => void;

--- a/src/lib/viewers/media/waveform/usePlayheadCamera.ts
+++ b/src/lib/viewers/media/waveform/usePlayheadCamera.ts
@@ -2,13 +2,15 @@ import { MutableRefObject, RefObject, useCallback, useEffect, useRef } from 'rea
 import WaveSurfer from 'wavesurfer.js';
 import { getCurrentTimeMs } from '../../../util';
 import { WAVEFORM_FOLLOW_SCROLL_SETTLE_MS, WAVEFORM_PLAYHEAD_JUMP_MS, WAVEFORM_ZOOM_MIN } from './constants';
-import { WaveformViewport } from './types';
+import { PlayheadCameraMode, WaveformViewport } from './types';
 import {
     getPinnedPlayheadLeft,
     getPlayheadCameraAction,
     getSeekCameraAction,
+    getTapePinnedPlayheadLeft,
     getViewportAtScroll,
     maxScrollLeft,
+    timeFromPositionPx,
     timeLeftPercent,
 } from './viewport';
 
@@ -25,6 +27,7 @@ function prefersReducedMotion(): boolean {
 }
 
 export type UsePlayheadCameraOptions = {
+    cameraMode?: PlayheadCameraMode;
     mediaElRef: MutableRefObject<HTMLMediaElement | null | undefined>;
     onViewportCommit: (scrollLeftPx: number, viewport: WaveformViewport, commitReactState?: boolean) => void;
     playheadRef: RefObject<HTMLDivElement | null>;
@@ -37,6 +40,7 @@ export type UsePlayheadCameraOptions = {
  * every frame. WaveformView owns WaveSurfer, zoom, and the media rAF loop.
  */
 export default function usePlayheadCamera({
+    cameraMode = 'desktop',
     mediaElRef,
     onViewportCommit,
     playheadRef,
@@ -49,6 +53,7 @@ export default function usePlayheadCamera({
     clearFollowPin: () => void;
     handleScroll: (onUserPan: (mediaTimeSec: number) => void) => void;
     isFollowPinned: () => boolean;
+    isUserPanning: () => boolean;
     onSeek: (timeSec: number) => void;
     onZoom: () => void;
     releaseUserPanHold: () => void;
@@ -56,6 +61,8 @@ export default function usePlayheadCamera({
 } {
     const onViewportCommitRef = useRef(onViewportCommit);
     onViewportCommitRef.current = onViewportCommit;
+    const cameraModeRef = useRef(cameraMode);
+    cameraModeRef.current = cameraMode;
 
     const programmaticScrollRef = useRef(false);
     const jumpAnimationRef = useRef(0);
@@ -68,6 +75,8 @@ export default function usePlayheadCamera({
     const applyRef = useRef<((timeSec: number, playJustStarted?: boolean) => void) | null>(null);
 
     const isFollowPinned = useCallback((): boolean => isFollowPinnedRef.current, []);
+    const isUserPanning = useCallback((): boolean => userIsScrollingRef.current, []);
+    const isTape = useCallback((): boolean => cameraModeRef.current === 'tape', []);
 
     const cancelJump = useCallback((): void => {
         if (!jumpAnimationRef.current) {
@@ -102,17 +111,24 @@ export default function usePlayheadCamera({
         (timeSec: number): void => {
             mediaTimeRef.current = timeSec;
             cancelJump();
-            clearFollowPin();
+            if (!isTape()) {
+                clearFollowPin();
+            }
         },
-        [cancelJump, clearFollowPin],
+        [cancelJump, clearFollowPin, isTape],
     );
 
     /** Unpin and hold follow so zoom setScroll (slider center or pinch origin) is not stolen. */
     const onZoom = useCallback((): void => {
         cancelJump();
+        if (isTape()) {
+            isFollowPinnedRef.current = true;
+            holdFollowUntilInsetRef.current = false;
+            return;
+        }
         isFollowPinnedRef.current = false;
         holdFollowUntilInsetRef.current = true;
-    }, [cancelJump]);
+    }, [cancelJump, isTape]);
 
     const applyScrollLeft = useCallback(
         (scrollLeftPx: number, shouldCommitState: boolean): void => {
@@ -146,9 +162,9 @@ export default function usePlayheadCamera({
             if (!playhead || !isPinned || !(viewport.widthPx > 0)) {
                 return;
             }
-            playhead.style.left = getPinnedPlayheadLeft(viewport.widthPx);
+            playhead.style.left = isTape() ? getTapePinnedPlayheadLeft() : getPinnedPlayheadLeft(viewport.widthPx);
         },
-        [],
+        [isTape],
     );
 
     const apply = useCallback(
@@ -159,7 +175,7 @@ export default function usePlayheadCamera({
             if (!wavesurfer) {
                 return;
             }
-            if (viewport.zoomLevel <= WAVEFORM_ZOOM_MIN) {
+            if (!isTape() && viewport.zoomLevel <= WAVEFORM_ZOOM_MIN) {
                 clearFollowPin();
                 return;
             }
@@ -172,12 +188,13 @@ export default function usePlayheadCamera({
 
             const liveViewport = getViewportAtScroll(viewport, getScrollLeft(wavesurfer, viewport.scrollLeftPx));
             const action = getPlayheadCameraAction({
+                cameraMode: cameraModeRef.current,
                 isPlaying: true,
                 playJustStarted,
                 timeSec,
                 viewport: liveViewport,
             });
-            if (holdFollowUntilInsetRef.current && !playJustStarted) {
+            if (!isTape() && holdFollowUntilInsetRef.current && !playJustStarted) {
                 if (action.type !== 'none') {
                     return;
                 }
@@ -213,6 +230,7 @@ export default function usePlayheadCamera({
             const tick = (now: number): void => {
                 const t = Math.min(1, (now - start) / WAVEFORM_PLAYHEAD_JUMP_MS);
                 const liveAction = getPlayheadCameraAction({
+                    cameraMode: cameraModeRef.current,
                     isPlaying: true,
                     playJustStarted: true,
                     timeSec: mediaTimeRef.current,
@@ -230,7 +248,16 @@ export default function usePlayheadCamera({
             };
             jumpAnimationRef.current = window.requestAnimationFrame(tick);
         },
-        [applyScrollLeft, cancelJump, clearFollowPin, pinFollowPlayhead, playheadRef, viewportRef, wavesurferRef],
+        [
+            applyScrollLeft,
+            cancelJump,
+            clearFollowPin,
+            isTape,
+            pinFollowPlayhead,
+            playheadRef,
+            viewportRef,
+            wavesurferRef,
+        ],
     );
     applyRef.current = apply;
 
@@ -265,13 +292,19 @@ export default function usePlayheadCamera({
 
             releaseUserPanHold();
             cancelJump();
-            isFollowPinnedRef.current = false;
+            if (!isTape()) {
+                isFollowPinnedRef.current = false;
+            }
 
             const liveViewport = getViewportAtScroll(
                 viewportRef.current,
                 getScrollLeft(wavesurfer, viewportRef.current.scrollLeftPx),
             );
-            const action = getSeekCameraAction({ timeSec, viewport: liveViewport });
+            const action = getSeekCameraAction({
+                cameraMode: cameraModeRef.current,
+                timeSec,
+                viewport: liveViewport,
+            });
             if (action.type !== 'jump') {
                 return;
             }
@@ -290,11 +323,9 @@ export default function usePlayheadCamera({
                 applyScrollLeft(from + (to - from) * (1 - (1 - t) * (1 - t)), false);
                 const playhead = playheadRef.current;
                 if (playhead) {
-                    playhead.style.left = timeLeftPercent(
-                        mediaTimeRef.current,
-                        viewportRef.current.durationSec,
-                        viewportRef.current,
-                    );
+                    playhead.style.left = isTape()
+                        ? getTapePinnedPlayheadLeft()
+                        : timeLeftPercent(mediaTimeRef.current, viewportRef.current.durationSec, viewportRef.current);
                 }
                 if (t < 1) {
                     jumpAnimationRef.current = window.requestAnimationFrame(tick);
@@ -305,7 +336,7 @@ export default function usePlayheadCamera({
             };
             jumpAnimationRef.current = window.requestAnimationFrame(tick);
         },
-        [applyScrollLeft, cancelJump, playheadRef, releaseUserPanHold, viewportRef, wavesurferRef],
+        [applyScrollLeft, cancelJump, isTape, playheadRef, releaseUserPanHold, viewportRef, wavesurferRef],
     );
 
     const handleScroll = useCallback(
@@ -321,8 +352,32 @@ export default function usePlayheadCamera({
             }
 
             viewportRef.current = getViewportAtScroll(viewportRef.current, scrollLeftPx);
-            const timeSec = readMediaTime();
             const playhead = playheadRef.current;
+            if (isTape()) {
+                if (playhead) {
+                    playhead.style.left = getTapePinnedPlayheadLeft();
+                }
+                const pinTimeSec = Math.min(
+                    viewportRef.current.durationSec,
+                    Math.max(0, timeFromPositionPx(viewportRef.current.widthPx / 2, viewportRef.current)),
+                );
+                userIsScrollingRef.current = true;
+                window.clearTimeout(scrollSettleTimerRef.current);
+                scrollSettleTimerRef.current = window.setTimeout(() => {
+                    userIsScrollingRef.current = false;
+                    scrollSettleTimerRef.current = 0;
+                    if (!mediaElRef.current || mediaElRef.current.paused) {
+                        return;
+                    }
+                    applyRef.current?.(readMediaTime(), false);
+                }, WAVEFORM_FOLLOW_SCROLL_SETTLE_MS);
+                cancelJump();
+                programmaticScrollRef.current = false;
+                onUserPan(pinTimeSec);
+                return;
+            }
+
+            const timeSec = readMediaTime();
             if (playhead) {
                 playhead.style.left = timeLeftPercent(timeSec, viewportRef.current.durationSec, viewportRef.current);
             }
@@ -343,7 +398,7 @@ export default function usePlayheadCamera({
             programmaticScrollRef.current = false;
             onUserPan(timeSec);
         },
-        [cancelJump, isUserPan, mediaElRef, playheadRef, readMediaTime, viewportRef, wavesurferRef],
+        [cancelJump, isTape, isUserPan, mediaElRef, playheadRef, readMediaTime, viewportRef, wavesurferRef],
     );
 
     useEffect(
@@ -361,6 +416,7 @@ export default function usePlayheadCamera({
         clearFollowPin,
         handleScroll,
         isFollowPinned,
+        isUserPanning,
         onSeek,
         onZoom,
         releaseUserPanHold,

--- a/src/lib/viewers/media/waveform/useTapeWaveform.ts
+++ b/src/lib/viewers/media/waveform/useTapeWaveform.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+/** Primary pointer is a finger, not a mouse/trackpad. */
+export const TAPE_POINTER_MQ = '(hover: none) and (pointer: coarse)';
+
+/** Navigator fields used to detect iPad, including iPadOS reporting itself as Mac. */
+export type TapeNavigator = Pick<Navigator, 'maxTouchPoints' | 'platform' | 'userAgent'>;
+
+/** Window bits needed to choose tape vs desktop (coarse pointer + iPad). */
+export type TapeDetectionWindow = Pick<Window, 'matchMedia'> & { navigator: TapeNavigator };
+
+export function isIPadNavigator(nav: TapeNavigator): boolean {
+    return /iPad/i.test(nav.userAgent || '') || (nav.platform === 'MacIntel' && (nav.maxTouchPoints || 0) > 1);
+}
+
+export function isCoarsePrimaryPointer(win: Pick<Window, 'matchMedia'>): boolean {
+    return typeof win.matchMedia === 'function' && win.matchMedia(TAPE_POINTER_MQ).matches;
+}
+
+/**
+ * Tape vs desktop camera: coarse primary pointer (finger) or iPad
+ * (including iPadOS reporting itself as Mac). Not width, not hasTouch,
+ * not Browser.isMobile().
+ */
+export function isTapeWaveformInput(win: TapeDetectionWindow = window): boolean {
+    return isCoarsePrimaryPointer(win) || isIPadNavigator(win.navigator);
+}
+
+/** Subscribe to the pointer media query; re-read the iPad heuristic on change. */
+export default function useTapeWaveform(): boolean {
+    const [isTape, setIsTape] = useState(() => typeof window !== 'undefined' && isTapeWaveformInput(window));
+
+    useEffect(() => {
+        if (typeof window.matchMedia !== 'function') {
+            setIsTape(isTapeWaveformInput(window));
+            return undefined;
+        }
+
+        const mediaQuery = window.matchMedia(TAPE_POINTER_MQ);
+        const sync = (): void => {
+            setIsTape(isTapeWaveformInput(window));
+        };
+        sync();
+        mediaQuery.addEventListener('change', sync);
+        return () => mediaQuery.removeEventListener('change', sync);
+    }, []);
+
+    return isTape;
+}

--- a/src/lib/viewers/media/waveform/viewport.ts
+++ b/src/lib/viewers/media/waveform/viewport.ts
@@ -1,15 +1,17 @@
 import {
     WAVEFORM_FOLLOW_INSET_PX,
     WAVEFORM_MIN_VIEW_WINDOW_SEC,
+    WAVEFORM_TAPE_DEFAULT_WINDOW_SEC,
     WAVEFORM_ZOOM_MAX,
     WAVEFORM_ZOOM_MIN,
     WAVEFORM_ZOOM_SLIDER_MAX,
 } from './constants';
-import { PlayheadCameraAction, WaveformViewport, WaveformViewportInput } from './types';
+import { PlayheadCameraAction, PlayheadCameraMode, WaveformViewport, WaveformViewportInput } from './types';
 
 /** Visible window: start/end times, pixels-per-second, and the current zoom. */
 export function createWaveformViewport({
     durationSec,
+    gutterPx = 0,
     heightPx,
     maxZoom,
     scrollLeftPx,
@@ -19,12 +21,21 @@ export function createWaveformViewport({
     const zoom = Number.isFinite(zoomLevel) && zoomLevel > 0 ? zoomLevel : WAVEFORM_ZOOM_MIN;
     const viewDurationSec = durationSec > 0 ? durationSec / zoom : 0; // seconds visible at this zoom
     const pixelsPerSecond = viewDurationSec > 0 && widthPx > 0 ? widthPx / viewDurationSec : 0;
-    const maxStartSec = Math.max(0, durationSec - viewDurationSec); // last start that still fills the window
-    const startSec = pixelsPerSecond > 0 ? Math.min(maxStartSec, Math.max(0, scrollLeftPx / pixelsPerSecond)) : 0;
+    const leadingGutterPx = Number.isFinite(gutterPx) && gutterPx > 0 ? gutterPx : 0;
+    const unclampedStartSec = pixelsPerSecond > 0 ? (scrollLeftPx - leadingGutterPx) / pixelsPerSecond : 0;
+    const gutterDurationSec = pixelsPerSecond > 0 ? leadingGutterPx / pixelsPerSecond : 0;
+    const latestWindowStartSec =
+        leadingGutterPx > 0
+            ? durationSec + gutterDurationSec - viewDurationSec
+            : Math.max(0, durationSec - viewDurationSec);
+    const earliestWindowStartSec = leadingGutterPx > 0 ? -gutterDurationSec : 0;
+    const startSec =
+        pixelsPerSecond > 0 ? Math.min(latestWindowStartSec, Math.max(earliestWindowStartSec, unclampedStartSec)) : 0;
 
     return {
         durationSec,
         endSec: startSec + viewDurationSec,
+        gutterPx: leadingGutterPx,
         heightPx,
         maxZoom,
         pixelsPerSecond,
@@ -46,6 +57,7 @@ export function viewportEquals(prev: WaveformViewport | null, next: WaveformView
         !!prev &&
         prev.durationSec === next.durationSec &&
         prev.endSec === next.endSec &&
+        prev.gutterPx === next.gutterPx &&
         prev.maxZoom === next.maxZoom &&
         prev.scrollLeftPx === next.scrollLeftPx &&
         prev.startSec === next.startSec &&
@@ -102,20 +114,38 @@ export function clampWaveformZoom(zoomLevel: number, maxZoom: number = WAVEFORM_
 /** WaveSurfer zoom density. 0 = fit the whole file in the view. */
 export function getZoomedPixelsPerSecond({
     durationSec,
+    isTape = false,
     maxZoom = WAVEFORM_ZOOM_MIN,
     viewWidthPx,
     zoomLevel,
 }: {
     durationSec: number;
+    isTape?: boolean;
     maxZoom?: number;
     viewWidthPx: number;
     zoomLevel: number;
 }): number {
     const zoom = clampWaveformZoom(zoomLevel, maxZoom);
-    if (zoom <= WAVEFORM_ZOOM_MIN || !(durationSec > 0) || !(viewWidthPx > 0)) {
+    if (!(durationSec > 0) || !(viewWidthPx > 0)) {
+        return 0;
+    }
+    if (!isTape && zoom <= WAVEFORM_ZOOM_MIN) {
         return 0;
     }
     return (viewWidthPx / durationSec) * zoom;
+}
+
+/** Half-view empty space so t=0 and duration can sit under the center pin. */
+export function getTapeGutterPx(widthPx: number): number {
+    return widthPx > 0 ? widthPx / 2 : 0;
+}
+
+/** Tape first paint: 10s on screen, or 1× when the file is shorter than that. */
+export function getTapeDefaultZoom(durationSec: number, maxZoom: number = WAVEFORM_ZOOM_MIN): number {
+    if (!(durationSec > 0)) {
+        return WAVEFORM_ZOOM_MIN;
+    }
+    return clampWaveformZoom(durationSec / WAVEFORM_TAPE_DEFAULT_WINDOW_SEC, maxZoom);
 }
 
 /** Map zoom (1…max) onto the 0–100 slider. */
@@ -138,9 +168,10 @@ export function zoomFromSliderValue(value: number, maxZoom: number = WAVEFORM_ZO
     return clampWaveformZoom(WAVEFORM_ZOOM_MIN + t * (max - WAVEFORM_ZOOM_MIN), max);
 }
 
-/** Max scroll that still shows a full window (no overscroll). */
+/** Max scroll that still shows a full window (no overscroll). Gutters add empty lead/trail. */
 export function maxScrollLeft(viewport: WaveformViewport): number {
-    return Math.max(0, viewport.durationSec * viewport.pixelsPerSecond - viewport.widthPx);
+    const gutterPx = viewport.gutterPx || 0;
+    return Math.max(0, viewport.durationSec * viewport.pixelsPerSecond + 2 * gutterPx - viewport.widthPx);
 }
 
 /** Scroll offset that still shows a full window (no overscroll). */
@@ -153,7 +184,10 @@ function clampScrollLeft(scrollLeftPx: number, viewport: WaveformViewport): numb
 
 /** Center this time in the view, clamped so the window still fills the canvas. */
 export function getCenteredScrollLeft(timeSec: number, viewport: WaveformViewport): number {
-    return clampScrollLeft(timeSec * viewport.pixelsPerSecond - viewport.widthPx / 2, viewport);
+    return clampScrollLeft(
+        timeSec * viewport.pixelsPerSecond + (viewport.gutterPx || 0) - viewport.widthPx / 2,
+        viewport,
+    );
 }
 
 /**
@@ -161,19 +195,49 @@ export function getCenteredScrollLeft(timeSec: number, viewport: WaveformViewpor
  * No-op at fit-to-width or when that time is already visible.
  */
 export function getSeekCameraAction({
+    cameraMode = 'desktop',
     timeSec,
     viewport,
 }: {
+    cameraMode?: PlayheadCameraMode;
     timeSec: number;
     viewport: WaveformViewport;
 }): PlayheadCameraAction {
-    if (viewport.zoomLevel <= WAVEFORM_ZOOM_MIN || !(viewport.widthPx > 0) || !(viewport.pixelsPerSecond > 0)) {
+    if (!(viewport.widthPx > 0) || !(viewport.pixelsPerSecond > 0)) {
+        return { type: 'none' };
+    }
+    if (cameraMode === 'tape') {
+        const scrollLeftPx = getCenteredScrollLeft(timeSec, viewport);
+        if (Math.abs(scrollLeftPx - viewport.scrollLeftPx) < 1) {
+            return { type: 'none' };
+        }
+        return { type: 'jump', scrollLeftPx };
+    }
+    if (viewport.zoomLevel <= WAVEFORM_ZOOM_MIN) {
         return { type: 'none' };
     }
     if (isTimeInView(timeSec, viewport)) {
         return { type: 'none' };
     }
     return { type: 'jump', scrollLeftPx: getCenteredScrollLeft(timeSec, viewport) };
+}
+
+/** Always keep this time under the center pin. Reuses followRight so the camera hook can pin. */
+export function getTapeCameraAction({
+    timeSec,
+    viewport,
+}: {
+    timeSec: number;
+    viewport: WaveformViewport;
+}): PlayheadCameraAction {
+    if (!(viewport.widthPx > 0) || !(viewport.pixelsPerSecond > 0)) {
+        return { type: 'none' };
+    }
+    return {
+        isPlayheadPinned: true,
+        scrollLeftPx: getCenteredScrollLeft(timeSec, viewport),
+        type: 'followRight',
+    };
 }
 
 /** Follow inset in CSS px, capped at one third of the view so a narrow player still has room. */
@@ -193,6 +257,11 @@ export function getPinnedPlayheadLeft(widthPx: number, insetPx: number = WAVEFOR
     return `${((widthPx - inset) / widthPx) * 100}%`;
 }
 
+/** CSS left for a playhead locked to the center of the view. */
+export function getTapePinnedPlayheadLeft(): string {
+    return '50%';
+}
+
 /** CSS left % of the playhead from the left of the visible window. */
 export function timeLeftPercent(timeSec: number, durationSec: number, viewport: WaveformViewport): string {
     if (viewport.widthPx > 0 && viewport.pixelsPerSecond > 0) {
@@ -207,18 +276,23 @@ export function timeLeftPercent(timeSec: number, durationSec: number, viewport: 
  * Off-screen at play start jumps in; off-screen right while playing keeps following.
  */
 export function getPlayheadCameraAction({
+    cameraMode = 'desktop',
     insetPx = WAVEFORM_FOLLOW_INSET_PX,
     isPlaying,
     playJustStarted,
     timeSec,
     viewport,
 }: {
+    cameraMode?: PlayheadCameraMode;
     insetPx?: number;
     isPlaying: boolean;
     playJustStarted: boolean;
     timeSec: number;
     viewport: WaveformViewport;
 }): PlayheadCameraAction {
+    if (cameraMode === 'tape') {
+        return getTapeCameraAction({ timeSec, viewport });
+    }
     if (
         !isPlaying ||
         viewport.zoomLevel <= WAVEFORM_ZOOM_MIN ||


### PR DESCRIPTION
## Summary
Adds a **tape** camera for the audio waveform on phone and tablet. Tape is a cassette-style window: the playhead stays pinned at the center of the view, and the bars scroll under it. Desktop keeps the existing follow/jump camera and mouse hover fills.

### When we use tape
Tape vs desktop is **input**, not viewport width and not `Browser.isMobile()` / `hasTouch`:

- coarse primary pointer: `(hover: none) and (pointer: coarse)` (finger, not mouse/trackpad)
- **or** iPad, including iPadOS that reports itself as Mac (`/iPad/` UA, or `platform === 'MacIntel'` && `maxTouchPoints > 1`)

A touch laptop with a mouse stays desktop. An iPad with a trackpad still gets tape.

### Tape UX
- **Center pin** — playhead is fixed at 50%. Half-view gutters so t=0 and duration can sit on the pin.
- **~10s default window** on long files (1× when the file is shorter than 10s). Pinch, wheel, and the overlay zoom in/out all stick; they do not snap back to 10s.
- **Tap** the wave to play/pause. **Swipe** seeks the time under the pin (one seek per animation frame). A delayed click after a swipe or pinch does not toggle play (iOS).
- **No hover fills** on tape, and no hover from touch (including Chrome’s fake mouse events after a tap). Desktop mouse hover is unchanged. Played bars use the brighter fill so the window still reads without a hover preview.
- **Taller stage** — `max(140px, 25%)` of the media player. WaveSurfer is created at the live canvas height so the first paint is already tall.
- **Comment badges** sit above the bars, not on them.
- **Scrub time chip** sits on the pin while swiping, then hides after the swipe settles.
- **iOS audio** does not set the HTML `autoplay` attribute (Safari was starting playback on tap-to-open). Video still does.

### Intentional
- Tape **pinch zooms around the pin**, not under the fingers. The window stays centered on the playhead; finger-origin zoom is out of this slice.
- Overlay zoom starts **collapsed** on tape (first tap on + opens the flyout; a later tap zooms).
- Desktop zoom/pan behavior is unchanged. Treat remaining desktop hitch reports as environmental unless they reproduce on a charged, restarted Chrome.

## Test plan
- [ ] Phone and iPad: tape camera (center pin, ~10s window on a long file, 1× on a short file)
- [ ] Tap play/pause on the wave with no hover flash; swipe seeks; swipe then lift does not toggle play
- [ ] Pinch then lift does not toggle play; pinch keeps the pin centered
- [ ] Overlay zoom in/out then pan — window does not snap back to 10s
- [ ] Comment badges sit above the tape wave and track the window
- [ ] First paint is already tall (not 140px then jump)
- [ ] iOS: audio does not start on tap-to-open; video autoplay behavior unchanged
- [ ] Fine-pointer laptop: desktop camera; mouse hover fill still works; slider/wheel zoom and pan